### PR TITLE
feat: sticky flip buttons + fix rotate direction when flipped

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,9 +6,11 @@
 - Added **Detect Aspect Ratio** button in the Geometry sidebar (crosshairs icon) — finds the film frame in the image and sets the crop ratio to the closest standard aspect ratio.
 - Added **Same folder as source** export option — exports files to their source directory instead of a fixed export path.
 - Added **Overwrite existing files** toggle — when disabled, exports get incrementing suffixes (`_2`, `_3`) to avoid overwriting.
+- **Sticky flip**: Flip Horizontal/Vertical buttons now show a pressed state when active and their state persists across files and app restarts (applied to new files only — files with saved edits keep their own flip).
 - Tutorial overlay now shows keyboard navigation hints at the bottom.
 - Fix: mouse input in tutorial (Windows) @alessandrv
 - Fix: exports are now written atomically — no partial files left on crash or interrupt.
+- Fix: Rotate CCW/CW buttons (and `[` / `]` shortcuts) reversed direction when the image was flipped horizontally or vertically (but not both).
 - Performance & stability improvements.
 
 ## 0.18.2

--- a/negpy/desktop/session.py
+++ b/negpy/desktop/session.py
@@ -269,11 +269,17 @@ class DesktopSessionManager(QObject):
 
         sticky_ratio = self.repo.get_global_setting("last_aspect_ratio")
         sticky_offset = self.repo.get_global_setting("last_autocrop_offset")
+        sticky_flip_h = self.repo.get_global_setting("last_flip_horizontal")
+        sticky_flip_v = self.repo.get_global_setting("last_flip_vertical")
         new_geo = config.geometry
         if sticky_ratio:
             new_geo = replace(new_geo, autocrop_ratio=sticky_ratio)
         if sticky_offset is not None:
             new_geo = replace(new_geo, autocrop_offset=int(sticky_offset))
+        if sticky_flip_h is not None:
+            new_geo = replace(new_geo, flip_horizontal=bool(sticky_flip_h))
+        if sticky_flip_v is not None:
+            new_geo = replace(new_geo, flip_vertical=bool(sticky_flip_v))
         config = replace(config, geometry=new_geo)
 
         # Exposure, lab, toning, retouch are per-image look decisions and are
@@ -318,6 +324,8 @@ class DesktopSessionManager(QObject):
 
         self.repo.save_global_setting("last_aspect_ratio", config.geometry.autocrop_ratio)
         self.repo.save_global_setting("last_autocrop_offset", config.geometry.autocrop_offset)
+        self.repo.save_global_setting("last_flip_horizontal", config.geometry.flip_horizontal)
+        self.repo.save_global_setting("last_flip_vertical", config.geometry.flip_vertical)
         self.repo.save_global_setting("last_export_config", asdict(config.export))
         self.repo.save_global_setting("last_lab_config", asdict(config.lab))
         self.repo.save_global_setting("last_toning_config", asdict(config.toning))

--- a/negpy/desktop/view/canvas/toolbar.py
+++ b/negpy/desktop/view/canvas/toolbar.py
@@ -87,9 +87,11 @@ class ActionToolbar(QWidget):
         self.btn_rot_r.setIcon(qta.icon("fa5s.redo", color=icon_color))
         self.btn_rot_r.setToolTip("Rotate CW  ]")
         self.btn_flip_h = QToolButton()
+        self.btn_flip_h.setCheckable(True)
         self.btn_flip_h.setIcon(qta.icon("fa5s.arrows-alt-h", color=icon_color))
         self.btn_flip_h.setToolTip("Flip Horizontal  H")
         self.btn_flip_v = QToolButton()
+        self.btn_flip_v.setCheckable(True)
         self.btn_flip_v.setIcon(qta.icon("fa5s.arrows-alt-v", color=icon_color))
         self.btn_flip_v.setToolTip("Flip Vertical  V")
 
@@ -158,8 +160,10 @@ class ActionToolbar(QWidget):
         self._ov_rot_r_action = overflow_menu.addAction(qta.icon("fa5s.redo", color=icon_color), "Rotate CW")
         self._ov_rot_r_action.setVisible(False)
         self._ov_flip_h_action = overflow_menu.addAction(qta.icon("fa5s.arrows-alt-h", color=icon_color), "Flip Horizontal")
+        self._ov_flip_h_action.setCheckable(True)
         self._ov_flip_h_action.setVisible(False)
         self._ov_flip_v_action = overflow_menu.addAction(qta.icon("fa5s.arrows-alt-v", color=icon_color), "Flip Vertical")
+        self._ov_flip_v_action.setCheckable(True)
         self._ov_flip_v_action.setVisible(False)
         self._ov_sep_rotate = overflow_menu.addSeparator()
         self._ov_sep_rotate.setVisible(False)
@@ -275,8 +279,12 @@ class ActionToolbar(QWidget):
     def rotate(self, direction: int) -> None:
         from dataclasses import replace
 
-        new_rot = (self.session.state.config.geometry.rotation + direction) % 4
-        new_geo = replace(self.session.state.config.geometry, rotation=new_rot)
+        geo = self.session.state.config.geometry
+        # Pipeline applies rotate-then-flip; a single mirror inverts rotation handedness.
+        if geo.flip_horizontal != geo.flip_vertical:
+            direction = -direction
+        new_rot = (geo.rotation + direction) % 4
+        new_geo = replace(geo, rotation=new_rot)
         new_config = replace(self.session.state.config, geometry=new_geo)
         self.session.update_config(new_config, persist=True)
         self.controller.request_render()
@@ -313,6 +321,12 @@ class ActionToolbar(QWidget):
         self.btn_next.setEnabled(state.selected_file_idx < len(state.uploaded_files) - 1)
         self.btn_hq.setChecked(state.hq_preview)
         self._ov_hq_action.setChecked(state.hq_preview)
+
+        geo = state.config.geometry
+        self.btn_flip_h.setChecked(geo.flip_horizontal)
+        self.btn_flip_v.setChecked(geo.flip_vertical)
+        self._ov_flip_h_action.setChecked(geo.flip_horizontal)
+        self._ov_flip_v_action.setChecked(geo.flip_vertical)
 
         self._action_undo.setEnabled(state.undo_index > 0)
         self._action_redo.setEnabled(state.undo_index < state.max_history_index)


### PR DESCRIPTION
- Flip H/V buttons now checkable (show pressed state) and persist globally across files/sessions; applied to new files only so files with saved sidecars keep their per-file flip. https://github.com/marcinz606/NegPy/issues/178
- Rotate CCW/CW buttons (and [ / ] shortcuts) no longer rotate in the reverse direction when image is flipped on a single axis. Pipeline applies rotate-then-flip; a single mirror inverts handedness, so toolbar inverts the requested direction in that case. https://github.com/marcinz606/NegPy/issues/179
