### PR TITLE
feat: rule-of-thirds grid overlay during fine rotation (#258)

### DIFF
--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -87,6 +87,7 @@ class AppController(QObject):
     preview_load_requested = pyqtSignal(PreviewLoadTask)
     normalization_requested = pyqtSignal(NormalizationTask)
     analysis_buffer_preview_requested = pyqtSignal(float)
+    rotation_guide_requested = pyqtSignal()
     asset_discovery_requested = pyqtSignal(AssetDiscoveryTask)
     thumbnail_requested = pyqtSignal(list)
     thumbnail_update_requested = pyqtSignal(ThumbnailUpdateTask)
@@ -508,6 +509,10 @@ class AppController(QObject):
     def cancel_active_tool(self) -> None:
         if self.state.active_tool != ToolMode.NONE:
             self.set_active_tool(ToolMode.NONE)
+
+    def show_rotation_guide(self) -> None:
+        """Request the canvas show the fine-rotation alignment grid."""
+        self.rotation_guide_requested.emit()
 
     def handle_crop_completed(self, nx1: float, ny1: float, nx2: float, ny2: float) -> None:
         if self.state.active_tool != ToolMode.CROP_MANUAL:

--- a/negpy/desktop/view/canvas/overlay.py
+++ b/negpy/desktop/view/canvas/overlay.py
@@ -56,6 +56,11 @@ class CanvasOverlay(QWidget):
         self._buffer_hide_timer.setSingleShot(True)
         self._buffer_hide_timer.timeout.connect(self._hide_buffer_overlay)
 
+        self._rotation_grid_visible: bool = False
+        self._rotation_grid_timer = QTimer(self)
+        self._rotation_grid_timer.setSingleShot(True)
+        self._rotation_grid_timer.timeout.connect(self._hide_rotation_grid)
+
         self.setMouseTracking(True)
         self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
 
@@ -77,6 +82,16 @@ class CanvasOverlay(QWidget):
 
     def _hide_buffer_overlay(self) -> None:
         self._buffer_overlay_visible = False
+        self.update()
+
+    def show_rotation_grid(self) -> None:
+        """Show the rule-of-thirds alignment grid while Fine Rot is adjusted; lingers 1s."""
+        self._rotation_grid_visible = True
+        self._rotation_grid_timer.start(1000)
+        self.update()
+
+    def _hide_rotation_grid(self) -> None:
+        self._rotation_grid_visible = False
         self.update()
 
     def set_tool_mode(self, mode: ToolMode) -> None:
@@ -225,8 +240,23 @@ class CanvasOverlay(QWidget):
                 painter.drawLine(QPointF(visible_rect.x(), self._mouse_pos.y()), QPointF(visible_rect.right(), self._mouse_pos.y()))
                 painter.drawLine(QPointF(self._mouse_pos.x(), visible_rect.top()), QPointF(self._mouse_pos.x(), visible_rect.bottom()))
 
+        if self._rotation_grid_visible:
+            self._draw_rotation_grid(painter, visible_rect)
+
         if getattr(self.state, "compare_mode", False):
             self._draw_compare_badge(painter, visible_rect)
+
+    def _draw_rotation_grid(self, painter: QPainter, visible_rect: QRectF) -> None:
+        """Rule-of-thirds grid: 2 horizontal + 2 vertical screen-aligned reference lines."""
+        pen = QPen(QColor(255, 255, 255, 90), 1, Qt.PenStyle.SolidLine)
+        pen.setCosmetic(True)
+        painter.setBrush(Qt.BrushStyle.NoBrush)
+        painter.setPen(pen)
+        for i in (1, 2):
+            x = visible_rect.left() + visible_rect.width() * i / 3.0
+            y = visible_rect.top() + visible_rect.height() * i / 3.0
+            painter.drawLine(QPointF(x, visible_rect.top()), QPointF(x, visible_rect.bottom()))
+            painter.drawLine(QPointF(visible_rect.left(), y), QPointF(visible_rect.right(), y))
 
     def _draw_compare_badge(self, painter: QPainter, visible_rect: QRectF) -> None:
         badge = QRectF(visible_rect.x() + 12, visible_rect.y() + 12, 78, 22)

--- a/negpy/desktop/view/main_window.py
+++ b/negpy/desktop/view/main_window.py
@@ -283,6 +283,7 @@ class MainWindow(QMainWindow):
         self.controller.config_updated.connect(self.canvas.overlay.update)
         self.controller.compare_changed.connect(lambda _on: self.canvas.overlay.update())
         self.controller.analysis_buffer_preview_requested.connect(self.canvas.overlay.show_analysis_buffer)
+        self.controller.rotation_guide_requested.connect(self.canvas.overlay.show_rotation_grid)
 
         self.controller.status_message_requested.connect(self.top_status.showMessage)
         self.controller.status_progress_requested.connect(self.top_status.set_progress)

--- a/negpy/desktop/view/sidebar/geometry.py
+++ b/negpy/desktop/view/sidebar/geometry.py
@@ -137,6 +137,7 @@ class GeometrySidebar(BaseSidebar):
         self.fine_rot_slider.valueChanged.connect(
             lambda v: self.update_config_section("geometry", render=True, persist=False, readback_metrics=False, fine_rotation=v)
         )
+        self.fine_rot_slider.valueChanged.connect(lambda _v: self.controller.show_rotation_guide())
         self.fine_rot_slider.valueCommitted.connect(
             lambda v: self.update_config_section("geometry", render=True, persist=True, readback_metrics=True, fine_rotation=v)
         )

--- a/tests/test_rotation_guide.py
+++ b/tests/test_rotation_guide.py
@@ -1,0 +1,14 @@
+from negpy.desktop.session import AppState
+from negpy.desktop.view.canvas.overlay import CanvasOverlay
+
+
+def test_rotation_grid_toggles_with_timer() -> None:
+    overlay = CanvasOverlay(AppState())
+    assert overlay._rotation_grid_visible is False
+
+    overlay.show_rotation_grid()
+    assert overlay._rotation_grid_visible is True
+    assert overlay._rotation_grid_timer.isActive()
+
+    overlay._hide_rotation_grid()
+    assert overlay._rotation_grid_visible is False


### PR DESCRIPTION
## Summary
Closes #258. Leveling a horizon/building with the **Fine Rot** slider had no straight reference on the canvas. This adds a rule-of-thirds grid overlay (2 horizontal + 2 vertical screen-aligned lines) that appears while the Fine Rot slider is adjusted and lingers ~1s after release.

## Implementation
Mirrors the existing `show_analysis_buffer` linger-timer plumbing end to end — no new tool mode, config field, or button.

- `overlay.py` — `_rotation_grid_visible` flag + 1s single-shot `QTimer`; `show_rotation_grid()` / `_hide_rotation_grid()` / `_draw_rotation_grid()`; draw call in `_draw_ui`
- `controller.py` — `rotation_guide_requested` signal + `show_rotation_guide()`
- `main_window.py` — connect signal to `overlay.show_rotation_grid`
- `geometry.py` — `fine_rot_slider.valueChanged` also fires `controller.show_rotation_guide()` (user interaction only; `sync_ui` blocks signals)

The grid is drawn screen-aligned (true horizontal/vertical) — the reference you level the tilted image against.

## Tests
- `tests/test_rotation_guide.py` covers the flag/timer state logic. Drawing verified manually.
- `make all` green: lint ✓, ty ✓, 702 passed.

## Manual verification
Open an image, drag **Fine Rot**: grid fades in over the tilting image, lingers ~1s after release, absent during normal viewing.