### PR TITLE
feat: thumbnail right-click context menu

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## 0.27.0
+
+- **Flat-field correction** (new, off by default) — corrects illumination falloff/vignetting from your light source or scanner using a reference scan of the bare light. New **Flat Field** section in the Setup tab: save named reference profiles, pick the active one, and toggle correction per image.
+- **Contact-sheet export** — render all visible frames into a single darkroom-style contact sheet. New **Contact Sheet** section in the Export panel with cell size, gap, margin and max-tiles controls.
+- **Thumbnail right-click menu** — right-click a frame in the filmstrip for quick access to Export, Copy / Paste / Reset Settings and Unload, without leaving the contact sheet. Right-clicking an unselected frame selects it first; with multiple frames selected the menu acts on the whole selection and adds **Export Selected** and **Sync Edits to Selection**.
+- **Export presets** — save named export configurations (format, sizing, output destination, color space) and run them in one click. A new **Manage** dialog lets you add, duplicate, reorder and delete presets; each preset has an enable toggle. Presets are stored globally and pinned to the top of the Export panel in a collapsible section. The **Export Presets** button exports the current file through every enabled preset at once, while the normal Export / Export All buttons keep exporting with the settings shown in the panel. New installs ship with **JPEG** (enabled), **TIFF** and **PNG** (disabled) starter presets. @reederphill
+- Fix: **Sync Edits** no longer overwrites the target's crop, rotation and flips — it now carries over only the manual-crop rectangle and fine rotation, leaving the target's geometry otherwise untouched. @reederphill
+- Fix: the **Unload** button now clears just the selected files when more than one is selected (falling back to clearing all), with a tooltip that reflects the action. @reederphill
+- Fix: next/previous navigation now follows the displayed (sorted/filtered) order. @reederphill
+- Fix: **trackpad scrolling** in the filmstrip now uses pixel-precise deltas with native momentum instead of feeling much faster than the rest of the OS. @reederphill
+
 ## 0.26.0
 
 **Reworked interface** — the panels have been reorganised around the editing workflow.

--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -1112,8 +1112,13 @@ class AppController(QObject):
             ]
         )
 
-    def request_batch_export(self, override_settings: bool = False) -> None:
-        """Batch-exports all visible files using current settings, optionally applied to all."""
+    def request_export_selected(self) -> None:
+        """Batch-exports the currently selected files using each file's own saved settings."""
+        selected = [self.state.uploaded_files[i] for i in self.state.selected_indices if 0 <= i < len(self.state.uploaded_files)]
+        self.request_batch_export(files=selected)
+
+    def request_batch_export(self, override_settings: bool = False, files: list[dict] | None = None) -> None:
+        """Batch-exports the given files (all visible by default) using current settings, optionally applied to all."""
         export_path = self._ensure_valid_export_path()
         if not export_path:
             return
@@ -1123,10 +1128,11 @@ class AppController(QObject):
         icc_output = self.state.icc_output_path
         sync_metadata = self.state.config.metadata.sync_to_batch
 
-        visible_files = [self.state.uploaded_files[i] for i in self.session.asset_model.visible_actual_indices_ordered()]
+        if files is None:
+            files = [self.state.uploaded_files[i] for i in self.session.asset_model.visible_actual_indices_ordered()]
 
         tasks = []
-        for f in visible_files:
+        for f in files:
             params = self.session.repo.load_file_settings(f["hash"]) or self.state.config
 
             if override_settings:

--- a/negpy/desktop/view/sidebar/files.py
+++ b/negpy/desktop/view/sidebar/files.py
@@ -280,6 +280,7 @@ class FileBrowser(QWidget):
         self.list_view.setResizeMode(QListView.ResizeMode.Adjust)
         self.list_view.setSelectionMode(QListView.SelectionMode.ExtendedSelection)
         self.list_view.setAlternatingRowColors(False)
+        self.list_view.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
 
         layout.addWidget(self.list_view)
 
@@ -288,6 +289,7 @@ class FileBrowser(QWidget):
         self.add_folder_btn.clicked.connect(self._on_add_folder)
         self.unload_btn.clicked.connect(self._on_unload_clicked)
         self.list_view.doubleClicked.connect(self._on_item_double_clicked)
+        self.list_view.customContextMenuRequested.connect(self._show_context_menu)
         self.list_view.selectionModel().selectionChanged.connect(self._on_selection_changed)
         self.hot_folder_btn.toggled.connect(self._on_hot_folder_toggled)
         self.sync_btn.clicked.connect(lambda *_: self.session.sync_selected_settings("edits"))
@@ -451,3 +453,52 @@ class FileBrowser(QWidget):
         actual = self.session.asset_model.display_to_actual(index.row())
         if actual >= 0:
             self.session.select_file(actual)
+
+    def _show_context_menu(self, pos) -> None:
+        index = self.list_view.indexAt(pos)
+        if not index.isValid():
+            return
+        actual = self.session.asset_model.display_to_actual(index.row())
+        if actual < 0:
+            return
+
+        # Right-clicking outside the current selection re-selects just that file;
+        # within a multi-selection, keep the selection and make the clicked file active.
+        state = self.session.state
+        if actual not in state.selected_indices:
+            self.session.select_file(actual)
+        elif actual != state.selected_file_idx:
+            self.session.select_file(actual, selection_override=list(state.selected_indices))
+
+        menu = self._build_context_menu()
+        menu.exec(self.list_view.viewport().mapToGlobal(pos))
+
+    def _build_context_menu(self) -> QMenu:
+        state = self.session.state
+        multi = len(state.selected_indices) > 1
+
+        menu = QMenu(self)
+        if multi:
+            menu.addAction("Export Selected").triggered.connect(lambda: self.controller.request_export_selected())
+        else:
+            menu.addAction("Export").triggered.connect(lambda: self.controller.request_export())
+        menu.addSeparator()
+        menu.addAction("Copy Settings  Ctrl+C").triggered.connect(self.session.copy_settings)
+        menu.addAction("Copy Settings + Bounds  Ctrl+Shift+C").triggered.connect(self.session.copy_settings_with_bounds)
+        act_paste = menu.addAction("Paste Settings  Ctrl+V")
+        act_paste.triggered.connect(self.session.paste_settings)
+        act_paste.setEnabled(state.clipboard is not None)
+        menu.addAction("Reset Settings").triggered.connect(self.session.reset_settings)
+        if multi:
+            menu.addSeparator()
+            menu.addAction("Sync Edits to Selection").triggered.connect(lambda: self.session.sync_selected_settings("edits"))
+        menu.addSeparator()
+        unload_label = "Unload Selected" if multi else "Unload"
+        menu.addAction(unload_label).triggered.connect(self._on_remove_from_menu)
+        return menu
+
+    def _on_remove_from_menu(self) -> None:
+        if len(self.session.state.selected_indices) > 1:
+            self.session.remove_selected_files()
+        else:
+            self.session.remove_current_file()

--- a/tests/test_file_browser_widget.py
+++ b/tests/test_file_browser_widget.py
@@ -99,6 +99,66 @@ def test_active_file_preserved_when_still_visible(browser, session):
     assert set(session.state.selected_indices) == {0, 1}
 
 
+def _action_labels(menu):
+    return [a.text() for a in menu.actions() if not a.isSeparator()]
+
+
+def test_context_menu_single_selection_items(browser, session):
+    session.state.selected_indices = [0]
+    session.state.selected_file_idx = 0
+    labels = _action_labels(browser._build_context_menu())
+    assert "Export" in labels
+    assert "Export Selected" not in labels
+    assert "Reset Settings" in labels
+    assert "Unload" in labels
+    assert "Sync Edits to Selection" not in labels
+
+
+def test_context_menu_multi_selection_uses_export_selected(browser, session):
+    session.state.selected_indices = [0, 1]
+    session.state.selected_file_idx = 0
+    labels = _action_labels(browser._build_context_menu())
+    assert "Export Selected" in labels
+    assert "Export" not in labels
+
+
+def test_context_menu_multi_selection_adds_sync_and_remove_selected(browser, session):
+    session.state.selected_indices = [0, 1]
+    session.state.selected_file_idx = 0
+    labels = _action_labels(browser._build_context_menu())
+    assert "Sync Edits to Selection" in labels
+    assert "Unload Selected" in labels
+    assert "Unload" not in labels
+
+
+def test_context_menu_paste_disabled_without_clipboard(browser, session):
+    session.state.clipboard = None
+    paste = next(a for a in browser._build_context_menu().actions() if a.text().startswith("Paste"))
+    assert not paste.isEnabled()
+
+
+def test_context_menu_paste_enabled_with_clipboard(browser, session):
+    session.state.clipboard = object()
+    paste = next(a for a in browser._build_context_menu().actions() if a.text().startswith("Paste"))
+    assert paste.isEnabled()
+
+
+def test_remove_from_menu_routes_single_vs_multi(browser, session):
+    session.remove_current_file = MagicMock()
+    session.remove_selected_files = MagicMock()
+
+    session.state.selected_indices = [1]
+    browser._on_remove_from_menu()
+    session.remove_current_file.assert_called_once()
+    session.remove_selected_files.assert_not_called()
+
+    session.remove_current_file.reset_mock()
+    session.state.selected_indices = [0, 1]
+    browser._on_remove_from_menu()
+    session.remove_selected_files.assert_called_once()
+    session.remove_current_file.assert_not_called()
+
+
 def test_clearing_filter_clears_error_stylesheet(browser):
     browser.regex_btn.setChecked(True)
     browser.search_input.setText("[")


### PR DESCRIPTION
## Summary

Right-click a frame in the filmstrip for quick per-file actions without leaving the contact sheet:

- **Export** (single selection) / **Export Selected** (multi-selection)
- **Copy Settings** / **Copy Settings + Bounds** / **Paste Settings** (paste disabled when clipboard empty)
- **Reset Settings**
- **Sync Edits to Selection** (multi-selection only)
- **Unload** / **Unload Selected**

Right-clicking an unselected frame selects it first (Lightroom-style); right-clicking within a multi-selection keeps the selection and acts on the whole set.

## Implementation

- `files.py`: `CustomContextMenu` policy on the grid + `_show_context_menu` / `_build_context_menu`. All actions reuse existing session/controller methods.
- `controller.py`: `request_batch_export` now accepts an explicit `files` list (defaults to visible); new `request_export_selected` reuses it for the selection — no duplicated export logic.

## Tests

`tests/test_file_browser_widget.py`: menu items per selection size, paste enable/disable, export-selected wiring, unload routing single vs multi.

`make lint`, `make type`, `make test` green.