### PR TITLE
feat: polygon-mask dodge/burn local adjustments

### DIFF
--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -33,6 +33,7 @@ from negpy.features.exposure.models import ExposureConfig
 from negpy.features.finish.models import FinishConfig
 from negpy.features.geometry.logic import apply_fine_rotation, detect_closest_aspect_ratio
 from negpy.features.lab.models import LabConfig
+from negpy.features.local.models import LocalAdjustmentsConfig
 from negpy.features.process.models import ProcessMode, invalidate_local_bounds
 from negpy.features.retouch.models import RetouchConfig
 from negpy.features.toning.models import ToningConfig
@@ -59,6 +60,7 @@ def baseline_compare_config(config: WorkspaceConfig) -> WorkspaceConfig:
         config,
         exposure=ExposureConfig(),
         lab=LabConfig(),
+        local=LocalAdjustmentsConfig(),
         toning=ToningConfig(),
         finish=FinishConfig(),
         retouch=RetouchConfig(),
@@ -604,6 +606,61 @@ class AppController(QObject):
                 retouch=replace(self.state.config.retouch, manual_dust_spots=new_spots),
             )
         )
+        self.request_render()
+
+    def handle_lasso_completed(self, viewport_vertices: list) -> None:
+        with self.state.metrics_lock:
+            uv_grid = self.state.last_metrics.get("uv_grid")
+        if uv_grid is None or len(viewport_vertices) < 3:
+            return
+
+        raw_vertices = tuple(
+            CoordinateMapping.map_click_to_raw(nx, ny, uv_grid) for nx, ny in viewport_vertices
+        )
+
+        from negpy.features.local.models import PolygonMask
+
+        mask = PolygonMask(vertices=raw_vertices, strength=0.3, feather=0.02)
+        local = self.state.config.local
+        new_masks = local.masks + (mask,)
+        new_local = replace(local, masks=new_masks)
+        self.session.update_config(replace(self.state.config, local=new_local), persist=True)
+        self.state.local_selected_mask = len(new_masks) - 1
+        self.config_updated.emit()
+        self.request_render()
+
+    def select_local_mask(self, index: int) -> None:
+        self.state.local_selected_mask = index
+        self.config_updated.emit()
+
+    def delete_selected_local_mask(self) -> None:
+        local = self.state.config.local
+        idx = self.state.local_selected_mask
+        if not (0 <= idx < len(local.masks)):
+            return
+        new_masks = local.masks[:idx] + local.masks[idx + 1:]
+        new_local = replace(local, masks=new_masks)
+        self.session.update_config(replace(self.state.config, local=new_local), persist=True)
+        self.state.local_selected_mask = -1
+        self.config_updated.emit()
+        self.request_render()
+
+    def clear_local(self) -> None:
+        new_local = replace(self.state.config.local, masks=())
+        self.session.update_config(replace(self.state.config, local=new_local), persist=True)
+        self.state.local_selected_mask = -1
+        self.config_updated.emit()
+        self.request_render()
+
+    def update_selected_local_mask(self, **changes) -> None:
+        local = self.state.config.local
+        idx = self.state.local_selected_mask
+        if not (0 <= idx < len(local.masks)):
+            return
+        masks = list(local.masks)
+        masks[idx] = replace(masks[idx], **changes)
+        new_local = replace(local, masks=tuple(masks))
+        self.session.update_config(replace(self.state.config, local=new_local), persist=True)
         self.request_render()
 
     def _handle_wb_pick(self, nx: float, ny: float) -> None:

--- a/negpy/desktop/session.py
+++ b/negpy/desktop/session.py
@@ -18,6 +18,7 @@ class ToolMode(Enum):
     CROP_MANUAL = auto()
     CROP_MOVE = auto()
     DUST_PICK = auto()
+    LOCAL_DRAW = auto()
 
 
 @dataclass
@@ -72,6 +73,10 @@ class AppState:
 
     # Canvas background color swatch index (0=Black, 1=Dark Grey, 2=Mid Grey)
     canvas_bg_index: int = 0
+
+    # Local adjustments UI state (not persisted in workspace config)
+    local_selected_mask: int = -1
+    show_local_overlay: bool = False
 
     # History tracking
     undo_index: int = 0
@@ -623,6 +628,7 @@ class DesktopSessionManager(QObject):
         """Reset a single feature section to its default config."""
         from negpy.features.exposure.models import ExposureConfig
         from negpy.features.lab.models import LabConfig
+        from negpy.features.local.models import LocalAdjustmentsConfig
         from negpy.features.toning.models import ToningConfig
         from negpy.features.geometry.models import GeometryConfig
         from negpy.features.process.models import ProcessConfig
@@ -632,6 +638,7 @@ class DesktopSessionManager(QObject):
         defaults = {
             "exposure": ExposureConfig(),
             "lab": LabConfig(),
+            "local": LocalAdjustmentsConfig(),
             "toning": ToningConfig(),
             "geometry": GeometryConfig(),
             "process": ProcessConfig(),
@@ -641,6 +648,8 @@ class DesktopSessionManager(QObject):
         if section not in defaults:
             return
         new_config = replace(self.state.config, **{section: defaults[section]})
+        if section == "local":
+            self.state.local_selected_mask = -1
         self.update_config(new_config, persist=True)
 
     def copy_settings(self, include_bounds: bool = False) -> None:

--- a/negpy/desktop/view/canvas/overlay.py
+++ b/negpy/desktop/view/canvas/overlay.py
@@ -9,7 +9,7 @@ from PyQt6.QtWidgets import QWidget
 from negpy.desktop.converters import ImageConverter
 from negpy.desktop.session import AppState, ToolMode
 from negpy.desktop.view.styles.theme import THEME
-from negpy.features.geometry.logic import map_coords_to_geometry, translate_manual_crop_rect
+from negpy.features.geometry.logic import translate_manual_crop_rect
 from negpy.kernel.system.config import APP_CONFIG
 from negpy.services.view.coordinate_mapping import CoordinateMapping
 

--- a/negpy/desktop/view/canvas/overlay.py
+++ b/negpy/desktop/view/canvas/overlay.py
@@ -1,17 +1,19 @@
 import sys
-from typing import Optional, Tuple
+from typing import List, Optional, Tuple
 
 import numpy as np
 from PyQt6.QtCore import QPointF, QRectF, QSize, Qt, QTimer, pyqtSignal
-from PyQt6.QtGui import QColor, QImage, QMouseEvent, QPainter, QPen
+from PyQt6.QtGui import QColor, QImage, QKeySequence, QMouseEvent, QPainter, QPainterPath, QPen, QPolygonF, QShortcut
 from PyQt6.QtWidgets import QWidget
 
 from negpy.desktop.converters import ImageConverter
 from negpy.desktop.session import AppState, ToolMode
 from negpy.desktop.view.styles.theme import THEME
-from negpy.features.geometry.logic import translate_manual_crop_rect
+from negpy.features.geometry.logic import map_coords_to_geometry, translate_manual_crop_rect
 from negpy.kernel.system.config import APP_CONFIG
 from negpy.services.view.coordinate_mapping import CoordinateMapping
+
+_LASSO_SNAP_PX = 12.0
 
 
 class CanvasOverlay(QWidget):
@@ -24,6 +26,8 @@ class CanvasOverlay(QWidget):
     crop_translated = pyqtSignal(float, float, float, float)
     cursor_moved = pyqtSignal(float, float)
     cursor_left = pyqtSignal()
+    lasso_completed = pyqtSignal(list)
+    local_mask_selected = pyqtSignal(int)
 
     def __init__(self, state: AppState, parent=None):
         super().__init__(parent)
@@ -44,6 +48,11 @@ class CanvasOverlay(QWidget):
         self._tool_mode: ToolMode = ToolMode.NONE
         self._mouse_pos: QPointF = QPointF()
 
+        # Lasso (polygon mask) interaction state
+        self._lasso_pts: List[QPointF] = []
+        self._lasso_drawing: bool = False
+        self._local_mask_screen_polys: List[List[QPointF]] = []
+
         self.zoom_level: float = 1.0
         self.pan_x: float = 0.0
         self.pan_y: float = 0.0
@@ -58,6 +67,10 @@ class CanvasOverlay(QWidget):
 
         self.setMouseTracking(True)
         self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
+
+        self._escape_shortcut = QShortcut(QKeySequence(Qt.Key.Key_Escape), self)
+        self._escape_shortcut.setContext(Qt.ShortcutContext.WidgetShortcut)
+        self._escape_shortcut.activated.connect(self._cancel_lasso)
 
         if sys.platform == "win32":
             self.setAttribute(Qt.WidgetAttribute.WA_StaticContents, False)
@@ -90,7 +103,16 @@ class CanvasOverlay(QWidget):
             self._move_orig_rect = None
             self._move_last_emitted = None
             self._move_uv_grid = None
+        if mode != ToolMode.LOCAL_DRAW:
+            self._lasso_pts = []
+            self._lasso_drawing = False
         self.update()
+
+    def _cancel_lasso(self) -> None:
+        if self._tool_mode == ToolMode.LOCAL_DRAW and self._lasso_drawing:
+            self._lasso_pts = []
+            self._lasso_drawing = False
+            self.update()
 
     def update_buffer(
         self,
@@ -218,12 +240,18 @@ class CanvasOverlay(QWidget):
         if self._tool_mode != ToolMode.NONE and visible_rect.contains(self._mouse_pos):
             if self._tool_mode == ToolMode.DUST_PICK:
                 self._draw_brush(painter)
-            else:
+            elif self._tool_mode != ToolMode.LOCAL_DRAW:
                 pen = QPen(QColor(255, 255, 255, 80), 1, Qt.PenStyle.DotLine)
                 pen.setCosmetic(True)
                 painter.setPen(pen)
                 painter.drawLine(QPointF(visible_rect.x(), self._mouse_pos.y()), QPointF(visible_rect.right(), self._mouse_pos.y()))
                 painter.drawLine(QPointF(self._mouse_pos.x(), visible_rect.top()), QPointF(self._mouse_pos.x(), visible_rect.bottom()))
+
+        show_masks = getattr(self.state, "show_local_overlay", False) or self._tool_mode == ToolMode.LOCAL_DRAW
+        if show_masks:
+            self._draw_local_masks(painter)
+        if self._tool_mode == ToolMode.LOCAL_DRAW:
+            self._draw_lasso_in_progress(painter)
 
         if getattr(self.state, "compare_mode", False):
             self._draw_compare_badge(painter, visible_rect)
@@ -253,6 +281,89 @@ class CanvasOverlay(QWidget):
         painter.setPen(Qt.PenStyle.NoPen)
         painter.drawEllipse(self._mouse_pos, radius, radius)
 
+    def _raw_to_screen(self, rx: float, ry: float, uv_grid: np.ndarray) -> QPointF:
+        """
+        Inverse UV-grid lookup: raw-normalised (0-1) -> screen position.
+
+        Downsamples the grid before the nearest-neighbour search so this stays
+        fast even for large preview buffers; precision loss is sub-pixel at
+        screen scale.
+        """
+        h_uv, w_uv = uv_grid.shape[:2]
+        step = max(1, h_uv // 100)
+        small = uv_grid[::step, ::step]
+        dist = (small[..., 0] - rx) ** 2 + (small[..., 1] - ry) ** 2
+        idx = int(np.argmin(dist))
+        h_s, w_s = small.shape[:2]
+        vy, vx = divmod(idx, w_s)
+        nx = min((vx * step + step // 2) / w_uv, 1.0)
+        ny = min((vy * step + step // 2) / h_uv, 1.0)
+        return QPointF(
+            self._view_rect.x() + nx * self._view_rect.width(),
+            self._view_rect.y() + ny * self._view_rect.height(),
+        )
+
+    def _draw_local_masks(self, painter: QPainter) -> None:
+        if self._view_rect.isEmpty():
+            return
+        masks = self.state.config.local.masks
+        self._local_mask_screen_polys = []
+        if not masks:
+            return
+
+        with self.state.metrics_lock:
+            uv_grid = self.state.last_metrics.get("uv_grid")
+        if uv_grid is None:
+            return
+
+        selected = getattr(self.state, "local_selected_mask", -1)
+        for i, mask in enumerate(masks):
+            if len(mask.vertices) < 3:
+                self._local_mask_screen_polys.append([])
+                continue
+            screen_pts = [self._raw_to_screen(rx, ry, uv_grid) for rx, ry in mask.vertices]
+            self._local_mask_screen_polys.append(screen_pts)
+
+            is_selected = i == selected
+            outline = QColor(232, 200, 74) if mask.strength >= 0 else QColor(74, 143, 232)
+            poly = QPolygonF(screen_pts)
+
+            if is_selected:
+                fill = QColor(outline)
+                fill.setAlpha(60)
+                painter.setBrush(fill)
+                pen = QPen(outline, 2.0, Qt.PenStyle.SolidLine)
+            else:
+                painter.setBrush(Qt.BrushStyle.NoBrush)
+                pen = QPen(QColor(255, 255, 255, 140), 1.0, Qt.PenStyle.SolidLine)
+            pen.setCosmetic(True)
+            painter.setPen(pen)
+            painter.drawPolygon(poly)
+
+    def _draw_lasso_in_progress(self, painter: QPainter) -> None:
+        if not self._lasso_drawing or not self._lasso_pts:
+            return
+
+        pen = QPen(Qt.GlobalColor.white, 1.5, Qt.PenStyle.SolidLine)
+        pen.setCosmetic(True)
+        painter.setPen(pen)
+        painter.setBrush(Qt.BrushStyle.NoBrush)
+
+        path = QPainterPath(self._lasso_pts[0])
+        for pt in self._lasso_pts[1:]:
+            path.lineTo(pt)
+        if self._view_rect.contains(self._mouse_pos):
+            path.lineTo(self._mouse_pos)
+        painter.drawPath(path)
+
+        first = self._lasso_pts[0]
+        near_close = len(self._lasso_pts) >= 3 and (self._mouse_pos - first).manhattanLength() < _LASSO_SNAP_PX * 2
+        accent = QColor(THEME.accent_primary) if near_close else QColor(255, 255, 255, 180)
+        painter.setBrush(accent)
+        painter.setPen(Qt.PenStyle.NoPen)
+        r = 5.0 if near_close else 3.0
+        painter.drawEllipse(first, r, r)
+
     def _map_to_image_coords(self, screen_pos: QPointF) -> Optional[Tuple[float, float]]:
         if self._view_rect.isEmpty() or not self._view_rect.contains(screen_pos):
             return None
@@ -276,6 +387,11 @@ class CanvasOverlay(QWidget):
             self.parent()._is_panning = True
             self.parent()._last_mouse_pos = event.position()
             self.parent().setCursor(Qt.CursorShape.ClosedHandCursor)
+            event.accept()
+            return
+
+        if self._tool_mode == ToolMode.LOCAL_DRAW:
+            self._handle_lasso_press(event.position())
             event.accept()
             return
 
@@ -360,6 +476,54 @@ class CanvasOverlay(QWidget):
             self.update()
         else:
             self.update()
+
+    def _handle_lasso_press(self, pos: QPointF) -> None:
+        if not self._view_rect.contains(pos):
+            return
+
+        if not self._lasso_drawing:
+            for i, poly_pts in enumerate(self._local_mask_screen_polys):
+                if len(poly_pts) < 3:
+                    continue
+                if QPolygonF(poly_pts).containsPoint(pos, Qt.FillRule.OddEvenFill):
+                    self.local_mask_selected.emit(i)
+                    return
+            self._lasso_drawing = True
+            self._lasso_pts = [pos]
+            self.update()
+            return
+
+        first = self._lasso_pts[0]
+        if len(self._lasso_pts) >= 3 and (pos - first).manhattanLength() < _LASSO_SNAP_PX * 2:
+            self._finish_lasso()
+            return
+
+        self._lasso_pts.append(pos)
+        self.update()
+
+    def _finish_lasso(self) -> None:
+        pts = self._lasso_pts
+        self._lasso_pts = []
+        self._lasso_drawing = False
+        if len(pts) < 3:
+            self.update()
+            return
+        vertices = []
+        for pt in pts:
+            coords = self._map_to_image_coords(pt)
+            if coords is None:
+                self.update()
+                return
+            vertices.append(coords)
+        self.lasso_completed.emit(vertices)
+        self.update()
+
+    def mouseDoubleClickEvent(self, event: QMouseEvent) -> None:
+        if self._tool_mode == ToolMode.LOCAL_DRAW and self._lasso_drawing:
+            self._finish_lasso()
+            event.accept()
+            return
+        super().mouseDoubleClickEvent(event)
 
     def mouseReleaseEvent(self, event: QMouseEvent) -> None:
         if self.parent()._is_panning:

--- a/negpy/desktop/view/canvas/widget.py
+++ b/negpy/desktop/view/canvas/widget.py
@@ -35,6 +35,7 @@ _TOOL_CURSORS: dict[ToolMode, Qt.CursorShape] = {
     ToolMode.CROP_MANUAL: Qt.CursorShape.CrossCursor,
     ToolMode.CROP_MOVE: Qt.CursorShape.OpenHandCursor,
     ToolMode.DUST_PICK: Qt.CursorShape.BlankCursor,
+    ToolMode.LOCAL_DRAW: Qt.CursorShape.CrossCursor,
 }
 # Do not apply more than this many notch-equivalents in a single event (huge flings).
 _WHEEL_MAX_NOTCHES = 4.0
@@ -79,6 +80,8 @@ class ImageCanvas(QWidget):
     zoom_changed = pyqtSignal(float)
     cursor_position_changed = pyqtSignal(float, float)
     cursor_left_canvas = pyqtSignal()
+    lasso_completed = pyqtSignal(list)
+    local_mask_selected = pyqtSignal(int)
 
     def __init__(self, state: AppState, parent=None):
         super().__init__(parent)
@@ -123,6 +126,8 @@ class ImageCanvas(QWidget):
         self.overlay.crop_translated.connect(self.crop_translated.emit)
         self.overlay.cursor_moved.connect(self.cursor_position_changed.emit)
         self.overlay.cursor_left.connect(self.cursor_left_canvas.emit)
+        self.overlay.lasso_completed.connect(self.lasso_completed.emit)
+        self.overlay.local_mask_selected.connect(self.local_mask_selected.emit)
 
         # Pixel readout overlay — absolute child, not in layout
         self.pixel_readout_overlay = PixelReadoutOverlay(self)

--- a/negpy/desktop/view/main_window.py
+++ b/negpy/desktop/view/main_window.py
@@ -272,6 +272,8 @@ class MainWindow(QMainWindow):
         self.canvas.clicked.connect(self.controller.handle_canvas_clicked)
         self.canvas.crop_completed.connect(self.controller.handle_crop_completed)
         self.canvas.crop_translated.connect(self.controller.handle_crop_translated)
+        self.canvas.lasso_completed.connect(self.controller.handle_lasso_completed)
+        self.canvas.local_mask_selected.connect(self.controller.select_local_mask)
 
         self.controller.export_progress.connect(self._on_export_progress)
         self.controller.export_finished.connect(self._on_export_finished)

--- a/negpy/desktop/view/sidebar/controls_panel.py
+++ b/negpy/desktop/view/sidebar/controls_panel.py
@@ -24,6 +24,7 @@ from negpy.desktop.view.sidebar.geometry import GeometrySidebar
 from negpy.desktop.view.sidebar.lab import LabSidebar
 from negpy.desktop.view.sidebar.toning import ToningSidebar
 from negpy.desktop.view.sidebar.retouch import RetouchSidebar
+from negpy.desktop.view.sidebar.local import LocalSidebar
 from negpy.desktop.view.sidebar.finish import FinishSidebar
 
 
@@ -100,6 +101,14 @@ class ControlsPanel(QWidget):
             icon=qta.icon("fa5s.brush", color=icon_color),
         )
 
+        self.local_sidebar = LocalSidebar(self.controller)
+        self.local_section = self._make_section(
+            "Dodge & Burn",
+            "local",
+            self.local_sidebar,
+            icon=qta.icon("fa5s.adjust", color=icon_color),
+        )
+
         self.finish_sidebar = FinishSidebar(self.controller)
         self.finish_section = self._make_section(
             "Finishing",
@@ -122,9 +131,9 @@ class ControlsPanel(QWidget):
             (
                 "finish",
                 "fa5s.brush",
-                "Finish — Retouch, Finishing",
-                [self.retouch_section, self.finish_section],
-                ["retouch_section", "finish_section"],
+                "Finish — Retouch, Dodge & Burn, Finishing",
+                [self.retouch_section, self.local_section, self.finish_section],
+                ["retouch_section", "local_section", "finish_section"],
             ),
         ]
 
@@ -185,7 +194,10 @@ class ControlsPanel(QWidget):
         self.geometry_section.reset_requested.connect(lambda: self.controller.session.reset_section("geometry"))
         self.process_section.reset_requested.connect(lambda: self.controller.session.reset_section("process"))
         self.retouch_section.reset_requested.connect(lambda: self.controller.session.reset_section("retouch"))
+        self.local_section.reset_requested.connect(lambda: self.controller.session.reset_section("local"))
         self.finish_section.reset_requested.connect(lambda: self.controller.session.reset_section("finish"))
+
+        self.local_section.expanded_changed.connect(self._on_local_section_expanded)
 
     def apply_shortcut_tooltips(self) -> None:
         exp = self.exposure_sidebar
@@ -437,6 +449,11 @@ class ControlsPanel(QWidget):
             )
         )
 
+    def _on_local_section_expanded(self, expanded: bool) -> None:
+        self.controller.state.show_local_overlay = expanded
+        if self.controller.canvas:
+            self.controller.canvas.overlay.update()
+
     def _sync_all_sidebars(self) -> None:
         """Force all sidebar panels to update their widgets from current AppState."""
         self.process_sidebar.sync_ui()
@@ -445,6 +462,7 @@ class ControlsPanel(QWidget):
         self.lab_sidebar.sync_ui()
         self.toning_sidebar.sync_ui()
         self.retouch_sidebar.sync_ui()
+        self.local_sidebar.sync_ui()
         self.finish_sidebar.sync_ui()
         self.presets_sidebar.sync_ui()
         self._sync_modified_dots()
@@ -555,8 +573,10 @@ class ControlsPanel(QWidget):
         self.geometry_section.set_modified(geometry_count)
         self.process_section.set_modified(process_count)
         self.retouch_section.set_modified(retouch_count)
+        self.local_section.set_modified(len(cfg.local.masks))
         self.finish_section.set_modified(finish_count)
 
     def _sync_tool_buttons(self) -> None:
         """Updates toggle button states to match active_tool."""
         self.geometry_sidebar.sync_ui()
+        self.local_sidebar.sync_ui()

--- a/negpy/desktop/view/sidebar/local.py
+++ b/negpy/desktop/view/sidebar/local.py
@@ -1,0 +1,99 @@
+from PyQt6.QtWidgets import QPushButton, QHBoxLayout, QLabel
+import qtawesome as qta
+from negpy.desktop.view.widgets.sliders import CompactSlider
+from negpy.desktop.view.sidebar.base import BaseSidebar
+from negpy.desktop.session import ToolMode
+from negpy.desktop.view.styles.theme import THEME
+
+
+class LocalSidebar(BaseSidebar):
+    """
+    Polygon-mask dodge/burn local adjustments. Draw a polygon, then tune
+    its strength (dodge/burn EV) and feather independently of other masks.
+    """
+
+    def _init_ui(self) -> None:
+        self.layout.setSpacing(10)
+
+        self.draw_btn = QPushButton(" Draw Mask")
+        self.draw_btn.setCheckable(True)
+        self.draw_btn.setIcon(qta.icon("fa5s.draw-polygon", color=THEME.text_primary))
+        self.draw_btn.setToolTip(
+            "Click to place vertices, double-click or click near the start to close. "
+            "Click inside an existing mask to select it. Esc cancels the current shape."
+        )
+        self.layout.addWidget(self.draw_btn)
+
+        self.strength_slider = CompactSlider(
+            "Strength", -1.0, 1.0, 0.3, step=0.05, precision=100, has_neutral=True, unit=" EV"
+        )
+        self.strength_slider.setToolTip(
+            "EV adjustment for the selected mask — positive brightens (dodge), negative darkens (burn)"
+        )
+        self.layout.addWidget(self.strength_slider)
+
+        self.feather_slider = CompactSlider(
+            "Feather", 0.0, 0.15, 0.02, step=0.005, precision=1000
+        )
+        self.feather_slider.setToolTip("Edge softness for the selected mask")
+        self.layout.addWidget(self.feather_slider)
+
+        status_row = QHBoxLayout()
+        self.mask_count_label = QLabel("0 masks")
+        self.mask_count_label.setStyleSheet(
+            f"font-size: {THEME.font_size_base}px; color: {THEME.text_secondary};"
+        )
+        self.delete_btn = QPushButton(" Delete")
+        self.delete_btn.setIcon(qta.icon("fa5s.times", color=THEME.text_primary))
+        self.delete_btn.setToolTip("Delete the selected mask")
+        self.delete_btn.setEnabled(False)
+        self.clear_btn = QPushButton(" Clear All")
+        self.clear_btn.setIcon(qta.icon("fa5s.trash-alt", color=THEME.text_primary))
+        self.clear_btn.setToolTip("Remove all dodge/burn masks")
+        status_row.addWidget(self.mask_count_label)
+        status_row.addStretch()
+        status_row.addWidget(self.delete_btn)
+        status_row.addWidget(self.clear_btn)
+        self.layout.addLayout(status_row)
+
+        self.layout.addStretch()
+
+    def _connect_signals(self) -> None:
+        self.draw_btn.toggled.connect(self._on_draw_toggled)
+        self.strength_slider.valueChanged.connect(
+            lambda v: self.controller.update_selected_local_mask(strength=float(v))
+        )
+        self.feather_slider.valueChanged.connect(
+            lambda v: self.controller.update_selected_local_mask(feather=float(v))
+        )
+        self.delete_btn.clicked.connect(self.controller.delete_selected_local_mask)
+        self.clear_btn.clicked.connect(self.controller.clear_local)
+
+    def _on_draw_toggled(self, checked: bool) -> None:
+        self.controller.set_active_tool(ToolMode.LOCAL_DRAW if checked else ToolMode.NONE)
+
+    def sync_ui(self) -> None:
+        conf = self.state.config.local
+        self.block_signals(True)
+        try:
+            self.draw_btn.setChecked(self.state.active_tool == ToolMode.LOCAL_DRAW)
+
+            n = len(conf.masks)
+            self.mask_count_label.setText(f"{n} mask{'s' if n != 1 else ''}")
+            self.clear_btn.setEnabled(n > 0)
+
+            idx = self.state.local_selected_mask
+            has_selection = 0 <= idx < n
+            self.delete_btn.setEnabled(has_selection)
+            self.strength_slider.setEnabled(has_selection)
+            self.feather_slider.setEnabled(has_selection)
+            if has_selection:
+                mask = conf.masks[idx]
+                self.strength_slider.setValue(mask.strength)
+                self.feather_slider.setValue(mask.feather)
+        finally:
+            self.block_signals(False)
+
+    def block_signals(self, blocked: bool) -> None:
+        for w in [self.draw_btn, self.strength_slider, self.feather_slider]:
+            w.blockSignals(blocked)

--- a/negpy/domain/models.py
+++ b/negpy/domain/models.py
@@ -7,6 +7,7 @@ from negpy.features.process.models import ProcessConfig
 from negpy.features.exposure.models import ExposureConfig
 from negpy.features.geometry.models import GeometryConfig
 from negpy.features.lab.models import LabConfig
+from negpy.features.local.models import LocalAdjustmentsConfig, PolygonMask
 from negpy.features.retouch.models import RetouchConfig
 from negpy.features.toning.models import ToningConfig
 from negpy.features.finish.models import FinishConfig
@@ -106,6 +107,7 @@ class WorkspaceConfig:
     exposure: ExposureConfig = field(default_factory=ExposureConfig)
     geometry: GeometryConfig = field(default_factory=GeometryConfig)
     lab: LabConfig = field(default_factory=LabConfig)
+    local: LocalAdjustmentsConfig = field(default_factory=LocalAdjustmentsConfig)
     retouch: RetouchConfig = field(default_factory=RetouchConfig)
     toning: ToningConfig = field(default_factory=ToningConfig)
     finish: FinishConfig = field(default_factory=FinishConfig)
@@ -121,6 +123,7 @@ class WorkspaceConfig:
         res.update(asdict(self.exposure))
         res.update(asdict(self.geometry))
         res.update(asdict(self.lab))
+        res["local_masks"] = asdict(self.local)
         res.update(asdict(self.retouch))
         res.update(asdict(self.toning))
         res.update(asdict(self.finish))
@@ -133,6 +136,8 @@ class WorkspaceConfig:
         """
         from DB/JSON.
         """
+
+        local_data = data.pop("local_masks", {})
 
         # Apply field renames for backward compatibility.
         for old_key, new_key in MIGRATIONS.items():
@@ -169,11 +174,23 @@ class WorkspaceConfig:
             valid = config_cls.__dataclass_fields__.keys()
             return {k: v for k, v in d.items() if k in valid}
 
+        def _build_local(d: Dict[str, Any]) -> LocalAdjustmentsConfig:
+            masks = []
+            for m in d.get("masks", []):
+                verts = tuple(tuple(v) for v in m.get("vertices", []))
+                masks.append(PolygonMask(
+                    vertices=verts,
+                    strength=float(m.get("strength", 0.3)),
+                    feather=float(m.get("feather", 0.02)),
+                ))
+            return LocalAdjustmentsConfig(masks=tuple(masks))
+
         return cls(
             process=ProcessConfig(**filter_keys(ProcessConfig, data)),
             exposure=ExposureConfig(**filter_keys(ExposureConfig, data)),
             geometry=GeometryConfig(**filter_keys(GeometryConfig, data)),
             lab=LabConfig(**filter_keys(LabConfig, data)),
+            local=_build_local(local_data),
             retouch=RetouchConfig(**filter_keys(RetouchConfig, data)),
             toning=ToningConfig(**filter_keys(ToningConfig, data)),
             finish=FinishConfig(**filter_keys(FinishConfig, data)),

--- a/negpy/features/local/logic.py
+++ b/negpy/features/local/logic.py
@@ -1,0 +1,75 @@
+from typing import List, Tuple
+
+import cv2
+import numpy as np
+
+from negpy.features.local.models import LocalAdjustmentsConfig
+from negpy.features.geometry.logic import map_coords_to_geometry
+
+
+def _rasterise_mask(
+    vertices_img: List[Tuple[float, float]],
+    h: int,
+    w: int,
+    feather_sigma: float,
+) -> np.ndarray:
+    """
+    Rasterise a polygon (in image-pixel coords) to a float32 mask [h, w].
+    Feather is a Gaussian sigma in pixels applied to the hard binary fill.
+    """
+    pts = np.array([[v[0] * w, v[1] * h] for v in vertices_img], dtype=np.float32)
+    mask = np.zeros((h, w), dtype=np.uint8)
+    cv2.fillPoly(mask, [pts.astype(np.int32)], 255)
+    mask_f = mask.astype(np.float32) / 255.0
+    if feather_sigma > 1e-3:
+        k = int(feather_sigma * 3) | 1  # odd kernel covering ~3 sigma
+        mask_f = cv2.GaussianBlur(mask_f, (k, k), feather_sigma)
+    return mask_f
+
+
+def apply_local_adjustments(
+    img: np.ndarray,
+    config: LocalAdjustmentsConfig,
+    orig_shape: Tuple[int, int],
+    rotation: int = 0,
+    fine_rotation: float = 0.0,
+    flip_horizontal: bool = False,
+    flip_vertical: bool = False,
+) -> np.ndarray:
+    """
+    Apply polygon dodge/burn masks to a linear float32 RGB image [H, W, 3].
+
+    Vertices are in raw-image normalised space; they are mapped into the
+    current image's geometry-transformed space before rasterisation.
+    Positive strength dodges (brightens), negative burns (darkens).
+    Returns the adjusted image clipped to [0, 1].
+    """
+    if not config.masks:
+        return img
+
+    h, w = img.shape[:2]
+    short_side = float(min(h, w))
+    result = img.astype(np.float32, copy=True)
+
+    for mask in config.masks:
+        if len(mask.vertices) < 3:
+            continue
+
+        transformed = [
+            map_coords_to_geometry(
+                rx, ry,
+                orig_shape,
+                rotation,
+                fine_rotation,
+                flip_horizontal,
+                flip_vertical,
+            )
+            for rx, ry in mask.vertices
+        ]
+
+        sigma_px = mask.feather * short_side
+        alpha = _rasterise_mask(transformed, h, w, sigma_px)
+        factor = np.power(2.0, mask.strength * alpha, dtype=np.float32)
+        result *= factor[..., np.newaxis]
+
+    return np.clip(result, 0.0, 1.0)

--- a/negpy/features/local/models.py
+++ b/negpy/features/local/models.py
@@ -1,0 +1,15 @@
+from dataclasses import dataclass, field
+from typing import Tuple
+
+
+@dataclass(frozen=True)
+class PolygonMask:
+    # Vertices in raw-image normalised coords [0,1]×[0,1].
+    vertices: Tuple[Tuple[float, float], ...] = field(default_factory=tuple)
+    strength: float = 0.3    # EV stops; positive = dodge, negative = burn
+    feather: float = 0.02    # Gaussian sigma as fraction of shorter image dimension
+
+
+@dataclass(frozen=True)
+class LocalAdjustmentsConfig:
+    masks: Tuple[PolygonMask, ...] = field(default_factory=tuple)

--- a/negpy/features/local/processor.py
+++ b/negpy/features/local/processor.py
@@ -1,0 +1,24 @@
+from negpy.domain.interfaces import PipelineContext
+from negpy.domain.types import ImageBuffer
+from negpy.features.local.logic import apply_local_adjustments
+from negpy.features.local.models import LocalAdjustmentsConfig
+
+
+class LocalProcessor:
+    def __init__(self, config: LocalAdjustmentsConfig):
+        self.config = config
+
+    def process(self, img: ImageBuffer, context: PipelineContext) -> ImageBuffer:
+        if not self.config.masks:
+            return img
+
+        geo = context.metrics.get("geometry_params", {})
+        return apply_local_adjustments(
+            img,
+            self.config,
+            orig_shape=context.original_size,
+            rotation=geo.get("rotation", 0),
+            fine_rotation=geo.get("fine_rotation", 0.0),
+            flip_horizontal=geo.get("flip_horizontal", False),
+            flip_vertical=geo.get("flip_vertical", False),
+        )

--- a/negpy/kernel/caching/manager.py
+++ b/negpy/kernel/caching/manager.py
@@ -15,10 +15,12 @@ class PipelineCache:
     exposure: Optional[CacheEntry] = None
     retouch: Optional[CacheEntry] = None
     lab: Optional[CacheEntry] = None
+    local: Optional[CacheEntry] = None
 
     def clear(self) -> None:
         self.base = None
         self.exposure = None
         self.retouch = None
         self.lab = None
+        self.local = None
         self.source_hash = ""

--- a/negpy/services/rendering/engine.py
+++ b/negpy/services/rendering/engine.py
@@ -13,6 +13,7 @@ from negpy.features.exposure.processor import (
 )
 from negpy.features.toning.processor import ToningProcessor
 from negpy.features.lab.processor import PhotoLabProcessor
+from negpy.features.local.processor import LocalProcessor
 from negpy.features.retouch.processor import RetouchProcessor
 from negpy.features.finish.processor import FinishProcessor
 from negpy.kernel.system.config import APP_CONFIG
@@ -141,6 +142,13 @@ class DarkroomEngine:
             return PhotoLabProcessor(settings.lab).process(img_in, ctx)
 
         current_img, pipeline_changed = self._run_stage(current_img, settings.lab, "lab", run_lab, context, pipeline_changed)
+
+        def run_local(img_in: ImageBuffer, ctx: PipelineContext) -> ImageBuffer:
+            return LocalProcessor(settings.local).process(img_in, ctx)
+
+        current_img, pipeline_changed = self._run_stage(
+            current_img, settings.local, "local", run_local, context, pipeline_changed
+        )
 
         current_img = ToningProcessor(settings.toning).process(current_img, context)
         current_img = CropProcessor(settings.geometry).process(current_img, context)

--- a/negpy/services/rendering/image_processor.py
+++ b/negpy/services/rendering/image_processor.py
@@ -86,7 +86,7 @@ class ImageProcessor:
         if metrics:
             context.metrics.update(metrics)
 
-        if prefer_gpu and self.engine_gpu:
+        if prefer_gpu and self.engine_gpu and not settings.local.masks:
             try:
                 processed, gpu_metrics = self.engine_gpu.process_to_texture(
                     img,


### PR DESCRIPTION
First go at adding dodge/burn mechanics. Tried a brush tool but really hated the UX and I find the polygon masking more accurate and efficient.

Rendering runs as a new cached pipeline stage after lab/before toning, falling back to CPU when masks are present since the GPU engine doesn't yet implement this stage.