### PR TITLE
refactor: share export form between sidebar and presets dialog

### DIFF
--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -1064,7 +1064,7 @@ class AppController(QObject):
         Returns the valid path or None if the user cancelled.
         """
         export_path = self.state.config.export.export_path
-        if self.state.config.export.same_as_source:
+        if self.state.config.export.output_mode == ExportPresetOutputMode.SAME_AS_SOURCE:
             return export_path  # path irrelevant when exporting to source folder
         if export_path.strip().lower() in ["export", "/export", ""]:
             from PyQt6.QtWidgets import QFileDialog
@@ -1236,7 +1236,7 @@ class AppController(QObject):
         if not visible_files:
             return
 
-        if self.state.config.export.same_as_source:
+        if self.state.config.export.output_mode == ExportPresetOutputMode.SAME_AS_SOURCE:
             out_dir = os.path.dirname(visible_files[0]["path"])
         else:
             resolved = self._ensure_valid_export_path()

--- a/negpy/desktop/view/sidebar/export.py
+++ b/negpy/desktop/view/sidebar/export.py
@@ -1,15 +1,10 @@
-import os
-
 import qtawesome as qta
 from PyQt6.QtCore import Qt, QTimer
 from PyQt6.QtWidgets import (
-    QButtonGroup,
     QCheckBox,
     QComboBox,
-    QDoubleSpinBox,
     QHBoxLayout,
     QLabel,
-    QLineEdit,
     QPushButton,
     QScrollArea,
     QSpinBox,
@@ -21,9 +16,8 @@ from negpy.desktop.view.sidebar.base import BaseSidebar
 from negpy.desktop.view.styles.templates import section_subheader
 from negpy.desktop.view.styles.theme import THEME
 from negpy.desktop.view.widgets.collapsible import CollapsibleSection
-from negpy.domain.models import AspectRatio, ColorSpace, ExportFormat, ExportResolutionMode
-from negpy.infrastructure.display.color_mgmt import ColorService
-from negpy.infrastructure.display.color_spaces import ColorSpaceRegistry
+from negpy.desktop.view.widgets.export_settings_form import ExportSettingsForm
+from negpy.domain.models import ColorSpace
 
 
 class ExportSidebar(BaseSidebar):
@@ -31,16 +25,8 @@ class ExportSidebar(BaseSidebar):
     Panel for export settings, presets and batch processing.
     """
 
-    @staticmethod
-    def _icc_row_label(text: str) -> QLabel:
-        """Fixed-width row label so the ICC-section dropdowns line up."""
-        label = QLabel(text)
-        label.setFixedWidth(52)
-        return label
-
     def _init_ui(self) -> None:
         self.layout.setSpacing(10)
-        conf = self.state.config.export
 
         self.update_timer = QTimer()
         self.update_timer.setSingleShot(True)
@@ -50,226 +36,24 @@ class ExportSidebar(BaseSidebar):
         self._add_presets_section()
         self._add_contact_sheet_section()
 
-        self.layout.addWidget(section_subheader("ICC"))
+        # Shared FORMAT / SIZE / COLOR / DESTINATION rows.
+        self.form = ExportSettingsForm()
+        self.form.load(self._config_to_form_values())
+        self.layout.addWidget(self.form)
 
-        # Soft proof: when off, Output/Input ICC affect export only (preview = the edit
-        # on the monitor); when on, the preview simulates the Output profile.
-        self.soft_proof_checkbox = QCheckBox("Soft proof")
-        self.soft_proof_checkbox.setChecked(self.state.soft_proof_enabled)
-        self.soft_proof_checkbox.setToolTip("Simulate the Output profile (incl. paper/printer) in the preview")
-        self.layout.addWidget(self.soft_proof_checkbox)
-
-        # Drop bundled profiles that already back a color-space enum (e.g.
-        # AdobeCompat-v4.icc ↔ "Adobe RGB") so the Output list isn't duplicated.
-        enum_mapped = {ColorSpaceRegistry.get_icc_path(cs.value) for cs in ColorSpace}
-        enum_mapped.discard(None)
-        custom_profiles = [p for p in ColorService.get_available_profiles() if p not in enum_mapped]
-
-        # Input: source profile correction.
-        self.input_profiles = ["None"] + custom_profiles
-        self.input_combo = QComboBox()
-        self.input_combo.addItems([os.path.basename(p) for p in self.input_profiles])
-        self.input_combo.setToolTip("Source/input ICC profile — soft-proofed in the preview")
-        in_path = self.state.icc_input_path
-        self.input_combo.setCurrentText(os.path.basename(in_path) if in_path else "None")
-        in_row = QHBoxLayout()
-        in_row.addWidget(self._icc_row_label("Input"))
-        in_row.addWidget(self.input_combo)
-        self.layout.addLayout(in_row)
-
-        # Output: one selector for a color space (→ export_color_space) or a custom
-        # ICC profile (→ icc_output_path).
-        self.output_spaces = [cs.value for cs in ColorSpace]
-        self.output_profiles = custom_profiles
-        self.output_map = list(self.output_spaces) + list(self.output_profiles)
-        self.output_combo = QComboBox()
-        self.output_combo.addItems(self.output_spaces + [os.path.basename(p) for p in self.output_profiles])
-        self.output_combo.setToolTip("Output color space or custom ICC profile — soft-proofed in the preview")
-        out_path = self.state.icc_output_path
-        self.output_combo.setCurrentText(os.path.basename(out_path) if out_path else conf.export_color_space)
-        out_row = QHBoxLayout()
-        out_row.addWidget(self._icc_row_label("Output"))
-        out_row.addWidget(self.output_combo)
-        self.layout.addLayout(out_row)
-
-        # Display: monitor profile the preview is shown on (preview only, not export).
-        self.display_spaces = [
-            ColorSpace.SRGB.value,
-            ColorSpace.P3_D65.value,
-            ColorSpace.ADOBE_RGB.value,
-            ColorSpace.REC2020.value,
-            ColorSpace.PROPHOTO.value,
-        ]
-        self.display_map = [None] + self.display_spaces
-        self.display_combo = QComboBox()
-        self.display_combo.addItems(["As detected"] + self.display_spaces)
-        self.display_combo.setToolTip("Monitor profile the preview is displayed on (affects preview only, not export)")
-        override = self.state.monitor_profile_override
-        self.display_combo.setCurrentText(override if override in self.display_spaces else "As detected")
-        disp_row = QHBoxLayout()
-        disp_row.addWidget(self._icc_row_label("Display"))
-        disp_row.addWidget(self.display_combo)
-        self.layout.addLayout(disp_row)
-
-        self.display_detected_label = QLabel()
-        self.display_detected_label.setStyleSheet(f"color: {THEME.text_muted}; font-size: 10px;")
-        self.layout.addWidget(self.display_detected_label)
-        self._refresh_display_info()
-
-        self.layout.addWidget(section_subheader("FORMAT"))
-
-        fmt_row = QHBoxLayout()
-        self.fmt_combo = QComboBox()
-        self.fmt_combo.addItems([f.value for f in ExportFormat])
-        self.fmt_combo.setCurrentText(conf.export_fmt)
-        self.fmt_combo.setToolTip("File format")
-        self.ratio_combo = QComboBox()
-        ratios = [AspectRatio.ORIGINAL] + [r.value for r in AspectRatio if r != AspectRatio.ORIGINAL]
-        self.ratio_combo.addItems(ratios)
-        self.ratio_combo.setCurrentText(conf.paper_aspect_ratio)
-        self.ratio_combo.setToolTip("Paper aspect ratio")
-        fmt_row.addWidget(self.fmt_combo)
-        fmt_row.addWidget(self.ratio_combo)
-        self.layout.addLayout(fmt_row)
-
-        self.layout.addWidget(section_subheader("SIZE"))
-
-        mode_row = QHBoxLayout()
-        mode_row.setSpacing(4)
-        self.mode_original_btn = QPushButton("Original")
-        self.mode_print_btn = QPushButton("Print")
-        self.mode_target_px_btn = QPushButton("Pixels")
-        btn_style = f"font-size: {THEME.font_size_base}px; padding: 8px;"
-        for btn in (self.mode_original_btn, self.mode_print_btn, self.mode_target_px_btn):
-            btn.setCheckable(True)
-            btn.setStyleSheet(btn_style)
-            mode_row.addWidget(btn)
-        self.mode_btn_group = QButtonGroup(self)
-        self.mode_btn_group.setExclusive(True)
-        self.mode_btn_group.addButton(self.mode_original_btn, 0)
-        self.mode_btn_group.addButton(self.mode_print_btn, 1)
-        self.mode_btn_group.addButton(self.mode_target_px_btn, 2)
-        self.layout.addLayout(mode_row)
-
-        # PRINT mode: cm + DPI
-        self.print_size_container = QWidget()
-        print_layout = QVBoxLayout(self.print_size_container)
-        print_layout.setContentsMargins(0, 0, 0, 0)
-        print_row = QHBoxLayout()
-
-        vbox_size = QVBoxLayout()
-        size_label = QLabel('Size <span style="color: #666666; font-size: 10px;">cm</span>')
-        vbox_size.addWidget(size_label)
-        self.size_input = QDoubleSpinBox()
-        self.size_input.setRange(1.0, 500.0)
-        self.size_input.setValue(conf.export_print_size)
-        vbox_size.addWidget(self.size_input)
-
-        vbox_dpi = QVBoxLayout()
-        vbox_dpi.addWidget(QLabel("DPI"))
-        self.dpi_input = QSpinBox()
-        self.dpi_input.setRange(72, 4800)
-        self.dpi_input.setValue(conf.export_dpi)
-        vbox_dpi.addWidget(self.dpi_input)
-
-        print_row.addLayout(vbox_size)
-        print_row.addLayout(vbox_dpi)
-        print_layout.addLayout(print_row)
-        self.layout.addWidget(self.print_size_container)
-
-        # TARGET_PX mode: long edge in pixels
-        self.target_px_container = QWidget()
-        target_px_layout = QVBoxLayout(self.target_px_container)
-        target_px_layout.setContentsMargins(0, 0, 0, 0)
-        target_px_layout.addWidget(QLabel('Long edge <span style="color: #666666; font-size: 10px;">px</span>'))
-        self.target_px_input = QSpinBox()
-        self.target_px_input.setRange(256, 32768)
-        self.target_px_input.setValue(conf.export_target_long_edge_px)
-        target_px_layout.addWidget(self.target_px_input)
-        self.layout.addWidget(self.target_px_container)
-
-        self._select_mode_button(conf.export_resolution_mode)
-        self._update_mode_visibility(conf.export_resolution_mode)
-
-        self.layout.addWidget(section_subheader("DESTINATION"))
-
-        self.pattern_input = QLineEdit(conf.filename_pattern)
-        self.pattern_input.setPlaceholderText("Filename Pattern...")
-        self.pattern_input.setToolTip(
-            "Jinja2 Template. Available variables:\n"
-            "- {{ original_name }}\n"
-            "- {{ colorspace }}\n"
-            "- {{ format }} (JPEG/TIFF/PNG)\n"
-            "- {{ paper_ratio }}\n"
-            "- {{ size }} (e.g. 20cm; PRINT mode only)\n"
-            "- {{ dpi }} (PRINT mode only)\n"
-            "- {{ target_px }} (e.g. 2000px; TARGET_PX mode only)\n"
-            "- {{ border }} ('border' or empty)\n"
-            "- {{ date }} (YYYYMMDD)"
-        )
-        self.layout.addWidget(self.pattern_input)
-
-        checkbox_row = QHBoxLayout()
-        self.overwrite_checkbox = QCheckBox("Overwrite existing files")
-        self.overwrite_checkbox.setChecked(conf.overwrite)
-        self.same_as_source_checkbox = QCheckBox("Same folder as source")
-        self.same_as_source_checkbox.setChecked(conf.same_as_source)
-        checkbox_row.addWidget(self.overwrite_checkbox)
-        checkbox_row.addWidget(self.same_as_source_checkbox)
-        self.layout.addLayout(checkbox_row)
-
-        path_layout = QHBoxLayout()
-        self.path_input = QLineEdit(conf.export_path)
-        self.path_input.setToolTip("Export folder")
-        self.path_input.setDisabled(conf.same_as_source)
-        self.browse_btn = QPushButton()
-        self.browse_btn.setIcon(qta.icon("fa5s.folder-open", color=THEME.text_primary))
-        self.browse_btn.setFixedWidth(40)
-        self.browse_btn.setToolTip("Choose export folder")
-        self.browse_btn.setDisabled(conf.same_as_source)
-        path_layout.addWidget(self.path_input)
-        path_layout.addWidget(self.browse_btn)
-        self.layout.addLayout(path_layout)
-
-        self.layout.addWidget(section_subheader("BATCH"))
-
-        self.apply_all_btn = QPushButton(" Sync export settings")
-        self.apply_all_btn.setFixedHeight(40)
-        self.apply_all_btn.setCheckable(True)
-        self.apply_all_btn.setChecked(True)
-        self.apply_all_btn.setToolTip("Apply current export settings (Size, DPI, Border) to all files")
-        self._update_apply_all_style(True)
-        self.layout.addWidget(self.apply_all_btn)
-
-        self.batch_export_btn = QPushButton(" Export All")
-        self.batch_export_btn.setObjectName("batch_export_btn")
-        self.batch_export_btn.setFixedHeight(40)
-        self.batch_export_btn.setIcon(qta.icon("fa5s.images", color=THEME.text_primary))
-        self.layout.addWidget(self.batch_export_btn)
+        self._add_preview_section()
+        self._add_batch_section()
 
         self.layout.addStretch()
 
         self._rebuild_preset_rows()
 
     def _connect_signals(self) -> None:
+        self.form.changed.connect(self.update_timer.start)
+
         self.soft_proof_checkbox.toggled.connect(self.controller.set_soft_proof)
-        self.input_combo.currentIndexChanged.connect(self._on_input_changed)
-        self.output_combo.currentIndexChanged.connect(self._on_output_changed)
         self.display_combo.currentIndexChanged.connect(self._on_display_changed)
         self.controller.monitor_profile_changed.connect(self._refresh_display_info)
-
-        self.fmt_combo.currentTextChanged.connect(lambda _: self.update_timer.start())
-        self.ratio_combo.currentTextChanged.connect(lambda _: self.update_timer.start())
-        self.mode_btn_group.idToggled.connect(self._on_mode_toggled)
-        self.size_input.valueChanged.connect(lambda _: self.update_timer.start())
-        self.dpi_input.valueChanged.connect(lambda _: self.update_timer.start())
-        self.target_px_input.valueChanged.connect(lambda _: self.update_timer.start())
-
-        self.browse_btn.clicked.connect(self._on_browse_clicked)
-        self.pattern_input.textChanged.connect(lambda _: self.update_timer.start())
-        self.path_input.textChanged.connect(lambda _: self.update_timer.start())
-        self.overwrite_checkbox.stateChanged.connect(lambda _: self.update_timer.start())
-        self.same_as_source_checkbox.stateChanged.connect(self._on_same_as_source_toggled)
 
         self.manage_presets_btn.clicked.connect(self._open_presets_dialog)
         self.export_presets_btn.clicked.connect(self.controller.request_preset_export)
@@ -368,6 +152,63 @@ class ExportSidebar(BaseSidebar):
         section.expanded_changed.connect(lambda checked: repo.save_global_setting("section_expanded_contact_sheet", checked))
         self.layout.addWidget(section)
 
+    # --- Preview (soft proof + monitor profile, preview only) ----------------
+
+    def _add_preview_section(self) -> None:
+        self.layout.addWidget(section_subheader("PREVIEW"))
+
+        # Soft proof: when on, the preview simulates the Output profile (incl.
+        # paper/printer); when off, Output/Input ICC affect export only.
+        self.soft_proof_checkbox = QCheckBox("Soft proof")
+        self.soft_proof_checkbox.setChecked(self.state.soft_proof_enabled)
+        self.soft_proof_checkbox.setToolTip("Simulate the Output profile (incl. paper/printer) in the preview")
+        self.layout.addWidget(self.soft_proof_checkbox)
+
+        # Display: monitor profile the preview is shown on (preview only, not export).
+        self.display_spaces = [
+            ColorSpace.SRGB.value,
+            ColorSpace.P3_D65.value,
+            ColorSpace.ADOBE_RGB.value,
+            ColorSpace.REC2020.value,
+            ColorSpace.PROPHOTO.value,
+        ]
+        self.display_map = [None] + self.display_spaces
+        self.display_combo = QComboBox()
+        self.display_combo.addItems(["As detected"] + self.display_spaces)
+        self.display_combo.setToolTip("Monitor profile the preview is displayed on (affects preview only, not export)")
+        override = self.state.monitor_profile_override
+        self.display_combo.setCurrentText(override if override in self.display_spaces else "As detected")
+        disp_row = QHBoxLayout()
+        disp_label = QLabel("Display")
+        disp_label.setFixedWidth(52)
+        disp_row.addWidget(disp_label)
+        disp_row.addWidget(self.display_combo)
+        self.layout.addLayout(disp_row)
+
+        self.display_detected_label = QLabel()
+        self.display_detected_label.setStyleSheet(f"color: {THEME.text_muted}; font-size: 10px;")
+        self.layout.addWidget(self.display_detected_label)
+        self._refresh_display_info()
+
+    # --- Batch ---------------------------------------------------------------
+
+    def _add_batch_section(self) -> None:
+        self.layout.addWidget(section_subheader("BATCH"))
+
+        self.apply_all_btn = QPushButton(" Sync export settings")
+        self.apply_all_btn.setFixedHeight(40)
+        self.apply_all_btn.setCheckable(True)
+        self.apply_all_btn.setChecked(True)
+        self.apply_all_btn.setToolTip("Apply current export settings (Size, DPI, Border) to all files")
+        self._update_apply_all_style(True)
+        self.layout.addWidget(self.apply_all_btn)
+
+        self.batch_export_btn = QPushButton(" Export All")
+        self.batch_export_btn.setObjectName("batch_export_btn")
+        self.batch_export_btn.setFixedHeight(40)
+        self.batch_export_btn.setIcon(qta.icon("fa5s.images", color=THEME.text_primary))
+        self.layout.addWidget(self.batch_export_btn)
+
     def _rebuild_preset_rows(self) -> None:
         """Rebuild the preset checkbox list from state."""
         for cb in self._preset_checkboxes:
@@ -425,47 +266,58 @@ class ExportSidebar(BaseSidebar):
             self.apply_all_btn.setStyleSheet("font-weight: bold;")
             self.apply_all_btn.setIcon(qta.icon("fa5s.clone", color=THEME.text_primary))
 
+    def _config_to_form_values(self) -> dict:
+        """Build the form's value dict from the export config + ICC AppState."""
+        conf = self.state.config.export
+        return {
+            "export_fmt": conf.export_fmt,
+            "jpeg_quality": conf.jpeg_quality,
+            "export_resolution_mode": conf.export_resolution_mode,
+            "paper_aspect_ratio": conf.paper_aspect_ratio,
+            "export_print_size": conf.export_print_size,
+            "export_dpi": conf.export_dpi,
+            "export_target_long_edge_px": conf.export_target_long_edge_px,
+            "output_mode": conf.output_mode,
+            "output_subfolder": conf.output_subfolder,
+            "output_path": conf.export_path,
+            "filename_pattern": conf.filename_pattern,
+            "overwrite": conf.overwrite,
+            "export_color_space": conf.export_color_space,
+            "icc_input_path": self.state.icc_input_path,
+            "icc_output_path": self.state.icc_output_path,
+        }
+
     def _persist_all_export_settings(self) -> None:
         """Collects all UI values and performs a single debounced config update."""
+        vals = self.form.values()
+
+        # ICC paths live in AppState (injected at export time), not the config.
+        self.state.icc_input_path = vals["icc_input_path"]
+        self.state.icc_output_path = vals["icc_output_path"]
+        self.controller.session.save_icc_prefs()
+
         self.update_config_section(
             "export",
             persist=True,
             render=True,
-            export_fmt=self.fmt_combo.currentText(),
-            export_color_space=self._current_export_color_space(),
-            paper_aspect_ratio=self.ratio_combo.currentText(),
-            export_resolution_mode=self._current_mode_value(),
-            export_print_size=self.size_input.value(),
-            export_dpi=self.dpi_input.value(),
-            export_target_long_edge_px=self.target_px_input.value(),
-            filename_pattern=self.pattern_input.text(),
-            export_path=self.path_input.text(),
-            overwrite=self.overwrite_checkbox.isChecked(),
-            same_as_source=self.same_as_source_checkbox.isChecked(),
+            export_fmt=vals["export_fmt"],
+            jpeg_quality=vals["jpeg_quality"],
+            export_color_space=vals["export_color_space"],
+            paper_aspect_ratio=vals["paper_aspect_ratio"],
+            export_resolution_mode=vals["export_resolution_mode"],
+            export_print_size=vals["export_print_size"],
+            export_dpi=vals["export_dpi"],
+            export_target_long_edge_px=vals["export_target_long_edge_px"],
+            output_mode=vals["output_mode"],
+            output_subfolder=vals["output_subfolder"],
+            export_path=vals["output_path"],
+            filename_pattern=vals["filename_pattern"],
+            overwrite=vals["overwrite"],
             contact_sheet_cell_px=self.cs_cell_px_input.value(),
             contact_sheet_gap=self.cs_gap_input.value(),
             contact_sheet_margin=self.cs_margin_input.value(),
             contact_sheet_max_tiles=self.cs_max_tiles_input.value(),
         )
-
-    def _on_input_changed(self, index: int) -> None:
-        path = self.input_profiles[index]
-        self.state.icc_input_path = path if path != "None" else None
-        self.controller.session.save_icc_prefs()
-        self.controller.request_render()
-
-    def _on_output_changed(self, index: int) -> None:
-        if index < len(self.output_spaces):
-            # Color space: persist synchronously (not debounced) so this render resolves
-            # the effective output from the new export_color_space.
-            self.state.icc_output_path = None
-            self.controller.session.save_icc_prefs()
-            self._persist_all_export_settings()
-        else:
-            # Custom output profile.
-            self.state.icc_output_path = self.output_map[index]
-            self.controller.session.save_icc_prefs()
-            self.controller.request_render()
 
     def _on_display_changed(self, index: int) -> None:
         self.controller.set_monitor_override(self.display_map[index])
@@ -478,77 +330,15 @@ class ExportSidebar(BaseSidebar):
         self.display_detected_label.setText(f"Detected: {desc}")
         self.display_combo.setItemText(0, f"As detected ({desc})")
 
-    def _current_export_color_space(self) -> str:
-        """Output dropdown value when a standard space is selected; else keep prior."""
-        idx = self.output_combo.currentIndex()
-        if 0 <= idx < len(self.output_spaces):
-            return self.output_map[idx]
-        return self.state.config.export.export_color_space
-
-    _MODE_BY_ID = {
-        0: ExportResolutionMode.ORIGINAL.value,
-        1: ExportResolutionMode.PRINT.value,
-        2: ExportResolutionMode.TARGET_PX.value,
-    }
-    _ID_BY_MODE = {v: k for k, v in _MODE_BY_ID.items()}
-
-    def _current_mode_value(self) -> str:
-        return self._MODE_BY_ID.get(self.mode_btn_group.checkedId(), ExportResolutionMode.PRINT.value)
-
-    def _select_mode_button(self, mode_value: str) -> None:
-        idx = self._ID_BY_MODE.get(mode_value, 1)
-        btn = self.mode_btn_group.button(idx)
-        if btn is not None:
-            btn.setChecked(True)
-
-    def _update_mode_visibility(self, mode_value: str) -> None:
-        self.print_size_container.setVisible(mode_value == ExportResolutionMode.PRINT.value)
-        self.target_px_container.setVisible(mode_value == ExportResolutionMode.TARGET_PX.value)
-
-    def _on_mode_toggled(self, _id: int, checked: bool) -> None:
-        if not checked:
-            return
-        self._update_mode_visibility(self._current_mode_value())
-        self.update_timer.start()
-
-    def _on_same_as_source_toggled(self) -> None:
-        checked = self.same_as_source_checkbox.isChecked()
-        self.path_input.setDisabled(checked)
-        self.browse_btn.setDisabled(checked)
-        self.update_timer.start()
-
-    def _on_browse_clicked(self) -> None:
-        from PyQt6.QtWidgets import QFileDialog
-
-        path = QFileDialog.getExistingDirectory(self, "Select Export Directory", self.state.config.export.export_path)
-        if path:
-            self.path_input.setText(path)
-
     def sync_ui(self) -> None:
         conf = self.state.config.export
         self.block_signals(True)
         try:
+            self.form.load(self._config_to_form_values())
             self.soft_proof_checkbox.setChecked(self.state.soft_proof_enabled)
-            self.fmt_combo.setCurrentText(conf.export_fmt)
-            in_path = self.state.icc_input_path
-            self.input_combo.setCurrentText(os.path.basename(in_path) if in_path else "None")
-            out_path = self.state.icc_output_path
-            self.output_combo.setCurrentText(os.path.basename(out_path) if out_path else conf.export_color_space)
             override = self.state.monitor_profile_override
             self.display_combo.setCurrentText(override if override in self.display_spaces else "As detected")
             self._refresh_display_info()
-            self.ratio_combo.setCurrentText(conf.paper_aspect_ratio)
-            self._select_mode_button(conf.export_resolution_mode)
-            self._update_mode_visibility(conf.export_resolution_mode)
-            self.size_input.setValue(conf.export_print_size)
-            self.dpi_input.setValue(conf.export_dpi)
-            self.target_px_input.setValue(conf.export_target_long_edge_px)
-            self.pattern_input.setText(conf.filename_pattern)
-            self.path_input.setText(conf.export_path)
-            self.overwrite_checkbox.setChecked(conf.overwrite)
-            self.same_as_source_checkbox.setChecked(conf.same_as_source)
-            self.path_input.setDisabled(conf.same_as_source)
-            self.browse_btn.setDisabled(conf.same_as_source)
             self.cs_cell_px_input.setValue(conf.contact_sheet_cell_px)
             self.cs_gap_input.setValue(conf.contact_sheet_gap)
             self.cs_margin_input.setValue(conf.contact_sheet_margin)
@@ -561,21 +351,7 @@ class ExportSidebar(BaseSidebar):
     def block_signals(self, blocked: bool) -> None:
         widgets = [
             self.soft_proof_checkbox,
-            self.fmt_combo,
-            self.input_combo,
-            self.output_combo,
             self.display_combo,
-            self.ratio_combo,
-            self.mode_original_btn,
-            self.mode_print_btn,
-            self.mode_target_px_btn,
-            self.size_input,
-            self.dpi_input,
-            self.target_px_input,
-            self.pattern_input,
-            self.path_input,
-            self.overwrite_checkbox,
-            self.same_as_source_checkbox,
             self.cs_cell_px_input,
             self.cs_gap_input,
             self.cs_margin_input,

--- a/negpy/desktop/view/widgets/export_presets_dialog.py
+++ b/negpy/desktop/view/widgets/export_presets_dialog.py
@@ -1,15 +1,10 @@
-import os
 import uuid
 
 import qtawesome as qta
 from PyQt6.QtCore import Qt, pyqtSignal
 from PyQt6.QtWidgets import (
-    QButtonGroup,
     QCheckBox,
-    QComboBox,
     QDialog,
-    QDoubleSpinBox,
-    QFileDialog,
     QHBoxLayout,
     QLabel,
     QLineEdit,
@@ -17,22 +12,13 @@ from PyQt6.QtWidgets import (
     QListWidgetItem,
     QPushButton,
     QScrollArea,
-    QSpinBox,
     QVBoxLayout,
     QWidget,
 )
 
 from negpy.desktop.view.styles.theme import THEME
-from negpy.domain.models import (
-    AspectRatio,
-    ColorSpace,
-    ExportFormat,
-    ExportPreset,
-    ExportPresetOutputMode,
-    ExportResolutionMode,
-)
-from negpy.infrastructure.display.color_mgmt import ColorService
-from negpy.infrastructure.display.color_spaces import ColorSpaceRegistry
+from negpy.desktop.view.widgets.export_settings_form import ExportSettingsForm
+from negpy.domain.models import ExportPreset
 
 
 class ExportPresetsDialog(QDialog):
@@ -157,205 +143,17 @@ class ExportPresetsDialog(QDialog):
         self.name_edit.setPlaceholderText("Preset name")
         self.name_edit.textChanged.connect(self._on_name_changed)
         self.enabled_check = QCheckBox("Enabled")
-        self.enabled_check.stateChanged.connect(lambda _: self._on_field_changed())
+        self.enabled_check.stateChanged.connect(self._on_enabled_changed)
         row.addWidget(self.name_edit)
         row.addWidget(self.enabled_check)
         form.addLayout(row)
 
-        form.addWidget(self._section("FORMAT"))
-
-        fmt_row = QHBoxLayout()
-        fmt_label = QLabel("Format")
-        fmt_label.setFixedWidth(90)
-        self.fmt_combo = QComboBox()
-        self.fmt_combo.addItems([f.value for f in ExportFormat])
-        self.fmt_combo.currentTextChanged.connect(self._on_fmt_changed)
-        fmt_row.addWidget(fmt_label)
-        fmt_row.addWidget(self.fmt_combo)
-        form.addLayout(fmt_row)
-
-        quality_row = QHBoxLayout()
-        quality_label = QLabel("JPEG Quality")
-        quality_label.setFixedWidth(90)
-        self.quality_spin = QSpinBox()
-        self.quality_spin.setRange(1, 100)
-        self.quality_spin.setValue(90)
-        self.quality_spin.valueChanged.connect(lambda _: self._on_field_changed())
-        quality_row.addWidget(quality_label)
-        quality_row.addWidget(self.quality_spin)
-        quality_row.addStretch()
-        self._quality_container = QWidget()
-        self._quality_container.setLayout(quality_row)
-        form.addWidget(self._quality_container)
-
-        form.addWidget(self._section("SIZE"))
-
-        mode_row = QHBoxLayout()
-        mode_row.setSpacing(4)
-        self.mode_original_btn = QPushButton("Original")
-        self.mode_print_btn = QPushButton("Print")
-        self.mode_target_px_btn = QPushButton("Pixels")
-        btn_style = f"font-size: {THEME.font_size_base}px; padding: 8px;"
-        for btn in (self.mode_original_btn, self.mode_print_btn, self.mode_target_px_btn):
-            btn.setCheckable(True)
-            btn.setStyleSheet(btn_style)
-            mode_row.addWidget(btn)
-        mode_row.addStretch()
-        self.mode_btn_group = QButtonGroup(self)
-        self.mode_btn_group.setExclusive(True)
-        self.mode_btn_group.addButton(self.mode_original_btn, 0)
-        self.mode_btn_group.addButton(self.mode_print_btn, 1)
-        self.mode_btn_group.addButton(self.mode_target_px_btn, 2)
-        self.mode_btn_group.idToggled.connect(self._on_mode_toggled)
-        form.addLayout(mode_row)
-
-        # Print mode controls
-        self._print_container = QWidget()
-        print_inner = QHBoxLayout(self._print_container)
-        print_inner.setContentsMargins(0, 0, 0, 0)
-        vbox_size = QVBoxLayout()
-        vbox_size.addWidget(QLabel('Size <span style="color: #666; font-size: 10px;">cm</span>'))
-        self.size_input = QDoubleSpinBox()
-        self.size_input.setRange(1.0, 500.0)
-        self.size_input.setValue(30.0)
-        self.size_input.valueChanged.connect(lambda _: self._on_field_changed())
-        vbox_size.addWidget(self.size_input)
-        vbox_dpi = QVBoxLayout()
-        vbox_dpi.addWidget(QLabel("DPI"))
-        self.dpi_input = QSpinBox()
-        self.dpi_input.setRange(72, 4800)
-        self.dpi_input.setValue(300)
-        self.dpi_input.valueChanged.connect(lambda _: self._on_field_changed())
-        vbox_dpi.addWidget(self.dpi_input)
-        print_inner.addLayout(vbox_size)
-        print_inner.addLayout(vbox_dpi)
-        print_inner.addStretch()
-        form.addWidget(self._print_container)
-
-        # Target px controls
-        self._target_px_container = QWidget()
-        target_px_inner = QVBoxLayout(self._target_px_container)
-        target_px_inner.setContentsMargins(0, 0, 0, 0)
-        target_px_inner.addWidget(QLabel('Long edge <span style="color: #666; font-size: 10px;">px</span>'))
-        self.target_px_input = QSpinBox()
-        self.target_px_input.setRange(256, 32768)
-        self.target_px_input.setValue(2000)
-        self.target_px_input.valueChanged.connect(lambda _: self._on_field_changed())
-        target_px_inner.addWidget(self.target_px_input)
-        form.addWidget(self._target_px_container)
-
-        ratio_row = QHBoxLayout()
-        ratio_label = QLabel("Paper ratio")
-        ratio_label.setFixedWidth(90)
-        self.ratio_combo = QComboBox()
-        ratios = [AspectRatio.ORIGINAL] + [r.value for r in AspectRatio if r != AspectRatio.ORIGINAL]
-        self.ratio_combo.addItems(ratios)
-        self.ratio_combo.currentTextChanged.connect(lambda _: self._on_field_changed())
-        ratio_row.addWidget(ratio_label)
-        ratio_row.addWidget(self.ratio_combo)
-        form.addLayout(ratio_row)
-
-        form.addWidget(self._section("OUTPUT"))
-
-        output_mode_row = QHBoxLayout()
-        output_mode_label = QLabel("Folder")
-        output_mode_label.setFixedWidth(90)
-        self.output_mode_combo = QComboBox()
-        self.output_mode_combo.addItem("Subfolder of source", ExportPresetOutputMode.SUBFOLDER_OF_SOURCE)
-        self.output_mode_combo.addItem("Same as source", ExportPresetOutputMode.SAME_AS_SOURCE)
-        self.output_mode_combo.addItem("Absolute path", ExportPresetOutputMode.ABSOLUTE)
-        self.output_mode_combo.currentIndexChanged.connect(self._on_output_mode_changed)
-        output_mode_row.addWidget(output_mode_label)
-        output_mode_row.addWidget(self.output_mode_combo)
-        form.addLayout(output_mode_row)
-
-        # Subfolder name (shown for SUBFOLDER_OF_SOURCE)
-        self._subfolder_container = QWidget()
-        sf_inner = QHBoxLayout(self._subfolder_container)
-        sf_inner.setContentsMargins(0, 0, 0, 0)
-        sf_label = QLabel("Subfolder")
-        sf_label.setFixedWidth(90)
-        self.subfolder_edit = QLineEdit()
-        self.subfolder_edit.setPlaceholderText("e.g. TIFF")
-        self.subfolder_edit.textChanged.connect(lambda _: self._on_field_changed())
-        sf_inner.addWidget(sf_label)
-        sf_inner.addWidget(self.subfolder_edit)
-        form.addWidget(self._subfolder_container)
-
-        # Absolute path (shown for ABSOLUTE)
-        self._abspath_container = QWidget()
-        ap_inner = QHBoxLayout(self._abspath_container)
-        ap_inner.setContentsMargins(0, 0, 0, 0)
-        ap_label = QLabel("Path")
-        ap_label.setFixedWidth(90)
-        self.abspath_edit = QLineEdit()
-        self.abspath_edit.textChanged.connect(lambda _: self._on_field_changed())
-        self.abspath_browse_btn = QPushButton()
-        self.abspath_browse_btn.setIcon(qta.icon("fa5s.folder-open", color=THEME.text_primary))
-        self.abspath_browse_btn.setFixedWidth(36)
-        self.abspath_browse_btn.clicked.connect(self._browse_output_path)
-        ap_inner.addWidget(ap_label)
-        ap_inner.addWidget(self.abspath_edit)
-        ap_inner.addWidget(self.abspath_browse_btn)
-        form.addWidget(self._abspath_container)
-
-        filename_row = QHBoxLayout()
-        fn_label = QLabel("Filename")
-        fn_label.setFixedWidth(90)
-        self.filename_edit = QLineEdit()
-        self.filename_edit.setToolTip(
-            "Jinja2 template. Variables:\n"
-            "{{ original_name }}, {{ colorspace }}, {{ format }},\n"
-            "{{ paper_ratio }}, {{ size }}, {{ dpi }}, {{ target_px }},\n"
-            "{{ border }}, {{ date }}"
-        )
-        self.filename_edit.textChanged.connect(lambda _: self._on_field_changed())
-        filename_row.addWidget(fn_label)
-        filename_row.addWidget(self.filename_edit)
-        form.addLayout(filename_row)
-
-        self.overwrite_check = QCheckBox("Overwrite existing files")
-        self.overwrite_check.stateChanged.connect(lambda _: self._on_field_changed())
-        form.addWidget(self.overwrite_check)
-
-        form.addWidget(self._section("COLOR"))
-
-        # Output profiles
-        enum_mapped = {ColorSpaceRegistry.get_icc_path(cs.value) for cs in ColorSpace}
-        enum_mapped.discard(None)
-        custom_profiles = [p for p in ColorService.get_available_profiles() if p not in enum_mapped]
-
-        cs_row = QHBoxLayout()
-        cs_label = QLabel("Color space")
-        cs_label.setFixedWidth(90)
-        self.color_space_combo = QComboBox()
-        self.color_space_combo.addItems([cs.value for cs in ColorSpace])
-        self.color_space_combo.currentTextChanged.connect(lambda _: self._on_field_changed())
-        cs_row.addWidget(cs_label)
-        cs_row.addWidget(self.color_space_combo)
-        form.addLayout(cs_row)
-
-        icc_row = QHBoxLayout()
-        icc_label = QLabel("Output ICC")
-        icc_label.setFixedWidth(90)
-        self._icc_profiles = ["None"] + custom_profiles
-        self.icc_output_combo = QComboBox()
-        self.icc_output_combo.addItems([os.path.basename(p) for p in self._icc_profiles])
-        self.icc_output_combo.setToolTip("Custom output ICC profile (overrides color space)")
-        self.icc_output_combo.currentIndexChanged.connect(lambda _: self._on_field_changed())
-        icc_row.addWidget(icc_label)
-        icc_row.addWidget(self.icc_output_combo)
-        form.addLayout(icc_row)
+        # Shared FORMAT / SIZE / COLOR / DESTINATION rows.
+        self.form = ExportSettingsForm()
+        self.form.changed.connect(self._on_form_changed)
+        form.addWidget(self.form)
 
         fl.addWidget(self._form_container)
-
-    def _section(self, text: str) -> QLabel:
-        lbl = QLabel(text)
-        lbl.setStyleSheet(
-            f"color: {THEME.text_muted}; font-size: 10px; font-weight: bold; "
-            f"letter-spacing: 1px; border-bottom: 1px solid {THEME.border_primary}; padding-bottom: 2px;"
-        )
-        return lbl
 
     # ------------------------------------------------------------------
     # List management
@@ -406,30 +204,7 @@ class ExportPresetsDialog(QDialog):
         try:
             self.name_edit.setText(preset.name)
             self.enabled_check.setChecked(preset.enabled)
-            self.fmt_combo.setCurrentText(preset.export_fmt)
-            self.quality_spin.setValue(preset.jpeg_quality)
-            self._select_mode_button(preset.export_resolution_mode)
-            self._update_mode_visibility(preset.export_resolution_mode)
-            self.size_input.setValue(preset.export_print_size)
-            self.dpi_input.setValue(preset.export_dpi)
-            self.target_px_input.setValue(preset.export_target_long_edge_px)
-            self.ratio_combo.setCurrentText(preset.paper_aspect_ratio)
-
-            # Output mode
-            idx = self.output_mode_combo.findData(preset.output_mode)
-            if idx >= 0:
-                self.output_mode_combo.setCurrentIndex(idx)
-            self._update_output_mode_visibility(preset.output_mode)
-            self.subfolder_edit.setText(preset.output_subfolder)
-            self.abspath_edit.setText(preset.output_path)
-            self.filename_edit.setText(preset.filename_pattern)
-            self.overwrite_check.setChecked(preset.overwrite)
-            self.color_space_combo.setCurrentText(preset.export_color_space)
-
-            icc_name = os.path.basename(preset.icc_output_path) if preset.icc_output_path else "None"
-            self.icc_output_combo.setCurrentText(icc_name)
-
-            self._quality_container.setVisible(preset.export_fmt == ExportFormat.JPEG)
+            self.form.load(preset.to_dict())
         finally:
             self._updating_form = False
 
@@ -442,55 +217,38 @@ class ExportPresetsDialog(QDialog):
             item.setText(text)
         self._emit_changed()
 
-    def _on_fmt_changed(self, fmt: str) -> None:
+    def _on_enabled_changed(self, _state: int) -> None:
         if self._updating_form or self._selected_idx < 0:
             return
-        self._quality_container.setVisible(fmt == ExportFormat.JPEG)
-        self._on_field_changed()
+        self._presets[self._selected_idx].enabled = self.enabled_check.isChecked()
+        item = self.preset_list.item(self._selected_idx)
+        if item:
+            item.setCheckState(Qt.CheckState.Checked if self.enabled_check.isChecked() else Qt.CheckState.Unchecked)
+        self._emit_changed()
 
-    def _on_mode_toggled(self, _id: int, checked: bool) -> None:
-        if not checked or self._updating_form:
-            return
-        mode = self._mode_by_id()[_id]
-        self._update_mode_visibility(mode)
-        self._on_field_changed()
-
-    def _on_output_mode_changed(self, _idx: int) -> None:
-        if self._updating_form:
-            return
-        mode = self.output_mode_combo.currentData()
-        self._update_output_mode_visibility(mode)
-        self._on_field_changed()
-
-    def _on_field_changed(self) -> None:
+    def _on_form_changed(self) -> None:
         if self._updating_form or self._selected_idx < 0:
             return
         self._write_form_to_preset(self._presets[self._selected_idx])
-        item = self.preset_list.item(self._selected_idx)
-        if item:
-            item.setText(self._presets[self._selected_idx].name)
-            item.setCheckState(Qt.CheckState.Checked if self._presets[self._selected_idx].enabled else Qt.CheckState.Unchecked)
         self._emit_changed()
 
     def _write_form_to_preset(self, preset: ExportPreset) -> None:
-        preset.name = self.name_edit.text() or "Untitled"
-        preset.enabled = self.enabled_check.isChecked()
-        preset.export_fmt = self.fmt_combo.currentText()
-        preset.jpeg_quality = self.quality_spin.value()
-        preset.export_resolution_mode = self._current_mode_value()
-        preset.export_print_size = self.size_input.value()
-        preset.export_dpi = self.dpi_input.value()
-        preset.export_target_long_edge_px = self.target_px_input.value()
-        preset.paper_aspect_ratio = self.ratio_combo.currentText()
-        mode_data = self.output_mode_combo.currentData()
-        preset.output_mode = mode_data if mode_data else ExportPresetOutputMode.SAME_AS_SOURCE
-        preset.output_subfolder = self.subfolder_edit.text()
-        preset.output_path = self.abspath_edit.text()
-        preset.filename_pattern = self.filename_edit.text() or "{{ original_name }}"
-        preset.overwrite = self.overwrite_check.isChecked()
-        preset.export_color_space = self.color_space_combo.currentText()
-        icc_idx = self.icc_output_combo.currentIndex()
-        preset.icc_output_path = self._icc_profiles[icc_idx] if icc_idx > 0 else None
+        vals = self.form.values()
+        preset.export_fmt = vals["export_fmt"]
+        preset.jpeg_quality = vals["jpeg_quality"]
+        preset.export_resolution_mode = vals["export_resolution_mode"]
+        preset.export_print_size = vals["export_print_size"]
+        preset.export_dpi = vals["export_dpi"]
+        preset.export_target_long_edge_px = vals["export_target_long_edge_px"]
+        preset.paper_aspect_ratio = vals["paper_aspect_ratio"]
+        preset.output_mode = vals["output_mode"]
+        preset.output_subfolder = vals["output_subfolder"]
+        preset.output_path = vals["output_path"]
+        preset.filename_pattern = vals["filename_pattern"] or "{{ original_name }}"
+        preset.overwrite = vals["overwrite"]
+        preset.export_color_space = vals["export_color_space"]
+        preset.icc_input_path = vals["icc_input_path"]
+        preset.icc_output_path = vals["icc_output_path"]
 
     # ------------------------------------------------------------------
     # Preset actions
@@ -545,11 +303,6 @@ class ExportPresetsDialog(QDialog):
         self._select_row(idx + 1)
         self._emit_changed()
 
-    def _browse_output_path(self) -> None:
-        path = QFileDialog.getExistingDirectory(self, "Select Output Folder", self.abspath_edit.text())
-        if path:
-            self.abspath_edit.setText(path)
-
     # ------------------------------------------------------------------
     # Helpers
     # ------------------------------------------------------------------
@@ -560,31 +313,3 @@ class ExportPresetsDialog(QDialog):
 
     def _emit_changed(self) -> None:
         self.presets_changed.emit(list(self._presets))
-
-    _MODE_BY_ID = {
-        0: ExportResolutionMode.ORIGINAL.value,
-        1: ExportResolutionMode.PRINT.value,
-        2: ExportResolutionMode.TARGET_PX.value,
-    }
-    _ID_BY_MODE = {v: k for k, v in _MODE_BY_ID.items()}
-
-    @classmethod
-    def _mode_by_id(cls) -> dict:
-        return cls._MODE_BY_ID
-
-    def _current_mode_value(self) -> str:
-        return self._MODE_BY_ID.get(self.mode_btn_group.checkedId(), ExportResolutionMode.ORIGINAL.value)
-
-    def _select_mode_button(self, mode_value: str) -> None:
-        btn_id = self._ID_BY_MODE.get(mode_value, 0)
-        btn = self.mode_btn_group.button(btn_id)
-        if btn:
-            btn.setChecked(True)
-
-    def _update_mode_visibility(self, mode_value: str) -> None:
-        self._print_container.setVisible(mode_value == ExportResolutionMode.PRINT.value)
-        self._target_px_container.setVisible(mode_value == ExportResolutionMode.TARGET_PX.value)
-
-    def _update_output_mode_visibility(self, mode) -> None:
-        self._subfolder_container.setVisible(mode == ExportPresetOutputMode.SUBFOLDER_OF_SOURCE)
-        self._abspath_container.setVisible(mode == ExportPresetOutputMode.ABSOLUTE)

--- a/negpy/desktop/view/widgets/export_settings_form.py
+++ b/negpy/desktop/view/widgets/export_settings_form.py
@@ -1,0 +1,358 @@
+import os
+from typing import Any, Dict
+
+import qtawesome as qta
+from PyQt6.QtCore import pyqtSignal
+from PyQt6.QtWidgets import (
+    QButtonGroup,
+    QCheckBox,
+    QComboBox,
+    QDoubleSpinBox,
+    QFileDialog,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QPushButton,
+    QSpinBox,
+    QVBoxLayout,
+    QWidget,
+)
+
+from negpy.desktop.view.styles.templates import section_subheader
+from negpy.desktop.view.styles.theme import THEME
+from negpy.domain.models import (
+    AspectRatio,
+    ColorSpace,
+    ExportFormat,
+    ExportPresetOutputMode,
+    ExportResolutionMode,
+)
+from negpy.infrastructure.display.color_mgmt import ColorService
+from negpy.infrastructure.display.color_spaces import ColorSpaceRegistry
+
+_LABEL_WIDTH = 90
+
+
+class ExportSettingsForm(QWidget):
+    """Shared FORMAT / SIZE / COLOR / DESTINATION rows for the export sidebar and
+    the presets dialog. Emits ``changed`` on any edit; the parent owns persistence.
+    Read/write the rows via ``values()`` / ``load()`` keyed by the shared field
+    names used by both ExportConfig and ExportPreset."""
+
+    changed = pyqtSignal()
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._loading = False
+        self._init_ui()
+
+    @staticmethod
+    def _row_label(text: str) -> QLabel:
+        label = QLabel(text)
+        label.setFixedWidth(_LABEL_WIDTH)
+        return label
+
+    def _init_ui(self) -> None:
+        root = QVBoxLayout(self)
+        root.setContentsMargins(0, 0, 0, 0)
+        root.setSpacing(10)
+
+        self._build_format(root)
+        self._build_size(root)
+        self._build_color(root)
+        self._build_destination(root)
+
+    # --- FORMAT --------------------------------------------------------------
+
+    def _build_format(self, root: QVBoxLayout) -> None:
+        root.addWidget(section_subheader("FORMAT"))
+
+        fmt_row = QHBoxLayout()
+        fmt_row.addWidget(self._row_label("Format"))
+        self.fmt_combo = QComboBox()
+        self.fmt_combo.addItems([f.value for f in ExportFormat])
+        self.fmt_combo.currentTextChanged.connect(self._on_fmt_changed)
+        fmt_row.addWidget(self.fmt_combo)
+        root.addLayout(fmt_row)
+
+        self._quality_container = QWidget()
+        quality_row = QHBoxLayout(self._quality_container)
+        quality_row.setContentsMargins(0, 0, 0, 0)
+        quality_row.addWidget(self._row_label("JPEG Quality"))
+        self.quality_spin = QSpinBox()
+        self.quality_spin.setRange(1, 100)
+        self.quality_spin.setValue(90)
+        self.quality_spin.valueChanged.connect(self._on_changed)
+        quality_row.addWidget(self.quality_spin)
+        root.addWidget(self._quality_container)
+
+    # --- SIZE ----------------------------------------------------------------
+
+    def _build_size(self, root: QVBoxLayout) -> None:
+        root.addWidget(section_subheader("SIZE"))
+
+        mode_row = QHBoxLayout()
+        mode_row.setSpacing(4)
+        self.mode_original_btn = QPushButton("Original")
+        self.mode_print_btn = QPushButton("Print")
+        self.mode_target_px_btn = QPushButton("Pixels")
+        btn_style = f"font-size: {THEME.font_size_base}px; padding: 8px;"
+        for btn in (self.mode_original_btn, self.mode_print_btn, self.mode_target_px_btn):
+            btn.setCheckable(True)
+            btn.setStyleSheet(btn_style)
+            mode_row.addWidget(btn)
+        self.mode_btn_group = QButtonGroup(self)
+        self.mode_btn_group.setExclusive(True)
+        self.mode_btn_group.addButton(self.mode_original_btn, 0)
+        self.mode_btn_group.addButton(self.mode_print_btn, 1)
+        self.mode_btn_group.addButton(self.mode_target_px_btn, 2)
+        self.mode_btn_group.idToggled.connect(self._on_mode_toggled)
+        root.addLayout(mode_row)
+
+        # PRINT mode: cm + DPI
+        self._print_container = QWidget()
+        print_inner = QHBoxLayout(self._print_container)
+        print_inner.setContentsMargins(0, 0, 0, 0)
+        vbox_size = QVBoxLayout()
+        vbox_size.addWidget(QLabel('Size <span style="color: #666666; font-size: 10px;">cm</span>'))
+        self.size_input = QDoubleSpinBox()
+        self.size_input.setRange(1.0, 500.0)
+        self.size_input.setValue(30.0)
+        self.size_input.valueChanged.connect(self._on_changed)
+        vbox_size.addWidget(self.size_input)
+        vbox_dpi = QVBoxLayout()
+        vbox_dpi.addWidget(QLabel("DPI"))
+        self.dpi_input = QSpinBox()
+        self.dpi_input.setRange(72, 4800)
+        self.dpi_input.setValue(300)
+        self.dpi_input.valueChanged.connect(self._on_changed)
+        vbox_dpi.addWidget(self.dpi_input)
+        print_inner.addLayout(vbox_size)
+        print_inner.addLayout(vbox_dpi)
+        root.addWidget(self._print_container)
+
+        # TARGET_PX mode: long edge in pixels
+        self._target_px_container = QWidget()
+        target_px_inner = QVBoxLayout(self._target_px_container)
+        target_px_inner.setContentsMargins(0, 0, 0, 0)
+        target_px_inner.addWidget(QLabel('Long edge <span style="color: #666666; font-size: 10px;">px</span>'))
+        self.target_px_input = QSpinBox()
+        self.target_px_input.setRange(256, 32768)
+        self.target_px_input.setValue(2000)
+        self.target_px_input.valueChanged.connect(self._on_changed)
+        target_px_inner.addWidget(self.target_px_input)
+        root.addWidget(self._target_px_container)
+
+        ratio_row = QHBoxLayout()
+        ratio_row.addWidget(self._row_label("Paper ratio"))
+        self.ratio_combo = QComboBox()
+        ratios = [AspectRatio.ORIGINAL] + [r.value for r in AspectRatio if r != AspectRatio.ORIGINAL]
+        self.ratio_combo.addItems(ratios)
+        self.ratio_combo.currentTextChanged.connect(self._on_changed)
+        ratio_row.addWidget(self.ratio_combo)
+        root.addLayout(ratio_row)
+
+    # --- COLOR ---------------------------------------------------------------
+
+    def _build_color(self, root: QVBoxLayout) -> None:
+        root.addWidget(section_subheader("COLOR"))
+
+        # Drop bundled profiles already backed by a color-space enum so the ICC
+        # lists don't duplicate the color-space selector.
+        enum_mapped = {ColorSpaceRegistry.get_icc_path(cs.value) for cs in ColorSpace}
+        enum_mapped.discard(None)
+        custom_profiles = [p for p in ColorService.get_available_profiles() if p not in enum_mapped]
+
+        self._icc_input_profiles = ["None"] + custom_profiles
+        input_row = QHBoxLayout()
+        input_row.addWidget(self._row_label("Input ICC"))
+        self.input_combo = QComboBox()
+        self.input_combo.addItems([os.path.basename(p) for p in self._icc_input_profiles])
+        self.input_combo.setToolTip("Source/input ICC profile")
+        self.input_combo.currentIndexChanged.connect(self._on_changed)
+        input_row.addWidget(self.input_combo)
+        root.addLayout(input_row)
+
+        cs_row = QHBoxLayout()
+        cs_row.addWidget(self._row_label("Color space"))
+        self.color_space_combo = QComboBox()
+        self.color_space_combo.addItems([cs.value for cs in ColorSpace])
+        self.color_space_combo.currentTextChanged.connect(self._on_changed)
+        cs_row.addWidget(self.color_space_combo)
+        root.addLayout(cs_row)
+
+        self._icc_output_profiles = ["None"] + custom_profiles
+        output_row = QHBoxLayout()
+        output_row.addWidget(self._row_label("Output ICC"))
+        self.icc_output_combo = QComboBox()
+        self.icc_output_combo.addItems([os.path.basename(p) for p in self._icc_output_profiles])
+        self.icc_output_combo.setToolTip("Custom output ICC profile (overrides color space)")
+        self.icc_output_combo.currentIndexChanged.connect(self._on_changed)
+        output_row.addWidget(self.icc_output_combo)
+        root.addLayout(output_row)
+
+    # --- DESTINATION ---------------------------------------------------------
+
+    def _build_destination(self, root: QVBoxLayout) -> None:
+        root.addWidget(section_subheader("DESTINATION"))
+
+        mode_row = QHBoxLayout()
+        mode_row.addWidget(self._row_label("Folder"))
+        self.output_mode_combo = QComboBox()
+        self.output_mode_combo.addItem("Subfolder of source", ExportPresetOutputMode.SUBFOLDER_OF_SOURCE)
+        self.output_mode_combo.addItem("Same as source", ExportPresetOutputMode.SAME_AS_SOURCE)
+        self.output_mode_combo.addItem("Absolute path", ExportPresetOutputMode.ABSOLUTE)
+        self.output_mode_combo.currentIndexChanged.connect(self._on_output_mode_changed)
+        mode_row.addWidget(self.output_mode_combo)
+        root.addLayout(mode_row)
+
+        self._subfolder_container = QWidget()
+        sf_inner = QHBoxLayout(self._subfolder_container)
+        sf_inner.setContentsMargins(0, 0, 0, 0)
+        sf_inner.addWidget(self._row_label("Subfolder"))
+        self.subfolder_edit = QLineEdit()
+        self.subfolder_edit.setPlaceholderText("e.g. TIFF")
+        self.subfolder_edit.textChanged.connect(self._on_changed)
+        sf_inner.addWidget(self.subfolder_edit)
+        root.addWidget(self._subfolder_container)
+
+        self._abspath_container = QWidget()
+        ap_inner = QHBoxLayout(self._abspath_container)
+        ap_inner.setContentsMargins(0, 0, 0, 0)
+        ap_inner.addWidget(self._row_label("Path"))
+        self.abspath_edit = QLineEdit()
+        self.abspath_edit.setToolTip("Export folder")
+        self.abspath_edit.textChanged.connect(self._on_changed)
+        self.abspath_browse_btn = QPushButton()
+        self.abspath_browse_btn.setIcon(qta.icon("fa5s.folder-open", color=THEME.text_primary))
+        self.abspath_browse_btn.setFixedWidth(40)
+        self.abspath_browse_btn.setToolTip("Choose export folder")
+        self.abspath_browse_btn.clicked.connect(self._browse_output_path)
+        ap_inner.addWidget(self.abspath_edit)
+        ap_inner.addWidget(self.abspath_browse_btn)
+        root.addWidget(self._abspath_container)
+
+        filename_row = QHBoxLayout()
+        filename_row.addWidget(self._row_label("Filename"))
+        self.filename_edit = QLineEdit()
+        self.filename_edit.setPlaceholderText("Filename Pattern...")
+        self.filename_edit.setToolTip(
+            "Jinja2 template. Variables:\n"
+            "{{ original_name }}, {{ colorspace }}, {{ format }},\n"
+            "{{ paper_ratio }}, {{ size }}, {{ dpi }}, {{ target_px }},\n"
+            "{{ border }}, {{ date }}"
+        )
+        self.filename_edit.textChanged.connect(self._on_changed)
+        filename_row.addWidget(self.filename_edit)
+        root.addLayout(filename_row)
+
+        self.overwrite_check = QCheckBox("Overwrite existing files")
+        self.overwrite_check.stateChanged.connect(self._on_changed)
+        root.addWidget(self.overwrite_check)
+
+    # --- Change handling -----------------------------------------------------
+
+    def _on_changed(self, *_) -> None:
+        if not self._loading:
+            self.changed.emit()
+
+    def _on_fmt_changed(self, fmt: str) -> None:
+        self._quality_container.setVisible(fmt == ExportFormat.JPEG)
+        self._on_changed()
+
+    def _on_mode_toggled(self, _id: int, checked: bool) -> None:
+        if not checked:
+            return
+        self._update_mode_visibility(self._current_mode_value())
+        self._on_changed()
+
+    def _on_output_mode_changed(self, _idx: int) -> None:
+        self._update_output_mode_visibility(self.output_mode_combo.currentData())
+        self._on_changed()
+
+    def _browse_output_path(self) -> None:
+        path = QFileDialog.getExistingDirectory(self, "Select Export Directory", self.abspath_edit.text())
+        if path:
+            self.abspath_edit.setText(path)
+
+    # --- Mode helpers --------------------------------------------------------
+
+    _MODE_BY_ID = {
+        0: ExportResolutionMode.ORIGINAL.value,
+        1: ExportResolutionMode.PRINT.value,
+        2: ExportResolutionMode.TARGET_PX.value,
+    }
+    _ID_BY_MODE = {v: k for k, v in _MODE_BY_ID.items()}
+
+    def _current_mode_value(self) -> str:
+        return self._MODE_BY_ID.get(self.mode_btn_group.checkedId(), ExportResolutionMode.PRINT.value)
+
+    def _select_mode_button(self, mode_value: str) -> None:
+        btn = self.mode_btn_group.button(self._ID_BY_MODE.get(mode_value, 1))
+        if btn is not None:
+            btn.setChecked(True)
+
+    def _update_mode_visibility(self, mode_value: str) -> None:
+        self._print_container.setVisible(mode_value == ExportResolutionMode.PRINT.value)
+        self._target_px_container.setVisible(mode_value == ExportResolutionMode.TARGET_PX.value)
+
+    def _update_output_mode_visibility(self, mode) -> None:
+        self._subfolder_container.setVisible(mode == ExportPresetOutputMode.SUBFOLDER_OF_SOURCE)
+        self._abspath_container.setVisible(mode == ExportPresetOutputMode.ABSOLUTE)
+
+    # --- Load / read ---------------------------------------------------------
+
+    def load(self, v: Dict[str, Any]) -> None:
+        """Populate all rows from a dict of shared field values."""
+        self._loading = True
+        try:
+            self.fmt_combo.setCurrentText(v["export_fmt"])
+            self.quality_spin.setValue(v.get("jpeg_quality", 90))
+            self._quality_container.setVisible(v["export_fmt"] == ExportFormat.JPEG)
+
+            self._select_mode_button(v["export_resolution_mode"])
+            self._update_mode_visibility(v["export_resolution_mode"])
+            self.size_input.setValue(v["export_print_size"])
+            self.dpi_input.setValue(v["export_dpi"])
+            self.target_px_input.setValue(v["export_target_long_edge_px"])
+            self.ratio_combo.setCurrentText(v["paper_aspect_ratio"])
+
+            in_path = v.get("icc_input_path")
+            self.input_combo.setCurrentText(os.path.basename(in_path) if in_path else "None")
+            self.color_space_combo.setCurrentText(v["export_color_space"])
+            out_path = v.get("icc_output_path")
+            self.icc_output_combo.setCurrentText(os.path.basename(out_path) if out_path else "None")
+
+            mode = v.get("output_mode", ExportPresetOutputMode.ABSOLUTE)
+            idx = self.output_mode_combo.findData(mode)
+            if idx >= 0:
+                self.output_mode_combo.setCurrentIndex(idx)
+            self._update_output_mode_visibility(mode)
+            self.subfolder_edit.setText(v.get("output_subfolder", ""))
+            self.abspath_edit.setText(v.get("output_path", ""))
+            self.filename_edit.setText(v["filename_pattern"])
+            self.overwrite_check.setChecked(v["overwrite"])
+        finally:
+            self._loading = False
+
+    def values(self) -> Dict[str, Any]:
+        """Read all rows back into a dict of shared field values."""
+        in_idx = self.input_combo.currentIndex()
+        out_idx = self.icc_output_combo.currentIndex()
+        return {
+            "export_fmt": self.fmt_combo.currentText(),
+            "jpeg_quality": self.quality_spin.value(),
+            "export_resolution_mode": self._current_mode_value(),
+            "paper_aspect_ratio": self.ratio_combo.currentText(),
+            "export_print_size": self.size_input.value(),
+            "export_dpi": self.dpi_input.value(),
+            "export_target_long_edge_px": self.target_px_input.value(),
+            "output_mode": self.output_mode_combo.currentData() or ExportPresetOutputMode.ABSOLUTE,
+            "output_subfolder": self.subfolder_edit.text(),
+            "output_path": self.abspath_edit.text(),
+            "filename_pattern": self.filename_edit.text(),
+            "overwrite": self.overwrite_check.isChecked(),
+            "export_color_space": self.color_space_combo.currentText(),
+            "icc_input_path": self._icc_input_profiles[in_idx] if in_idx > 0 else None,
+            "icc_output_path": self._icc_output_profiles[out_idx] if out_idx > 0 else None,
+        }

--- a/negpy/domain/models.py
+++ b/negpy/domain/models.py
@@ -92,6 +92,7 @@ class ExportConfig:
 
     export_path: str = field(default_factory=lambda: os.path.join(paths.get_default_user_dir(), "export"))
     export_fmt: str = ExportFormat.JPEG
+    jpeg_quality: int = 90
     export_color_space: str = ColorSpace.ADOBE_RGB.value
     paper_aspect_ratio: str = AspectRatio.ORIGINAL
     export_print_size: float = 30.0
@@ -100,7 +101,8 @@ class ExportConfig:
     export_target_long_edge_px: int = 2000
     filename_pattern: str = "{{ original_name }}"
     overwrite: bool = True
-    same_as_source: bool = False
+    output_mode: str = ExportPresetOutputMode.ABSOLUTE
+    output_subfolder: str = ""
     icc_input_path: Optional[str] = None
     icc_output_path: Optional[str] = None
 
@@ -175,23 +177,19 @@ class ExportPreset:
 def preset_from_export_config(conf: ExportConfig, name: str = "Current settings") -> ExportPreset:
     """Builds an ephemeral preset from the current export settings so the export
     pipeline (which is preset-driven) can run a one-off 'export as currently seen'."""
-    if conf.same_as_source:
-        output_mode = ExportPresetOutputMode.SAME_AS_SOURCE
-        output_path = ""
-    else:
-        output_mode = ExportPresetOutputMode.ABSOLUTE
-        output_path = conf.export_path
     return ExportPreset(
         name=name,
         enabled=True,
         export_fmt=conf.export_fmt,
+        jpeg_quality=conf.jpeg_quality,
         export_resolution_mode=conf.export_resolution_mode,
         paper_aspect_ratio=conf.paper_aspect_ratio,
         export_print_size=conf.export_print_size,
         export_dpi=conf.export_dpi,
         export_target_long_edge_px=conf.export_target_long_edge_px,
-        output_mode=output_mode,
-        output_path=output_path,
+        output_mode=conf.output_mode,
+        output_subfolder=conf.output_subfolder,
+        output_path=conf.export_path,
         overwrite=conf.overwrite,
         filename_pattern=conf.filename_pattern,
         export_color_space=conf.export_color_space,
@@ -251,6 +249,13 @@ class WorkspaceConfig:
             )
         else:
             data.pop("use_original_res", None)
+
+        if "same_as_source" in data and "output_mode" not in data:
+            data["output_mode"] = (
+                ExportPresetOutputMode.SAME_AS_SOURCE if data.pop("same_as_source") else ExportPresetOutputMode.ABSOLUTE
+            )
+        else:
+            data.pop("same_as_source", None)
 
         config_classes = [
             ProcessConfig,

--- a/tests/test_export_presets.py
+++ b/tests/test_export_presets.py
@@ -10,12 +10,15 @@ import tifffile
 from PIL import Image
 
 from negpy.domain.models import (
+    ExportConfig,
     ExportFormat,
     ExportPreset,
     ExportPresetOutputMode,
     ExportResolutionMode,
     AspectRatio,
     ColorSpace,
+    WorkspaceConfig,
+    preset_from_export_config,
 )
 from negpy.infrastructure.display.color_spaces import WORKING_COLOR_SPACE
 from negpy.infrastructure.storage.repository import StorageRepository
@@ -98,6 +101,56 @@ def test_preset_unknown_keys_dropped():
     d["unknown_future_field"] = "should be ignored"
     p = ExportPreset.from_dict(d)
     assert not hasattr(p, "unknown_future_field")
+
+
+# ---------------------------------------------------------------------------
+# ExportConfig -> ExportPreset passthrough
+# ---------------------------------------------------------------------------
+
+
+def test_preset_from_export_config_passthrough():
+    conf = ExportConfig(
+        export_fmt=ExportFormat.JPEG,
+        jpeg_quality=72,
+        output_mode=ExportPresetOutputMode.SUBFOLDER_OF_SOURCE,
+        output_subfolder="web",
+        export_path="/abs/out",
+    )
+    preset = preset_from_export_config(conf)
+    assert preset.jpeg_quality == 72
+    assert preset.output_mode == ExportPresetOutputMode.SUBFOLDER_OF_SOURCE
+    assert preset.output_subfolder == "web"
+    # ExportConfig's absolute path maps to the preset's output_path.
+    assert preset.output_path == "/abs/out"
+
+
+# ---------------------------------------------------------------------------
+# from_flat_dict back-compat: same_as_source -> output_mode
+# ---------------------------------------------------------------------------
+
+
+def test_from_flat_dict_same_as_source_true_maps_to_same():
+    data = WorkspaceConfig().to_dict()
+    data.pop("output_mode", None)
+    data["same_as_source"] = True
+    cfg = WorkspaceConfig.from_flat_dict(data)
+    assert cfg.export.output_mode == ExportPresetOutputMode.SAME_AS_SOURCE
+
+
+def test_from_flat_dict_same_as_source_false_maps_to_absolute():
+    data = WorkspaceConfig().to_dict()
+    data.pop("output_mode", None)
+    data["same_as_source"] = False
+    cfg = WorkspaceConfig.from_flat_dict(data)
+    assert cfg.export.output_mode == ExportPresetOutputMode.ABSOLUTE
+
+
+def test_from_flat_dict_output_mode_wins_over_legacy_flag():
+    data = WorkspaceConfig().to_dict()
+    data["output_mode"] = ExportPresetOutputMode.SUBFOLDER_OF_SOURCE
+    data["same_as_source"] = True  # legacy flag ignored when output_mode present
+    cfg = WorkspaceConfig.from_flat_dict(data)
+    assert cfg.export.output_mode == ExportPresetOutputMode.SUBFOLDER_OF_SOURCE
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_export_settings_form.py
+++ b/tests/test_export_settings_form.py
@@ -1,0 +1,68 @@
+"""Round-trip tests for the shared ExportSettingsForm widget."""
+
+from negpy.desktop.view.widgets.export_settings_form import ExportSettingsForm
+from negpy.domain.models import (
+    AspectRatio,
+    ColorSpace,
+    ExportFormat,
+    ExportPresetOutputMode,
+    ExportResolutionMode,
+)
+
+
+def _values(**overrides) -> dict:
+    base = {
+        "export_fmt": ExportFormat.JPEG,
+        "jpeg_quality": 88,
+        "export_resolution_mode": ExportResolutionMode.PRINT.value,
+        "paper_aspect_ratio": AspectRatio.ORIGINAL,
+        "export_print_size": 24.0,
+        "export_dpi": 360,
+        "export_target_long_edge_px": 3000,
+        "output_mode": ExportPresetOutputMode.SUBFOLDER_OF_SOURCE,
+        "output_subfolder": "web",
+        "output_path": "/tmp/out",
+        "filename_pattern": "{{ original_name }}_{{ size }}",
+        "overwrite": False,
+        "export_color_space": ColorSpace.SRGB.value,
+        "icc_input_path": None,
+        "icc_output_path": None,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_load_then_values_round_trip(qapp):
+    form = ExportSettingsForm()
+    v = _values()
+    form.load(v)
+    out = form.values()
+    for key, expected in v.items():
+        assert out[key] == expected, key
+
+
+def test_jpeg_quality_hidden_for_non_jpeg(qapp):
+    form = ExportSettingsForm()
+    form.load(_values(export_fmt=ExportFormat.TIFF))
+    assert not form._quality_container.isVisible()
+    form.load(_values(export_fmt=ExportFormat.JPEG))
+    # Visibility flag flips even though the widget isn't shown on screen.
+    assert not form._quality_container.isHidden()
+
+
+def test_destination_subfields_track_output_mode(qapp):
+    form = ExportSettingsForm()
+    form.load(_values(output_mode=ExportPresetOutputMode.ABSOLUTE))
+    assert not form._abspath_container.isHidden()
+    assert form._subfolder_container.isHidden()
+    form.load(_values(output_mode=ExportPresetOutputMode.SUBFOLDER_OF_SOURCE))
+    assert not form._subfolder_container.isHidden()
+    assert form._abspath_container.isHidden()
+
+
+def test_load_does_not_emit_changed(qapp):
+    form = ExportSettingsForm()
+    fired = []
+    form.changed.connect(lambda: fired.append(True))
+    form.load(_values())
+    assert not fired


### PR DESCRIPTION
## Why

The export **sidebar** and the export **presets dialog** presented the same
settings with slightly different layouts and two copies of the row-building code
(plus duplicated mode-button helpers). They could — and did — drift visually.

## What

Extract a shared **`ExportSettingsForm`** widget as the single source for the
**FORMAT / SIZE / COLOR / DESTINATION** rows, embedded by both views. Each parent
keeps its own save semantics (sidebar = debounced config update; dialog =
per-preset write) and its own extras (sidebar: soft-proof, display ICC, batch,
presets list, contact sheet; dialog: preset list + name/enabled).

The dialog's conventions win for the shared parts:
- JPEG quality (shown only for JPEG)
- labeled paper-ratio row
- separate color-space + output ICC, **plus** an input ICC (now in both views)
- output-mode destination dropdown (subfolder / same-as-source / absolute)

## Model

`ExportConfig` gains `jpeg_quality`, `output_mode`, `output_subfolder` and drops
`same_as_source`. `preset_from_export_config` becomes a passthrough;
`from_flat_dict` migrates the legacy `same_as_source` flag. Controller destination
checks switch to `output_mode == SAME_AS_SOURCE`. Serialization auto-handles the
new fields (`asdict` / `filter_keys`).

Net: +635 / -650 lines; the duplicated builders and the two mode-helper copies are gone.

## Tests
- `preset_from_export_config` passthrough
- `from_flat_dict` back-compat (`same_as_source` → `output_mode`, 3 cases)
- `ExportSettingsForm` `load()`→`values()` round-trip + visibility (4 cases)

`make lint` ✓ · `make type` ✓ · full suite **691 passed, 1 xfailed** ✓

## Not verified
Visual side-by-side in `make run` (headless env) — sections should now render
identically from the one widget.