### PR TITLE
fix: UX improvements for loading, selection, and disabled sliders

### DIFF
--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -306,6 +306,7 @@ class AppController(QObject):
 
     def _on_discovery_progress(self, current: int, total: int, name: str) -> None:
         self.set_status(f"HASHING {current}/{total}: {name}")
+
     def _on_discovery_finished(self, valid_assets: List[Dict]) -> None:
         """
         Adds discovered assets to the session and starts thumbnail generation.

--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -106,6 +106,7 @@ class AppController(QObject):
         self._first_render_done = False
         self._export_start_time = 0.0
         self._discovery_running = False
+        self._auto_open_after_discovery = False
         self._gpu_fallback_notified = False
         self._cleaned_up = False
 
@@ -287,7 +288,7 @@ class AppController(QObject):
                 self.state.thumbnails[name] = QIcon(QPixmap.fromImage(ImageConverter.to_qimage(u8_arr)))
         self.session.asset_model.refresh()
 
-    def request_asset_discovery(self, paths: List[str]) -> None:
+    def request_asset_discovery(self, paths: List[str], auto_open: bool = False) -> None:
         """
         Starts asynchronous discovery of supported assets.
         Silently skips if a discovery task is already in progress.
@@ -298,27 +299,31 @@ class AppController(QObject):
         from negpy.infrastructure.loaders.constants import SUPPORTED_RAW_EXTENSIONS
 
         self._discovery_running = True
+        self._auto_open_after_discovery = auto_open
         self.set_status("SCANNING FOR ASSETS...")
         task = AssetDiscoveryTask(paths=paths, supported_extensions=tuple(SUPPORTED_RAW_EXTENSIONS))
         self.asset_discovery_requested.emit(task)
 
     def _on_discovery_progress(self, current: int, total: int, name: str) -> None:
         self.set_status(f"HASHING {current}/{total}: {name}")
-        self.status_progress_requested.emit(current, total)
-
     def _on_discovery_finished(self, valid_assets: List[Dict]) -> None:
         """
         Adds discovered assets to the session and starts thumbnail generation.
         """
         self._discovery_running = False
+        auto_open = self._auto_open_after_discovery
+        self._auto_open_after_discovery = False
         pending_scan = getattr(self, "_pending_scanned_file", None)
+
         if valid_assets:
+            first_new_idx = len(self.session.state.uploaded_files)
             self.session.add_files([], validated_info=valid_assets)
             self.generate_missing_thumbnails()
-            # If this was a scan result, auto-select the file
             if pending_scan:
                 self._select_file_by_path(pending_scan)
                 self._pending_scanned_file = None
+            elif auto_open and not self.state.current_file_path and len(self.session.state.uploaded_files) > first_new_idx:
+                self.session.select_file(first_new_idx)
         else:
             self.set_status("NO SUPPORTED ASSETS FOUND", 3000)
             self.status_progress_requested.emit(0, 0)

--- a/negpy/desktop/view/sidebar/files.py
+++ b/negpy/desktop/view/sidebar/files.py
@@ -190,7 +190,7 @@ class FileBrowser(QWidget):
         self.add_files_btn.clicked.connect(self._on_add_files)
         self.add_folder_btn.clicked.connect(self._on_add_folder)
         self.unload_btn.clicked.connect(self.session.clear_files)
-        self.list_view.clicked.connect(self._on_item_clicked)
+        self.list_view.doubleClicked.connect(self._on_item_double_clicked)
         self.list_view.selectionModel().selectionChanged.connect(self._on_selection_changed)
         self.hot_folder_btn.toggled.connect(self._on_hot_folder_toggled)
         self.sync_btn.clicked.connect(lambda *_: self.session.sync_selected_settings("edits"))
@@ -218,13 +218,6 @@ class FileBrowser(QWidget):
         self.list_view.viewport().update()
 
         if current_actual == target_actual:
-            active_idx = self.session.state.selected_file_idx
-            if active_idx >= 0:
-                display_row = model.actual_to_display(active_idx)
-                if display_row >= 0:
-                    qt_idx = model.index(display_row, 0)
-                    if self.list_view.currentIndex() != qt_idx:
-                        self.list_view.setCurrentIndex(qt_idx)
             return
 
         selection_model.blockSignals(True)
@@ -241,7 +234,7 @@ class FileBrowser(QWidget):
                 display_row = model.actual_to_display(active_idx)
                 if display_row >= 0:
                     qt_idx = model.index(display_row, 0)
-                    self.list_view.setCurrentIndex(qt_idx)
+                    selection_model.setCurrentIndex(qt_idx, QItemSelectionModel.SelectionFlag.NoUpdate)
                     self.list_view.scrollTo(qt_idx)
         finally:
             selection_model.blockSignals(False)
@@ -348,15 +341,7 @@ class FileBrowser(QWidget):
         if folder:
             self.controller.request_asset_discovery([folder])
 
-    def _on_item_clicked(self, index) -> None:
-        from PyQt6.QtWidgets import QApplication
-
-        model = self.session.asset_model
-        modifiers = QApplication.keyboardModifiers()
-        actual_indices = [a for idx in self.list_view.selectionModel().selectedIndexes() if (a := model.display_to_actual(idx.row())) >= 0]
-        actual_clicked = model.display_to_actual(index.row())
-
-        if modifiers & Qt.KeyboardModifier.ControlModifier:
-            self.session.update_selection(actual_indices)
-        else:
-            self.session.select_file(actual_clicked, selection_override=actual_indices)
+    def _on_item_double_clicked(self, index) -> None:
+        actual = self.session.asset_model.display_to_actual(index.row())
+        if actual >= 0:
+            self.session.select_file(actual)

--- a/negpy/desktop/view/sidebar/files.py
+++ b/negpy/desktop/view/sidebar/files.py
@@ -334,12 +334,12 @@ class FileBrowser(QWidget):
             f"Supported Images ({wildcards})",
         )
         if files:
-            self.controller.request_asset_discovery(files)
+            self.controller.request_asset_discovery(files, auto_open=True)
 
     def _on_add_folder(self) -> None:
         folder = QFileDialog.getExistingDirectory(self, "Select Folder")
         if folder:
-            self.controller.request_asset_discovery([folder])
+            self.controller.request_asset_discovery([folder], auto_open=True)
 
     def _on_item_double_clicked(self, index) -> None:
         actual = self.session.asset_model.display_to_actual(index.row())

--- a/negpy/desktop/view/sidebar/files.py
+++ b/negpy/desktop/view/sidebar/files.py
@@ -1,7 +1,7 @@
 import os
 
 import qtawesome as qta
-from PyQt6.QtCore import QItemSelectionModel, QModelIndex, QSize, Qt, QTimer, pyqtSignal
+from PyQt6.QtCore import QItemSelectionModel, QModelIndex, QSize, QTimer, pyqtSignal
 from PyQt6.QtGui import QColor, QPainter, QPen
 from PyQt6.QtWidgets import (
     QButtonGroup,

--- a/negpy/desktop/view/sidebar/process.py
+++ b/negpy/desktop/view/sidebar/process.py
@@ -293,8 +293,10 @@ class ProcessSidebar(BaseSidebar):
             self.use_roll_avg_btn.setChecked(conf.use_roll_average)
 
             locked = conf.lock_bounds
-            for w in (self.analysis_buffer_slider, self.drange_clip_slider, self.white_point_slider, self.black_point_slider):
+            for w in (self.analysis_buffer_slider, self.drange_clip_slider):
                 w.setEnabled(not locked and not conf.use_roll_average)
+            for w in (self.white_point_slider, self.black_point_slider):
+                w.setEnabled(not locked)
 
             self._refresh_rolls()
             if conf.roll_name:

--- a/negpy/desktop/view/widgets/sliders.py
+++ b/negpy/desktop/view/widgets/sliders.py
@@ -283,11 +283,13 @@ class CompactSlider(BaseSlider):
         if obj is self.label:
             et = event.type()
             if et == QEvent.Type.MouseButtonPress and event.button() == Qt.MouseButton.LeftButton:
+                if not self.isEnabled():
+                    return True
                 self._scrub_active = True
                 self._scrub_start_x = event.position().x()
                 self._scrub_start_val = self.spin.value()
                 return True
-            if et == QEvent.Type.MouseMove and self._scrub_active:
+            if et == QEvent.Type.MouseMove and self._scrub_active and self.isEnabled():
                 dx = event.position().x() - self._scrub_start_x
                 span = self._max - self._min
                 sensitivity = span / 400.0


### PR DESCRIPTION
- Load file on open: When adding files or a folder via the file browser, the first discovered asset is automatically selected and loaded if no file is currently open
- Fix shift and ctrl selections: Replaced single-click selection with double-click to open a file. Selection (multi-select with shift/ctrl) now works independently via the selection model without also triggering a file load, fixing accidental loads during multi-select operations.
- Disable drange slider on roll average: When "use roll average" is enabled, only the analysis buffer and drange clip sliders are disabled — white point and black point sliders remain enabled. Also fixes a bug where label scrubbing on a disabled CompactSlider would still activate.