### PR TITLE
fix: show all export presets by removing nested scroll area (#270)

### DIFF
--- a/negpy/desktop/view/sidebar/export.py
+++ b/negpy/desktop/view/sidebar/export.py
@@ -6,7 +6,6 @@ from PyQt6.QtWidgets import (
     QHBoxLayout,
     QLabel,
     QPushButton,
-    QScrollArea,
     QSpinBox,
     QVBoxLayout,
     QWidget,
@@ -75,18 +74,12 @@ class ExportSidebar(BaseSidebar):
         content_layout.setContentsMargins(0, 0, 0, 0)
         content_layout.setSpacing(6)
 
-        self._presets_scroll = QScrollArea()
-        self._presets_scroll.setWidgetResizable(True)
-        self._presets_scroll.setMaximumHeight(140)
-        self._presets_scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
-        self._presets_scroll.setStyleSheet(f"QScrollArea {{ border: 1px solid {THEME.border_primary}; background: {THEME.bg_dark}; }}")
         self._presets_container = QWidget()
-        self._presets_container.setStyleSheet(f"background: {THEME.bg_dark};")
+        self._presets_container.setStyleSheet(f"border: 1px solid {THEME.border_primary}; background: {THEME.bg_dark};")
         self._presets_inner = QVBoxLayout(self._presets_container)
         self._presets_inner.setContentsMargins(4, 4, 4, 4)
         self._presets_inner.setSpacing(2)
-        self._presets_scroll.setWidget(self._presets_container)
-        content_layout.addWidget(self._presets_scroll)
+        content_layout.addWidget(self._presets_container)
 
         self._no_presets_label = QLabel("No presets — click Manage to add some.")
         self._no_presets_label.setStyleSheet(f"color: {THEME.text_muted}; font-size: 10px;")


### PR DESCRIPTION
## Problem

Closes #270. In the Export panel's collapsible **Presets** subpanel, users on smaller-resolution screens saw only 2 of 3 presets.

## Root cause

The preset list nested a second `QScrollArea` inside the panel's existing outer scroll area. With no minimum height, the inner area collapsed below its content on short screens, clipping the 3rd checkbox. Because two scroll areas were nested, wheel events bubbled to the outer panel — so the user scrolled past the section before the hidden preset came into view.

## Fix

Removed the inner `QScrollArea`. Preset checkboxes now render directly inside the collapsible section; the existing outer scroll area handles any overflow. This eliminates both the height-compression clipping and the scroll-bubbling. Bordered-frame styling preserved on the container.

## Verification

- `make lint` ✓  `make type` ✓
- `uv run pytest` — 702 passed
- Manual: Export tab → expand Presets → all 3 presets (JPEG/TIFF/PNG) visible and toggleable, no inner scrollbar