### PR TITLE
fix: make export colors trustworthy by default

### DIFF
--- a/negpy/desktop/session.py
+++ b/negpy/desktop/session.py
@@ -59,7 +59,8 @@ class AppState:
     # User override: a ColorSpace value (e.g. "Display P3") or None = use detected.
     monitor_profile_override: Optional[str] = None
     # Soft-proof toggle: when off, Output/Input ICC affect export only, not the preview.
-    soft_proof_enabled: bool = False
+    # Defaults on so the preview is true to export by default.
+    soft_proof_enabled: bool = True
 
     # Hardware Acceleration
     gpu_enabled: bool = True

--- a/negpy/desktop/view/main_window.py
+++ b/negpy/desktop/view/main_window.py
@@ -54,6 +54,7 @@ def _read_screen_icc(screen: object) -> Optional[bytes]:
             return prof.tobytes()
     except Exception as e:
         logger.debug("PIL display profile unavailable: %s", e)
+    logger.warning("No monitor ICC profile detected from Qt or PIL; preview will assume sRGB")
     return None
 
 

--- a/negpy/desktop/view/sidebar/export.py
+++ b/negpy/desktop/view/sidebar/export.py
@@ -50,8 +50,10 @@ class ExportSidebar(BaseSidebar):
 
     def _connect_signals(self) -> None:
         self.form.changed.connect(self.update_timer.start)
+        self.form.changed.connect(self._refresh_proof_mismatch_warning)
 
         self.soft_proof_checkbox.toggled.connect(self.controller.set_soft_proof)
+        self.soft_proof_checkbox.toggled.connect(self._refresh_proof_mismatch_warning)
         self.display_combo.currentIndexChanged.connect(self._on_display_changed)
         self.controller.monitor_profile_changed.connect(self._refresh_display_info)
 
@@ -157,11 +159,16 @@ class ExportSidebar(BaseSidebar):
     def _add_preview_section(self) -> None:
         self.layout.addWidget(section_subheader("PREVIEW"))
 
-        # Soft proof: when on, the preview simulates the Output profile (incl.
-        # paper/printer); when off, Output/Input ICC affect export only.
-        self.soft_proof_checkbox = QCheckBox("Soft proof")
+        # Soft proof: on by default so the preview is true to export. When off,
+        # Output/Input ICC and the export color space affect export only, not
+        # the preview — i.e. exported colors may differ from what's shown.
+        self.soft_proof_checkbox = QCheckBox("Soft proof (preview matches export)")
         self.soft_proof_checkbox.setChecked(self.state.soft_proof_enabled)
-        self.soft_proof_checkbox.setToolTip("Simulate the Output profile (incl. paper/printer) in the preview")
+        self.soft_proof_checkbox.setToolTip(
+            "Simulate the export color space and Output profile (incl. paper/printer) in the "
+            "preview, so what you see matches what you'll get. Turn off only to preview at full "
+            "gamut regardless of the export target."
+        )
         self.layout.addWidget(self.soft_proof_checkbox)
 
         # Display: monitor profile the preview is shown on (preview only, not export).
@@ -189,6 +196,14 @@ class ExportSidebar(BaseSidebar):
         self.display_detected_label.setStyleSheet(f"color: {THEME.text_muted}; font-size: 10px;")
         self.layout.addWidget(self.display_detected_label)
         self._refresh_display_info()
+
+        # Warns when the preview won't reflect the export's gamut clamp (soft
+        # proof off + export space narrower than the working space).
+        self.proof_mismatch_label = QLabel("Soft proof is off — preview won't show the export's color clipping")
+        self.proof_mismatch_label.setWordWrap(True)
+        self.proof_mismatch_label.setStyleSheet(f"color: {THEME.accent_edited}; font-size: 10px;")
+        self.layout.addWidget(self.proof_mismatch_label)
+        self._refresh_proof_mismatch_warning()
 
     # --- Batch ---------------------------------------------------------------
 
@@ -330,6 +345,18 @@ class ExportSidebar(BaseSidebar):
         self.display_detected_label.setText(f"Detected: {desc}")
         self.display_combo.setItemText(0, f"As detected ({desc})")
 
+    def _refresh_proof_mismatch_warning(self) -> None:
+        """Show a hint when soft proof is off and export will clamp to a
+        narrower/different color space than the preview is shown in, so the
+        preview can't be trusted to predict the exported colors."""
+        from negpy.infrastructure.display.color_spaces import WORKING_COLOR_SPACE
+
+        export_cs = self.form.values()["export_color_space"]
+        mismatch = (
+            not self.soft_proof_checkbox.isChecked() and export_cs != ColorSpace.SAME_AS_SOURCE.value and export_cs != WORKING_COLOR_SPACE
+        )
+        self.proof_mismatch_label.setVisible(mismatch)
+
     def sync_ui(self) -> None:
         conf = self.state.config.export
         self.block_signals(True)
@@ -346,6 +373,7 @@ class ExportSidebar(BaseSidebar):
         finally:
             self.block_signals(False)
 
+        self._refresh_proof_mismatch_warning()
         self._rebuild_preset_rows()
 
     def block_signals(self, blocked: bool) -> None:

--- a/negpy/domain/models.py
+++ b/negpy/domain/models.py
@@ -93,7 +93,7 @@ class ExportConfig:
     export_path: str = field(default_factory=lambda: os.path.join(paths.get_default_user_dir(), "export"))
     export_fmt: str = ExportFormat.JPEG
     jpeg_quality: int = 90
-    export_color_space: str = ColorSpace.ADOBE_RGB.value
+    export_color_space: str = ColorSpace.SRGB.value
     paper_aspect_ratio: str = AspectRatio.ORIGINAL
     export_print_size: float = 30.0
     export_dpi: int = 300
@@ -142,7 +142,7 @@ class ExportPreset:
     filename_pattern: str = "{{ original_name }}"
 
     # Color
-    export_color_space: str = ColorSpace.ADOBE_RGB.value
+    export_color_space: str = ColorSpace.SRGB.value
     icc_input_path: Optional[str] = None
     icc_output_path: Optional[str] = None
 
@@ -251,9 +251,7 @@ class WorkspaceConfig:
             data.pop("use_original_res", None)
 
         if "same_as_source" in data and "output_mode" not in data:
-            data["output_mode"] = (
-                ExportPresetOutputMode.SAME_AS_SOURCE if data.pop("same_as_source") else ExportPresetOutputMode.ABSOLUTE
-            )
+            data["output_mode"] = ExportPresetOutputMode.SAME_AS_SOURCE if data.pop("same_as_source") else ExportPresetOutputMode.ABSOLUTE
         else:
             data.pop("same_as_source", None)
 

--- a/negpy/kernel/system/config.py
+++ b/negpy/kernel/system/config.py
@@ -77,7 +77,7 @@ DEFAULT_WORKSPACE_CONFIG = WorkspaceConfig(
     ),
     export=ExportConfig(
         export_fmt=ExportFormat.JPEG,
-        export_color_space=ColorSpace.ADOBE_RGB.value,
+        export_color_space=ColorSpace.SRGB.value,
         export_print_size=30.0,
         export_dpi=300,
         export_path=APP_CONFIG.default_export_dir,


### PR DESCRIPTION
## Summary
- Default `export_color_space` to sRGB instead of Adobe RGB. Previously the default export space matched the internal working space, so exports skipped the ICC pixel transform entirely and just tagged wide-gamut pixel values as Adobe RGB — many viewers/platforms that don't fully honor embedded profiles render this as oversaturated/"punchy", matching some chatter I've seen on reddit
- Default Soft Proof to **on** so the preview reflects the actual export color-space clamp instead of silently diverging from it. Relabeled the checkbox/tooltip ("Soft proof (preview matches export)") so its purpose is obvious without prior color-management knowledge, and reworded the off-state warning label accordingly.
- Log a `warning` (was `debug`) when monitor ICC detection fails on both the Qt and PIL paths, so a silent sRGB fallback is discoverable instead of invisible.

## Why
Several users reported exported images not matching the in-app preview despite a "fully color-managed workflow," with some compensating by oversaturating before export. Root cause: the default export config produced untransformed wide-gamut-tagged files, and the preview never simulated the export's gamut clamp unless the buried Soft Proof toggle was manually enabled.

## Test plan
- [x] `make format` / `make lint` / `make type` clean
- [x] `make test` — 698 passed
- [ ] Manual: export a saturated frame with default settings before/after and compare in a non-color-managed viewer