### PR TITLE
fix(metadata): guarantee EXIF fits JPEG 64 KB APP1 limit

### DIFF
--- a/negpy/features/metadata/writer.py
+++ b/negpy/features/metadata/writer.py
@@ -170,7 +170,7 @@ def embed_metadata(
         output = io.BytesIO()
         if image_bytes[:2] == b"\xff\xd8":
             # JPEG APP1 (EXIF) must fit in a single 64 KB segment.
-            exif_bytes = _dump_exif_within_app1_limit(merged)
+            exif_bytes = _dump_exif_within_app1_limit(merged, config)
             piexif.insert(exif_bytes, image_bytes, output)
         else:
             # TIFF has no 64 KB EXIF cap (tifffile writes a separate IFD).
@@ -187,16 +187,19 @@ def embed_metadata(
 _APP1_EXIF_LIMIT = 65533
 
 
-def _dump_exif_within_app1_limit(merged: dict) -> bytes:
+def _dump_exif_within_app1_limit(merged: dict, config: MetadataConfig) -> bytes:
     """
-    Serialize EXIF for a JPEG, progressively dropping the largest optional blocks until it
-    fits the 64 KB APP1 segment. Source RAWs often carry an embedded thumbnail and/or a
-    multi-KB MakerNote that overflow it; the small user/override fields are always kept.
+    Serialize EXIF for a JPEG so it always fits the 64 KB APP1 segment.
+
+    Tries to keep as much source EXIF as fits, dropping the usual offenders first
+    (thumbnail, then MakerNote). If a non-standard large tag (e.g. embedded XMP in
+    ImageDescription) still overflows, falls back to NegPy's own small fields, and finally
+    to orientation-only — which is guaranteed to fit, so piexif.insert can never overflow.
     """
     candidate = _sanitize_exif(merged)
 
-    def _try_dump() -> Optional[bytes]:
-        # Treat both an oversized result and a dump failure (e.g. a malformed source
+    def _fits() -> Optional[bytes]:
+        # Treat both an oversized result and a dump failure (e.g. malformed source
         # thumbnail) as "needs more trimming".
         try:
             b = piexif.dump(candidate)
@@ -204,29 +207,35 @@ def _dump_exif_within_app1_limit(merged: dict) -> bytes:
             return None
         return b if len(b) <= _APP1_EXIF_LIMIT else None
 
-    exif_bytes = _try_dump()
+    exif_bytes = _fits()
     if exif_bytes is not None:
         return exif_bytes
 
     # 1) Drop the embedded thumbnail (largest blob, and it'd be the un-edited source anyway).
     candidate.pop("thumbnail", None)
     candidate["1st"] = {}
-    exif_bytes = _try_dump()
+    exif_bytes = _fits()
     if exif_bytes is not None:
         return exif_bytes
 
     # 2) Drop MakerNote (can be tens of KB on some bodies).
     if isinstance(candidate.get("Exif"), dict):
         candidate["Exif"].pop(piexif.ExifIFD.MakerNote, None)
-    exif_bytes = _try_dump()
+    exif_bytes = _fits()
     if exif_bytes is not None:
         return exif_bytes
 
-    # 3) Last resort: drop UserComment + Interop too.
-    _log.warning("EXIF still oversized after trimming thumbnail+MakerNote")
-    if isinstance(candidate.get("Exif"), dict):
-        candidate["Exif"].pop(piexif.ExifIFD.UserComment, None)
-    candidate["Interop"] = {}
+    # 3) Source EXIF still too big (e.g. a bloated ImageDescription/XMP/GPS): discard it and
+    #    keep only NegPy's own fields, which are always small.
+    _log.warning("source EXIF too large for JPEG APP1; keeping only NegPy metadata")
+    candidate = _sanitize_exif(_build_custom_exif(config))
+    candidate.setdefault("0th", {})[piexif.ImageIFD.Orientation] = 1
+    exif_bytes = _fits()
+    if exif_bytes is not None:
+        return exif_bytes
+
+    # 4) Absolute floor — orientation only. Cannot exceed the limit.
+    candidate = {"0th": {piexif.ImageIFD.Orientation: 1}, "Exif": {}, "GPS": {}, "Interop": {}, "1st": {}}
     return piexif.dump(candidate)
 
 

--- a/tests/test_metadata_writer.py
+++ b/tests/test_metadata_writer.py
@@ -40,6 +40,25 @@ def test_embed_handles_oversized_exif_without_dropping_metadata() -> None:
     assert piexif.ExifIFD.MakerNote not in loaded["Exif"]
 
 
+def test_embed_trims_oversized_nonstandard_tag_keeps_custom_fields() -> None:
+    # Overflow from a tag the targeted trims don't touch (e.g. bloated ImageDescription/XMP).
+    source_exif = {
+        "0th": {piexif.ImageIFD.ImageDescription: b"x" * 70_000},
+        "Exif": {},
+        "GPS": {},
+        "Interop": {},
+        "1st": {},
+    }
+    config = MetadataConfig(camera_override="MyCam")
+
+    out = embed_metadata(_jpeg(), config, source_exif)
+
+    loaded = piexif.load(out)
+    # Embed succeeded (no fallback to original) and the user's field survived.
+    assert loaded["0th"][piexif.ImageIFD.Orientation] == 1
+    assert loaded["0th"][piexif.ImageIFD.Model] == b"MyCam"
+
+
 def test_embed_keeps_small_exif_intact() -> None:
     source_exif = {
         "0th": {piexif.ImageIFD.Make: b"TestCam"},


### PR DESCRIPTION
## Problem
Exporting a JPEG from a source with large EXIF overflowed piexif's APP1 segment:
```
struct.error: 'H' format requires 0 <= number <= 65535
  piexif/_insert.py: exif = b"\xff\xe1" + struct.pack(">H", len(exif) + 2) + exif
```
`read_exif_from_file` copies the **entire** source EXIF (`piexif.load`), so a big embedded thumbnail, MakerNote, **or** a bloated `ImageDescription`/XMP/GPS blob pushes EXIF past JPEG's 64 KB APP1 cap. `embed_metadata` caught the error but **silently dropped all metadata** (the traceback is the logged warning).

The first patch (already on main, `655671a`) only stripped thumbnail + MakerNote and its last step had no size guarantee, so any *other* large tag still overflowed.

## Fix
`_dump_exif_within_app1_limit` now guarantees the result fits, keeping as much source EXIF as possible:
1. full source EXIF (if it fits)
2. drop thumbnail + 1st IFD
3. drop MakerNote
4. **NegPy's own fields only** (always small)
5. **orientation-only** (absolute floor — cannot exceed the limit)

`piexif.insert` can never overflow now; worst case keeps NegPy metadata + correct orientation instead of losing everything.

## Tests
- `tests/test_metadata_writer.py`: overflow via thumbnail+MakerNote **and** via a non-standard tag (bloated ImageDescription) — both embed successfully and preserve user fields; small EXIF passes through untouched.
- `make lint` ✓ · `make type` ✓ · `make test` → 495 passed.

Note: the reported traceback line numbers indicate the running build predates even the first fix — a rebuild/pull is needed to pick this up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)