### PR TITLE
fix: filmstrip trackpad scroll sensitivity

### DIFF
--- a/negpy/desktop/view/sidebar/files.py
+++ b/negpy/desktop/view/sidebar/files.py
@@ -118,6 +118,14 @@ class ThumbnailGridView(QListView):
         super().resizeEvent(event)
         self._relayout()
 
+    def wheelEvent(self, event) -> None:
+        pixel = event.pixelDelta()
+        if not pixel.isNull() and pixel.y() != 0:
+            self.verticalScrollBar().setValue(self.verticalScrollBar().value() - pixel.y())
+            event.accept()
+        else:
+            super().wheelEvent(event)
+
 
 class FileBrowser(QWidget):
     """


### PR DESCRIPTION
re: https://github.com/marcinz606/NegPy/issues/248
## Summary

- Two-finger trackpad scrolling in the left-side filmstrip view was much faster than native scroll views
- Root cause: Qt's default `QAbstractScrollArea.wheelEvent` ignores `pixelDelta` and converts `angleDelta` using its own fixed step size, producing scroll distances far larger than the actual finger movement
- Fix: override `wheelEvent` in `ThumbnailGridView` to scroll by `pixelDelta` directly when available (macOS trackpad), falling back to `super().wheelEvent` for regular mouse wheels

## Test plan

- [ ] Two-finger scroll in the filmstrip — speed should feel natural and match other native scroll views
- [ ] Scroll bar dragging should be unaffected
- [ ] Mouse wheel scrolling should still work normally
- [ ] Momentum scrolling (lift fingers mid-swipe) should coast naturally