### PR TITLE
feat: implement High Quality toggle for viewport preview

### DIFF
--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -187,11 +187,12 @@ class AppController(QObject):
             self.set_status("NO SUPPORTED ASSETS FOUND", 3000)
             self.status_progress_requested.emit(0, 0)
 
-    def load_file(self, file_path: str) -> None:
+    def load_file(self, file_path: str, preserve_zoom: bool = False) -> None:
         """
         Loads a new RAW file into the linear preview workspace.
         """
-        self.zoom_requested.emit(1.0)
+        if not preserve_zoom:
+            self.zoom_requested.emit(1.0)
         self.set_status(f"Loading {os.path.basename(file_path)}...")
         self.loading_started.emit()
         self._first_render_done = False
@@ -203,6 +204,7 @@ class AppController(QObject):
                 file_path,
                 self.state.workspace_color_space,
                 use_camera_wb=self.state.config.exposure.use_camera_wb,
+                full_resolution=self.state.hq_preview,
             )
             self.state.preview_raw = raw
             self.state.original_res = dims
@@ -210,6 +212,11 @@ class AppController(QObject):
             self.request_render()
         except Exception as e:
             logger.error(f"Asset load failed: {e}")
+
+    def toggle_hq_preview(self) -> None:
+        self.state.hq_preview = not self.state.hq_preview
+        if self.state.current_file_path:
+            self.load_file(self.state.current_file_path, preserve_zoom=True)
 
     def handle_canvas_clicked(self, nx: float, ny: float) -> None:
         if self.state.active_tool == ToolMode.WB_PICK:
@@ -462,11 +469,16 @@ class AppController(QObject):
             return
 
         self.set_status("Rendering...")
+        
+        target_size = float(APP_CONFIG.preview_render_size)
+        if self.state.hq_preview and self.state.preview_raw is not None:
+            target_size = float(max(self.state.preview_raw.shape[:2]))
+
         task = RenderTask(
             buffer=self.state.preview_raw,
             config=self.state.config,
             source_hash=self.state.current_file_hash or "preview",
-            preview_size=float(APP_CONFIG.preview_render_size),
+            preview_size=target_size,
             icc_profile_path=self.state.icc_profile_path,
             icc_invert=self.state.icc_invert,
             color_space=self.state.workspace_color_space,

--- a/negpy/desktop/session.py
+++ b/negpy/desktop/session.py
@@ -46,6 +46,9 @@ class AppState:
     # Hardware Acceleration
     gpu_enabled: bool = True
 
+    # High Quality / Full Resoluiton Preview Toggle
+    hq_preview: bool = False
+
     # History tracking
     undo_index: int = 0
     max_history_index: int = 0

--- a/negpy/desktop/view/canvas/toolbar.py
+++ b/negpy/desktop/view/canvas/toolbar.py
@@ -105,6 +105,11 @@ class ActionToolbar(QWidget):
         self.zoom_label = QLabel("100%")
         self.zoom_label.setFixedWidth(35)
         self.zoom_label.setStyleSheet(f"color: {THEME.text_secondary}; font-size: 11px;")
+        
+        self.btn_hq = QToolButton()
+        self.btn_hq.setText("HQ")
+        self.btn_hq.setCheckable(True)
+        self.btn_hq.setToolTip("Toggle High Quality Preview")
 
         # 6. Session
         self.btn_save = QPushButton(" Save")
@@ -130,6 +135,7 @@ class ActionToolbar(QWidget):
             self.btn_save,
             self.btn_export,
             self.btn_unload,
+            self.btn_hq,
         ]
 
         for btn in all_buttons:
@@ -141,6 +147,7 @@ class ActionToolbar(QWidget):
         row1_layout.addWidget(self.btn_next)
         row1_layout.addWidget(self.zoom_slider)
         row1_layout.addWidget(self.zoom_label)
+        row1_layout.addWidget(self.btn_hq)
         row1_layout.addWidget(self.btn_rot_l)
         row1_layout.addWidget(self.btn_rot_r)
         row1_layout.addWidget(self.btn_flip_h)
@@ -181,6 +188,7 @@ class ActionToolbar(QWidget):
 
         # Zoom
         self.zoom_slider.valueChanged.connect(lambda v: self.controller.zoom_requested.emit(float(v / 100.0)))
+        self.btn_hq.clicked.connect(self.controller.toggle_hq_preview)
         self.controller.zoom_changed.connect(self._on_zoom_changed)
 
         # State sync for button enabled/disabled
@@ -223,3 +231,4 @@ class ActionToolbar(QWidget):
 
         self.btn_undo.setEnabled(state.undo_index > 0)
         self.btn_redo.setEnabled(state.undo_index < state.max_history_index)
+        self.btn_hq.setChecked(state.hq_preview)

--- a/negpy/services/rendering/preview_manager.py
+++ b/negpy/services/rendering/preview_manager.py
@@ -20,6 +20,7 @@ class PreviewManager:
         file_path: str,
         color_space: str | None = None,
         use_camera_wb: bool = False,
+        full_resolution: bool = False,
     ) -> Tuple[ImageBuffer, Dimensions, dict]:
         """
         Loads linear RGB, downsamples for display.
@@ -53,7 +54,7 @@ class PreviewManager:
             h_orig, w_orig = full_linear.shape[:2]
 
             max_res = APP_CONFIG.preview_render_size
-            if max(h_orig, w_orig) > max_res:
+            if max(h_orig, w_orig) > max_res and not full_resolution:
                 scale = max_res / max(h_orig, w_orig)
                 target_w = int(w_orig * scale)
                 target_h = int(h_orig * scale)

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1,0 +1,78 @@
+import unittest
+from unittest.mock import MagicMock
+
+from negpy.desktop.controller import AppController
+from negpy.desktop.session import DesktopSessionManager, AppState
+from negpy.services.rendering.preview_manager import PreviewManager
+
+class TestAppController(unittest.TestCase):
+    def setUp(self):
+        # Create a mock session manager
+        self.mock_session_manager = MagicMock(spec=DesktopSessionManager)
+        self.mock_session_manager.state = AppState()
+        self.mock_session_manager.repo = MagicMock()
+        
+        # We need a QCoreApplication instance to create QThreads inside AppController
+        import sys
+        from PyQt6.QtCore import QCoreApplication
+        if not QCoreApplication.instance():
+            self.app = QCoreApplication(sys.argv)
+        else:
+            self.app = QCoreApplication.instance()
+            
+        self.controller = AppController(self.mock_session_manager)
+        
+        # Mock preview service
+        self.controller.preview_service = MagicMock(spec=PreviewManager)
+        self.controller.preview_service.load_linear_preview.return_value = (None, (0, 0), {})
+
+    def tearDown(self):
+        # Clean up dynamically created threads
+        for thread in [
+            self.controller.render_thread,
+            self.controller.export_thread,
+            self.controller.thumb_thread,
+            self.controller.norm_thread,
+            self.controller.discovery_thread
+        ]:
+            if thread is not None and thread.isRunning():
+                thread.quit()
+                thread.wait()
+
+    def test_load_file_emits_zoom_reset(self):
+        """Test that loading a file normally resets the zoom."""
+        mock_slot = MagicMock()
+        self.controller.zoom_requested.connect(mock_slot)
+        
+        self.controller.load_file("dummy.dng")
+        
+        mock_slot.assert_called_once_with(1.0)
+        self.assertFalse(self.controller.state.hq_preview)
+        
+    def test_load_file_preserve_zoom(self):
+        """Test that load_file with preserve_zoom=True skips resetting zoom."""
+        mock_slot = MagicMock()
+        self.controller.zoom_requested.connect(mock_slot)
+        
+        self.controller.load_file("dummy.dng", preserve_zoom=True)
+        
+        mock_slot.assert_not_called()
+        
+    def test_toggle_hq_preview_preserves_zoom(self):
+        """Test that toggling HQ mode automatically preserves zoom."""
+        self.controller.state.current_file_path = "dummy.dng"
+        
+        mock_slot = MagicMock()
+        self.controller.zoom_requested.connect(mock_slot)
+        
+        self.controller.toggle_hq_preview()
+        
+        # State should be toggled
+        self.assertTrue(self.controller.state.hq_preview)
+        
+        # Zoom should NOT be reset
+        mock_slot.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This pull request adds a high-quality (HQ) preview toggle feature to the application, allowing users to switch between standard and full-resolution previews. It includes changes to the controller, UI, rendering logic, and adds new unit tests to ensure correct behavior. The most important changes are grouped below:

**High-Quality Preview Feature:**

* Added an `hq_preview` boolean state to `AppState` to track whether HQ preview is enabled. (`negpy/desktop/session.py`)
* Updated `load_linear_preview` in `PreviewManager` to accept a `full_resolution` argument, and only downsample the preview if HQ mode is off. (`negpy/services/rendering/preview_manager.py`)
* Modified `AppController` to support toggling HQ preview, reload the current file at the appropriate resolution, and preserve zoom level when toggling. (`negpy/desktop/controller.py`) 
**UI Enhancements:**

* Added an "HQ" toggle button to the toolbar, connected it to the controller, and synchronized button state with the application state. (`negpy/desktop/view/canvas/toolbar.py`)

**Rendering Logic Updates:**

* Updated `request_render` to use the full image resolution when HQ preview is enabled, otherwise use the configured preview size. (`negpy/desktop/controller.py`)

**Testing:**

* Added a new test suite for `AppController` to verify correct behavior of HQ preview toggling and zoom preservation. (`tests/test_controller.py`)…ed zoom

**Issue:**
* Closes #117 