### PR TITLE
Add performance metrics infrastructure for preview load timing

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -1,0 +1,158 @@
+# Wall-clock preview load metrics. Uploads JSON artifact for trending and posts a
+# PR comment with cold/warm times. Never blocks merge.
+#
+# The Fujifilm X70 RAF fixture (~20 MB) is cached on the runner after first download.
+# If the source URL is unavailable the download step continues-on-error and the timing
+# tests skip gracefully — the workflow still passes.
+
+name: Metrics
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 6 * * 1"  # Mondays 06:00 UTC
+  push:
+    branches: [main]
+    paths:
+      - "negpy/services/rendering/preview_manager.py"
+      - "negpy/services/rendering/preview_cache.py"
+      - "negpy/desktop/workers/render.py"
+      - "negpy/desktop/prefetch_logic.py"
+      - "negpy/kernel/caching/logic.py"
+      - "tests/metrics/**"
+  pull_request:
+    branches: [main]
+    paths:
+      - "negpy/services/rendering/preview_manager.py"
+      - "negpy/services/rendering/preview_cache.py"
+      - "negpy/desktop/workers/render.py"
+      - "negpy/desktop/prefetch_logic.py"
+      - "negpy/kernel/caching/logic.py"
+      - "tests/metrics/**"
+
+concurrency:
+  group: metrics-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  preview-metrics:
+    name: Preview load metrics
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --group dev
+
+      - name: Install system deps (Linux)
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y libegl1 libxkbcommon-x11-0 libgl1
+
+      - name: Restore perf fixture cache
+        id: cache-fixture
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/negpy-metrics
+          key: negpy-perf-raw-dscf1276-v1
+
+      - name: Download perf fixture
+        if: steps.cache-fixture.outputs.cache-hit != 'true'
+        continue-on-error: true
+        run: |
+          mkdir -p ~/.cache/negpy-metrics
+          curl -fL "https://kristoffertrolle.com/raw-samples/x70/DSCF1276.RAF" \
+            -o ~/.cache/negpy-metrics/DSCF1276.RAF \
+            --max-time 120 \
+            --retry 2
+
+      - name: Run metrics tests
+        env:
+          NEGPY_METRICS_OUT: metrics-artifacts/preview_metrics.json
+          NEGPY_METRICS_BASELINE: ${{ vars.NEGPY_METRICS_BASELINE }}
+          QT_QPA_PLATFORM: offscreen
+          XDG_RUNTIME_DIR: /tmp/runtime-runner
+        run: |
+          mkdir -p metrics-artifacts
+          uv run pytest tests/metrics/ -m "slow" -q --tb=short
+          echo "---"
+          test -f "$NEGPY_METRICS_OUT" && cat "$NEGPY_METRICS_OUT" || true
+
+      - name: Upload metrics JSON
+        uses: actions/upload-artifact@v4
+        with:
+          name: preview-metrics
+          path: metrics-artifacts/preview_metrics.json
+          if-no-files-found: warn
+
+      - name: Post PR comment
+        if: github.event_name == 'pull_request'
+        continue-on-error: true
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const jsonPath = 'metrics-artifacts/preview_metrics.json';
+            if (!fs.existsSync(jsonPath)) {
+              console.log('No metrics JSON — skipping comment');
+              return;
+            }
+
+            const data = JSON.parse(fs.readFileSync(jsonPath, 'utf8'));
+            const m = data.metrics || {};
+            const machine = data.machine_label || 'unknown';
+            const cold = m['preview.load.cold_s'];
+            const warm = m['preview.load.warm_s'];
+
+            const fmt = v => v != null ? `${v.toFixed(3)} s` : 'skipped';
+            const ratio = (cold != null && warm != null && warm > 0)
+              ? `×${Math.round(cold / warm)} faster`
+              : 'n/a';
+
+            const sha = context.sha.slice(0, 7);
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+            const body = [
+              '<!-- negpy-metrics -->',
+              `## Preview load metrics (${machine})`,
+              '| metric | value |',
+              '|---|---|',
+              `| cold load | ${fmt(cold)} |`,
+              `| warm hit  | ${fmt(warm)} |`,
+              `| ratio     | ${ratio} |`,
+              '',
+              `_fixture: DSCF1276.RAF · sha: ${sha} · [full JSON](${runUrl})_`,
+            ].join('\n');
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const existing = comments.find(c => c.body.includes('<!-- negpy-metrics -->'));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,8 @@ venv/
 
 __pycache__
 VERSION
+# metrics artifacts
+metrics.json
 # llm stuff
 TODO.md
 CLAUDE.md
@@ -36,3 +38,4 @@ PLAN.md
 plans/
 .superpowers/
 *superpowers
+.serena/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,18 @@ We use `pytest`. New features should include unit tests in the `tests/` director
 make test
 ```
 
+`make test` skips tests marked `slow` by default (see `addopts` in `pyproject.toml`). This includes the performance metrics suite in `tests/metrics/`.
+
+To run the metrics tests locally, point `NEGPY_PERF_RAW` at a Fujifilm X70 RAF file and run:
+
+```bash
+NEGPY_PERF_RAW=/path/to/DSCF1276.RAF \
+NEGPY_METRICS_OUT=metrics-artifacts/preview_metrics.json \
+uv run pytest tests/metrics/ -m "slow" -q
+```
+
+If `NEGPY_PERF_RAW` is not set the suite will attempt to download the fixture to `~/.cache/negpy-metrics/` automatically, or skip if the download fails.
+
 ### 3. Workflow (The Makefile)
 The `Makefile` is the central source of truth for developer commands and executes everything via `uv run`:
 - `make install`: Set up environment and sync dependencies.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,13 @@ packages = ["negpy"]
 [tool.setuptools.dynamic]
 version = { file = "VERSION" }
 
+[tool.pytest.ini_options]
+markers = [
+    "slow: wall-clock tests that require I/O or a real RAW file (deselect with '-m not slow')",
+    "metrics: opt-in performance metrics tests",
+]
+addopts = "-m 'not slow'"
+
 [tool.ruff]
 line-length = 140
 exclude = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,16 @@ os.environ["QT_QPA_PLATFORM"] = "offscreen"
 os.environ["XDG_RUNTIME_DIR"] = "/tmp/runtime-runner"
 
 
+def pytest_addoption(parser: pytest.Parser) -> None:
+    g = parser.getgroup("metrics", "negpy performance metrics export")
+    g.addoption(
+        "--metrics-out",
+        action="store",
+        default=None,
+        help="Write session metrics to this JSON path (overrides NEGPY_METRICS_OUT if set as non-empty).",
+    )
+
+
 @pytest.fixture(scope="session", autouse=True)
 def qapp():
     from PyQt6.QtWidgets import QApplication

--- a/tests/metrics/__init__.py
+++ b/tests/metrics/__init__.py
@@ -1,0 +1,1 @@
+"""Opt-in performance / metrics tests with JSON export for CI artifacts."""

--- a/tests/metrics/baseline.example.json
+++ b/tests/metrics/baseline.example.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": 2,
+  "note": "per_machine: merge outputs from my-mac.json and ci-linux.json, or hand-edit. Regression picks the entry for the current machine_label only.",
+  "per_machine": {
+    "github-linux-x64": {
+      "updated_utc": "2026-04-24T00:00:00+00:00",
+      "metrics": {
+        "preview.load.cold_s": 2.0,
+        "preview.load.warm_s": 0.15
+      }
+    },
+    "local-darwin-arm64-my-mac": {
+      "metrics": {
+        "preview.load.cold_s": 0.9,
+        "preview.load.warm_s": 0.02
+      }
+    }
+  }
+}

--- a/tests/metrics/conftest.py
+++ b/tests/metrics/conftest.py
@@ -1,0 +1,74 @@
+"""
+Session hooks: write `NEGPY_METRICS_OUT` JSON, order regression test last, optional options.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import platform
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from . import recorder
+from .labeling import metrics_machine_label
+
+_SCHEMA_VERSION = 2
+
+
+def pytest_sessionstart(session: pytest.Session) -> None:
+    recorder.clear()
+
+
+def pytest_collection_modifyitems(session: pytest.Session, config: pytest.Config, items: list) -> None:
+    """Run regression test after all other metrics tests in this package."""
+    metrics = [i for i in items if i.nodeid.startswith("tests/metrics/")]
+    outside = [i for i in items if not i.nodeid.startswith("tests/metrics/")]
+    reg = [i for i in metrics if "regression" in i.nodeid]
+    non_reg = [i for i in metrics if "regression" not in i.nodeid]
+    items[:] = outside + non_reg + reg
+
+
+def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
+    out = _metrics_output_path(session.config)
+    if not out:
+        return
+
+    mlabel = metrics_machine_label()
+    payload: dict[str, Any] = {
+        "schema_version": _SCHEMA_VERSION,
+        "machine_label": mlabel,
+        "created_at_utc": datetime.now(timezone.utc).isoformat(),
+        "exitstatus": exitstatus,
+        "environment": {
+            "python": sys.version.split()[0],
+            "platform": platform.platform(),
+            "implementation": platform.python_implementation(),
+            "machine_label": mlabel,
+        },
+        "ci": {
+            "github_ref": os.environ.get("GITHUB_REF", ""),
+            "github_sha": os.environ.get("GITHUB_SHA", ""),
+            "github_workflow": os.environ.get("GITHUB_WORKFLOW", ""),
+        },
+        "input": {
+            "negpy_perf_raw": os.environ.get("NEGPY_PERF_RAW", ""),
+        },
+        "metrics": recorder.snapshot(),
+    }
+    path = Path(out)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    print(f"\n[metrics] machine_label={mlabel!r} wrote {path} — metric keys: {list(payload['metrics'].keys())}")
+
+
+def _metrics_output_path(config: pytest.Config) -> str | None:
+    opt = config.getoption("--metrics-out", default=None)
+    if opt:
+        return str(opt).strip() or None
+    ev = os.environ.get("NEGPY_METRICS_OUT", "").strip()
+    return ev or None

--- a/tests/metrics/fixture.py
+++ b/tests/metrics/fixture.py
@@ -1,0 +1,49 @@
+"""
+Resolves a real RAW file path for performance timing tests.
+
+Priority:
+  1. NEGPY_PERF_RAW env var (local dev or self-hosted runner)
+  2. ~/.cache/negpy-metrics/DSCF1276.RAF (previously cached)
+  3. Download from public URL and cache
+  4. None — caller should pytest.skip()
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+_RAF_URL = "https://kristoffertrolle.com/raw-samples/x70/DSCF1276.RAF"
+_RAF_FILENAME = "DSCF1276.RAF"
+_CACHE_DIR = Path.home() / ".cache" / "negpy-metrics"
+
+
+def get_perf_raw_path() -> str | None:
+    env = os.environ.get("NEGPY_PERF_RAW", "").strip()
+    if env and os.path.isfile(env):
+        return env
+
+    cached = _CACHE_DIR / _RAF_FILENAME
+    if cached.is_file():
+        return str(cached)
+
+    if _download(_RAF_URL, cached):
+        return str(cached)
+
+    return None
+
+
+def _download(url: str, dest: Path) -> bool:
+    """Download *url* to *dest*, creating parent dirs. Returns True on success."""
+    import urllib.request
+
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    tmp = dest.with_suffix(".tmp")
+    try:
+        with urllib.request.urlopen(url, timeout=120) as resp, tmp.open("wb") as f:
+            f.write(resp.read())
+        tmp.rename(dest)
+        return True
+    except Exception:
+        tmp.unlink(missing_ok=True)
+        return False

--- a/tests/metrics/labeling.py
+++ b/tests/metrics/labeling.py
@@ -1,0 +1,110 @@
+"""
+Stable machine labels for metrics so Mac vs CI (and other hosts) are tracked separately.
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+import re
+import socket
+from typing import Any
+
+
+def _slug(s: str) -> str:
+    s = s.strip().lower()
+    s = re.sub(r"[^a-z0-9._-]+", "-", s)
+    s = re.sub(r"-+", "-", s).strip("-")
+    return s or "unknown"
+
+
+def metrics_machine_label() -> str:
+    """
+    Human-readable, filesystem-safe id for the current host / runner.
+
+    Override: ``NEGPY_METRICS_MACHINE=dev-mac`` (stored as slug: ``dev-mac``).
+    GitHub Actions: ``github-<RUNNER_OS>-<RUNNER_ARCH>`` (e.g. ``github-linux-x64``).
+    Local: ``local-<system>-<machine>-<short-hostname>``.
+    """
+    override = os.environ.get("NEGPY_METRICS_MACHINE", "").strip()
+    if override:
+        return _slug(override)
+    if os.environ.get("GITHUB_ACTIONS", "").lower() == "true":
+        runner_os = os.environ.get("RUNNER_OS", "unknown")
+        runner_arch = os.environ.get("RUNNER_ARCH", "unknown")
+        return f"github-{_slug(runner_os)}-{_slug(runner_arch)}"
+    hn = socket.gethostname().split(".")[0]
+    return _slug(f"local-{platform.system()}-{platform.machine()}-{hn}")
+
+
+def _as_float_metrics(d: Any) -> dict[str, float]:
+    if not isinstance(d, dict):
+        return {}
+    out: dict[str, float] = {}
+    for k, v in d.items():
+        if isinstance(v, (int, float)):
+            out[str(k)] = float(v)
+    return out
+
+
+def resolve_baseline_metrics(
+    baseline: dict[str, Any],
+    machine_label: str,
+) -> tuple[dict[str, float] | None, str | None]:
+    """
+    Returns (metrics dict, None) or (None, skip reason) for pytest.
+
+    **1) Multi-host (recommended)** — one file, trends per machine::
+
+        {"per_machine": {"github-linux-x64": {"metrics": {"preview.load.cold_s": 2.0}}}}
+
+    **2) Single past export** — same shape as a metrics run; used only if
+    ``machine_label`` matches the current host.
+
+    **3) Legacy** — top-level ``metrics`` and no ``machine_label``: only if
+    ``NEGPY_METRICS_BASELINE_UNLABELED=1``.
+    """
+    per = baseline.get("per_machine")
+    if isinstance(per, dict) and per:
+        ent = per.get(machine_label)
+        if ent is None:
+            known = ", ".join(sorted(per.keys())[:16])
+            more = "…" if len(per) > 16 else ""
+            return (
+                None,
+                f"no per_machine[{machine_label!r}] in baseline (known: {known}{more}).",
+            )
+        if isinstance(ent, dict) and "metrics" in ent:
+            m = _as_float_metrics(ent.get("metrics"))
+            if m:
+                return m, None
+        if isinstance(ent, dict):
+            m = _as_float_metrics(ent)
+            if m:
+                return m, None
+        return None, f"per_machine[{machine_label!r}] has no numeric metrics"
+
+    m = baseline.get("metrics")
+    m = _as_float_metrics(m) if m else {}
+    if not m:
+        return None, "baseline has no metrics"
+
+    bl_label = baseline.get("machine_label")
+    if bl_label is not None and str(bl_label) != "" and str(bl_label) != machine_label:
+        return (
+            None,
+            f"baseline is for machine {bl_label!r}, this run is {machine_label!r}. "
+            f"Use a per_machine file or copy this host's numbers into per_machine['{machine_label}'].",
+        )
+
+    if (bl_label is None or str(bl_label) == "") and os.environ.get("NEGPY_METRICS_BASELINE_UNLABELED", "").strip() not in (
+        "1",
+        "true",
+        "yes",
+    ):
+        return (
+            None,
+            "legacy unlabeled baseline: set NEGPY_METRICS_BASELINE_UNLABELED=1 to compare, or switch to per_machine[...] in the JSON.",
+        )
+
+    return m, None

--- a/tests/metrics/recorder.py
+++ b/tests/metrics/recorder.py
@@ -1,0 +1,19 @@
+"""
+Collect named floating-point metrics during a pytest session (e.g. wall-clock seconds).
+"""
+
+from __future__ import annotations
+
+_metrics: dict[str, float] = {}
+
+
+def clear() -> None:
+    _metrics.clear()
+
+
+def record(name: str, value: float) -> None:
+    _metrics[name] = value
+
+
+def snapshot() -> dict[str, float]:
+    return dict(_metrics)

--- a/tests/metrics/test_fixture.py
+++ b/tests/metrics/test_fixture.py
@@ -1,0 +1,88 @@
+"""Unit tests for fixture.py — all network calls are mocked."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from . import fixture
+
+
+def test_env_var_takes_priority(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    real = tmp_path / "real.raf"
+    real.write_bytes(b"x")
+    monkeypatch.setenv("NEGPY_PERF_RAW", str(real))
+    assert fixture.get_perf_raw_path() == str(real)
+
+
+def test_env_var_ignored_if_file_missing(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("NEGPY_PERF_RAW", str(tmp_path / "missing.raf"))
+    monkeypatch.setattr(fixture, "_CACHE_DIR", tmp_path)
+    monkeypatch.setattr(fixture, "_download", lambda url, dest: False)
+    assert fixture.get_perf_raw_path() is None
+
+
+def test_cached_file_returned_without_download(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.delenv("NEGPY_PERF_RAW", raising=False)
+    monkeypatch.setattr(fixture, "_CACHE_DIR", tmp_path)
+    cached = tmp_path / fixture._RAF_FILENAME
+    cached.write_bytes(b"cached")
+    downloaded = {"called": False}
+
+    def fake_download(url: str, dest: Path) -> bool:
+        downloaded["called"] = True
+        return True
+
+    monkeypatch.setattr(fixture, "_download", fake_download)
+    result = fixture.get_perf_raw_path()
+    assert result == str(cached)
+    assert not downloaded["called"]
+
+
+def test_downloads_on_cache_miss(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.delenv("NEGPY_PERF_RAW", raising=False)
+    monkeypatch.setattr(fixture, "_CACHE_DIR", tmp_path)
+
+    def fake_download(url: str, dest: Path) -> bool:
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(b"downloaded")
+        return True
+
+    monkeypatch.setattr(fixture, "_download", fake_download)
+    result = fixture.get_perf_raw_path()
+    assert result == str(tmp_path / fixture._RAF_FILENAME)
+    assert Path(result).read_bytes() == b"downloaded"
+
+
+def test_returns_none_when_download_fails(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.delenv("NEGPY_PERF_RAW", raising=False)
+    monkeypatch.setattr(fixture, "_CACHE_DIR", tmp_path)
+    monkeypatch.setattr(fixture, "_download", lambda url, dest: False)
+    assert fixture.get_perf_raw_path() is None
+
+
+def test_download_creates_parent_dir(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """_download should create parent dirs so the file can be written."""
+    import io
+    import urllib.request
+
+    dest = tmp_path / "subdir" / "file.raf"
+    assert not dest.parent.exists()
+
+    monkeypatch.setattr(urllib.request, "urlopen", lambda url, timeout=None: io.BytesIO(b"ok"))
+    ok = fixture._download("https://example.com/fake.raf", dest)
+    assert ok
+    assert dest.read_bytes() == b"ok"
+
+
+def test_download_returns_false_on_network_error(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    import urllib.request
+
+    def fail(*a: object, **kw: object) -> None:
+        raise OSError("network down")
+
+    monkeypatch.setattr(urllib.request, "urlopen", fail)
+    dest = tmp_path / "out.raf"
+    assert not fixture._download("https://example.com/fake.raf", dest)
+    assert not dest.exists()

--- a/tests/metrics/test_labeling.py
+++ b/tests/metrics/test_labeling.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+
+import pytest
+
+from .labeling import metrics_machine_label, resolve_baseline_metrics
+
+
+def test_resolve_per_machine_hits_current_label() -> None:
+    base = {
+        "per_machine": {
+            "github-linux-x64": {"metrics": {"preview.load.cold_s": 2.0}},
+        }
+    }
+    m, err = resolve_baseline_metrics(base, "github-linux-x64")
+    assert err is None
+    assert m == {"preview.load.cold_s": 2.0}
+
+
+def test_resolve_per_machine_missing_key() -> None:
+    m, err = resolve_baseline_metrics({"per_machine": {"other": {"metrics": {}}}}, "github-linux-x64")
+    assert m is None
+    assert err and "per_machine" in err
+
+
+def test_resolve_single_file_matching_machine() -> None:
+    m, err = resolve_baseline_metrics(
+        {
+            "machine_label": "dev-box",
+            "metrics": {"preview.load.cold_s": 1.0},
+        },
+        "dev-box",
+    )
+    assert err is None
+    assert m == {"preview.load.cold_s": 1.0}
+
+
+def test_resolve_mismatch_skips() -> None:
+    m, err = resolve_baseline_metrics(
+        {
+            "machine_label": "dev-box",
+            "metrics": {"preview.load.cold_s": 1.0},
+        },
+        "other-host",
+    )
+    assert m is None
+    assert err and "other-host" in err
+
+
+def test_metrics_machine_label_respects_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NEGPY_METRICS_MACHINE", " My MacBook ")
+    monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+    assert metrics_machine_label() == "my-macbook"
+
+
+def test_metrics_machine_label_github_format(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("NEGPY_METRICS_MACHINE", raising=False)
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+    monkeypatch.setenv("RUNNER_OS", "Linux")
+    monkeypatch.setenv("RUNNER_ARCH", "X64")
+    assert metrics_machine_label() == "github-linux-x64"

--- a/tests/metrics/test_preview_load.py
+++ b/tests/metrics/test_preview_load.py
@@ -1,0 +1,95 @@
+"""
+Wall-clock metrics for PreviewManager (real RAF on disk).
+
+Environment:
+  NEGPY_PERF_RAW              — override fixture path (local dev / self-hosted runner)
+  NEGPY_PERF_RAW_MAX_SEC      — cold-load budget in seconds (default 30)
+  NEGPY_METRICS_OUT           — write session metrics to this JSON path
+  NEGPY_METRICS_BASELINE      — path to prior-run JSON; enables regression test
+  NEGPY_METRICS_MAX_REGRESSION_PCT — max allowed regression % vs baseline (default 40.0)
+  NEGPY_METRICS_MACHINE       — override auto machine label
+  NEGPY_METRICS_BASELINE_UNLABELED=1 — accept legacy baselines with no machine_label
+
+On CI the RAF fixture is pre-downloaded by the workflow cache step so tests never skip.
+Locally, fixture.get_perf_raw_path() downloads on first run (~20 MB) and caches in
+~/.cache/negpy-metrics/.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from negpy.services.rendering.preview_manager import PreviewManager
+
+from . import fixture, recorder
+from .labeling import metrics_machine_label, resolve_baseline_metrics
+
+pytestmark = [pytest.mark.slow, pytest.mark.metrics]
+
+
+def _max_seconds() -> float:
+    return float(os.environ.get("NEGPY_PERF_RAW_MAX_SEC", "30").strip())
+
+
+def _regression_pct() -> float:
+    return float(os.environ.get("NEGPY_METRICS_MAX_REGRESSION_PCT", "40.0").strip())
+
+
+def test_preview_load_cold_within_budget() -> None:
+    path = fixture.get_perf_raw_path()
+    if path is None:
+        pytest.skip("No perf fixture available (network down and NEGPY_PERF_RAW not set)")
+
+    max_sec = _max_seconds()
+    t0 = time.perf_counter()
+    buf, dims, meta = PreviewManager().load_linear_preview(path)
+    elapsed = time.perf_counter() - t0
+    recorder.record("preview.load.cold_s", elapsed)
+
+    assert buf is not None and buf.ndim == 3
+    assert len(dims) == 2
+    assert isinstance(meta, dict)
+
+    suggest = max(elapsed * 1.05, max_sec + 0.5)
+    assert elapsed < max_sec, (
+        f"Preview load took {elapsed:.2f}s (budget {max_sec}s) for {path!r}.\n"
+        f"Raise NEGPY_PERF_RAW_MAX_SEC (e.g. {suggest:.0f}) to match this machine, or optimize decode."
+    )
+
+
+def test_regression_against_baseline_if_configured() -> None:
+    base = os.environ.get("NEGPY_METRICS_BASELINE", "").strip()
+    if not base:
+        pytest.skip("Set NEGPY_METRICS_BASELINE to a JSON file from a prior run to enforce regression bounds")
+
+    p = Path(base)
+    if not p.is_file():
+        pytest.skip(f"NEGPY_METRICS_BASELINE is not a file: {base!r}")
+
+    cur = recorder.snapshot()
+    if not cur:
+        pytest.skip("No metrics recorded this session (did the timing tests run?)")
+
+    label = metrics_machine_label()
+    prev_data = json.loads(p.read_text(encoding="utf-8"))
+    prev, err = resolve_baseline_metrics(prev_data, label)
+    if prev is None:
+        pytest.skip(f"Regression: {err}")
+
+    pct = _regression_pct()
+    failures: list[str] = []
+    for k, new_v in cur.items():
+        if k not in prev:
+            continue
+        old_v = float(prev[k])
+        if old_v <= 0:
+            continue
+        if new_v > old_v * (1.0 + pct / 100.0):
+            failures.append(f"{k}: {new_v:.3f}s vs baseline {old_v:.3f}s (>{pct}% worse) [machine {label!r}]")
+
+    assert not failures, "Metrics regression vs baseline:\n" + "\n".join(failures)


### PR DESCRIPTION
I'm working to make some changes to the preview loading pipeline and wanted to have an objective way to validate that they actually help (or at least don't hurt) before submitting anything.

It adds a metrics test suite in tests/metrics/ that times a cold preview load against a real RAF fixture and writes the results to a JSON artifact. There's a new CI workflow that runs on changes to the rendering path and posts the numbers as a PR comment, so any future perf-related PR will have hard numbers attached rather than just "felt faster on my machine."

The tests are marked slow and excluded from the normal make test run, so they shouldn't get in anyone's way. CONTRIBUTING.md has instructions for running them locally if you want to try it out.