### PR TITLE
fix: restore Windows tutorial mouse input

### DIFF
--- a/negpy/desktop/view/widgets/tutorial_overlay.py
+++ b/negpy/desktop/view/widgets/tutorial_overlay.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from typing import TYPE_CHECKING, Callable, Optional
 
 from PyQt6.QtCore import QEvent, QObject, QRectF, Qt, pyqtSignal
@@ -42,11 +43,17 @@ class TutorialOverlay(QWidget):
     def __init__(self, window: "MainWindow") -> None:
         super().__init__(window)
         self._win = window
+        self._use_top_level_window = sys.platform == "win32"
+
+        if self._use_top_level_window:
+            self.setWindowFlags(Qt.WindowType.Tool | Qt.WindowType.FramelessWindowHint)
+            self.setWindowModality(Qt.WindowModality.WindowModal)
+            self.setAttribute(Qt.WidgetAttribute.WA_NativeWindow)
 
         self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
         self.setAttribute(Qt.WidgetAttribute.WA_NoSystemBackground)
         self.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
-        self.setGeometry(window.rect())
+        self._sync_geometry()
         window.installEventFilter(self)
 
         self._steps: list[TutorialStep] = []
@@ -133,10 +140,12 @@ class TutorialOverlay(QWidget):
         self._steps = steps
         self._idx = 0
         self._expanded = {}
-        self.setGeometry(self._win.rect())
+        self._sync_geometry()
         self.show()
         self.raise_()
-        self.setFocus()
+        self.activateWindow()
+        self._popup.raise_()
+        self.setFocus(Qt.FocusReason.ActiveWindowFocusReason)
         self._goto(0)
 
     def dismiss(self) -> None:
@@ -244,6 +253,12 @@ class TutorialOverlay(QWidget):
                 section.toggle_button.setChecked(False)
         self._expanded = {}
 
+    def _sync_geometry(self) -> None:
+        if self._use_top_level_window:
+            self.setGeometry(self._win.geometry())
+        else:
+            self.setGeometry(self._win.rect())
+
     # ------------------------------------------------------------------
     # Qt overrides
     # ------------------------------------------------------------------
@@ -290,8 +305,13 @@ class TutorialOverlay(QWidget):
             super().keyPressEvent(a0)
 
     def eventFilter(self, a0: Optional[QObject], a1: Optional[QEvent]) -> bool:  # type: ignore[override]
-        if a0 is self._win and a1 is not None and a1.type() == QEvent.Type.Resize:
-            self.setGeometry(self._win.rect())
+        if a0 is self._win and a1 is not None and a1.type() in {
+            QEvent.Type.Move,
+            QEvent.Type.Resize,
+            QEvent.Type.Show,
+            QEvent.Type.WindowStateChange,
+        }:
+            self._sync_geometry()
             target: Optional[QWidget] = None
             if self._steps:
                 target = self._steps[self._idx].target(self._win)

--- a/tests/test_tutorial_overlay.py
+++ b/tests/test_tutorial_overlay.py
@@ -1,0 +1,49 @@
+import sys
+
+from PyQt6.QtCore import Qt
+from PyQt6.QtTest import QTest
+from PyQt6.QtWidgets import QApplication, QMainWindow
+
+from negpy.desktop.view.widgets.tutorial_overlay import TutorialOverlay, TutorialStep
+
+
+def _steps() -> list[TutorialStep]:
+    return [
+        TutorialStep("Welcome", "First step", lambda _: None),
+        TutorialStep("Finish", "Second step", lambda _: None),
+    ]
+
+
+def test_tutorial_overlay_next_button_is_clickable() -> None:
+    win = QMainWindow()
+    win.setGeometry(100, 100, 900, 700)
+    win.show()
+
+    overlay = TutorialOverlay(win)
+    finished: list[bool] = []
+    overlay.finished.connect(finished.append)
+
+    overlay.start(_steps())
+    QApplication.processEvents()
+
+    QTest.mouseClick(overlay._next_btn, Qt.MouseButton.LeftButton)
+    QApplication.processEvents()
+    assert overlay._idx == 1
+
+    QTest.mouseClick(overlay._next_btn, Qt.MouseButton.LeftButton)
+    QApplication.processEvents()
+    assert finished == [True]
+    assert not overlay.isVisible()
+
+
+def test_tutorial_overlay_uses_top_level_window_on_windows() -> None:
+    win = QMainWindow()
+    overlay = TutorialOverlay(win)
+
+    if sys.platform == "win32":
+        assert overlay.isWindow()
+        assert overlay.windowFlags() & Qt.WindowType.Tool
+        assert overlay.windowFlags() & Qt.WindowType.FramelessWindowHint
+        assert overlay.windowModality() == Qt.WindowModality.WindowModal
+    else:
+        assert not overlay.isWindow()


### PR DESCRIPTION
Fixed #177 

On windows the tutorial now uses a top-level frameless modal overlay instead of a regular child widget, which puts it above the native canvas path and restores mouse interaction.