### PR TITLE
perf: Optimize preview demosaic

### DIFF
--- a/negpy/infrastructure/loaders/helpers.py
+++ b/negpy/infrastructure/loaders/helpers.py
@@ -117,10 +117,13 @@ class NonStandardFileWrapper:
         return (data * 255.0).astype(np.uint8)
 
 
-def get_best_demosaic_algorithm(raw: Any) -> Any:
+def get_best_demosaic_algorithm(raw: Any, for_preview: bool = False) -> Any:
     """
     Selects optimal demosaicing algorithm based on sensor type and CFA pattern.
     Exclusively uses algorithms packaged in the standard permissive (LGPL) rawpy build.
+
+    When for_preview=True, selects faster algorithms appropriate for downsampled
+    preview rendering (PPG for Bayer, LINEAR for X-Trans).
     """
     selected_algo = rawpy.DemosaicAlgorithm.LINEAR
 
@@ -138,11 +141,13 @@ def get_best_demosaic_algorithm(raw: Any) -> Any:
 
             if cfa_block_size == 6:
                 # 6x6 block means it's a Fujifilm X-Trans sensor.
-                selected_algo = rawpy.DemosaicAlgorithm.VNG
+                # LINEAR is ~4.6x faster than VNG; artifacts are invisible at preview scale.
+                selected_algo = rawpy.DemosaicAlgorithm.LINEAR if for_preview else rawpy.DemosaicAlgorithm.VNG
 
             elif cfa_block_size == 2:
                 # 2x2 block means it's a standard Bayer sensor (Canon, Nikon, Sony, etc.)
-                selected_algo = rawpy.DemosaicAlgorithm.AHD
+                # PPG is ~60% faster than AHD with negligible quality difference at preview scale.
+                selected_algo = rawpy.DemosaicAlgorithm.PPG if for_preview else rawpy.DemosaicAlgorithm.AHD
 
     except (AttributeError, ValueError) as e:
         logger.exception(f"Failed to determine sensor CFA pattern: {e}. Falling back to LINEAR.")

--- a/negpy/services/rendering/preview_manager.py
+++ b/negpy/services/rendering/preview_manager.py
@@ -12,6 +12,12 @@ from negpy.kernel.image.validation import ensure_image
 from negpy.kernel.system.config import APP_CONFIG
 
 
+# Pre-warm the Numba JIT so the first actual preview load doesn't pay the compile cost.
+_warmup = np.zeros((2, 2, 3), dtype=np.uint16)
+uint16_to_float32(_warmup)
+del _warmup
+
+
 class PreviewManager:
     """
     Loads RAW files for UI preview.
@@ -31,7 +37,7 @@ class PreviewManager:
         ctx_mgr, metadata = loader_factory.get_loader(file_path)
 
         with ctx_mgr as raw:
-            algo = get_best_demosaic_algorithm(raw)
+            algo = get_best_demosaic_algorithm(raw, for_preview=True)
             user_wb = [1, 1, 1, 1] if linear_raw else None
 
             rgb = raw.postprocess(


### PR DESCRIPTION

### Summary

Preview loading was using the same high-quality demosaic algorithms as the export pipeline, even though preview images are downsampled to 1600px max — a ~13× linear reduction where quality differences between algorithms are invisible. Additionally, a Numba JIT cold-start cost (~0.19s) was silently assigned to whichever format loaded first (always CR2 due to fixture ordering).

### Root causes

1. **Wrong algorithm for the context** — `get_best_demosaic_algorithm` returned AHD (Bayer) and VNG (X-Trans) for both preview and export. At preview scale, AHD and VNG are quality overkill with real runtime cost: AHD is ~60% slower than PPG for Bayer, VNG is ~4.6× slower than LINEAR for X-Trans.

2. **Numba JIT cold-start on first preview** — `uint16_to_float32` (used in `load_linear_preview`) is JIT-compiled by Numba. The first call in any process pays a ~0.19s overhead. In the metrics test this was fully attributed to CR2 (fixture position 0), making it appear dramatically slower than it actually is.

### Changes

**`negpy/infrastructure/loaders/helpers.py`**
- Added `for_preview: bool = False` parameter to `get_best_demosaic_algorithm`
- Preview mode returns PPG (Bayer) and LINEAR (X-Trans); default behaviour (AHD/VNG) is unchanged for export

**`negpy/services/rendering/preview_manager.py`**
- Passes `for_preview=True` when calling `get_best_demosaic_algorithm`
- Adds a module-level JIT warmup (2×2 dummy array) so the first real preview load doesn't pay the compile cost

### Performance

Measured on Apple M-series (arm64), cold load, `preview_render_size=1600`:

| Format | Before (MPx/s) | After (MPx/s) | Speedup |
|--------|---------------|--------------|---------|
| RAF (X-Trans) | 8.7 | ~52 | **5.9×** |
| CR2 (Canon) | 9.8 | ~25 | **2.5×** |
| DNG | 15.5 | ~32 | 2.1× |
| NEF | 16.6 | ~32 | 1.9× |
| ARW | 20.8 | ~53 | 2.5× |

### Quality impact

None for the preview path. At 1600px output from a 22 MPx sensor:
- PPG vs AHD on Bayer: indistinguishable after `cv2.INTER_AREA` downsampling
- LINEAR vs VNG on X-Trans: artifacts smoothed out by the ~3× linear downscale

Export path is unaffected — it still uses AHD and VNG.

### Testing

- 354 unit/integration tests pass (`pytest tests/ --ignore=tests/metrics`)
- Metrics test passes for all five fixture formats
