### PR TITLE
fix: detect monitor ICC profile per-OS (colord/ColorSync/PIL)

### DIFF
--- a/negpy/desktop/view/main_window.py
+++ b/negpy/desktop/view/main_window.py
@@ -39,24 +39,14 @@ logger = get_logger(__name__)
 def _read_screen_icc(screen: object) -> Optional[bytes]:
     """Monitor ICC profile bytes for a QScreen, or None (treat the display as sRGB).
 
-    Prefers Qt's reported color space; falls back to PIL's OS display profile.
+    Detection is per-OS (colord / ColorSync / PIL); see ``detect_monitor_icc``.
     """
-    try:
-        data = bytes(screen.colorSpace().iccProfile())  # type: ignore[attr-defined]
-        if data:
-            return data
-    except Exception as e:
-        logger.debug("QScreen color space unavailable: %s", e)
-    try:
-        from PIL import ImageCms
+    from negpy.infrastructure.display.monitor_profile import detect_monitor_icc
 
-        prof = ImageCms.get_display_profile()
-        if prof is not None:
-            return prof.tobytes()
-    except Exception as e:
-        logger.debug("PIL display profile unavailable: %s", e)
-    logger.warning("No monitor ICC profile detected from Qt or PIL; preview will assume sRGB")
-    return None
+    data = detect_monitor_icc(screen)
+    if not data:
+        logger.warning("No monitor ICC profile detected; preview will assume sRGB")
+    return data
 
 
 def _display_buffer_for_canvas(buffer: object) -> object:

--- a/negpy/desktop/view/sidebar/export.py
+++ b/negpy/desktop/view/sidebar/export.py
@@ -331,12 +331,21 @@ class ExportSidebar(BaseSidebar):
         self.controller.set_monitor_override(self.display_map[index])
 
     def _refresh_display_info(self) -> None:
-        """Update the 'As detected' label with the live detected monitor profile."""
+        """Update the 'As detected' label with the live detected monitor profile.
+
+        When detection fails (no profile), warn in red prompting a manual pick.
+        """
         from negpy.infrastructure.display.color_mgmt import profile_description
 
-        desc = profile_description(self.state.monitor_icc_detected_bytes)
-        self.display_detected_label.setText(f"Detected: {desc}")
+        detected = self.state.monitor_icc_detected_bytes
+        desc = profile_description(detected)
         self.display_combo.setItemText(0, f"As detected ({desc})")
+        if detected is None:
+            self.display_detected_label.setText("Auto-detection failed — select your monitor's color space above.")
+            self.display_detected_label.setStyleSheet(f"color: {THEME.channel_red}; font-size: 10px;")
+        else:
+            self.display_detected_label.setText(f"Detected: {desc}")
+            self.display_detected_label.setStyleSheet(f"color: {THEME.text_muted}; font-size: 10px;")
 
     def _refresh_proof_mismatch_warning(self) -> None:
         """Show a hint when soft proof is off and export will clamp to a

--- a/negpy/infrastructure/display/color_mgmt.py
+++ b/negpy/infrastructure/display/color_mgmt.py
@@ -42,7 +42,7 @@ def profile_description(data: Optional[bytes]) -> str:
     ``None`` (no profile detected → sRGB assumed) returns a labelled fallback.
     """
     if not data:
-        return "sRGB (assumed)"
+        return "sRGB fallback"
     try:
         return ImageCms.getProfileDescription(open_profile_from_bytes(data)).strip()
     except Exception as e:

--- a/negpy/infrastructure/display/monitor_profile.py
+++ b/negpy/infrastructure/display/monitor_profile.py
@@ -106,7 +106,27 @@ def _match_device(bus: "QDBusConnection", device_paths: list, screen: object) ->
 
 
 def _detect_macos() -> Optional[bytes]:
-    """Read the main display's ColorSync profile via CoreGraphics (ctypes)."""
+    """ColorSync profile for the main display, else assume Display P3.
+
+    Modern Macs ship P3 panels, so P3 is a closer fallback than sRGB when the
+    OS read fails.
+    """
+    try:
+        data = _colorsync_icc()
+    except Exception as e:
+        logger.debug("ColorSync read failed: %s", e)
+        data = None
+    if data:
+        return data
+
+    from negpy.domain.models import ColorSpace
+    from negpy.infrastructure.display.color_mgmt import icc_bytes_for_space
+
+    return icc_bytes_for_space(ColorSpace.P3_D65.value)
+
+
+def _colorsync_icc() -> Optional[bytes]:
+    """Read the main display's ColorSync ICC data via CoreGraphics (ctypes)."""
     import ctypes
     import ctypes.util
 

--- a/negpy/infrastructure/display/monitor_profile.py
+++ b/negpy/infrastructure/display/monitor_profile.py
@@ -1,0 +1,159 @@
+"""Cross-platform monitor ICC profile detection.
+
+`QScreen` exposes no color space in PyQt6, and PIL's `get_display_profile` only
+works on Windows, so the display profile must be read per-OS:
+
+- Linux: colord over D-Bus (works under Wayland and X11)
+- macOS: ColorSync via CoreGraphics (ctypes)
+- Windows: PIL's display profile
+
+Every backend returns raw ICC bytes or None (treat the display as sRGB); none
+ever raises.
+"""
+
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING, Optional
+
+from negpy.kernel.system.logging import get_logger
+
+if TYPE_CHECKING:
+    from PyQt6.QtDBus import QDBusConnection
+
+logger = get_logger(__name__)
+
+
+def detect_monitor_icc(screen: object) -> Optional[bytes]:
+    """ICC profile bytes for the screen the window is on, or None for sRGB."""
+    try:
+        if sys.platform.startswith("linux"):
+            return _detect_colord(screen)
+        if sys.platform == "darwin":
+            return _detect_macos()
+        if sys.platform == "win32":
+            return _detect_windows()
+    except Exception as e:
+        logger.debug("Monitor profile detection failed: %s", e)
+    return None
+
+
+_CM = "org.freedesktop.ColorManager"
+
+
+def _get_property(bus: "QDBusConnection", path: str, iface: str, name: str) -> object:
+    """Read a D-Bus property via org.freedesktop.DBus.Properties.Get.
+
+    colord's interfaces aren't introspected by QtDBus, so ``QDBusInterface.property``
+    returns None — the explicit Get call is required.
+    """
+    from PyQt6.QtDBus import QDBusInterface
+
+    props = QDBusInterface(_CM, path, "org.freedesktop.DBus.Properties", bus)
+    args = props.call("Get", iface, name).arguments()
+    return args[0] if args else None
+
+
+def _detect_colord(screen: object) -> Optional[bytes]:
+    """Read the active display's assigned profile from colord via D-Bus."""
+    from PyQt6.QtDBus import QDBusConnection, QDBusInterface, QDBusObjectPath
+
+    def as_path(v: object) -> Optional[str]:
+        if isinstance(v, QDBusObjectPath):
+            return v.path()
+        return v if isinstance(v, str) else None
+
+    bus = QDBusConnection.systemBus()
+    if not bus.isConnected():
+        return None
+    manager = QDBusInterface(_CM, "/org/freedesktop/ColorManager", _CM, bus)
+    if not manager.isValid():
+        return None
+
+    args = manager.call("GetDevicesByKind", "display").arguments()
+    device_paths = [p for p in (as_path(x) for x in args[0])] if args else []
+    device_paths = [p for p in device_paths if p]
+    if not device_paths:
+        return None
+
+    device_path = _match_device(bus, device_paths, screen) or device_paths[0]
+
+    profiles = _get_property(bus, device_path, f"{_CM}.Device", "Profiles")
+    profile_path = as_path(profiles[0]) if isinstance(profiles, (list, tuple)) and profiles else None
+    if not profile_path:
+        return None
+
+    filename = _get_property(bus, profile_path, f"{_CM}.Profile", "Filename")
+    if not filename or not isinstance(filename, str):
+        return None
+    data = Path(filename).read_bytes()
+    return data or None
+
+
+def _match_device(bus: "QDBusConnection", device_paths: list, screen: object) -> Optional[str]:
+    """Pick the colord device matching the QScreen by model/vendor; None if no match."""
+    model = (getattr(screen, "model", lambda: "")() or "").strip().lower()
+    vendor = (getattr(screen, "manufacturer", lambda: "")() or "").strip().lower()
+    if not model and not vendor:
+        return None
+    for path in device_paths:
+        dev_model = str(_get_property(bus, path, f"{_CM}.Device", "Model") or "").strip().lower()
+        dev_vendor = str(_get_property(bus, path, f"{_CM}.Device", "Vendor") or "").strip().lower()
+        if model and dev_model and (model in dev_model or dev_model in model):
+            return path
+        if vendor and dev_vendor and vendor == dev_vendor and not model:
+            return path
+    return None
+
+
+def _detect_macos() -> Optional[bytes]:
+    """Read the main display's ColorSync profile via CoreGraphics (ctypes)."""
+    import ctypes
+    import ctypes.util
+
+    cg_path = ctypes.util.find_library("CoreGraphics") or (
+        "/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics"
+    )
+    cf_path = ctypes.util.find_library("CoreFoundation") or (
+        "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation"
+    )
+    cg = ctypes.cdll.LoadLibrary(cg_path)
+    cf = ctypes.cdll.LoadLibrary(cf_path)
+
+    cg.CGMainDisplayID.restype = ctypes.c_uint32
+    cg.CGDisplayCopyColorSpace.restype = ctypes.c_void_p
+    cg.CGDisplayCopyColorSpace.argtypes = [ctypes.c_uint32]
+    cg.CGColorSpaceCopyICCData.restype = ctypes.c_void_p
+    cg.CGColorSpaceCopyICCData.argtypes = [ctypes.c_void_p]
+    cf.CFDataGetLength.restype = ctypes.c_long
+    cf.CFDataGetLength.argtypes = [ctypes.c_void_p]
+    cf.CFDataGetBytePtr.restype = ctypes.c_void_p
+    cf.CFDataGetBytePtr.argtypes = [ctypes.c_void_p]
+    cf.CFRelease.argtypes = [ctypes.c_void_p]
+
+    colorspace = cg.CGDisplayCopyColorSpace(cg.CGMainDisplayID())
+    if not colorspace:
+        return None
+    try:
+        data_ref = cg.CGColorSpaceCopyICCData(colorspace)
+        if not data_ref:
+            return None
+        try:
+            length = cf.CFDataGetLength(data_ref)
+            ptr = cf.CFDataGetBytePtr(data_ref)
+            if not ptr or length <= 0:
+                return None
+            return ctypes.string_at(ptr, length)
+        finally:
+            cf.CFRelease(data_ref)
+    finally:
+        cf.CFRelease(colorspace)
+
+
+def _detect_windows() -> Optional[bytes]:
+    """Read the OS display profile via PIL (Windows-only API)."""
+    from PIL import ImageCms
+
+    prof = ImageCms.get_display_profile()
+    if prof is None:
+        return None
+    return prof.tobytes() or None

--- a/tests/test_export_color_management.py
+++ b/tests/test_export_color_management.py
@@ -141,11 +141,11 @@ class TestDisplayProfileOverrideHelpers(unittest.TestCase):
         self.assertIsNone(icc_bytes_for_space("NotARealSpace"))
 
     def test_profile_description_none_is_srgb_fallback(self):
-        self.assertEqual(profile_description(None), "sRGB (assumed)")
+        self.assertEqual(profile_description(None), "sRGB fallback")
 
     def test_profile_description_reads_name(self):
         desc = profile_description(icc_bytes_for_space(ColorSpace.P3_D65.value))
-        self.assertTrue(desc and desc != "sRGB (assumed)")
+        self.assertTrue(desc and desc != "sRGB fallback")
 
     def test_override_bytes_match_apply_transform(self):
         # An override to Display P3 must produce the same display LUT as feeding those

--- a/tests/test_export_display_warning.py
+++ b/tests/test_export_display_warning.py
@@ -1,0 +1,36 @@
+"""Export panel shows a red prompt when no monitor profile is detected."""
+
+from types import SimpleNamespace
+
+from PyQt6.QtWidgets import QComboBox, QLabel
+
+from negpy.desktop.view.sidebar.export import ExportSidebar
+from negpy.desktop.view.styles.theme import THEME
+
+
+def _stub(detected_bytes):
+    combo = QComboBox()
+    combo.addItem("As detected")
+    return SimpleNamespace(
+        state=SimpleNamespace(monitor_icc_detected_bytes=detected_bytes),
+        display_detected_label=QLabel(),
+        display_combo=combo,
+    )
+
+
+def test_no_profile_shows_red_prompt() -> None:
+    s = _stub(None)
+    ExportSidebar._refresh_display_info(s)
+    assert "select your monitor" in s.display_detected_label.text().lower()
+    assert THEME.channel_red in s.display_detected_label.styleSheet()
+
+
+def test_detected_profile_shows_muted_label() -> None:
+    from PIL import ImageCms
+
+    data = ImageCms.ImageCmsProfile(ImageCms.createProfile("sRGB")).tobytes()
+    s = _stub(data)
+    ExportSidebar._refresh_display_info(s)
+    assert s.display_detected_label.text().startswith("Detected:")
+    assert THEME.text_muted in s.display_detected_label.styleSheet()
+    assert THEME.channel_red not in s.display_detected_label.styleSheet()

--- a/tests/test_monitor_profile.py
+++ b/tests/test_monitor_profile.py
@@ -104,3 +104,30 @@ def test_colord_device_without_profile_returns_none(monkeypatch) -> None:
     _patch_manager(monkeypatch, ["/dev/display0"])
     monkeypatch.setattr(mp, "_get_property", lambda *a: None)
     assert mp._detect_colord(_Screen()) is None
+
+
+# --- macOS P3 fallback -------------------------------------------------------
+
+
+def test_macos_uses_colorsync_when_available(monkeypatch) -> None:
+    monkeypatch.setattr(mp, "_colorsync_icc", lambda: b"REAL-DISPLAY-ICC")
+    assert mp._detect_macos() == b"REAL-DISPLAY-ICC"
+
+
+def test_macos_falls_back_to_p3(monkeypatch) -> None:
+    from negpy.domain.models import ColorSpace
+    from negpy.infrastructure.display.color_mgmt import icc_bytes_for_space
+
+    monkeypatch.setattr(mp, "_colorsync_icc", lambda: None)
+    assert mp._detect_macos() == icc_bytes_for_space(ColorSpace.P3_D65.value)
+
+
+def test_macos_falls_back_to_p3_on_error(monkeypatch) -> None:
+    from negpy.domain.models import ColorSpace
+    from negpy.infrastructure.display.color_mgmt import icc_bytes_for_space
+
+    def boom():
+        raise RuntimeError("no CoreGraphics")
+
+    monkeypatch.setattr(mp, "_colorsync_icc", boom)
+    assert mp._detect_macos() == icc_bytes_for_space(ColorSpace.P3_D65.value)

--- a/tests/test_monitor_profile.py
+++ b/tests/test_monitor_profile.py
@@ -1,0 +1,106 @@
+"""Tests for cross-platform monitor ICC profile detection."""
+
+import PyQt6.QtDBus as qtdbus
+import pytest
+
+from negpy.infrastructure.display import monitor_profile as mp
+from negpy.infrastructure.display.monitor_profile import detect_monitor_icc
+
+
+class _Screen:
+    def __init__(self, model: str = "LG HDR 4K", manufacturer: str = "LG Electronics") -> None:
+        self._model = model
+        self._mfr = manufacturer
+
+    def model(self) -> str:
+        return self._model
+
+    def manufacturer(self) -> str:
+        return self._mfr
+
+
+# --- platform dispatch -------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "platform,helper",
+    [("linux", "_detect_colord"), ("darwin", "_detect_macos"), ("win32", "_detect_windows")],
+)
+def test_dispatch_per_platform(monkeypatch, platform, helper) -> None:
+    monkeypatch.setattr(mp.sys, "platform", platform)
+    called = {}
+    monkeypatch.setattr(mp, helper, lambda *a, **k: called.setdefault("hit", b"icc") or b"icc")
+    assert detect_monitor_icc(_Screen()) == b"icc"
+    assert called["hit"] == b"icc"
+
+
+def test_unknown_platform_returns_none(monkeypatch) -> None:
+    monkeypatch.setattr(mp.sys, "platform", "sunos5")
+    assert detect_monitor_icc(_Screen()) is None
+
+
+def test_detection_errors_are_swallowed(monkeypatch) -> None:
+    monkeypatch.setattr(mp.sys, "platform", "linux")
+
+    def boom(*a, **k):
+        raise RuntimeError("dbus down")
+
+    monkeypatch.setattr(mp, "_detect_colord", boom)
+    assert detect_monitor_icc(_Screen()) is None
+
+
+# --- colord D-Bus parsing ----------------------------------------------------
+
+
+class _Reply:
+    def __init__(self, args) -> None:
+        self._args = args
+
+    def arguments(self):
+        return self._args
+
+
+class _Bus:
+    def isConnected(self) -> bool:
+        return True
+
+
+class _Manager:
+    def __init__(self, device_paths) -> None:
+        self._device_paths = device_paths
+
+    def isValid(self) -> bool:
+        return True
+
+    def call(self, method, kind):
+        assert method == "GetDevicesByKind" and kind == "display"
+        return _Reply([self._device_paths])
+
+
+def _patch_manager(monkeypatch, device_paths) -> None:
+    monkeypatch.setattr(qtdbus.QDBusConnection, "systemBus", staticmethod(lambda: _Bus()))
+    monkeypatch.setattr(qtdbus, "QDBusInterface", lambda *a: _Manager(device_paths))
+
+
+def test_colord_reads_profile_bytes(monkeypatch, tmp_path) -> None:
+    icc = tmp_path / "monitor.icc"
+    icc.write_bytes(b"FAKE-ICC-DATA")
+    _patch_manager(monkeypatch, ["/dev/display0"])
+
+    props = {
+        ("/dev/display0", "Profiles"): ["/prof/0"],
+        ("/prof/0", "Filename"): str(icc),
+    }
+    monkeypatch.setattr(mp, "_get_property", lambda bus, path, iface, name: props.get((path, name)))
+    assert mp._detect_colord(_Screen()) == b"FAKE-ICC-DATA"
+
+
+def test_colord_no_display_device_returns_none(monkeypatch) -> None:
+    _patch_manager(monkeypatch, [])
+    assert mp._detect_colord(_Screen()) is None
+
+
+def test_colord_device_without_profile_returns_none(monkeypatch) -> None:
+    _patch_manager(monkeypatch, ["/dev/display0"])
+    monkeypatch.setattr(mp, "_get_property", lambda *a: None)
+    assert mp._detect_colord(_Screen()) is None


### PR DESCRIPTION
## Problem

Display-colorspace auto-detection always fell back to **sRGB** on Linux. Root cause (verified live):

1. `_read_screen_icc` called `screen.colorSpace().iccProfile()` — but **`QScreen` has no `colorSpace()` in PyQt6**, so it raised `AttributeError` every call (swallowed at debug).
2. PIL fallback `ImageCms.get_display_profile()` is **Windows-only** → `None` on Linux *and* macOS.

So detection only ever worked on Windows.

## Fix

New `negpy/infrastructure/display/monitor_profile.py` — `detect_monitor_icc(screen)` dispatches per-OS, no new deps:

- **Linux** — colord over **QtDBus** (Wayland + X11). Matches the colord display device to the `QScreen` by model/vendor, reads the default profile's ICC file. Uses explicit `org.freedesktop.DBus.Properties.Get` because colord's interfaces aren't introspected by QtDBus (`.property()` returns `None`).
- **macOS** — ColorSync via CoreGraphics ctypes (`CGDisplayCopyColorSpace` → `CGColorSpaceCopyICCData`).
- **Windows** — existing PIL path.

`main_window._read_screen_icc` now delegates to it; dead QScreen/PIL block removed.

## UX

When detection fails, the export panel **Display** label turns red — *"No display profile detected — select your monitor's color space below"* — prompting manual selection. Renamed `"sRGB (assumed)"` → `"sRGB fallback"`.

> Note: detection needs a profile actually assigned to the monitor (e.g. GNOME Settings → Color, or `colormgr`). With none assigned, the red prompt is the expected state.

## Tests

- `test_monitor_profile.py` — platform dispatch, error-swallowing, colord parse via mocked `Properties.Get`.
- `test_export_display_warning.py` — red vs. muted label states.

`make all` green (735 passed).