### PR TITLE
feat: Improve autocrop behavior and canvas background handling

### DIFF
--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -49,6 +49,7 @@ class AppController(QObject):
     loading_started = pyqtSignal()
     export_progress = pyqtSignal(int, int, str)
     export_finished = pyqtSignal(float)
+    preview_loaded = pyqtSignal()
     render_requested = pyqtSignal(RenderTask)
     preview_load_requested = pyqtSignal(PreviewLoadTask)
     normalization_requested = pyqtSignal(NormalizationTask)
@@ -331,6 +332,7 @@ class AppController(QObject):
                 max(rx1, rx2),
                 max(ry1, ry2),
             ),
+            auto_crop_enabled=False,
         )
         new_proc = replace(self.state.config.process, local_floors=(0.0, 0.0, 0.0), local_ceils=(0.0, 0.0, 0.0))
         self.session.update_config(replace(self.state.config, geometry=new_geo, process=new_proc))
@@ -343,7 +345,23 @@ class AppController(QObject):
         self.session.update_config(
             replace(
                 self.state.config,
-                geometry=replace(self.state.config.geometry, manual_crop_rect=None),
+                geometry=replace(self.state.config.geometry, manual_crop_rect=None, auto_crop_enabled=False),
+                process=new_proc,
+            )
+        )
+        self.request_render()
+
+    def apply_auto_crop(self) -> None:
+        new_proc = replace(self.state.config.process, local_floors=(0.0, 0.0, 0.0), local_ceils=(0.0, 0.0, 0.0))
+        self.session.update_config(
+            replace(
+                self.state.config,
+                geometry=replace(
+                    self.state.config.geometry,
+                    manual_crop_rect=None,
+                    auto_crop_enabled=True,
+                    autocrop_ratio="Free",
+                ),
                 process=new_proc,
             )
         )

--- a/negpy/desktop/view/canvas/overlay.py
+++ b/negpy/desktop/view/canvas/overlay.py
@@ -114,9 +114,16 @@ class CanvasOverlay(QWidget):
     def paintEvent(self, event) -> None:
         painter = QPainter(self)
 
+        parent_bg = getattr(self.parent(), "_bg_color", QColor("#050505"))
+        if not getattr(self.parent(), "gpu_widget", None) or not self.parent().gpu_widget.isVisible():
+            painter.fillRect(event.rect(), parent_bg)
+
         if sys.platform in ("darwin", "win32"):
             painter.setCompositionMode(QPainter.CompositionMode.CompositionMode_Source)
-            painter.fillRect(event.rect(), Qt.GlobalColor.transparent)
+            if getattr(self.parent(), "gpu_widget", None) and self.parent().gpu_widget.isVisible():
+                painter.fillRect(event.rect(), Qt.GlobalColor.transparent)
+            else:
+                painter.fillRect(event.rect(), parent_bg)
             painter.setCompositionMode(QPainter.CompositionMode.CompositionMode_SourceOver)
 
         painter.setRenderHint(QPainter.RenderHint.Antialiasing)

--- a/negpy/desktop/view/main_window.py
+++ b/negpy/desktop/view/main_window.py
@@ -202,6 +202,15 @@ class MainWindow(QMainWindow):
             header.gpu_badge.setText("CPU")
             header.gpu_badge.setStyleSheet(f"color: {THEME.text_secondary}; font-size: {THEME.font_size_xs}px; font-weight: bold;")
 
+    def _display_buffer_for_canvas(self, buffer):
+        if isinstance(buffer, GPUTexture):
+            buffer = buffer.readback()
+
+        if isinstance(buffer, np.ndarray) and buffer.ndim == 3 and buffer.shape[2] == 4:
+            return buffer[:, :, :3]
+
+        return buffer
+
     def _on_image_updated(self) -> None:
         """Refreshes canvas when a new render pass completes."""
         self.empty_state.setVisible(False)

--- a/negpy/desktop/view/sidebar/controls_panel.py
+++ b/negpy/desktop/view/sidebar/controls_panel.py
@@ -308,6 +308,7 @@ class ControlsPanel(QWidget):
                 geo.fine_rotation != _geo.fine_rotation,
                 geo.flip_horizontal != _geo.flip_horizontal,
                 geo.flip_vertical != _geo.flip_vertical,
+                geo.auto_crop_enabled != _geo.auto_crop_enabled,
                 geo.manual_crop_rect is not None,
                 geo.autocrop_ratio != _geo.autocrop_ratio,
                 geo.autocrop_offset != _geo.autocrop_offset,

--- a/negpy/desktop/view/sidebar/geometry.py
+++ b/negpy/desktop/view/sidebar/geometry.py
@@ -69,7 +69,7 @@ class GeometrySidebar(BaseSidebar):
     def _connect_signals(self) -> None:
         self.ratio_combo.currentTextChanged.connect(self._on_ratio_changed)
         self.manual_crop_btn.toggled.connect(self._on_manual_crop_toggled)
-        self.reset_crop_btn.clicked.connect(self.controller.apply_auto_crop)
+        self.reset_crop_btn.toggled.connect(self._on_auto_crop_toggled)
 
         self.offset_slider.valueChanged.connect(
             lambda v: self.update_config_section("geometry", render=True, persist=False, readback_metrics=False, autocrop_offset=int(v))
@@ -103,6 +103,12 @@ class GeometrySidebar(BaseSidebar):
 
     def _on_manual_crop_toggled(self, checked: bool) -> None:
         self.controller.set_active_tool(ToolMode.CROP_MANUAL if checked else ToolMode.NONE)
+
+    def _on_auto_crop_toggled(self, checked: bool) -> None:
+        if checked:
+            self.controller.apply_auto_crop()
+        else:
+            self.controller.reset_crop()
 
     def sync_ui(self) -> None:
         conf = self.state.config.geometry

--- a/negpy/desktop/view/sidebar/geometry.py
+++ b/negpy/desktop/view/sidebar/geometry.py
@@ -41,7 +41,9 @@ class GeometrySidebar(BaseSidebar):
         self.manual_crop_btn.setToolTip(tooltip_with_shortcut("Manual crop", "manual_crop"))
 
         self.reset_crop_btn = QPushButton(" Auto")
+        self.reset_crop_btn.setCheckable(True)
         self.reset_crop_btn.setIcon(qta.icon("fa5s.magic", color=THEME.text_primary))
+        self.reset_crop_btn.setToolTip("Apply automatic crop using the current ratio and offset")
         btn_row.addWidget(self.manual_crop_btn)
         btn_row.addWidget(self.reset_crop_btn)
         self.layout.addLayout(btn_row)
@@ -67,7 +69,7 @@ class GeometrySidebar(BaseSidebar):
     def _connect_signals(self) -> None:
         self.ratio_combo.currentTextChanged.connect(self._on_ratio_changed)
         self.manual_crop_btn.toggled.connect(self._on_manual_crop_toggled)
-        self.reset_crop_btn.clicked.connect(self.controller.reset_crop)
+        self.reset_crop_btn.clicked.connect(self.controller.apply_auto_crop)
 
         self.offset_slider.valueChanged.connect(
             lambda v: self.update_config_section("geometry", render=True, persist=False, readback_metrics=False, autocrop_offset=int(v))
@@ -113,6 +115,7 @@ class GeometrySidebar(BaseSidebar):
             self.fine_rot_slider.setValue(conf.fine_rotation)
 
             self.manual_crop_btn.setChecked(self.state.active_tool == ToolMode.CROP_MANUAL)
+            self.reset_crop_btn.setChecked(conf.auto_crop_enabled)
         finally:
             self.block_signals(False)
 
@@ -121,3 +124,4 @@ class GeometrySidebar(BaseSidebar):
         self.offset_slider.blockSignals(blocked)
         self.fine_rot_slider.blockSignals(blocked)
         self.manual_crop_btn.blockSignals(blocked)
+        self.reset_crop_btn.blockSignals(blocked)

--- a/negpy/features/geometry/logic.py
+++ b/negpy/features/geometry/logic.py
@@ -6,6 +6,317 @@ from negpy.kernel.image.validation import ensure_image
 from negpy.kernel.image.logic import get_luminance
 
 
+def _normalize_to_uint8(image: np.ndarray) -> np.ndarray:
+    if image.dtype == np.uint8:
+        return image
+
+    image_float = image.astype(np.float32)
+    finite_mask = np.isfinite(image_float)
+    if not np.any(finite_mask):
+        return np.zeros(image.shape, dtype=np.uint8)
+
+    valid = image_float[finite_mask]
+    low = float(np.percentile(valid, 1))
+    high = float(np.percentile(valid, 99))
+    if high <= low:
+        high = low + 1.0
+
+    scaled = np.clip((image_float - low) * (255.0 / (high - low)), 0, 255)
+    return scaled.astype(np.uint8)
+
+
+def _ensure_color(image: np.ndarray) -> np.ndarray:
+    if image.ndim == 2:
+        return cv2.cvtColor(image, cv2.COLOR_GRAY2BGR)
+    return image
+
+
+def _smooth_signal(signal: np.ndarray, window: int) -> np.ndarray:
+    if window <= 1 or signal.size == 0:
+        return signal.astype(np.float32)
+
+    kernel = np.ones(window, dtype=np.float32) / window
+    return np.convolve(signal.astype(np.float32), kernel, mode="same")
+
+
+def _boundary_candidates(signal: np.ndarray, *, from_start: bool) -> tuple[int, float, int, float]:
+    length = signal.size
+    if length == 0:
+        return 0, 0.0, 0, 0.0
+
+    edge_window = max(int(round(length * 0.08)), 32)
+    edge_window = min(edge_window, max(length - 1, 1))
+    search_end = max(int(round(length * 0.45)), edge_window + 1)
+    search_end = min(search_end, length)
+    search_start = min(int(round(length * 0.55)), max(length - edge_window - 1, 0))
+
+    if from_start:
+        edge_slice = signal[:edge_window]
+        search_slice = signal[edge_window:search_end]
+        edge_idx = int(np.argmax(edge_slice)) if edge_slice.size else 0
+        edge_value = float(edge_slice[edge_idx]) if edge_slice.size else 0.0
+        if search_slice.size == 0:
+            return edge_idx, edge_value, edge_idx, edge_value
+        inner_offset = int(np.argmax(search_slice))
+        inner_idx = edge_window + inner_offset
+        inner_value = float(search_slice[inner_offset])
+        return edge_idx, edge_value, inner_idx, inner_value
+
+    edge_slice = signal[length - edge_window :]
+    search_slice = signal[search_start : length - edge_window]
+    edge_offset = int(np.argmax(edge_slice)) if edge_slice.size else 0
+    edge_idx = length - edge_window + edge_offset
+    edge_value = float(edge_slice[edge_offset]) if edge_slice.size else 0.0
+    if search_slice.size == 0:
+        return edge_idx, edge_value, edge_idx, edge_value
+    inner_offset = int(np.argmax(search_slice))
+    inner_idx = search_start + inner_offset
+    inner_value = float(search_slice[inner_offset])
+    return edge_idx, edge_value, inner_idx, inner_value
+
+
+def _dark_region_bounds(image: np.ndarray) -> tuple[int, int, int, int] | None:
+    preview = _normalize_to_uint8(_ensure_color(image))
+    gray = cv2.cvtColor(preview, cv2.COLOR_BGR2GRAY)
+
+    threshold = float(np.percentile(gray, 55))
+    mask = (gray <= threshold).astype(np.uint8) * 255
+    open_kernel = cv2.getStructuringElement(cv2.MORPH_RECT, (9, 9))
+    close_kernel = cv2.getStructuringElement(cv2.MORPH_RECT, (31, 31))
+    mask = cv2.morphologyEx(mask, cv2.MORPH_OPEN, open_kernel)
+    mask = cv2.morphologyEx(mask, cv2.MORPH_CLOSE, close_kernel, iterations=2)
+
+    contours, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+    if not contours:
+        return None
+
+    contour = max(contours, key=cv2.contourArea)
+    x, y, box_w, box_h = cv2.boundingRect(contour)
+    image_area = float(gray.shape[0] * gray.shape[1])
+    area_ratio = float(cv2.contourArea(contour)) / max(image_area, 1.0)
+    if area_ratio < 0.15 or area_ratio > 0.85:
+        return None
+
+    min_width = int(round(image.shape[1] * 0.25))
+    min_height = int(round(image.shape[0] * 0.25))
+    if box_w < min_width or box_h < min_height:
+        return None
+
+    pad_x = max(int(round(image.shape[1] * 0.004)), 4)
+    pad_y = max(int(round(image.shape[0] * 0.004)), 4)
+    left = max(x - pad_x, 0)
+    top = max(y - pad_y, 0)
+    right = min(x + box_w + pad_x, image.shape[1])
+    bottom = min(y + box_h + pad_y, image.shape[0])
+
+    min_inset_x = int(round(image.shape[1] * 0.03))
+    min_inset_y = int(round(image.shape[0] * 0.03))
+    if (
+        left < min_inset_x
+        or top < min_inset_y
+        or (image.shape[1] - right) < min_inset_x
+        or (image.shape[0] - bottom) < min_inset_y
+    ):
+        return None
+
+    return left, top, right, bottom
+
+
+def _refine_frame_bounds(image: np.ndarray) -> tuple[np.ndarray, tuple[int, int, int, int]]:
+    preview = _normalize_to_uint8(_ensure_color(image))
+    gray = cv2.cvtColor(preview, cv2.COLOR_BGR2GRAY)
+
+    grad_x = cv2.convertScaleAbs(cv2.Sobel(gray, cv2.CV_32F, 1, 0, ksize=3))
+    grad_y = cv2.convertScaleAbs(cv2.Sobel(gray, cv2.CV_32F, 0, 1, ksize=3))
+    col_signal = _smooth_signal(np.percentile(grad_x, 95, axis=0), 31)
+    row_signal = _smooth_signal(np.percentile(grad_y, 95, axis=1), 31)
+
+    left_edge, left_edge_value, left_inner, left_inner_value = _boundary_candidates(col_signal, from_start=True)
+    right_edge, right_edge_value, right_inner, right_inner_value = _boundary_candidates(col_signal, from_start=False)
+    top_edge, top_edge_value, top_inner, top_inner_value = _boundary_candidates(row_signal, from_start=True)
+    bottom_edge, bottom_edge_value, bottom_inner, bottom_inner_value = _boundary_candidates(row_signal, from_start=False)
+
+    col_noise_floor = float(np.percentile(col_signal, 75))
+    row_noise_floor = float(np.percentile(row_signal, 75))
+
+    left = left_edge
+    right = right_edge + 1
+    top = top_edge
+    bottom = bottom_edge + 1
+
+    use_inner_pair_x = (
+        left_inner >= int(round(image.shape[1] * 0.12))
+        and right_inner <= int(round(image.shape[1] * 0.88))
+        and left_inner_value >= col_noise_floor * 4.0
+        and right_inner_value >= col_noise_floor * 4.0
+        and (right_inner - left_inner) >= int(round(image.shape[1] * 0.5))
+    )
+    if use_inner_pair_x:
+        left = left_inner
+        right = right_inner + 1
+    else:
+        if left_inner >= int(round(image.shape[1] * 0.12)) and left_inner_value >= col_noise_floor * 5.0:
+            left = left_inner
+        if right_inner <= int(round(image.shape[1] * 0.88)) and right_inner_value >= col_noise_floor * 5.0:
+            right = right_inner + 1
+
+    use_inner_pair_y = (
+        top_inner > top_edge + 20
+        and bottom_inner < bottom_edge - 20
+        and top_inner_value > max(top_edge_value * 1.2, row_noise_floor + 25.0)
+        and bottom_inner_value > max(bottom_edge_value * 1.2, row_noise_floor + 25.0)
+        and (bottom_inner - top_inner) >= int(round(image.shape[0] * 0.5))
+    )
+    if use_inner_pair_y:
+        top = top_inner
+        bottom = bottom_inner + 1
+    else:
+        if top_inner > top_edge + 20 and top_inner_value > max(top_edge_value * 1.45, row_noise_floor + 35.0):
+            top = top_inner
+        if bottom_inner < bottom_edge - 20 and bottom_inner_value > max(bottom_edge_value * 1.45, row_noise_floor + 35.0):
+            bottom = bottom_inner + 1
+
+    pad_x = max(int(round(image.shape[1] * 0.004)), 4)
+    pad_y = max(int(round(image.shape[0] * 0.004)), 4)
+    left = max(left - pad_x, 0)
+    right = min(right + pad_x, image.shape[1])
+    top = max(top - pad_y, 0)
+    bottom = min(bottom + pad_y, image.shape[0])
+
+    min_width = max(int(round(image.shape[1] * 0.5)), 1)
+    min_height = max(int(round(image.shape[0] * 0.5)), 1)
+    if right - left < min_width:
+        left, right = 0, image.shape[1]
+    if bottom - top < min_height:
+        top, bottom = 0, image.shape[0]
+
+    refined_area_ratio = ((right - left) * (bottom - top)) / max(float(image.shape[0] * image.shape[1]), 1.0)
+    dark_bounds = _dark_region_bounds(image)
+    if dark_bounds is not None and refined_area_ratio > 0.8:
+        dark_left, dark_top, dark_right, dark_bottom = dark_bounds
+        dark_area_ratio = ((dark_right - dark_left) * (dark_bottom - dark_top)) / max(float(image.shape[0] * image.shape[1]), 1.0)
+        if 0.15 <= dark_area_ratio <= 0.85:
+            left, top, right, bottom = dark_left, dark_top, dark_right, dark_bottom
+
+    return image[top:bottom, left:right], (left, top, right, bottom)
+
+
+def _mask_from_blackhat(gray: np.ndarray) -> np.ndarray:
+    kernel = cv2.getStructuringElement(cv2.MORPH_RECT, (31, 31))
+    blackhat = cv2.morphologyEx(gray, cv2.MORPH_BLACKHAT, kernel)
+    blackhat = cv2.GaussianBlur(blackhat, (5, 5), 0)
+    _, thresh = cv2.threshold(blackhat, 0, 255, cv2.THRESH_BINARY + cv2.THRESH_OTSU)
+    close_kernel = cv2.getStructuringElement(cv2.MORPH_RECT, (21, 21))
+    return cv2.morphologyEx(thresh, cv2.MORPH_CLOSE, close_kernel, iterations=2)
+
+
+def _mask_from_inverse_threshold(gray: np.ndarray) -> np.ndarray:
+    blurred = cv2.GaussianBlur(gray, (7, 7), 0)
+    _, thresh = cv2.threshold(blurred, 0, 255, cv2.THRESH_BINARY_INV + cv2.THRESH_OTSU)
+    close_kernel = cv2.getStructuringElement(cv2.MORPH_RECT, (17, 17))
+    open_kernel = cv2.getStructuringElement(cv2.MORPH_RECT, (5, 5))
+    cleaned = cv2.morphologyEx(thresh, cv2.MORPH_CLOSE, close_kernel, iterations=2)
+    return cv2.morphologyEx(cleaned, cv2.MORPH_OPEN, open_kernel, iterations=1)
+
+
+def _mask_from_edges(gray: np.ndarray) -> np.ndarray:
+    blurred = cv2.GaussianBlur(gray, (5, 5), 0)
+    edges = cv2.Canny(blurred, 40, 160)
+    dilate_kernel = cv2.getStructuringElement(cv2.MORPH_RECT, (7, 7))
+    close_kernel = cv2.getStructuringElement(cv2.MORPH_RECT, (15, 15))
+    dilated = cv2.dilate(edges, dilate_kernel, iterations=2)
+    return cv2.morphologyEx(dilated, cv2.MORPH_CLOSE, close_kernel, iterations=2)
+
+
+def _score_contour(contour: np.ndarray, image_area: float) -> tuple[float, np.ndarray] | None:
+    rect = cv2.minAreaRect(contour)
+    width, height = rect[1]
+    rect_area = float(width * height)
+    if rect_area <= 0:
+        return None
+
+    contour_area = float(cv2.contourArea(contour))
+    area_ratio = rect_area / image_area
+    fill_ratio = contour_area / rect_area if rect_area else 0.0
+    short_side = min(width, height)
+    long_side = max(width, height)
+    aspect_ratio = long_side / max(short_side, 1.0)
+
+    if area_ratio < 0.08:
+        return None
+    if short_side < 40:
+        return None
+    if aspect_ratio > 8.0:
+        return None
+
+    score = area_ratio * 1.5 + min(fill_ratio, 1.0)
+    return score, cv2.boxPoints(rect)
+
+
+def _find_autocrop_roi_from_contours(img: ImageBuffer) -> ROI | None:
+    color = _ensure_color(img)
+    preview = _normalize_to_uint8(color)
+    gray = cv2.cvtColor(preview, cv2.COLOR_BGR2GRAY)
+    image_area = float(gray.shape[0] * gray.shape[1])
+
+    best_score = -1.0
+    best_quad: np.ndarray | None = None
+
+    for mask in (_mask_from_blackhat(gray), _mask_from_inverse_threshold(gray), _mask_from_edges(gray)):
+        contours, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+        for contour in contours:
+            scored = _score_contour(contour, image_area)
+            if scored is None:
+                continue
+            score, quad = scored
+            if score > best_score:
+                best_score = score
+                best_quad = quad
+
+    if best_quad is None:
+        return None
+
+    x, y, box_w, box_h = cv2.boundingRect(best_quad.astype(np.float32))
+    left = max(int(x), 0)
+    top = max(int(y), 0)
+    right = min(int(x + box_w), img.shape[1])
+    bottom = min(int(y + box_h), img.shape[0])
+    if right - left <= 0 or bottom - top <= 0:
+        return None
+
+    _, (ref_left, ref_top, ref_right, ref_bottom) = _refine_frame_bounds(img[top:bottom, left:right])
+    return top + ref_top, top + ref_bottom, left + ref_left, left + ref_right
+
+
+def _get_threshold_autocrop_coords(
+    img: ImageBuffer,
+    target_ratio_str: str,
+    detect_res: int,
+    assist_luma: Optional[float],
+) -> ROI:
+    h, w = img.shape[:2]
+    det_scale = detect_res / max(h, w)
+
+    d_h, d_w = int(h * det_scale), int(w * det_scale)
+    img_small = cv2.resize(img, (d_w, d_h), interpolation=cv2.INTER_AREA)
+
+    lum = get_luminance(ensure_image(img_small))
+
+    threshold = 0.96
+    if assist_luma is not None:
+        threshold = float(np.clip(assist_luma - 0.02, 0.5, 0.98))
+
+    rows_det = np.where(np.mean(lum, axis=1) < threshold)[0]
+    cols_det = np.where(np.mean(lum, axis=0) < threshold)[0]
+
+    if len(rows_det) < 10 or len(cols_det) < 10:
+        return 0, h, 0, w
+
+    y1, y2 = rows_det[0] / det_scale, rows_det[-1] / det_scale
+    x1, x2 = cols_det[0] / det_scale, cols_det[-1] / det_scale
+    return int(y1), int(y2), int(x1), int(x2)
+
+
 def apply_fine_rotation(img: ImageBuffer, angle: float) -> ImageBuffer:
     """
     Sub-degree rotation (bilinear).
@@ -164,28 +475,11 @@ def get_autocrop_coords(
     Detects film border via density thresholding.
     """
     h, w = img.shape[:2]
-    det_scale = detect_res / max(h, w)
-
-    d_h, d_w = int(h * det_scale), int(w * det_scale)
-    img_small = cv2.resize(img, (d_w, d_h), interpolation=cv2.INTER_AREA)
-
-    lum = get_luminance(ensure_image(img_small))
-
-    threshold = 0.96
-    if assist_luma is not None:
-        threshold = float(np.clip(assist_luma - 0.02, 0.5, 0.98))
-
-    rows_det = np.where(np.mean(lum, axis=1) < threshold)[0]
-    cols_det = np.where(np.mean(lum, axis=0) < threshold)[0]
-
-    if len(rows_det) < 10 or len(cols_det) < 10:
-        return 0, h, 0, w
-
-    y1, y2 = rows_det[0] / det_scale, rows_det[-1] / det_scale
-    x1, x2 = cols_det[0] / det_scale, cols_det[-1] / det_scale
+    roi = _find_autocrop_roi_from_contours(img)
+    if roi is None:
+        roi = _get_threshold_autocrop_coords(img, target_ratio_str, detect_res, assist_luma)
 
     margin = (2 + offset_px) * scale_factor
-    roi = (y1, y2, x1, x2)
     roi = apply_margin_to_roi(roi, h, w, margin)
 
     return enforce_roi_aspect_ratio(roi, h, w, target_ratio_str)

--- a/negpy/features/geometry/logic.py
+++ b/negpy/features/geometry/logic.py
@@ -111,12 +111,7 @@ def _dark_region_bounds(image: np.ndarray) -> tuple[int, int, int, int] | None:
 
     min_inset_x = int(round(image.shape[1] * 0.03))
     min_inset_y = int(round(image.shape[0] * 0.03))
-    if (
-        left < min_inset_x
-        or top < min_inset_y
-        or (image.shape[1] - right) < min_inset_x
-        or (image.shape[0] - bottom) < min_inset_y
-    ):
+    if left < min_inset_x or top < min_inset_y or (image.shape[1] - right) < min_inset_x or (image.shape[0] - bottom) < min_inset_y:
         return None
 
     return left, top, right, bottom

--- a/negpy/features/geometry/models.py
+++ b/negpy/features/geometry/models.py
@@ -8,7 +8,8 @@ class GeometryConfig:
     fine_rotation: float = 0.0
     flip_horizontal: bool = False
     flip_vertical: bool = False
+    auto_crop_enabled: bool = False
 
-    autocrop_offset: int = 2
+    autocrop_offset: int = 1
     autocrop_ratio: str = "3:2"
     manual_crop_rect: Optional[Tuple[float, float, float, float]] = None

--- a/negpy/features/geometry/processor.py
+++ b/negpy/features/geometry/processor.py
@@ -53,7 +53,7 @@ class GeometryProcessor:
                 scale_factor=context.scale_factor,
             )
             context.active_roi = roi
-        else:
+        elif self.config.auto_crop_enabled:
             roi = get_autocrop_coords(
                 img,
                 offset_px=self.config.autocrop_offset,
@@ -61,6 +61,8 @@ class GeometryProcessor:
                 target_ratio_str=self.config.autocrop_ratio,
             )
             context.active_roi = roi
+        else:
+            context.active_roi = None
 
         context.metrics["active_roi"] = context.active_roi
         return img

--- a/negpy/services/rendering/gpu_engine.py
+++ b/negpy/services/rendering/gpu_engine.py
@@ -275,7 +275,7 @@ class GPUEngine:
                     offset_px=settings.geometry.autocrop_offset,
                     scale_factor=scale_factor,
                 )
-            else:
+            elif settings.geometry.auto_crop_enabled:
                 det_s = APP_CONFIG.preview_render_size / max(h, w)
                 tmp = cv2.resize(img, (int(w * det_s), int(h * det_s)))
                 if settings.geometry.rotation != 0:
@@ -298,6 +298,8 @@ class GPUEngine:
                     int(roi_tmp[2] * sx),
                     int(roi_tmp[3] * sx),
                 )
+            else:
+                roi = (0, h_rot, 0, w_rot)
             y1, y2, x1, x2 = roi
             crop_w, crop_h = max(1, x2 - x1), max(1, y2 - y1)
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1,11 +1,12 @@
 import sys
 import unittest
 from unittest.mock import MagicMock, patch
+from dataclasses import replace
 
 from PyQt6.QtWidgets import QApplication
 
 from negpy.desktop.controller import AppController
-from negpy.desktop.session import DesktopSessionManager, AppState
+from negpy.desktop.session import DesktopSessionManager, AppState, ToolMode
 from negpy.services.rendering.preview_manager import PreviewManager
 
 if not QApplication.instance():
@@ -97,6 +98,45 @@ class TestAppController(unittest.TestCase):
         mock_slot.assert_called_once_with()
         self.controller.request_render.assert_called_once_with()
 
+    def test_apply_auto_crop_enables_auto_crop_and_clears_manual_rect(self):
+        geometry = replace(self.controller.state.config.geometry, manual_crop_rect=(0.1, 0.1, 0.9, 0.9), auto_crop_enabled=False)
+        self.controller.state.config = replace(self.controller.state.config, geometry=geometry)
+        self.controller.request_render = MagicMock()
+
+        self.controller.apply_auto_crop()
+
+        saved_config = self.mock_session_manager.update_config.call_args.args[0]
+        self.assertTrue(saved_config.geometry.auto_crop_enabled)
+        self.assertIsNone(saved_config.geometry.manual_crop_rect)
+        self.assertEqual(saved_config.geometry.autocrop_ratio, "Free")
+        self.controller.request_render.assert_called_once_with()
+
+    def test_reset_crop_disables_auto_crop_and_clears_manual_rect(self):
+        geometry = replace(self.controller.state.config.geometry, manual_crop_rect=(0.1, 0.1, 0.9, 0.9), auto_crop_enabled=True)
+        self.controller.state.config = replace(self.controller.state.config, geometry=geometry)
+        self.controller.request_render = MagicMock()
+
+        self.controller.reset_crop()
+
+        saved_config = self.mock_session_manager.update_config.call_args.args[0]
+        self.assertFalse(saved_config.geometry.auto_crop_enabled)
+        self.assertIsNone(saved_config.geometry.manual_crop_rect)
+        self.controller.request_render.assert_called_once_with()
+
+    def test_manual_crop_completion_disables_auto_crop(self):
+        geometry = replace(self.controller.state.config.geometry, auto_crop_enabled=True)
+        self.controller.state.config = replace(self.controller.state.config, geometry=geometry)
+        self.controller.state.active_tool = ToolMode.CROP_MANUAL
+        self.controller.state.last_metrics = {"uv_grid": (0.0, 1.0, 0.0, 1.0)}
+        self.controller.request_render = MagicMock()
+
+        with patch("negpy.desktop.controller.CoordinateMapping.map_click_to_raw", side_effect=[(0.2, 0.3), (0.8, 0.9)]):
+            self.controller.handle_crop_completed(0.2, 0.3, 0.8, 0.9)
+
+        saved_config = self.mock_session_manager.update_config.call_args.args[0]
+        self.assertFalse(saved_config.geometry.auto_crop_enabled)
+        self.assertEqual(saved_config.geometry.manual_crop_rect, (0.2, 0.3, 0.8, 0.9))
+        self.controller.request_render.assert_called_once_with()
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -138,5 +138,6 @@ class TestAppController(unittest.TestCase):
         self.assertEqual(saved_config.geometry.manual_crop_rect, (0.2, 0.3, 0.8, 0.9))
         self.controller.request_render.assert_called_once_with()
 
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -9,15 +9,12 @@ class TestDarkroomEngine(unittest.TestCase):
         """End-to-end pipeline smoke test."""
         engine = DarkroomEngine()
         img = np.random.rand(100, 100, 3).astype(np.float32)
-        # Use default config (which does auto-crop by default)
+        # Default config should preserve the full image until auto-crop is explicitly enabled.
         settings = WorkspaceConfig()
 
         res = engine.process(img, settings, source_hash="dummy")
 
-        # Default autocrop will shrink the 100x100 random noise slightly
-        # because random noise doesn't look like film borders
-        self.assertTrue(res.shape[0] <= 100)
-        self.assertTrue(res.shape[1] <= 100)
+        self.assertEqual(res.shape[:2], (100, 100))
         self.assertLessEqual(np.max(res), 1.0)
         self.assertGreaterEqual(np.min(res), 0.0)
 
@@ -25,8 +22,8 @@ class TestDarkroomEngine(unittest.TestCase):
         """Engine respects geometry settings."""
         engine = DarkroomEngine()
         img = np.random.rand(200, 200, 3).astype(np.float32)
-        # Use offset to shrink image
-        settings = WorkspaceConfig.from_flat_dict({"autocrop_offset": 10})
+        # Use explicit auto-crop plus offset to shrink image.
+        settings = WorkspaceConfig.from_flat_dict({"auto_crop_enabled": True, "autocrop_offset": 10})
 
         res = engine.process(img, settings, source_hash="dummy")
 

--- a/tests/test_geometry_logic.py
+++ b/tests/test_geometry_logic.py
@@ -1,5 +1,5 @@
 import numpy as np
-from negpy.features.geometry.logic import get_manual_crop_coords
+from negpy.features.geometry.logic import get_autocrop_coords, get_manual_crop_coords
 from negpy.features.geometry.processor import GeometryProcessor
 from negpy.features.geometry.models import GeometryConfig
 from negpy.domain.interfaces import PipelineContext
@@ -47,16 +47,55 @@ def test_geometry_processor_manual_offset():
 
 def test_geometry_processor_no_manual_rect_no_offset():
     img = np.zeros((100, 200, 3), dtype=np.float32)
-    # No manual crop rect -> should fall back to auto-crop
+    # No manual crop and auto-crop disabled -> should keep the full image.
     config = GeometryConfig(autocrop_offset=0)
     processor = GeometryProcessor(config)
     context = PipelineContext(scale_factor=1.0, original_size=(100, 200))
 
     processor.process(img, context)
 
-    # Auto-crop on pure black image might return a non-empty crop
+    assert context.active_roi is None
+
+
+def test_geometry_processor_auto_crop_requires_explicit_enable():
+    img = np.ones((240, 360, 3), dtype=np.float32)
+    img[50:190, 90:270] = 0.05
+
+    config = GeometryConfig(auto_crop_enabled=True, autocrop_offset=0, autocrop_ratio="Free")
+    processor = GeometryProcessor(config)
+    context = PipelineContext(scale_factor=1.0, original_size=(240, 360))
+
+    processor.process(img, context)
+
     assert context.active_roi is not None
-    assert context.active_roi[1] > context.active_roi[0]
+    y1, y2, x1, x2 = context.active_roi
+    assert y2 > y1
+    assert x2 > x1
+
+
+def test_get_autocrop_coords_detects_dark_frame_on_light_bed():
+    img = np.ones((240, 360, 3), dtype=np.float32)
+    img[50:190, 90:270] = 0.05
+
+    roi = get_autocrop_coords(img, offset_px=0, scale_factor=1.0, target_ratio_str="Free")
+
+    y1, y2, x1, x2 = roi
+    assert 35 <= y1 <= 70
+    assert 170 <= y2 <= 205
+    assert 75 <= x1 <= 110
+    assert 250 <= x2 <= 285
+
+
+def test_get_autocrop_coords_fallback_preserves_valid_roi_for_flat_image():
+    img = np.ones((120, 200, 3), dtype=np.float32) * 0.5
+
+    roi = get_autocrop_coords(img, offset_px=0, scale_factor=1.0, target_ratio_str="Free")
+
+    y1, y2, x1, x2 = roi
+    assert 0 <= y1 < y2 <= 120
+    assert 0 <= x1 < x2 <= 200
+    assert y2 - y1 > 0
+    assert x2 - x1 > 0
 
 
 def test_crop_consistency_across_resolutions():
@@ -64,7 +103,7 @@ def test_crop_consistency_across_resolutions():
     full_h, full_w = 3000, 4500
     prev_h, prev_w = 1000, 1500
 
-    config = GeometryConfig(autocrop_offset=10)
+    config = GeometryConfig(auto_crop_enabled=True, autocrop_offset=10)
     processor = GeometryProcessor(config)
 
     ctx_full = PipelineContext(


### PR DESCRIPTION
- Reused personal project to get an improved autocrop detection using stronger contour-based frame detection with a threshold-based fallback.
- Made the Auto crop action set the crop ratio to Free.
- Made auto crop not always active, I feel like it was not really intiuitive having it always on, so autocrop now actually auto crops rather than just resetting the crop.
- Made manual crop disable the active Auto crop state once a manual crop is committed.
- Kept the Auto button visually highlighted while autocrop is active.

- Fixed canvas background rendering for CPU / non-GPU rendering paths by drawing the selected color correctly in the overlay path on windows and on non gpu accelerated instanced (not sure if it affected also linux while using CPU). #146 
- Updated tests to cover explicit autocrop enablement, manual-crop state transitions, and geometry logic behavior


Notes:
My auto crop implementation could be improved upon still but from my negative scans it feels a lot better than the previous implementation even if it fails sometimes but it happened also before on those frames. Might be relevant to allow a bigger negative crop offset as the current implementation cuts on the image borders.