### PR TITLE
feat: persist loaded-file session across restarts

### DIFF
--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -338,6 +338,20 @@ class AppController(QObject):
         elif self._active_batch == "Analyzing roll":
             self.norm_worker.cancel()
 
+    def saved_session_paths(self) -> List[str]:
+        """Returns last session's file paths that still exist on disk."""
+        paths = self.session.repo.get_global_setting("session_files", []) or []
+        return [p for p in paths if os.path.exists(p)]
+
+    def restore_session(self) -> None:
+        """Re-loads the previous session's files and reselects the active one."""
+        paths = self.saved_session_paths()
+        if not paths:
+            return
+        active = self.session.repo.get_global_setting("session_active_path")
+        self._pending_scanned_file = active if active in paths else paths[0]
+        self.request_asset_discovery(paths, auto_open=True)
+
     def request_asset_discovery(self, paths: List[str], auto_open: bool = False) -> None:
         """
         Starts asynchronous discovery of supported assets.

--- a/negpy/desktop/session.py
+++ b/negpy/desktop/session.py
@@ -503,6 +503,7 @@ class DesktopSessionManager(QObject):
 
             self.file_selected.emit(file_info["path"])
             self.state_changed.emit()
+            self._persist_session()
 
     def update_selection(self, indices: List[int]) -> None:
         """Updates the list of currently selected indices."""
@@ -700,6 +701,12 @@ class DesktopSessionManager(QObject):
             self.update_config(copy.deepcopy(self.state.clipboard), persist=True)
             self.settings_pasted.emit()
 
+    def _persist_session(self) -> None:
+        """Saves the open-file manifest (paths + active) for restore on next launch."""
+        paths = [f["path"] for f in self.state.uploaded_files]
+        self.repo.save_global_setting("session_files", paths)
+        self.repo.save_global_setting("session_active_path", self.state.current_file_path)
+
     def add_files(self, file_paths: List[str], validated_info: Optional[List[Dict]] = None) -> None:
         """
         Adds new files to the session.
@@ -731,6 +738,7 @@ class DesktopSessionManager(QObject):
 
         self.asset_model.refresh()
         self.files_changed.emit()
+        self._persist_session()
 
     def clear_files(self) -> None:
         """
@@ -746,6 +754,7 @@ class DesktopSessionManager(QObject):
 
         self.asset_model.refresh()
         self.state_changed.emit()
+        self._persist_session()
 
     def remove_current_file(self) -> None:
         """
@@ -771,6 +780,7 @@ class DesktopSessionManager(QObject):
 
             self.asset_model.refresh()
             self.state_changed.emit()
+            self._persist_session()
 
     def remove_selected_files(self) -> None:
         """
@@ -800,3 +810,4 @@ class DesktopSessionManager(QObject):
 
         self.asset_model.refresh()
         self.state_changed.emit()
+        self._persist_session()

--- a/negpy/desktop/view/main_window.py
+++ b/negpy/desktop/view/main_window.py
@@ -7,6 +7,7 @@ from PyQt6.QtCore import Qt, QTimer
 from PyQt6.QtWidgets import (
     QDockWidget,
     QMainWindow,
+    QMessageBox,
     QStatusBar,
     QVBoxLayout,
     QWidget,
@@ -144,6 +145,23 @@ class MainWindow(QMainWindow):
                 handle.screenChanged.connect(lambda _screen: self._refresh_monitor_profile())
             # force=True so a persisted override is resolved even when detection is None.
             self._refresh_monitor_profile(force=True)
+
+        if not getattr(self, "_session_restore_checked", False):
+            self._session_restore_checked = True
+            QTimer.singleShot(0, self._maybe_restore_session)
+
+    def _maybe_restore_session(self) -> None:
+        """Offers to reopen the previous session's files on first show."""
+        paths = self.controller.saved_session_paths()
+        if not paths:
+            return
+        reply = QMessageBox.question(
+            self,
+            "Restore Session",
+            f"Reopen your last session ({len(paths)} file(s))?",
+        )
+        if reply == QMessageBox.StandardButton.Yes:
+            self.controller.restore_session()
 
     def _refresh_monitor_profile(self, force: bool = False) -> None:
         """Detect the active screen's ICC profile and hand it to the controller, which

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -290,6 +290,69 @@ class TestBatchExportFiltering(unittest.TestCase):
             self.assertEqual(t.params.export.export_path, "/tmp/out")
 
 
+class TestSessionRestore(unittest.TestCase):
+    def setUp(self):
+        self.mock_session_manager = MagicMock(spec=DesktopSessionManager)
+        self.mock_session_manager.state = AppState()
+        self.mock_session_manager.repo = MagicMock()
+
+        with (
+            patch("negpy.desktop.controller.RenderWorker") as mock_rw_class,
+            patch("negpy.desktop.controller.PreviewManager") as mock_pm_class,
+        ):
+            mock_rw_class.return_value = MagicMock()
+            mock_pm_class.return_value = MagicMock(spec=PreviewManager)
+            self.controller = AppController(self.mock_session_manager)
+        self.controller.request_asset_discovery = MagicMock()
+
+    def tearDown(self):
+        import gc
+
+        for thread in [
+            self.controller.render_thread,
+            self.controller.export_thread,
+            self.controller.thumb_thread,
+            self.controller.norm_thread,
+            self.controller.discovery_thread,
+            self.controller.preview_load_thread,
+            self.controller.scan_thread,
+        ]:
+            if thread is not None and thread.isRunning():
+                thread.quit()
+                thread.wait()
+        del self.controller
+        gc.collect()
+
+    def _mock_settings(self, files, active):
+        def get(key, default=None):
+            return {"session_files": files, "session_active_path": active}.get(key, default)
+
+        self.mock_session_manager.repo.get_global_setting.side_effect = get
+
+    def test_saved_session_paths_filters_missing(self):
+        import os
+        import tempfile
+
+        with tempfile.NamedTemporaryFile(suffix=".dng") as tf:
+            self._mock_settings([tf.name, "/does/not/exist.dng"], tf.name)
+            self.assertEqual(self.controller.saved_session_paths(), [tf.name])
+            self.assertFalse(os.path.exists("/does/not/exist.dng"))
+
+    def test_restore_session_selects_active_and_discovers(self):
+        import tempfile
+
+        with tempfile.NamedTemporaryFile(suffix=".dng") as a, tempfile.NamedTemporaryFile(suffix=".dng") as b:
+            self._mock_settings([a.name, b.name], b.name)
+            self.controller.restore_session()
+            self.assertEqual(self.controller._pending_scanned_file, b.name)
+            self.controller.request_asset_discovery.assert_called_once_with([a.name, b.name], auto_open=True)
+
+    def test_restore_session_no_saved_files_is_noop(self):
+        self._mock_settings([], None)
+        self.controller.restore_session()
+        self.controller.request_asset_discovery.assert_not_called()
+
+
 class TestBatchAnalysisFiltering(unittest.TestCase):
     def setUp(self):
         self.mock_session_manager = MagicMock(spec=DesktopSessionManager)

--- a/tests/test_desktop_session.py
+++ b/tests/test_desktop_session.py
@@ -229,6 +229,23 @@ class TestDesktopSessionSync(unittest.TestCase):
         self.assertEqual(self.session.state.undo_index, 5)
         self.assertEqual(self.session.state.max_history_index, 5)
 
+    def _last_session_manifest(self):
+        """Returns (paths, active_path) from the most recent _persist_session calls."""
+        saved = {c.args[0]: c.args[1] for c in self.mock_repo.save_global_setting.call_args_list}
+        return saved.get("session_files"), saved.get("session_active_path")
+
+    def test_select_file_persists_manifest(self):
+        self.session.select_file(1)
+        paths, active = self._last_session_manifest()
+        self.assertEqual(paths, ["path1", "path2"])
+        self.assertEqual(active, "path2")
+
+    def test_clear_files_persists_empty_manifest(self):
+        self.session.clear_files()
+        paths, active = self._last_session_manifest()
+        self.assertEqual(paths, [])
+        self.assertIsNone(active)
+
 
 class TestAssetListModelFilter(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## What

NegPy lost the list of loaded files on every restart — users re-imported their roll each launch. Per-file edits/history already persist by hash; only the session manifest (which files were open + active) was missing.

## Changes

- **Persist** (`session.py`): new `_persist_session()` saves `session_files` (paths) + `session_active_path` to existing `settings.db`. Called from `add_files`, `clear_files`, `remove_current_file`, `remove_selected_files`, `select_file` — saves on every change, crash-safe, no `closeEvent` needed.
- **Restore** (`controller.py`): `saved_session_paths()` filters to existing paths; `restore_session()` reuses the async asset-discovery path (re-hashes, validates, drops moved/deleted) and reselects the active file. Edits return automatically by hash.
- **Prompt** (`main_window.py`): `showEvent` one-shot → `QMessageBox.question("Reopen your last session (N file(s))?")`. Yes restores; decline keeps manifest (overwritten on next load).

Scope: files + active selection only (no zoom/tool), per design decision.

## Tests

- `test_desktop_session.py`: manifest written on select/clear.
- `test_controller.py` (`TestSessionRestore`): missing-path filter, active-selection + discovery dispatch, empty no-op.

`make all` green (ruff + ty + pytest).

## Manual verification (needs GUI)

Load 2-3 files, select 2nd, edit, quit → relaunch → dialog → Yes restores files + active + edits; No starts empty; deleted source excluded from count.