### PR TITLE
Add other RAW types to metrics test

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -1,9 +1,9 @@
 # Wall-clock preview load metrics. Uploads JSON artifact for trending and posts a
-# PR comment with cold/warm times. Never blocks merge.
+# PR comment with cold times per format. Never blocks merge.
 #
-# The Fujifilm X70 RAF fixture (~20 MB) is cached on the runner after first download.
-# If the source URL is unavailable the download step continues-on-error and the timing
-# tests skip gracefully — the workflow still passes.
+# Fixtures (CR2, NEF, ARW, ~20-30 MB each) are sourced from rawsamples.ch and
+# cached on the runner. If a download fails the timing tests skip gracefully —
+# the workflow still passes.
 
 name: Metrics
 
@@ -64,17 +64,29 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/negpy-metrics
-          key: negpy-perf-raw-dscf1276-v1
+          key: negpy-perf-raw-rawsamples-v1
 
-      - name: Download perf fixture
+      - name: Download perf fixtures
         if: steps.cache-fixture.outputs.cache-hit != 'true'
         continue-on-error: true
         run: |
           mkdir -p ~/.cache/negpy-metrics
-          curl -fL "https://kristoffertrolle.com/raw-samples/x70/DSCF1276.RAF" \
-            -o ~/.cache/negpy-metrics/DSCF1276.RAF \
-            --max-time 120 \
-            --retry 2
+          curl -fL "http://www.rawsamples.ch/raws/canon/RAW_CANON_EOS_5DMARK3.CR2" \
+            -o ~/.cache/negpy-metrics/RAW_CANON_EOS_5DMARK3.CR2 \
+            --max-time 120 --retry 2
+          curl -fL "http://www.rawsamples.ch/raws/nikon/d3x/RAW_NIKON_D3X.NEF" \
+            -o ~/.cache/negpy-metrics/RAW_NIKON_D3X.NEF \
+            --max-time 120 --retry 2
+          curl -fL "http://rawsamples.ch/raws/sony/RAW_SONY_RX10.ARW" \
+            -o ~/.cache/negpy-metrics/RAW_SONY_RX10.ARW \
+            --max-time 120 --retry 2
+          curl -fL "http://www.rawsamples.ch/raws/fuji/RAW_FUJI_X-T10.RAF" \
+            -o ~/.cache/negpy-metrics/RAW_FUJI_X-T10.RAF \
+            --max-time 120 --retry 2
+          curl -fL "http://www.rawsamples.ch/raws/leica/RAW_LEICA_M240.DNG" \
+            -o ~/.cache/negpy-metrics/RAW_LEICA_M240.DNG \
+            --max-time 120 --retry 2
+
 
       - name: Run metrics tests
         env:
@@ -111,27 +123,26 @@ jobs:
             const data = JSON.parse(fs.readFileSync(jsonPath, 'utf8'));
             const m = data.metrics || {};
             const machine = data.machine_label || 'unknown';
-            const cold = m['preview.load.cold_s'];
-            const warm = m['preview.load.warm_s'];
-
-            const fmt = v => v != null ? `${v.toFixed(3)} s` : 'skipped';
-            const ratio = (cold != null && warm != null && warm > 0)
-              ? `×${Math.round(cold / warm)} faster`
-              : 'n/a';
-
             const sha = context.sha.slice(0, 7);
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+            const fmtS = v => v != null ? `${v.toFixed(3)} s` : 'skipped';
+            const fmtMpx = v => v != null ? `${v.toFixed(2)} MPx/s` : 'skipped';
+            const formats = ['cr2', 'nef', 'arw', 'raf', 'dng'];
+            const rows = formats.map(f => {
+              const s = m[`preview.load.cold_s.${f}`];
+              const mpx = m[`preview.load.cold_mpx_per_s.${f}`];
+              return `| ${f.toUpperCase()} | ${fmtS(s)} | ${fmtMpx(mpx)} |`;
+            }).join('\n');
 
             const body = [
               '<!-- negpy-metrics -->',
               `## Preview load metrics (${machine})`,
-              '| metric | value |',
-              '|---|---|',
-              `| cold load | ${fmt(cold)} |`,
-              `| warm hit  | ${fmt(warm)} |`,
-              `| ratio     | ${ratio} |`,
+              '| format | cold load | throughput |',
+              '|---|---|---|',
+              rows,
               '',
-              `_fixture: DSCF1276.RAF · sha: ${sha} · [full JSON](${runUrl})_`,
+              `_fixtures: rawsamples.ch · sha: ${sha} · [full JSON](${runUrl})_`,
             ].join('\n');
 
             const { data: comments } = await github.rest.issues.listComments({

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,15 +71,23 @@ make test
 
 `make test` skips tests marked `slow` by default (see `addopts` in `pyproject.toml`). This includes the performance metrics suite in `tests/metrics/`.
 
-To run the metrics tests locally, point `NEGPY_PERF_RAW` at a Fujifilm X70 RAF file and run:
+To run the metrics tests and write a JSON results file:
 
 ```bash
-NEGPY_PERF_RAW=/path/to/DSCF1276.RAF \
-NEGPY_METRICS_OUT=metrics-artifacts/preview_metrics.json \
+NEGPY_METRICS_OUT=metrics.json uv run pytest tests/metrics/ -m "slow" -q
+```
+
+Fixtures (Canon CR2, Nikon NEF, Sony ARW, Fuji RAF, Leica DNG) are downloaded automatically from rawsamples.ch on first run (~20–30 MB each) and cached in `~/.cache/negpy-metrics/`. Tests skip gracefully if a download fails.
+
+To point a test at a local file instead of downloading, set the per-format env var:
+
+```bash
+NEGPY_PERF_RAW_CR2=/path/to/file.CR2 \
+NEGPY_METRICS_OUT=metrics.json \
 uv run pytest tests/metrics/ -m "slow" -q
 ```
 
-If `NEGPY_PERF_RAW` is not set the suite will attempt to download the fixture to `~/.cache/negpy-metrics/` automatically, or skip if the download fails.
+Available overrides: `NEGPY_PERF_RAW_CR2`, `NEGPY_PERF_RAW_NEF`, `NEGPY_PERF_RAW_ARW`, `NEGPY_PERF_RAW_RAF`, `NEGPY_PERF_RAW_DNG`.
 
 ### 3. Workflow (The Makefile)
 The `Makefile` is the central source of truth for developer commands and executes everything via `uv run`:

--- a/tests/metrics/conftest.py
+++ b/tests/metrics/conftest.py
@@ -14,6 +14,7 @@ from typing import Any
 
 import pytest
 
+from . import fixture as _fixture_mod
 from . import recorder
 from .labeling import metrics_machine_label
 
@@ -56,7 +57,8 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
             "github_workflow": os.environ.get("GITHUB_WORKFLOW", ""),
         },
         "input": {
-            "negpy_perf_raw": os.environ.get("NEGPY_PERF_RAW", ""),
+            f"negpy_perf_raw_{f.key}": os.environ.get(f"NEGPY_PERF_RAW_{f.key.upper()}", "")
+            for f in _fixture_mod.FIXTURES
         },
         "metrics": recorder.snapshot(),
     }

--- a/tests/metrics/fixture.py
+++ b/tests/metrics/fixture.py
@@ -1,24 +1,78 @@
 """
-Resolves a real RAW file path for performance timing tests.
+Resolves real RAW file paths for performance timing tests.
 
-Priority:
-  1. NEGPY_PERF_RAW env var (local dev or self-hosted runner)
-  2. ~/.cache/negpy-metrics/DSCF1276.RAF (previously cached)
-  3. Download from public URL and cache
+Priority for each fixture:
+  1. NEGPY_PERF_RAW_<KEY> env var (e.g. NEGPY_PERF_RAW_CR2)
+  2. ~/.cache/negpy-metrics/<filename> (previously cached)
+  3. Download from rawsamples.ch and cache
   4. None — caller should pytest.skip()
 """
 
 from __future__ import annotations
 
 import os
+from dataclasses import dataclass
 from pathlib import Path
 
-_RAF_URL = "https://kristoffertrolle.com/raw-samples/x70/DSCF1276.RAF"
-_RAF_FILENAME = "DSCF1276.RAF"
 _CACHE_DIR = Path.home() / ".cache" / "negpy-metrics"
+_RAF_FILENAME = "RAW_FUJI_X-T10.RAF"
+_RAF_URL = "http://www.rawsamples.ch/raws/fuji/RAW_FUJI_X-T10.RAF"
+
+
+@dataclass(frozen=True)
+class RawFixture:
+    key: str       # short lowercase id used in env vars and metric names
+    filename: str  # basename for the local cache file
+    url: str       # public download URL
+
+
+FIXTURES: list[RawFixture] = [
+    RawFixture(
+        key="cr2",
+        filename="RAW_CANON_EOS_5DMARK3.CR2",
+        url="http://www.rawsamples.ch/raws/canon/RAW_CANON_EOS_5DMARK3.CR2",
+    ),
+    RawFixture(
+        key="nef",
+        filename="RAW_NIKON_D3X.NEF",
+        url="http://www.rawsamples.ch/raws/nikon/d3x/RAW_NIKON_D3X.NEF",
+    ),
+    RawFixture(
+        key="arw",
+        filename="RAW_SONY_RX10.ARW",
+        url="http://rawsamples.ch/raws/sony/RAW_SONY_RX10.ARW",
+    ),
+    RawFixture(
+        key="raf",
+        filename="RAW_FUJI_X-T10.RAF",
+        url="http://www.rawsamples.ch/raws/fuji/RAW_FUJI_X-T10.RAF",
+    ),
+    RawFixture(
+        key="dng",
+        filename="RAW_LEICA_M240.DNG",
+        url="http://www.rawsamples.ch/raws/leica/RAW_LEICA_M240.DNG",
+    ),
+]
+
+
+def get_fixture_path(fix: RawFixture) -> str | None:
+    """Return a local path for *fix*, downloading if needed. None if unavailable."""
+    env = os.environ.get(f"NEGPY_PERF_RAW_{fix.key.upper()}", "").strip()
+    if env and os.path.isfile(env):
+        return env
+
+    cached = _CACHE_DIR / fix.filename
+    if cached.is_file():
+        return str(cached)
+
+    if _download(fix.url, cached):
+        return str(cached)
+
+    return None
 
 
 def get_perf_raw_path() -> str | None:
+    """Return a local path for the RAF perf fixture, downloading if needed."""
     env = os.environ.get("NEGPY_PERF_RAW", "").strip()
     if env and os.path.isfile(env):
         return env

--- a/tests/metrics/test_preview_load.py
+++ b/tests/metrics/test_preview_load.py
@@ -1,17 +1,21 @@
 """
-Wall-clock metrics for PreviewManager (real RAF on disk).
+Wall-clock metrics for PreviewManager (real RAW files on disk).
+
+Fixtures are sourced from rawsamples.ch and cached in ~/.cache/negpy-metrics/.
 
 Environment:
-  NEGPY_PERF_RAW              — override fixture path (local dev / self-hosted runner)
-  NEGPY_PERF_RAW_MAX_SEC      — cold-load budget in seconds (default 30)
-  NEGPY_METRICS_OUT           — write session metrics to this JSON path
-  NEGPY_METRICS_BASELINE      — path to prior-run JSON; enables regression test
+  NEGPY_PERF_RAW_CR2             — override CR2 fixture path
+  NEGPY_PERF_RAW_NEF             — override NEF fixture path
+  NEGPY_PERF_RAW_ARW             — override ARW fixture path
+  NEGPY_PERF_RAW_MAX_SEC         — cold-load budget in seconds (default 30)
+  NEGPY_METRICS_OUT              — write session metrics to this JSON path
+  NEGPY_METRICS_BASELINE         — path to prior-run JSON; enables regression test
   NEGPY_METRICS_MAX_REGRESSION_PCT — max allowed regression % vs baseline (default 40.0)
-  NEGPY_METRICS_MACHINE       — override auto machine label
+  NEGPY_METRICS_MACHINE          — override auto machine label
   NEGPY_METRICS_BASELINE_UNLABELED=1 — accept legacy baselines with no machine_label
 
-On CI the RAF fixture is pre-downloaded by the workflow cache step so tests never skip.
-Locally, fixture.get_perf_raw_path() downloads on first run (~20 MB) and caches in
+On CI fixtures are pre-downloaded by the workflow cache step so tests never skip.
+Locally, get_fixture_path() downloads on first run (~20-30 MB each) and caches in
 ~/.cache/negpy-metrics/.
 """
 
@@ -40,16 +44,24 @@ def _regression_pct() -> float:
     return float(os.environ.get("NEGPY_METRICS_MAX_REGRESSION_PCT", "40.0").strip())
 
 
-def test_preview_load_cold_within_budget() -> None:
-    path = fixture.get_perf_raw_path()
+@pytest.mark.parametrize("fix", fixture.FIXTURES, ids=lambda f: f.key)
+def test_preview_load_cold_within_budget(fix: fixture.RawFixture) -> None:
+    path = fixture.get_fixture_path(fix)
     if path is None:
-        pytest.skip("No perf fixture available (network down and NEGPY_PERF_RAW not set)")
+        pytest.skip(
+            f"No perf fixture for {fix.key!r} "
+            f"(network down and NEGPY_PERF_RAW_{fix.key.upper()} not set)"
+        )
 
     max_sec = _max_seconds()
     t0 = time.perf_counter()
     buf, dims, meta = PreviewManager().load_linear_preview(path)
     elapsed = time.perf_counter() - t0
-    recorder.record("preview.load.cold_s", elapsed)
+
+    h, w = dims
+    mp = (h * w) / 1_000_000
+    recorder.record(f"preview.load.cold_s.{fix.key}", elapsed)
+    recorder.record(f"preview.load.cold_mpx_per_s.{fix.key}", mp / elapsed)
 
     assert buf is not None and buf.ndim == 3
     assert len(dims) == 2
@@ -57,7 +69,7 @@ def test_preview_load_cold_within_budget() -> None:
 
     suggest = max(elapsed * 1.05, max_sec + 0.5)
     assert elapsed < max_sec, (
-        f"Preview load took {elapsed:.2f}s (budget {max_sec}s) for {path!r}.\n"
+        f"Preview load took {elapsed:.2f}s (budget {max_sec}s) for {path!r} ({mp:.1f} MPx).\n"
         f"Raise NEGPY_PERF_RAW_MAX_SEC (e.g. {suggest:.0f}) to match this machine, or optimize decode."
     )
 


### PR DESCRIPTION
Filled out the metrics test for cross file type comparison. You can see on a per-megapixel scale, the RAF files are loading half as fast as DNG.