### PR TITLE
feat: export presets

### DIFF
--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -24,7 +24,7 @@ from negpy.desktop.workers.render import (
     ThumbnailWorker,
 )
 from negpy.desktop.workers.scan_worker import ScanRequest, ScanWorker
-from negpy.domain.models import WorkspaceConfig
+from negpy.domain.models import ExportPreset, ExportPresetOutputMode, WorkspaceConfig
 from negpy.features.exposure.logic import (
     calculate_wb_shifts,
     calculate_wb_shifts_from_log,
@@ -971,110 +971,115 @@ class AppController(QObject):
             self.compare_changed.emit(True)
             self.request_render(readback_metrics=False, config_override=self._baseline_compare_config())
 
-    def _ensure_valid_export_path(self) -> Optional[str]:
-        """
-        Checks if the current export path is valid. If not, prompts the user.
-        Returns the valid path or None if the user cancelled.
-        """
-        export_path = self.state.config.export.export_path
-        if self.state.config.export.same_as_source:
-            return export_path  # path irrelevant when exporting to source folder
-        if export_path.strip().lower() in ["export", "/export", ""]:
-            from PyQt6.QtWidgets import QFileDialog
+    def _enabled_presets(self) -> List[ExportPreset]:
+        return [p for p in self.state.export_presets if p.enabled]
 
-            new_path = QFileDialog.getExistingDirectory(None, "Select Export Directory", os.path.expanduser("~"))
-            if new_path:
-                new_export = replace(self.state.config.export, export_path=new_path)
-                self.session.update_config(replace(self.state.config, export=new_export), persist=True)
-                return new_path
-            return None
-        return export_path
+    def _validate_preset_paths(self, presets: List[ExportPreset]) -> bool:
+        """Returns True if all absolute-path presets have a valid directory configured."""
+        from PyQt6.QtWidgets import QFileDialog
+
+        for p in presets:
+            if p.output_mode == ExportPresetOutputMode.ABSOLUTE and not p.output_path.strip():
+                new_path = QFileDialog.getExistingDirectory(
+                    None, f"Select output folder for preset '{p.name}'", os.path.expanduser("~")
+                )
+                if not new_path:
+                    return False
+                p.output_path = new_path
+                self.session.save_export_presets()
+        return True
+
+    def _tasks_for_file(
+        self,
+        file_info: dict,
+        params: WorkspaceConfig,
+        presets: List[ExportPreset],
+        bounds_override=None,
+        source_exif=None,
+        metadata_config=None,
+    ) -> List[ExportTask]:
+        tasks = []
+        for preset in presets:
+            from copy import copy
+
+            p = copy(preset)
+            p.icc_input_path = self.state.icc_input_path
+            tasks.append(
+                ExportTask(
+                    file_info=file_info,
+                    params=params,
+                    export_settings=p,
+                    gpu_enabled=self.state.gpu_enabled,
+                    bounds_override=bounds_override,
+                    source_exif=source_exif,
+                    metadata_config=metadata_config,
+                    working_color_space=self.state.workspace_color_space,
+                )
+            )
+        return tasks
 
     def request_export(self) -> None:
-        """
-        Initiates high-resolution export for the current file.
-        """
+        """Initiates high-resolution export for the current file using enabled presets."""
         if not self.state.current_file_path:
             return
 
-        export_path = self._ensure_valid_export_path()
-        if not export_path:
+        presets = self._enabled_presets()
+        if not presets:
+            QMessageBox.information(None, "No presets enabled", "Enable at least one export preset in the Export panel.")
             return
 
-        export_conf = replace(
-            self.state.config.export,
-            export_path=export_path,
-            icc_input_path=self.state.icc_input_path,
-            icc_output_path=self.state.icc_output_path,
-        )
+        if not self._validate_preset_paths(presets):
+            return
 
         source_exif = self.state.source_exif.get(self.state.current_file_hash or "")
-
-        self._run_export_tasks(
-            [
-                ExportTask(
-                    file_info={
-                        "name": os.path.basename(self.state.current_file_path),
-                        "path": self.state.current_file_path,
-                        "hash": self.state.current_file_hash,
-                    },
-                    params=self.state.config,
-                    export_settings=export_conf,
-                    gpu_enabled=self.state.gpu_enabled,
-                    source_exif=source_exif,
-                    metadata_config=self.state.config.metadata,
-                    working_color_space=self.state.workspace_color_space,
-                )
-            ]
+        file_info = {
+            "name": os.path.basename(self.state.current_file_path),
+            "path": self.state.current_file_path,
+            "hash": self.state.current_file_hash,
+        }
+        tasks = self._tasks_for_file(
+            file_info,
+            self.state.config,
+            presets,
+            source_exif=source_exif,
+            metadata_config=self.state.config.metadata,
         )
+        if tasks:
+            self._run_export_tasks(tasks)
 
     def request_batch_export(self, override_settings: bool = False) -> None:
-        """
-        Initiates batch export, optionally applying current export settings to all files.
-        """
-        export_path = self._ensure_valid_export_path()
-        if not export_path:
+        """Initiates batch export for all visible files using enabled presets."""
+        presets = self._enabled_presets()
+        if not presets:
+            QMessageBox.information(None, "No presets enabled", "Enable at least one export preset in the Export panel.")
             return
 
-        current_export = replace(self.state.config.export, export_path=export_path)
-        icc_input = self.state.icc_input_path
-        icc_output = self.state.icc_output_path
-        sync_metadata = self.state.config.metadata.sync_to_batch
+        if not self._validate_preset_paths(presets):
+            return
 
+        sync_metadata = self.state.config.metadata.sync_to_batch
         visible_files = [self.state.uploaded_files[i] for i in self.session.asset_model.visible_actual_indices_ordered()]
 
         tasks = []
         for f in visible_files:
             params = self.session.repo.load_file_settings(f["hash"]) or self.state.config
 
-            if override_settings:
-                params = replace(params, export=current_export)
-
-            final_export = replace(
-                params.export,
-                icc_input_path=icc_input,
-                icc_output_path=icc_output,
-            )
-
             bounds_override = None
             if f["hash"] == self.state.current_file_hash:
                 with self.state.metrics_lock:
                     bounds_override = self.state.last_metrics.get("log_bounds")
 
-            # Metadata: if sync enabled, use current config for all files
             source_exif = self.state.source_exif.get(f["hash"])
             metadata_config = self.state.config.metadata if sync_metadata else params.metadata
 
-            tasks.append(
-                ExportTask(
-                    file_info=f,
-                    params=params,
-                    export_settings=final_export,
-                    gpu_enabled=self.state.gpu_enabled,
+            tasks.extend(
+                self._tasks_for_file(
+                    f,
+                    params,
+                    presets,
                     bounds_override=bounds_override,
                     source_exif=source_exif,
                     metadata_config=metadata_config,
-                    working_color_space=self.state.workspace_color_space,
                 )
             )
 

--- a/negpy/desktop/session.py
+++ b/negpy/desktop/session.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Optional
 
 from PyQt6.QtCore import QAbstractListModel, QModelIndex, QObject, Qt, pyqtSignal
 
-from negpy.domain.models import WorkspaceConfig
+from negpy.domain.models import ExportPreset, WorkspaceConfig
 from negpy.infrastructure.storage.repository import StorageRepository
 from negpy.kernel.system.config import APP_CONFIG
 
@@ -85,6 +85,9 @@ class AppState:
 
     # True while the before/after view shows the un-graded auto baseline instead of edits
     compare_mode: bool = False
+
+    # Export presets (globally managed, not per-file)
+    export_presets: List[ExportPreset] = field(default_factory=list)
 
 
 class AssetListModel(QAbstractListModel):
@@ -268,6 +271,8 @@ class DesktopSessionManager(QObject):
         if saved_soft_proof is not None:
             self.state.soft_proof_enabled = bool(saved_soft_proof)
 
+        self.state.export_presets = self.repo.load_export_presets()
+
     def set_gpu_enabled(self, enabled: bool) -> None:
         """Updates and persists the hardware acceleration preference."""
         if self.state.gpu_enabled != enabled:
@@ -301,6 +306,10 @@ class DesktopSessionManager(QObject):
         self.repo.save_global_setting("icc_output_path", self.state.icc_output_path)
         self.repo.save_global_setting("monitor_profile_override", self.state.monitor_profile_override)
         self.repo.save_global_setting("soft_proof_enabled", self.state.soft_proof_enabled)
+
+    def save_export_presets(self) -> None:
+        """Persists current export presets."""
+        self.repo.save_export_presets(self.state.export_presets)
 
     def _apply_sticky_settings(self, config: WorkspaceConfig, only_global: bool = False) -> WorkspaceConfig:
         """

--- a/negpy/desktop/view/sidebar/export.py
+++ b/negpy/desktop/view/sidebar/export.py
@@ -1,17 +1,14 @@
 import os
 
 import qtawesome as qta
-from PyQt6.QtCore import QTimer
+from PyQt6.QtCore import Qt
 from PyQt6.QtWidgets import (
-    QButtonGroup,
     QCheckBox,
     QComboBox,
-    QDoubleSpinBox,
     QHBoxLayout,
     QLabel,
-    QLineEdit,
     QPushButton,
-    QSpinBox,
+    QScrollArea,
     QVBoxLayout,
     QWidget,
 )
@@ -19,7 +16,7 @@ from PyQt6.QtWidgets import (
 from negpy.desktop.view.sidebar.base import BaseSidebar
 from negpy.desktop.view.styles.templates import section_subheader
 from negpy.desktop.view.styles.theme import THEME
-from negpy.domain.models import AspectRatio, ColorSpace, ExportFormat, ExportResolutionMode
+from negpy.domain.models import ColorSpace
 from negpy.infrastructure.display.color_mgmt import ColorService
 from negpy.infrastructure.display.color_spaces import ColorSpaceRegistry
 
@@ -31,36 +28,24 @@ class ExportSidebar(BaseSidebar):
 
     @staticmethod
     def _icc_row_label(text: str) -> QLabel:
-        """Fixed-width row label so the ICC-section dropdowns line up."""
         label = QLabel(text)
         label.setFixedWidth(52)
         return label
 
     def _init_ui(self) -> None:
         self.layout.setSpacing(10)
-        conf = self.state.config.export
-
-        self.update_timer = QTimer()
-        self.update_timer.setSingleShot(True)
-        self.update_timer.setInterval(500)
-        self.update_timer.timeout.connect(self._persist_all_export_settings)
 
         self.layout.addWidget(section_subheader("ICC"))
 
-        # Soft proof: when off, Output/Input ICC affect export only (preview = the edit
-        # on the monitor); when on, the preview simulates the Output profile.
         self.soft_proof_checkbox = QCheckBox("Soft proof")
         self.soft_proof_checkbox.setChecked(self.state.soft_proof_enabled)
         self.soft_proof_checkbox.setToolTip("Simulate the Output profile (incl. paper/printer) in the preview")
         self.layout.addWidget(self.soft_proof_checkbox)
 
-        # Drop bundled profiles that already back a color-space enum (e.g.
-        # AdobeCompat-v4.icc ↔ "Adobe RGB") so the Output list isn't duplicated.
         enum_mapped = {ColorSpaceRegistry.get_icc_path(cs.value) for cs in ColorSpace}
         enum_mapped.discard(None)
         custom_profiles = [p for p in ColorService.get_available_profiles() if p not in enum_mapped]
 
-        # Input: source profile correction.
         self.input_profiles = ["None"] + custom_profiles
         self.input_combo = QComboBox()
         self.input_combo.addItems([os.path.basename(p) for p in self.input_profiles])
@@ -72,8 +57,6 @@ class ExportSidebar(BaseSidebar):
         in_row.addWidget(self.input_combo)
         self.layout.addLayout(in_row)
 
-        # Output: one selector for a color space (→ export_color_space) or a custom
-        # ICC profile (→ icc_output_path).
         self.output_spaces = [cs.value for cs in ColorSpace]
         self.output_profiles = custom_profiles
         self.output_map = list(self.output_spaces) + list(self.output_profiles)
@@ -81,15 +64,14 @@ class ExportSidebar(BaseSidebar):
         self.output_combo.addItems(self.output_spaces + [os.path.basename(p) for p in self.output_profiles])
         self.output_combo.setToolTip("Output color space or custom ICC profile — soft-proofed in the preview")
         out_path = self.state.icc_output_path
-        self.output_combo.setCurrentText(os.path.basename(out_path) if out_path else conf.export_color_space)
+        self.output_combo.setCurrentText(
+            os.path.basename(out_path) if out_path else self.state.config.export.export_color_space
+        )
         out_row = QHBoxLayout()
         out_row.addWidget(self._icc_row_label("Output"))
         out_row.addWidget(self.output_combo)
         self.layout.addLayout(out_row)
 
-        # Display: monitor profile the preview is shown on (preview only, not export).
-        # "As detected" uses the OS-reported profile; the rest override it for
-        # wide-gamut monitors the OS does not report (common on Linux).
         self.display_spaces = [
             ColorSpace.SRGB.value,
             ColorSpace.P3_D65.value,
@@ -100,9 +82,13 @@ class ExportSidebar(BaseSidebar):
         self.display_map = [None] + self.display_spaces
         self.display_combo = QComboBox()
         self.display_combo.addItems(["As detected"] + self.display_spaces)
-        self.display_combo.setToolTip("Monitor profile the preview is displayed on (affects preview only, not export)")
+        self.display_combo.setToolTip(
+            "Monitor profile the preview is displayed on (affects preview only, not export)"
+        )
         override = self.state.monitor_profile_override
-        self.display_combo.setCurrentText(override if override in self.display_spaces else "As detected")
+        self.display_combo.setCurrentText(
+            override if override in self.display_spaces else "As detected"
+        )
         disp_row = QHBoxLayout()
         disp_row.addWidget(self._icc_row_label("Display"))
         disp_row.addWidget(self.display_combo)
@@ -113,119 +99,35 @@ class ExportSidebar(BaseSidebar):
         self.layout.addWidget(self.display_detected_label)
         self._refresh_display_info()
 
-        self.layout.addWidget(section_subheader("FORMAT"))
+        # Presets section
+        self.layout.addWidget(section_subheader("PRESETS"))
 
-        fmt_row = QHBoxLayout()
-        self.fmt_combo = QComboBox()
-        self.fmt_combo.addItems([f.value for f in ExportFormat])
-        self.fmt_combo.setCurrentText(conf.export_fmt)
-        self.fmt_combo.setToolTip("File format")
-        self.ratio_combo = QComboBox()
-        # "Original" is first, then the rest
-        ratios = [AspectRatio.ORIGINAL] + [r.value for r in AspectRatio if r != AspectRatio.ORIGINAL]
-        self.ratio_combo.addItems(ratios)
-        self.ratio_combo.setCurrentText(conf.paper_aspect_ratio)
-        self.ratio_combo.setToolTip("Paper aspect ratio")
-        fmt_row.addWidget(self.fmt_combo)
-        fmt_row.addWidget(self.ratio_combo)
-        self.layout.addLayout(fmt_row)
-
-        self.layout.addWidget(section_subheader("SIZE"))
-
-        mode_row = QHBoxLayout()
-        mode_row.setSpacing(4)
-        self.mode_original_btn = QPushButton("Original")
-        self.mode_print_btn = QPushButton("Print")
-        self.mode_target_px_btn = QPushButton("Pixels")
-        btn_style = f"font-size: {THEME.font_size_base}px; padding: 8px;"
-        for btn in (self.mode_original_btn, self.mode_print_btn, self.mode_target_px_btn):
-            btn.setCheckable(True)
-            btn.setStyleSheet(btn_style)
-            mode_row.addWidget(btn)
-        self.mode_btn_group = QButtonGroup(self)
-        self.mode_btn_group.setExclusive(True)
-        self.mode_btn_group.addButton(self.mode_original_btn, 0)
-        self.mode_btn_group.addButton(self.mode_print_btn, 1)
-        self.mode_btn_group.addButton(self.mode_target_px_btn, 2)
-        self.layout.addLayout(mode_row)
-
-        # PRINT mode: cm + DPI
-        self.print_size_container = QWidget()
-        print_layout = QVBoxLayout(self.print_size_container)
-        print_layout.setContentsMargins(0, 0, 0, 0)
-        print_row = QHBoxLayout()
-
-        vbox_size = QVBoxLayout()
-        size_label = QLabel('Size <span style="color: #666666; font-size: 10px;">cm</span>')
-        vbox_size.addWidget(size_label)
-        self.size_input = QDoubleSpinBox()
-        self.size_input.setRange(1.0, 500.0)
-        self.size_input.setValue(conf.export_print_size)
-        vbox_size.addWidget(self.size_input)
-
-        vbox_dpi = QVBoxLayout()
-        vbox_dpi.addWidget(QLabel("DPI"))
-        self.dpi_input = QSpinBox()
-        self.dpi_input.setRange(72, 4800)
-        self.dpi_input.setValue(conf.export_dpi)
-        vbox_dpi.addWidget(self.dpi_input)
-
-        print_row.addLayout(vbox_size)
-        print_row.addLayout(vbox_dpi)
-        print_layout.addLayout(print_row)
-        self.layout.addWidget(self.print_size_container)
-
-        # TARGET_PX mode: long edge in pixels
-        self.target_px_container = QWidget()
-        target_px_layout = QVBoxLayout(self.target_px_container)
-        target_px_layout.setContentsMargins(0, 0, 0, 0)
-        target_px_layout.addWidget(QLabel('Long edge <span style="color: #666666; font-size: 10px;">px</span>'))
-        self.target_px_input = QSpinBox()
-        self.target_px_input.setRange(256, 32768)
-        self.target_px_input.setValue(conf.export_target_long_edge_px)
-        target_px_layout.addWidget(self.target_px_input)
-        self.layout.addWidget(self.target_px_container)
-
-        self._select_mode_button(conf.export_resolution_mode)
-        self._update_mode_visibility(conf.export_resolution_mode)
-
-        self.layout.addWidget(section_subheader("DESTINATION"))
-
-        self.pattern_input = QLineEdit(conf.filename_pattern)
-        self.pattern_input.setPlaceholderText("Filename Pattern...")
-        self.pattern_input.setToolTip(
-            "Jinja2 Template. Available variables:\n"
-            "- {{ original_name }}\n"
-            "- {{ colorspace }}\n"
-            "- {{ format }} (JPEG/TIFF)\n"
-            "- {{ paper_ratio }}\n"
-            "- {{ size }} (e.g. 20cm; PRINT mode only)\n"
-            "- {{ dpi }} (PRINT mode only)\n"
-            "- {{ target_px }} (e.g. 2000px; TARGET_PX mode only)\n"
-            "- {{ border }} ('border' or empty)\n"
-            "- {{ date }} (YYYYMMDD)"
+        self._presets_scroll = QScrollArea()
+        self._presets_scroll.setWidgetResizable(True)
+        self._presets_scroll.setMaximumHeight(160)
+        self._presets_scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        self._presets_scroll.setStyleSheet(
+            f"QScrollArea {{ border: 1px solid {THEME.border_primary}; background: {THEME.bg_dark}; }}"
         )
-        self.layout.addWidget(self.pattern_input)
+        self._presets_container = QWidget()
+        self._presets_container.setStyleSheet(f"background: {THEME.bg_dark};")
+        self._presets_inner = QVBoxLayout(self._presets_container)
+        self._presets_inner.setContentsMargins(4, 4, 4, 4)
+        self._presets_inner.setSpacing(2)
+        self._presets_scroll.setWidget(self._presets_container)
+        self.layout.addWidget(self._presets_scroll)
 
-        checkbox_row = QHBoxLayout()
-        self.overwrite_checkbox = QCheckBox("Overwrite existing files")
-        self.overwrite_checkbox.setChecked(conf.overwrite)
-        self.same_as_source_checkbox = QCheckBox("Same folder as source")
-        self.same_as_source_checkbox.setChecked(conf.same_as_source)
-        checkbox_row.addWidget(self.overwrite_checkbox)
-        checkbox_row.addWidget(self.same_as_source_checkbox)
-        self.layout.addLayout(checkbox_row)
+        self._no_presets_label = QLabel("No presets — click Manage to add some.")
+        self._no_presets_label.setStyleSheet(f"color: {THEME.text_muted}; font-size: 10px;")
+        self._no_presets_label.setWordWrap(True)
+        self._presets_inner.addWidget(self._no_presets_label)
+        self._preset_checkboxes: list[QCheckBox] = []
 
-        path_layout = QHBoxLayout()
-        self.path_input = QLineEdit(conf.export_path)
-        self.path_input.setToolTip("Export folder")
-        self.browse_btn = QPushButton()
-        self.browse_btn.setIcon(qta.icon("fa5s.folder-open", color=THEME.text_primary))
-        self.browse_btn.setFixedWidth(40)
-        self.browse_btn.setToolTip("Choose export folder")
-        path_layout.addWidget(self.path_input)
-        path_layout.addWidget(self.browse_btn)
-        self.layout.addLayout(path_layout)
+        manage_btn = QPushButton(" Manage Presets")
+        manage_btn.setObjectName("manage_presets_btn")
+        manage_btn.setIcon(qta.icon("fa5s.sliders-h", color=THEME.text_primary))
+        manage_btn.clicked.connect(self._open_presets_dialog)
+        self.layout.addWidget(manage_btn)
 
         self.layout.addWidget(section_subheader("BATCH"))
 
@@ -239,7 +141,7 @@ class ExportSidebar(BaseSidebar):
         self.apply_all_btn.setFixedHeight(40)
         self.apply_all_btn.setCheckable(True)
         self.apply_all_btn.setChecked(True)
-        self.apply_all_btn.setToolTip("Apply current export settings (Size, DPI, Border) to all files")
+        self.apply_all_btn.setToolTip("Apply current export settings to all files")
         self._update_apply_all_style(True)
 
         batch_row.addWidget(self.batch_export_btn)
@@ -248,33 +150,62 @@ class ExportSidebar(BaseSidebar):
 
         self.layout.addStretch()
 
+        self._rebuild_preset_rows()
+
     def _connect_signals(self) -> None:
-        self.fmt_combo.currentTextChanged.connect(lambda _: self.update_timer.start())
         self.soft_proof_checkbox.toggled.connect(self.controller.set_soft_proof)
         self.input_combo.currentIndexChanged.connect(self._on_input_changed)
         self.output_combo.currentIndexChanged.connect(self._on_output_changed)
         self.display_combo.currentIndexChanged.connect(self._on_display_changed)
         self.controller.monitor_profile_changed.connect(self._refresh_display_info)
-        self.ratio_combo.currentTextChanged.connect(lambda _: self.update_timer.start())
-        self.mode_btn_group.idToggled.connect(self._on_mode_toggled)
-
-        self.size_input.valueChanged.connect(lambda _: self.update_timer.start())
-        self.dpi_input.valueChanged.connect(lambda _: self.update_timer.start())
-        self.target_px_input.valueChanged.connect(lambda _: self.update_timer.start())
-
-        self.browse_btn.clicked.connect(self._on_browse_clicked)
-        self.pattern_input.textChanged.connect(lambda _: self.update_timer.start())
-        self.path_input.textChanged.connect(lambda _: self.update_timer.start())
-        self.overwrite_checkbox.stateChanged.connect(lambda _: self.update_timer.start())
-        self.same_as_source_checkbox.stateChanged.connect(self._on_same_as_source_toggled)
-
         self.apply_all_btn.toggled.connect(self._update_apply_all_style)
         self.batch_export_btn.clicked.connect(
-            lambda: self.controller.request_batch_export(override_settings=self.apply_all_btn.isChecked())
+            lambda: self.controller.request_batch_export(
+                override_settings=self.apply_all_btn.isChecked()
+            )
         )
 
+    def _rebuild_preset_rows(self) -> None:
+        """Rebuild the preset checkbox list from state."""
+        # Remove old checkboxes
+        for cb in self._preset_checkboxes:
+            self._presets_inner.removeWidget(cb)
+            cb.deleteLater()
+        self._preset_checkboxes.clear()
+
+        presets = self.state.export_presets
+        has_presets = bool(presets)
+        self._no_presets_label.setVisible(not has_presets)
+
+        for i, preset in enumerate(presets):
+            cb = QCheckBox(preset.name)
+            cb.setChecked(preset.enabled)
+            cb.setStyleSheet(f"color: {THEME.text_primary};")
+            cb.stateChanged.connect(lambda state, idx=i: self._on_preset_toggled(idx, state))
+            self._presets_inner.addWidget(cb)
+            self._preset_checkboxes.append(cb)
+
+        self._presets_inner.addStretch()
+
+    def _on_preset_toggled(self, idx: int, state: int) -> None:
+        presets = self.state.export_presets
+        if 0 <= idx < len(presets):
+            presets[idx].enabled = state == Qt.CheckState.Checked.value
+            self.controller.session.save_export_presets()
+
+    def _open_presets_dialog(self) -> None:
+        from negpy.desktop.view.widgets.export_presets_dialog import ExportPresetsDialog
+
+        dlg = ExportPresetsDialog(self.state.export_presets, parent=self)
+        dlg.presets_changed.connect(self._on_presets_changed)
+        dlg.exec()
+
+    def _on_presets_changed(self, presets: list) -> None:
+        self.state.export_presets = presets
+        self.controller.session.save_export_presets()
+        self._rebuild_preset_rows()
+
     def _update_apply_all_style(self, checked: bool) -> None:
-        """Toggle checked appearance for the Sync export settings button."""
         if checked:
             self.apply_all_btn.setStyleSheet("""
                 QPushButton {
@@ -290,25 +221,6 @@ class ExportSidebar(BaseSidebar):
             self.apply_all_btn.setStyleSheet("font-weight: bold;")
             self.apply_all_btn.setIcon(qta.icon("fa5s.clone", color=THEME.text_primary))
 
-    def _persist_all_export_settings(self) -> None:
-        """Collects all UI values and performs a single debounced config update."""
-        self.update_config_section(
-            "export",
-            persist=True,
-            render=True,
-            export_fmt=self.fmt_combo.currentText(),
-            export_color_space=self._current_export_color_space(),
-            paper_aspect_ratio=self.ratio_combo.currentText(),
-            export_resolution_mode=self._current_mode_value(),
-            export_print_size=self.size_input.value(),
-            export_dpi=self.dpi_input.value(),
-            export_target_long_edge_px=self.target_px_input.value(),
-            filename_pattern=self.pattern_input.text(),
-            export_path=self.path_input.text(),
-            overwrite=self.overwrite_checkbox.isChecked(),
-            same_as_source=self.same_as_source_checkbox.isChecked(),
-        )
-
     def _on_input_changed(self, index: int) -> None:
         path = self.input_profiles[index]
         self.state.icc_input_path = path if path != "None" else None
@@ -317,13 +229,18 @@ class ExportSidebar(BaseSidebar):
 
     def _on_output_changed(self, index: int) -> None:
         if index < len(self.output_spaces):
-            # Color space: persist synchronously (not debounced) so this render resolves
-            # the effective output from the new export_color_space.
             self.state.icc_output_path = None
             self.controller.session.save_icc_prefs()
-            self._persist_all_export_settings()
+            from dataclasses import replace
+            new_export = replace(
+                self.state.config.export,
+                export_color_space=self.output_map[index],
+            )
+            self.controller.session.update_config(
+                replace(self.state.config, export=new_export), persist=True, render=True
+            )
+            self.controller.request_render()
         else:
-            # Custom output profile.
             self.state.icc_output_path = self.output_map[index]
             self.controller.session.save_icc_prefs()
             self.controller.request_render()
@@ -332,7 +249,6 @@ class ExportSidebar(BaseSidebar):
         self.controller.set_monitor_override(self.display_map[index])
 
     def _refresh_display_info(self) -> None:
-        """Update the 'As detected' label with the live detected monitor profile."""
         from negpy.infrastructure.display.color_mgmt import profile_description
 
         desc = profile_description(self.state.monitor_icc_detected_bytes)
@@ -340,97 +256,37 @@ class ExportSidebar(BaseSidebar):
         self.display_combo.setItemText(0, f"As detected ({desc})")
 
     def _current_export_color_space(self) -> str:
-        """Output dropdown value when a standard space is selected; else keep prior."""
         idx = self.output_combo.currentIndex()
         if 0 <= idx < len(self.output_spaces):
             return self.output_map[idx]
         return self.state.config.export.export_color_space
 
-    _MODE_BY_ID = {
-        0: ExportResolutionMode.ORIGINAL.value,
-        1: ExportResolutionMode.PRINT.value,
-        2: ExportResolutionMode.TARGET_PX.value,
-    }
-    _ID_BY_MODE = {v: k for k, v in _MODE_BY_ID.items()}
-
-    def _current_mode_value(self) -> str:
-        return self._MODE_BY_ID.get(self.mode_btn_group.checkedId(), ExportResolutionMode.PRINT.value)
-
-    def _select_mode_button(self, mode_value: str) -> None:
-        idx = self._ID_BY_MODE.get(mode_value, 1)
-        btn = self.mode_btn_group.button(idx)
-        if btn is not None:
-            btn.setChecked(True)
-
-    def _update_mode_visibility(self, mode_value: str) -> None:
-        self.print_size_container.setVisible(mode_value == ExportResolutionMode.PRINT.value)
-        self.target_px_container.setVisible(mode_value == ExportResolutionMode.TARGET_PX.value)
-
-    def _on_mode_toggled(self, _id: int, checked: bool) -> None:
-        if not checked:
-            return
-        self._update_mode_visibility(self._current_mode_value())
-        self.update_timer.start()
-
-    def _on_same_as_source_toggled(self) -> None:
-        checked = self.same_as_source_checkbox.isChecked()
-        self.path_input.setDisabled(checked)
-        self.browse_btn.setDisabled(checked)
-        self.update_timer.start()
-
-    def _on_browse_clicked(self) -> None:
-        from PyQt6.QtWidgets import QFileDialog
-
-        path = QFileDialog.getExistingDirectory(self, "Select Export Directory", self.state.config.export.export_path)
-        if path:
-            self.path_input.setText(path)
-
     def sync_ui(self) -> None:
-        conf = self.state.config.export
         self.block_signals(True)
         try:
             self.soft_proof_checkbox.setChecked(self.state.soft_proof_enabled)
-            self.fmt_combo.setCurrentText(conf.export_fmt)
             in_path = self.state.icc_input_path
             self.input_combo.setCurrentText(os.path.basename(in_path) if in_path else "None")
             out_path = self.state.icc_output_path
-            self.output_combo.setCurrentText(os.path.basename(out_path) if out_path else conf.export_color_space)
+            self.output_combo.setCurrentText(
+                os.path.basename(out_path) if out_path else self.state.config.export.export_color_space
+            )
             override = self.state.monitor_profile_override
-            self.display_combo.setCurrentText(override if override in self.display_spaces else "As detected")
+            self.display_combo.setCurrentText(
+                override if override in self.display_spaces else "As detected"
+            )
             self._refresh_display_info()
-            self.ratio_combo.setCurrentText(conf.paper_aspect_ratio)
-            self._select_mode_button(conf.export_resolution_mode)
-            self._update_mode_visibility(conf.export_resolution_mode)
-            self.size_input.setValue(conf.export_print_size)
-            self.dpi_input.setValue(conf.export_dpi)
-            self.target_px_input.setValue(conf.export_target_long_edge_px)
-            self.pattern_input.setText(conf.filename_pattern)
-            self.path_input.setText(conf.export_path)
-            self.overwrite_checkbox.setChecked(conf.overwrite)
-            self.same_as_source_checkbox.setChecked(conf.same_as_source)
-            self.path_input.setDisabled(conf.same_as_source)
-            self.browse_btn.setDisabled(conf.same_as_source)
         finally:
             self.block_signals(False)
+
+        self._rebuild_preset_rows()
 
     def block_signals(self, blocked: bool) -> None:
         widgets = [
             self.soft_proof_checkbox,
-            self.fmt_combo,
             self.input_combo,
             self.output_combo,
             self.display_combo,
-            self.ratio_combo,
-            self.mode_original_btn,
-            self.mode_print_btn,
-            self.mode_target_px_btn,
-            self.size_input,
-            self.dpi_input,
-            self.target_px_input,
-            self.pattern_input,
-            self.path_input,
-            self.overwrite_checkbox,
-            self.same_as_source_checkbox,
         ]
         for w in widgets:
             w.blockSignals(blocked)

--- a/negpy/desktop/view/widgets/export_presets_dialog.py
+++ b/negpy/desktop/view/widgets/export_presets_dialog.py
@@ -1,0 +1,592 @@
+import os
+import uuid
+
+import qtawesome as qta
+from PyQt6.QtCore import Qt, pyqtSignal
+from PyQt6.QtWidgets import (
+    QButtonGroup,
+    QCheckBox,
+    QComboBox,
+    QDialog,
+    QDoubleSpinBox,
+    QFileDialog,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QListWidget,
+    QListWidgetItem,
+    QPushButton,
+    QScrollArea,
+    QSpinBox,
+    QVBoxLayout,
+    QWidget,
+)
+
+from negpy.desktop.view.styles.theme import THEME
+from negpy.domain.models import (
+    AspectRatio,
+    ColorSpace,
+    ExportFormat,
+    ExportPreset,
+    ExportPresetOutputMode,
+    ExportResolutionMode,
+)
+from negpy.infrastructure.display.color_mgmt import ColorService
+from negpy.infrastructure.display.color_spaces import ColorSpaceRegistry
+
+
+class ExportPresetsDialog(QDialog):
+    """Modal dialog for managing export presets."""
+
+    presets_changed = pyqtSignal(list)  # emits updated list[ExportPreset]
+
+    def __init__(self, presets: list, parent=None):
+        super().__init__(parent)
+        self._presets: list[ExportPreset] = [self._copy_preset(p) for p in presets]
+        self._selected_idx: int = -1
+        self._updating_form = False
+
+        self.setWindowTitle("Export Presets")
+        self.resize(860, 620)
+        self._init_ui()
+        if self._presets:
+            self._select_row(0)
+
+    # ------------------------------------------------------------------
+    # UI setup
+    # ------------------------------------------------------------------
+
+    def _init_ui(self) -> None:
+        root = QHBoxLayout(self)
+        root.setContentsMargins(0, 0, 0, 0)
+        root.setSpacing(0)
+
+        # Left: preset list + action buttons
+        left = QWidget()
+        left.setFixedWidth(220)
+        left.setStyleSheet(f"background: {THEME.bg_panel}; border-right: 1px solid {THEME.border_primary};")
+        left_layout = QVBoxLayout(left)
+        left_layout.setContentsMargins(8, 8, 8, 8)
+        left_layout.setSpacing(6)
+
+        list_label = QLabel("PRESETS")
+        list_label.setStyleSheet(f"color: {THEME.text_muted}; font-size: 10px; font-weight: bold; letter-spacing: 1px;")
+        left_layout.addWidget(list_label)
+
+        self.preset_list = QListWidget()
+        self.preset_list.setStyleSheet(f"""
+            QListWidget {{ background: {THEME.bg_dark}; border: 1px solid {THEME.border_primary}; }}
+            QListWidget::item {{ padding: 8px; color: {THEME.text_primary}; }}
+            QListWidget::item:selected {{ background: #2a2a2a; color: white; }}
+        """)
+        self.preset_list.currentRowChanged.connect(self._on_list_selection_changed)
+        left_layout.addWidget(self.preset_list)
+
+        btn_row = QHBoxLayout()
+        self.add_btn = QPushButton()
+        self.add_btn.setIcon(qta.icon("fa5s.plus", color=THEME.text_primary))
+        self.add_btn.setToolTip("Add preset")
+        self.add_btn.setFixedWidth(36)
+        self.add_btn.clicked.connect(self._add_preset)
+
+        self.dup_btn = QPushButton()
+        self.dup_btn.setIcon(qta.icon("fa5s.copy", color=THEME.text_primary))
+        self.dup_btn.setToolTip("Duplicate preset")
+        self.dup_btn.setFixedWidth(36)
+        self.dup_btn.clicked.connect(self._duplicate_preset)
+
+        self.del_btn = QPushButton()
+        self.del_btn.setIcon(qta.icon("fa5s.trash-alt", color=THEME.text_primary))
+        self.del_btn.setToolTip("Delete preset")
+        self.del_btn.setFixedWidth(36)
+        self.del_btn.clicked.connect(self._delete_preset)
+
+        self.up_btn = QPushButton()
+        self.up_btn.setIcon(qta.icon("fa5s.arrow-up", color=THEME.text_primary))
+        self.up_btn.setToolTip("Move up")
+        self.up_btn.setFixedWidth(36)
+        self.up_btn.clicked.connect(self._move_up)
+
+        self.down_btn = QPushButton()
+        self.down_btn.setIcon(qta.icon("fa5s.arrow-down", color=THEME.text_primary))
+        self.down_btn.setToolTip("Move down")
+        self.down_btn.setFixedWidth(36)
+        self.down_btn.clicked.connect(self._move_down)
+
+        for btn in (self.add_btn, self.dup_btn, self.del_btn, self.up_btn, self.down_btn):
+            btn_row.addWidget(btn)
+        btn_row.addStretch()
+        left_layout.addLayout(btn_row)
+
+        root.addWidget(left)
+
+        # Right: edit form in a scroll area
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll.setStyleSheet(f"QScrollArea {{ border: none; background: {THEME.bg_dark}; }}")
+
+        form_widget = QWidget()
+        form_widget.setStyleSheet(f"background: {THEME.bg_dark};")
+        self._form_layout = QVBoxLayout(form_widget)
+        self._form_layout.setContentsMargins(20, 20, 20, 20)
+        self._form_layout.setSpacing(14)
+
+        self._build_form()
+        self._form_layout.addStretch()
+
+        scroll.setWidget(form_widget)
+        root.addWidget(scroll)
+
+        self._rebuild_list()
+
+    def _build_form(self) -> None:
+        fl = self._form_layout
+
+        self._no_preset_label = QLabel("No preset selected. Add one with the + button.")
+        self._no_preset_label.setStyleSheet(f"color: {THEME.text_muted};")
+        fl.addWidget(self._no_preset_label)
+
+        self._form_container = QWidget()
+        form = QVBoxLayout(self._form_container)
+        form.setContentsMargins(0, 0, 0, 0)
+        form.setSpacing(14)
+
+        # Name & enabled
+        row = QHBoxLayout()
+        self.name_edit = QLineEdit()
+        self.name_edit.setPlaceholderText("Preset name")
+        self.name_edit.textChanged.connect(self._on_name_changed)
+        self.enabled_check = QCheckBox("Enabled")
+        self.enabled_check.stateChanged.connect(lambda _: self._on_field_changed())
+        row.addWidget(self.name_edit)
+        row.addWidget(self.enabled_check)
+        form.addLayout(row)
+
+        form.addWidget(self._section("FORMAT"))
+
+        fmt_row = QHBoxLayout()
+        fmt_label = QLabel("Format")
+        fmt_label.setFixedWidth(90)
+        self.fmt_combo = QComboBox()
+        self.fmt_combo.addItems([f.value for f in ExportFormat])
+        self.fmt_combo.currentTextChanged.connect(self._on_fmt_changed)
+        fmt_row.addWidget(fmt_label)
+        fmt_row.addWidget(self.fmt_combo)
+        form.addLayout(fmt_row)
+
+        quality_row = QHBoxLayout()
+        quality_label = QLabel("JPEG Quality")
+        quality_label.setFixedWidth(90)
+        self.quality_spin = QSpinBox()
+        self.quality_spin.setRange(1, 100)
+        self.quality_spin.setValue(90)
+        self.quality_spin.valueChanged.connect(lambda _: self._on_field_changed())
+        quality_row.addWidget(quality_label)
+        quality_row.addWidget(self.quality_spin)
+        quality_row.addStretch()
+        self._quality_container = QWidget()
+        self._quality_container.setLayout(quality_row)
+        form.addWidget(self._quality_container)
+
+        form.addWidget(self._section("SIZE"))
+
+        mode_row = QHBoxLayout()
+        mode_row.setSpacing(4)
+        self.mode_original_btn = QPushButton("Original")
+        self.mode_print_btn = QPushButton("Print")
+        self.mode_target_px_btn = QPushButton("Pixels")
+        btn_style = f"font-size: {THEME.font_size_base}px; padding: 8px;"
+        for btn in (self.mode_original_btn, self.mode_print_btn, self.mode_target_px_btn):
+            btn.setCheckable(True)
+            btn.setStyleSheet(btn_style)
+            mode_row.addWidget(btn)
+        mode_row.addStretch()
+        self.mode_btn_group = QButtonGroup(self)
+        self.mode_btn_group.setExclusive(True)
+        self.mode_btn_group.addButton(self.mode_original_btn, 0)
+        self.mode_btn_group.addButton(self.mode_print_btn, 1)
+        self.mode_btn_group.addButton(self.mode_target_px_btn, 2)
+        self.mode_btn_group.idToggled.connect(self._on_mode_toggled)
+        form.addLayout(mode_row)
+
+        # Print mode controls
+        self._print_container = QWidget()
+        print_inner = QHBoxLayout(self._print_container)
+        print_inner.setContentsMargins(0, 0, 0, 0)
+        vbox_size = QVBoxLayout()
+        vbox_size.addWidget(QLabel('Size <span style="color: #666; font-size: 10px;">cm</span>'))
+        self.size_input = QDoubleSpinBox()
+        self.size_input.setRange(1.0, 500.0)
+        self.size_input.setValue(30.0)
+        self.size_input.valueChanged.connect(lambda _: self._on_field_changed())
+        vbox_size.addWidget(self.size_input)
+        vbox_dpi = QVBoxLayout()
+        vbox_dpi.addWidget(QLabel("DPI"))
+        self.dpi_input = QSpinBox()
+        self.dpi_input.setRange(72, 4800)
+        self.dpi_input.setValue(300)
+        self.dpi_input.valueChanged.connect(lambda _: self._on_field_changed())
+        vbox_dpi.addWidget(self.dpi_input)
+        print_inner.addLayout(vbox_size)
+        print_inner.addLayout(vbox_dpi)
+        print_inner.addStretch()
+        form.addWidget(self._print_container)
+
+        # Target px controls
+        self._target_px_container = QWidget()
+        target_px_inner = QVBoxLayout(self._target_px_container)
+        target_px_inner.setContentsMargins(0, 0, 0, 0)
+        target_px_inner.addWidget(QLabel('Long edge <span style="color: #666; font-size: 10px;">px</span>'))
+        self.target_px_input = QSpinBox()
+        self.target_px_input.setRange(256, 32768)
+        self.target_px_input.setValue(2000)
+        self.target_px_input.valueChanged.connect(lambda _: self._on_field_changed())
+        target_px_inner.addWidget(self.target_px_input)
+        form.addWidget(self._target_px_container)
+
+        ratio_row = QHBoxLayout()
+        ratio_label = QLabel("Paper ratio")
+        ratio_label.setFixedWidth(90)
+        self.ratio_combo = QComboBox()
+        ratios = [AspectRatio.ORIGINAL] + [r.value for r in AspectRatio if r != AspectRatio.ORIGINAL]
+        self.ratio_combo.addItems(ratios)
+        self.ratio_combo.currentTextChanged.connect(lambda _: self._on_field_changed())
+        ratio_row.addWidget(ratio_label)
+        ratio_row.addWidget(self.ratio_combo)
+        form.addLayout(ratio_row)
+
+        form.addWidget(self._section("OUTPUT"))
+
+        output_mode_row = QHBoxLayout()
+        output_mode_label = QLabel("Folder")
+        output_mode_label.setFixedWidth(90)
+        self.output_mode_combo = QComboBox()
+        self.output_mode_combo.addItem("Subfolder of source", ExportPresetOutputMode.SUBFOLDER_OF_SOURCE)
+        self.output_mode_combo.addItem("Same as source", ExportPresetOutputMode.SAME_AS_SOURCE)
+        self.output_mode_combo.addItem("Absolute path", ExportPresetOutputMode.ABSOLUTE)
+        self.output_mode_combo.currentIndexChanged.connect(self._on_output_mode_changed)
+        output_mode_row.addWidget(output_mode_label)
+        output_mode_row.addWidget(self.output_mode_combo)
+        form.addLayout(output_mode_row)
+
+        # Subfolder name (shown for SUBFOLDER_OF_SOURCE)
+        self._subfolder_container = QWidget()
+        sf_inner = QHBoxLayout(self._subfolder_container)
+        sf_inner.setContentsMargins(0, 0, 0, 0)
+        sf_label = QLabel("Subfolder")
+        sf_label.setFixedWidth(90)
+        self.subfolder_edit = QLineEdit()
+        self.subfolder_edit.setPlaceholderText("e.g. TIFF")
+        self.subfolder_edit.textChanged.connect(lambda _: self._on_field_changed())
+        sf_inner.addWidget(sf_label)
+        sf_inner.addWidget(self.subfolder_edit)
+        form.addWidget(self._subfolder_container)
+
+        # Absolute path (shown for ABSOLUTE)
+        self._abspath_container = QWidget()
+        ap_inner = QHBoxLayout(self._abspath_container)
+        ap_inner.setContentsMargins(0, 0, 0, 0)
+        ap_label = QLabel("Path")
+        ap_label.setFixedWidth(90)
+        self.abspath_edit = QLineEdit()
+        self.abspath_edit.textChanged.connect(lambda _: self._on_field_changed())
+        self.abspath_browse_btn = QPushButton()
+        self.abspath_browse_btn.setIcon(qta.icon("fa5s.folder-open", color=THEME.text_primary))
+        self.abspath_browse_btn.setFixedWidth(36)
+        self.abspath_browse_btn.clicked.connect(self._browse_output_path)
+        ap_inner.addWidget(ap_label)
+        ap_inner.addWidget(self.abspath_edit)
+        ap_inner.addWidget(self.abspath_browse_btn)
+        form.addWidget(self._abspath_container)
+
+        filename_row = QHBoxLayout()
+        fn_label = QLabel("Filename")
+        fn_label.setFixedWidth(90)
+        self.filename_edit = QLineEdit()
+        self.filename_edit.setToolTip(
+            "Jinja2 template. Variables:\n"
+            "{{ original_name }}, {{ colorspace }}, {{ format }},\n"
+            "{{ paper_ratio }}, {{ size }}, {{ dpi }}, {{ target_px }},\n"
+            "{{ border }}, {{ date }}"
+        )
+        self.filename_edit.textChanged.connect(lambda _: self._on_field_changed())
+        filename_row.addWidget(fn_label)
+        filename_row.addWidget(self.filename_edit)
+        form.addLayout(filename_row)
+
+        self.overwrite_check = QCheckBox("Overwrite existing files")
+        self.overwrite_check.stateChanged.connect(lambda _: self._on_field_changed())
+        form.addWidget(self.overwrite_check)
+
+        form.addWidget(self._section("COLOR"))
+
+        # Output profiles
+        enum_mapped = {ColorSpaceRegistry.get_icc_path(cs.value) for cs in ColorSpace}
+        enum_mapped.discard(None)
+        custom_profiles = [p for p in ColorService.get_available_profiles() if p not in enum_mapped]
+
+        cs_row = QHBoxLayout()
+        cs_label = QLabel("Color space")
+        cs_label.setFixedWidth(90)
+        self.color_space_combo = QComboBox()
+        self.color_space_combo.addItems([cs.value for cs in ColorSpace])
+        self.color_space_combo.currentTextChanged.connect(lambda _: self._on_field_changed())
+        cs_row.addWidget(cs_label)
+        cs_row.addWidget(self.color_space_combo)
+        form.addLayout(cs_row)
+
+        icc_row = QHBoxLayout()
+        icc_label = QLabel("Output ICC")
+        icc_label.setFixedWidth(90)
+        self._icc_profiles = ["None"] + custom_profiles
+        self.icc_output_combo = QComboBox()
+        self.icc_output_combo.addItems([os.path.basename(p) for p in self._icc_profiles])
+        self.icc_output_combo.setToolTip("Custom output ICC profile (overrides color space)")
+        self.icc_output_combo.currentIndexChanged.connect(lambda _: self._on_field_changed())
+        icc_row.addWidget(icc_label)
+        icc_row.addWidget(self.icc_output_combo)
+        form.addLayout(icc_row)
+
+        fl.addWidget(self._form_container)
+
+    def _section(self, text: str) -> QLabel:
+        lbl = QLabel(text)
+        lbl.setStyleSheet(
+            f"color: {THEME.text_muted}; font-size: 10px; font-weight: bold; "
+            f"letter-spacing: 1px; border-bottom: 1px solid {THEME.border_primary}; padding-bottom: 2px;"
+        )
+        return lbl
+
+    # ------------------------------------------------------------------
+    # List management
+    # ------------------------------------------------------------------
+
+    def _rebuild_list(self) -> None:
+        self.preset_list.blockSignals(True)
+        self.preset_list.clear()
+        for p in self._presets:
+            item = QListWidgetItem(p.name)
+            item.setCheckState(Qt.CheckState.Checked if p.enabled else Qt.CheckState.Unchecked)
+            item.setFlags(item.flags() | Qt.ItemFlag.ItemIsUserCheckable)
+            self.preset_list.addItem(item)
+        self.preset_list.blockSignals(False)
+
+        has = len(self._presets) > 0
+        self._no_preset_label.setVisible(not has)
+        self._form_container.setVisible(has)
+
+    def _select_row(self, idx: int) -> None:
+        if 0 <= idx < len(self._presets):
+            self._selected_idx = idx
+            self.preset_list.blockSignals(True)
+            self.preset_list.setCurrentRow(idx)
+            self.preset_list.blockSignals(False)
+            self._populate_form(self._presets[idx])
+
+    def _on_list_selection_changed(self, row: int) -> None:
+        if row < 0 or row >= len(self._presets):
+            return
+        # Check if enabled state toggled via checkbox
+        item = self.preset_list.item(row)
+        if item and self._selected_idx == row:
+            enabled = item.checkState() == Qt.CheckState.Checked
+            if self._presets[row].enabled != enabled:
+                self._presets[row].enabled = enabled
+                self.enabled_check.setChecked(enabled)
+                self._emit_changed()
+                return
+        self._select_row(row)
+
+    # ------------------------------------------------------------------
+    # Form population and change handling
+    # ------------------------------------------------------------------
+
+    def _populate_form(self, preset: ExportPreset) -> None:
+        self._updating_form = True
+        try:
+            self.name_edit.setText(preset.name)
+            self.enabled_check.setChecked(preset.enabled)
+            self.fmt_combo.setCurrentText(preset.export_fmt)
+            self.quality_spin.setValue(preset.jpeg_quality)
+            self._select_mode_button(preset.export_resolution_mode)
+            self._update_mode_visibility(preset.export_resolution_mode)
+            self.size_input.setValue(preset.export_print_size)
+            self.dpi_input.setValue(preset.export_dpi)
+            self.target_px_input.setValue(preset.export_target_long_edge_px)
+            self.ratio_combo.setCurrentText(preset.paper_aspect_ratio)
+
+            # Output mode
+            idx = self.output_mode_combo.findData(preset.output_mode)
+            if idx >= 0:
+                self.output_mode_combo.setCurrentIndex(idx)
+            self._update_output_mode_visibility(preset.output_mode)
+            self.subfolder_edit.setText(preset.output_subfolder)
+            self.abspath_edit.setText(preset.output_path)
+            self.filename_edit.setText(preset.filename_pattern)
+            self.overwrite_check.setChecked(preset.overwrite)
+            self.color_space_combo.setCurrentText(preset.export_color_space)
+
+            icc_name = os.path.basename(preset.icc_output_path) if preset.icc_output_path else "None"
+            self.icc_output_combo.setCurrentText(icc_name)
+
+            self._quality_container.setVisible(preset.export_fmt == ExportFormat.JPEG)
+        finally:
+            self._updating_form = False
+
+    def _on_name_changed(self, text: str) -> None:
+        if self._updating_form or self._selected_idx < 0:
+            return
+        self._presets[self._selected_idx].name = text
+        item = self.preset_list.item(self._selected_idx)
+        if item:
+            item.setText(text)
+        self._emit_changed()
+
+    def _on_fmt_changed(self, fmt: str) -> None:
+        if self._updating_form or self._selected_idx < 0:
+            return
+        self._quality_container.setVisible(fmt == ExportFormat.JPEG)
+        self._on_field_changed()
+
+    def _on_mode_toggled(self, _id: int, checked: bool) -> None:
+        if not checked or self._updating_form:
+            return
+        mode = self._mode_by_id()[_id]
+        self._update_mode_visibility(mode)
+        self._on_field_changed()
+
+    def _on_output_mode_changed(self, _idx: int) -> None:
+        if self._updating_form:
+            return
+        mode = self.output_mode_combo.currentData()
+        self._update_output_mode_visibility(mode)
+        self._on_field_changed()
+
+    def _on_field_changed(self) -> None:
+        if self._updating_form or self._selected_idx < 0:
+            return
+        self._write_form_to_preset(self._presets[self._selected_idx])
+        item = self.preset_list.item(self._selected_idx)
+        if item:
+            item.setText(self._presets[self._selected_idx].name)
+            item.setCheckState(
+                Qt.CheckState.Checked if self._presets[self._selected_idx].enabled else Qt.CheckState.Unchecked
+            )
+        self._emit_changed()
+
+    def _write_form_to_preset(self, preset: ExportPreset) -> None:
+        preset.name = self.name_edit.text() or "Untitled"
+        preset.enabled = self.enabled_check.isChecked()
+        preset.export_fmt = self.fmt_combo.currentText()
+        preset.jpeg_quality = self.quality_spin.value()
+        preset.export_resolution_mode = self._current_mode_value()
+        preset.export_print_size = self.size_input.value()
+        preset.export_dpi = self.dpi_input.value()
+        preset.export_target_long_edge_px = self.target_px_input.value()
+        preset.paper_aspect_ratio = self.ratio_combo.currentText()
+        mode_data = self.output_mode_combo.currentData()
+        preset.output_mode = mode_data if mode_data else ExportPresetOutputMode.SAME_AS_SOURCE
+        preset.output_subfolder = self.subfolder_edit.text()
+        preset.output_path = self.abspath_edit.text()
+        preset.filename_pattern = self.filename_edit.text() or "{{ original_name }}"
+        preset.overwrite = self.overwrite_check.isChecked()
+        preset.export_color_space = self.color_space_combo.currentText()
+        icc_idx = self.icc_output_combo.currentIndex()
+        preset.icc_output_path = self._icc_profiles[icc_idx] if icc_idx > 0 else None
+
+    # ------------------------------------------------------------------
+    # Preset actions
+    # ------------------------------------------------------------------
+
+    def _add_preset(self) -> None:
+        preset = ExportPreset(id=str(uuid.uuid4()), name="New Preset")
+        self._presets.append(preset)
+        self._rebuild_list()
+        self._select_row(len(self._presets) - 1)
+        self._emit_changed()
+
+    def _duplicate_preset(self) -> None:
+        if self._selected_idx < 0:
+            return
+        src = self._presets[self._selected_idx]
+        dup = ExportPreset.from_dict({**src.to_dict(), "id": str(uuid.uuid4()), "name": f"{src.name} Copy"})
+        self._presets.insert(self._selected_idx + 1, dup)
+        self._rebuild_list()
+        self._select_row(self._selected_idx + 1)
+        self._emit_changed()
+
+    def _delete_preset(self) -> None:
+        if self._selected_idx < 0 or not self._presets:
+            return
+        self._presets.pop(self._selected_idx)
+        new_idx = min(self._selected_idx, len(self._presets) - 1)
+        self._rebuild_list()
+        if new_idx >= 0:
+            self._select_row(new_idx)
+        else:
+            self._selected_idx = -1
+            self._no_preset_label.setVisible(True)
+            self._form_container.setVisible(False)
+        self._emit_changed()
+
+    def _move_up(self) -> None:
+        idx = self._selected_idx
+        if idx <= 0:
+            return
+        self._presets[idx - 1], self._presets[idx] = self._presets[idx], self._presets[idx - 1]
+        self._rebuild_list()
+        self._select_row(idx - 1)
+        self._emit_changed()
+
+    def _move_down(self) -> None:
+        idx = self._selected_idx
+        if idx < 0 or idx >= len(self._presets) - 1:
+            return
+        self._presets[idx], self._presets[idx + 1] = self._presets[idx + 1], self._presets[idx]
+        self._rebuild_list()
+        self._select_row(idx + 1)
+        self._emit_changed()
+
+    def _browse_output_path(self) -> None:
+        path = QFileDialog.getExistingDirectory(self, "Select Output Folder", self.abspath_edit.text())
+        if path:
+            self.abspath_edit.setText(path)
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _copy_preset(p: ExportPreset) -> ExportPreset:
+        return ExportPreset.from_dict(p.to_dict())
+
+    def _emit_changed(self) -> None:
+        self.presets_changed.emit(list(self._presets))
+
+    _MODE_BY_ID = {
+        0: ExportResolutionMode.ORIGINAL.value,
+        1: ExportResolutionMode.PRINT.value,
+        2: ExportResolutionMode.TARGET_PX.value,
+    }
+    _ID_BY_MODE = {v: k for k, v in _MODE_BY_ID.items()}
+
+    @classmethod
+    def _mode_by_id(cls) -> dict:
+        return cls._MODE_BY_ID
+
+    def _current_mode_value(self) -> str:
+        return self._MODE_BY_ID.get(self.mode_btn_group.checkedId(), ExportResolutionMode.ORIGINAL.value)
+
+    def _select_mode_button(self, mode_value: str) -> None:
+        btn_id = self._ID_BY_MODE.get(mode_value, 0)
+        btn = self.mode_btn_group.button(btn_id)
+        if btn:
+            btn.setChecked(True)
+
+    def _update_mode_visibility(self, mode_value: str) -> None:
+        self._print_container.setVisible(mode_value == ExportResolutionMode.PRINT.value)
+        self._target_px_container.setVisible(mode_value == ExportResolutionMode.TARGET_PX.value)
+
+    def _update_output_mode_visibility(self, mode) -> None:
+        self._subfolder_container.setVisible(mode == ExportPresetOutputMode.SUBFOLDER_OF_SOURCE)
+        self._abspath_container.setVisible(mode == ExportPresetOutputMode.ABSOLUTE)

--- a/negpy/desktop/workers/export.py
+++ b/negpy/desktop/workers/export.py
@@ -3,7 +3,7 @@ from typing import List, Optional, Any
 import os
 import tempfile
 from PyQt6.QtCore import QObject, pyqtSignal, pyqtSlot
-from negpy.domain.models import WorkspaceConfig, ExportConfig, ExportFormat
+from negpy.domain.models import WorkspaceConfig, ExportFormat, ExportPreset, ExportPresetOutputMode
 from negpy.features.metadata.writer import embed_metadata
 from negpy.features.metadata.models import MetadataConfig
 from negpy.infrastructure.display.color_spaces import WORKING_COLOR_SPACE
@@ -17,7 +17,7 @@ class ExportTask:
 
     file_info: dict
     params: WorkspaceConfig
-    export_settings: ExportConfig
+    export_settings: ExportPreset
     gpu_enabled: bool = True
     bounds_override: Optional[Any] = None
     source_exif: Optional[dict] = None
@@ -64,12 +64,19 @@ class ExportWorker(QObject):
                     if task.metadata_config is not None:
                         bits = embed_metadata(bits, task.metadata_config, task.source_exif)
 
-                    out_dir = (
-                        os.path.dirname(task.file_info["path"]) if task.export_settings.same_as_source else task.export_settings.export_path
-                    )
+                    source_dir = os.path.dirname(task.file_info["path"])
+                    output_mode = task.export_settings.output_mode
+                    if output_mode == ExportPresetOutputMode.SUBFOLDER_OF_SOURCE:
+                        subfolder = task.export_settings.output_subfolder or ""
+                        out_dir = os.path.join(source_dir, subfolder) if subfolder else source_dir
+                    elif output_mode == ExportPresetOutputMode.ABSOLUTE:
+                        out_dir = task.export_settings.output_path or source_dir
+                    else:
+                        out_dir = source_dir
                     os.makedirs(out_dir, exist_ok=True)
 
-                    ext = "jpg" if task.export_settings.export_fmt == ExportFormat.JPEG else "tiff"
+                    _EXT = {ExportFormat.JPEG: "jpg", ExportFormat.TIFF: "tiff", ExportFormat.PNG: "png"}
+                    ext = _EXT.get(task.export_settings.export_fmt, "jpg")
 
                     filename = render_export_filename(
                         task.file_info["path"], task.export_settings, border_size=task.params.finish.border_size

--- a/negpy/domain/models.py
+++ b/negpy/domain/models.py
@@ -1,4 +1,5 @@
 import os
+import uuid
 
 from dataclasses import dataclass, field, asdict
 from typing import Dict, Any, Optional
@@ -48,6 +49,13 @@ class AspectRatio(StrEnum):
 class ExportFormat(StrEnum):
     JPEG = "JPEG"
     TIFF = "TIFF"
+    PNG = "PNG"
+
+
+class ExportPresetOutputMode(StrEnum):
+    SUBFOLDER_OF_SOURCE = "subfolder_of_source"
+    SAME_AS_SOURCE = "same_as_source"
+    ABSOLUTE = "absolute"
 
 
 class ExportResolutionMode(StrEnum):
@@ -94,6 +102,68 @@ class ExportConfig:
     same_as_source: bool = False
     icc_input_path: Optional[str] = None
     icc_output_path: Optional[str] = None
+
+
+@dataclass
+class ExportPreset:
+    """
+    A single export preset defining format, sizing, destination, and color settings.
+    Field names for sizing/color match ExportConfig so PrintService can accept either.
+    """
+
+    id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    name: str = "Untitled Preset"
+    enabled: bool = True
+
+    # Format
+    export_fmt: str = ExportFormat.JPEG
+    jpeg_quality: int = 90
+
+    # Sizing (same field names as ExportConfig for PrintService compatibility)
+    export_resolution_mode: str = ExportResolutionMode.ORIGINAL.value
+    paper_aspect_ratio: str = AspectRatio.ORIGINAL
+    export_print_size: float = 30.0
+    export_dpi: int = 300
+    export_target_long_edge_px: int = 2000
+
+    # Output destination
+    output_mode: str = ExportPresetOutputMode.SAME_AS_SOURCE
+    output_subfolder: str = ""
+    output_path: str = ""
+    overwrite: bool = True
+    filename_pattern: str = "{{ original_name }}"
+
+    # Color
+    export_color_space: str = ColorSpace.ADOBE_RGB.value
+    icc_input_path: Optional[str] = None
+    icc_output_path: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.id,
+            "name": self.name,
+            "enabled": self.enabled,
+            "export_fmt": self.export_fmt,
+            "jpeg_quality": self.jpeg_quality,
+            "export_resolution_mode": self.export_resolution_mode,
+            "paper_aspect_ratio": self.paper_aspect_ratio,
+            "export_print_size": self.export_print_size,
+            "export_dpi": self.export_dpi,
+            "export_target_long_edge_px": self.export_target_long_edge_px,
+            "output_mode": self.output_mode,
+            "output_subfolder": self.output_subfolder,
+            "output_path": self.output_path,
+            "overwrite": self.overwrite,
+            "filename_pattern": self.filename_pattern,
+            "export_color_space": self.export_color_space,
+            "icc_input_path": self.icc_input_path,
+            "icc_output_path": self.icc_output_path,
+        }
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> "ExportPreset":
+        known = cls.__dataclass_fields__.keys()
+        return cls(**{k: v for k, v in d.items() if k in known})
 
 
 @dataclass(frozen=True)

--- a/negpy/infrastructure/storage/repository.py
+++ b/negpy/infrastructure/storage/repository.py
@@ -1,8 +1,8 @@
 import sqlite3
 import json
 import os
-from typing import Any, Optional
-from negpy.domain.models import WorkspaceConfig
+from typing import Any, List, Optional
+from negpy.domain.models import ExportPreset, WorkspaceConfig
 from negpy.domain.interfaces import IRepository
 
 
@@ -187,3 +187,27 @@ class StorageRepository(IRepository):
             if row:
                 return json.loads(row[0])
         return default
+
+    def save_export_presets(self, presets: List[ExportPreset]) -> None:
+        self.save_global_setting("export_presets", [p.to_dict() for p in presets])
+
+    def load_export_presets(self) -> List[ExportPreset]:
+        from negpy.domain.models import ExportFormat, ExportResolutionMode
+
+        raw = self.get_global_setting("export_presets", default=None)
+        if raw is None:
+            return [
+                ExportPreset(name="JPEG", enabled=True, export_fmt=ExportFormat.JPEG, jpeg_quality=90,
+                             export_resolution_mode=ExportResolutionMode.ORIGINAL.value),
+                ExportPreset(name="TIFF", enabled=False, export_fmt=ExportFormat.TIFF,
+                             export_resolution_mode=ExportResolutionMode.ORIGINAL.value),
+                ExportPreset(name="PNG", enabled=False, export_fmt=ExportFormat.PNG,
+                             export_resolution_mode=ExportResolutionMode.ORIGINAL.value),
+            ]
+        result = []
+        for d in raw:
+            try:
+                result.append(ExportPreset.from_dict(d))
+            except Exception:
+                pass
+        return result

--- a/negpy/services/export/templating.py
+++ b/negpy/services/export/templating.py
@@ -1,13 +1,14 @@
 import os
 import re
 from datetime import datetime
+from typing import Union
 from jinja2 import Template
-from negpy.domain.models import ExportConfig, ExportResolutionMode
+from negpy.domain.models import ExportConfig, ExportPreset, ExportResolutionMode
 
 
 def render_export_filename(
     original_path: str,
-    export_settings: ExportConfig,
+    export_settings: Union[ExportConfig, ExportPreset],
     border_size: float = 0.0,
 ) -> str:
     """

--- a/negpy/services/rendering/image_processor.py
+++ b/negpy/services/rendering/image_processor.py
@@ -129,7 +129,7 @@ class ImageProcessor:
         self,
         file_path: str,
         params: WorkspaceConfig,
-        export_settings: ExportConfig,
+        export_settings,  # ExportConfig or ExportPreset
         source_hash: str,
         metrics: Optional[Dict[str, Any]] = None,
         prefer_gpu: bool = True,
@@ -195,14 +195,14 @@ class ImageProcessor:
                 self.engine_cpu.cache.clear()
 
             is_greyscale = color_space == ColorSpace.GREYSCALE.value
-            is_tiff = export_settings.export_fmt != ExportFormat.JPEG
+            fmt = export_settings.export_fmt
 
             # Input ICC overrides the source, output ICC the destination; both always
             # applied so the file matches the preview.
             icc_input = export_settings.icc_input_path
             icc_output = export_settings.icc_output_path
 
-            if is_tiff:
+            if fmt == ExportFormat.TIFF:
                 img_out_f32 = buffer
                 img_int = (
                     float_to_uint_luma(np.ascontiguousarray(img_out_f32), bit_depth=16) if is_greyscale else float_to_uint16(img_out_f32)
@@ -234,6 +234,25 @@ class ImageProcessor:
                     compression="lzw",
                 )
                 return output_buf.getvalue(), "tiff"
+            elif fmt == ExportFormat.PNG:
+                img_int = (
+                    float_to_uint_luma(np.ascontiguousarray(buffer), bit_depth=16) if is_greyscale else float_to_uint16(buffer)
+                )
+                if is_greyscale:
+                    img_out, icc_bytes = self._apply_color_management_u16_greyscale(
+                        img_int, working_color_space, color_space, icc_output, icc_input
+                    )
+                else:
+                    img_out, icc_bytes = self._apply_color_management_u16_rgb(
+                        img_int, working_color_space, color_space, icc_output, icc_input
+                    )
+                pil_img = Image.fromarray(img_out)
+                output_buf = io.BytesIO()
+                save_kwargs: Dict[str, Any] = {"format": "PNG", "compress_level": 6}
+                if icc_bytes:
+                    save_kwargs["icc_profile"] = icc_bytes
+                pil_img.save(output_buf, **save_kwargs)
+                return output_buf.getvalue(), "png"
             else:
                 img_int = float_to_uint_luma(np.ascontiguousarray(buffer), bit_depth=8) if is_greyscale else float_to_uint8(buffer)
 
@@ -475,15 +494,16 @@ class ImageProcessor:
         self,
         pil_img: Image.Image,
         buf: io.BytesIO,
-        export_settings: ExportConfig,
+        export_settings,
         icc_bytes: Optional[bytes],
     ) -> None:
         """Encodes PIL image to byte stream."""
         fmt = "JPEG" if export_settings.export_fmt == ExportFormat.JPEG else "TIFF"
+        quality = getattr(export_settings, "jpeg_quality", 95)
         pil_img.save(
             buf,
             format=fmt,
-            quality=95,
+            quality=quality,
             subsampling=0,
             dpi=(export_settings.export_dpi, export_settings.export_dpi),
             icc_profile=icc_bytes,

--- a/tests/test_export_presets.py
+++ b/tests/test_export_presets.py
@@ -1,0 +1,212 @@
+"""Tests for export preset serialization, persistence, and worker path resolution."""
+import os
+import uuid
+import pytest
+
+from negpy.domain.models import (
+    ExportFormat,
+    ExportPreset,
+    ExportPresetOutputMode,
+    ExportResolutionMode,
+    AspectRatio,
+    ColorSpace,
+)
+from negpy.infrastructure.storage.repository import StorageRepository
+
+
+# ---------------------------------------------------------------------------
+# ExportPreset serialization
+# ---------------------------------------------------------------------------
+
+def _make_preset(**kwargs) -> ExportPreset:
+    defaults = dict(
+        id=str(uuid.uuid4()),
+        name="Test Preset",
+        enabled=True,
+        export_fmt=ExportFormat.TIFF,
+        jpeg_quality=90,
+        export_resolution_mode=ExportResolutionMode.ORIGINAL.value,
+        paper_aspect_ratio=AspectRatio.ORIGINAL,
+        export_print_size=30.0,
+        export_dpi=300,
+        export_target_long_edge_px=2000,
+        output_mode=ExportPresetOutputMode.SAME_AS_SOURCE,
+        output_subfolder="",
+        output_path="",
+        overwrite=True,
+        filename_pattern="{{ original_name }}",
+        export_color_space=ColorSpace.ADOBE_RGB.value,
+        icc_input_path=None,
+        icc_output_path=None,
+    )
+    defaults.update(kwargs)
+    return ExportPreset(**defaults)
+
+
+def test_preset_round_trip_tiff():
+    p = _make_preset(name="TIFF Archive", export_fmt=ExportFormat.TIFF)
+    p2 = ExportPreset.from_dict(p.to_dict())
+    assert p2.name == "TIFF Archive"
+    assert p2.export_fmt == ExportFormat.TIFF
+    assert p2.id == p.id
+
+
+def test_preset_round_trip_jpeg():
+    p = _make_preset(name="JPEG Preview", export_fmt=ExportFormat.JPEG, jpeg_quality=75)
+    p2 = ExportPreset.from_dict(p.to_dict())
+    assert p2.export_fmt == ExportFormat.JPEG
+    assert p2.jpeg_quality == 75
+
+
+def test_preset_round_trip_png():
+    p = _make_preset(name="PNG Full Size", export_fmt=ExportFormat.PNG)
+    p2 = ExportPreset.from_dict(p.to_dict())
+    assert p2.export_fmt == ExportFormat.PNG
+
+
+def test_preset_subfolder_of_source():
+    p = _make_preset(
+        output_mode=ExportPresetOutputMode.SUBFOLDER_OF_SOURCE,
+        output_subfolder="TIFF",
+    )
+    p2 = ExportPreset.from_dict(p.to_dict())
+    assert p2.output_mode == ExportPresetOutputMode.SUBFOLDER_OF_SOURCE
+    assert p2.output_subfolder == "TIFF"
+
+
+def test_preset_absolute_path():
+    p = _make_preset(
+        output_mode=ExportPresetOutputMode.ABSOLUTE,
+        output_path="/some/export/path",
+    )
+    p2 = ExportPreset.from_dict(p.to_dict())
+    assert p2.output_mode == ExportPresetOutputMode.ABSOLUTE
+    assert p2.output_path == "/some/export/path"
+
+
+def test_preset_unknown_keys_dropped():
+    d = _make_preset().to_dict()
+    d["unknown_future_field"] = "should be ignored"
+    p = ExportPreset.from_dict(d)
+    assert not hasattr(p, "unknown_future_field")
+
+
+# ---------------------------------------------------------------------------
+# ExportFormat enum
+# ---------------------------------------------------------------------------
+
+def test_export_format_png_exists():
+    assert ExportFormat.PNG == "PNG"
+    assert ExportFormat.TIFF == "TIFF"
+    assert ExportFormat.JPEG == "JPEG"
+
+
+# ---------------------------------------------------------------------------
+# Output path resolution (mirroring worker logic)
+# ---------------------------------------------------------------------------
+
+def _resolve_output_dir(preset: ExportPreset, source_path: str) -> str:
+    source_dir = os.path.dirname(source_path)
+    if preset.output_mode == ExportPresetOutputMode.SUBFOLDER_OF_SOURCE:
+        subfolder = preset.output_subfolder or ""
+        return os.path.join(source_dir, subfolder) if subfolder else source_dir
+    elif preset.output_mode == ExportPresetOutputMode.ABSOLUTE:
+        return preset.output_path or source_dir
+    else:
+        return source_dir
+
+
+def test_output_dir_same_as_source():
+    p = _make_preset(output_mode=ExportPresetOutputMode.SAME_AS_SOURCE)
+    source = "/photos/roll/IMG_001.RAF"
+    assert _resolve_output_dir(p, source) == "/photos/roll"
+
+
+def test_output_dir_subfolder_of_source():
+    p = _make_preset(
+        output_mode=ExportPresetOutputMode.SUBFOLDER_OF_SOURCE,
+        output_subfolder="TIFF",
+    )
+    source = "/photos/roll/IMG_001.RAF"
+    assert _resolve_output_dir(p, source) == "/photos/roll/TIFF"
+
+
+def test_output_dir_subfolder_empty_falls_back_to_source():
+    p = _make_preset(
+        output_mode=ExportPresetOutputMode.SUBFOLDER_OF_SOURCE,
+        output_subfolder="",
+    )
+    source = "/photos/roll/IMG_001.RAF"
+    assert _resolve_output_dir(p, source) == "/photos/roll"
+
+
+def test_output_dir_absolute():
+    p = _make_preset(
+        output_mode=ExportPresetOutputMode.ABSOLUTE,
+        output_path="/mnt/export/archive",
+    )
+    source = "/photos/roll/IMG_001.RAF"
+    assert _resolve_output_dir(p, source) == "/mnt/export/archive"
+
+
+# ---------------------------------------------------------------------------
+# Extension mapping
+# ---------------------------------------------------------------------------
+
+_EXT_MAP = {ExportFormat.JPEG: "jpg", ExportFormat.TIFF: "tiff", ExportFormat.PNG: "png"}
+
+
+def test_extension_jpeg():
+    assert _EXT_MAP[ExportFormat.JPEG] == "jpg"
+
+
+def test_extension_tiff():
+    assert _EXT_MAP[ExportFormat.TIFF] == "tiff"
+
+
+def test_extension_png():
+    assert _EXT_MAP[ExportFormat.PNG] == "png"
+
+
+# ---------------------------------------------------------------------------
+# Repository persistence
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def repo(tmp_path):
+    edits_db = str(tmp_path / "edits.db")
+    settings_db = str(tmp_path / "settings.db")
+    r = StorageRepository(edits_db, settings_db)
+    r.initialize()
+    return r
+
+
+def test_save_and_load_presets(repo):
+    presets = [
+        _make_preset(name="TIFF Archive", export_fmt=ExportFormat.TIFF),
+        _make_preset(name="PNG Preview", export_fmt=ExportFormat.PNG, enabled=False),
+    ]
+    repo.save_export_presets(presets)
+    loaded = repo.load_export_presets()
+    assert len(loaded) == 2
+    assert loaded[0].name == "TIFF Archive"
+    assert loaded[0].export_fmt == ExportFormat.TIFF
+    assert loaded[1].name == "PNG Preview"
+    assert loaded[1].enabled is False
+
+
+def test_load_presets_empty(repo):
+    assert repo.load_export_presets() == []
+
+
+def test_save_empty_presets_clears(repo):
+    repo.save_export_presets([_make_preset(name="Old")])
+    repo.save_export_presets([])
+    assert repo.load_export_presets() == []
+
+
+def test_preset_order_preserved(repo):
+    presets = [_make_preset(name=f"Preset {i}") for i in range(5)]
+    repo.save_export_presets(presets)
+    loaded = repo.load_export_presets()
+    assert [p.name for p in loaded] == [f"Preset {i}" for i in range(5)]


### PR DESCRIPTION
re: https://github.com/marcinz606/NegPy/issues/250
## Summary
- Adds `ExportPreset` model with per-preset format, sizing, output destination, and color space settings
- New `ExportPresetsDialog` for managing presets (add, duplicate, delete, reorder)
- Export sidebar now shows preset list with per-preset enable/disable toggles
- New installations pre-populated with JPEG (enabled), TIFF, and PNG (disabled) defaults
- Batch export dispatches one job per enabled preset per file

## Test plan
- [ ] Fresh install shows JPEG/TIFF/PNG defaults with JPEG checked
- [ ] Opening Manage Presets dialog shows all three defaults
- [ ] Adding, duplicating, deleting, and reordering presets persists across restarts
- [ ] Toggling a preset enabled state persists across restarts
- [ ] Batch export produces one output file per enabled preset
- [ ] Absolute output path presets prompt for a folder if none is set