### PR TITLE
fix: use DHT instead of VNG for X-Trans full-res demosaic

### DIFF
--- a/negpy/infrastructure/loaders/helpers.py
+++ b/negpy/infrastructure/loaders/helpers.py
@@ -166,8 +166,11 @@ def get_best_demosaic_algorithm(raw: Any, for_preview: bool = False) -> Any:
 
             if cfa_block_size == 6:
                 # 6x6 block means it's a Fujifilm X-Trans sensor.
-                # LINEAR is ~4.6x faster than VNG; artifacts are invisible at preview scale.
-                selected_algo = rawpy.DemosaicAlgorithm.LINEAR if for_preview else rawpy.DemosaicAlgorithm.VNG
+                # LINEAR is ~4.6x faster than DHT; artifacts are invisible at preview scale.
+                # VNG was used previously, but it produces dot/maze artifacts on X-Trans's
+                # 6x6 pattern in high-contrast regions (see #272). DHT was added to dcraw/
+                # LibRaw specifically to handle X-Trans correctly and is also LGPL-clean.
+                selected_algo = rawpy.DemosaicAlgorithm.LINEAR if for_preview else rawpy.DemosaicAlgorithm.DHT
 
             elif cfa_block_size == 2:
                 # 2x2 block means it's a standard Bayer sensor (Canon, Nikon, Sony, etc.)

--- a/tests/test_preview_manager.py
+++ b/tests/test_preview_manager.py
@@ -129,7 +129,7 @@ def test_load_linear_preview_hq_uses_best_demosaic_no_half() -> None:
 
 @pytest.mark.parametrize("cfa_block", [2, 6])
 def test_load_linear_preview_hq_demosaic_xtrans_vs_bayer(cfa_block: int) -> None:
-    """HQ: X-Trans (6) uses VNG; Bayer (2) uses AHD."""
+    """HQ: X-Trans (6) uses DHT; Bayer (2) uses AHD."""
     rgb_u16 = np.ones((32, 32, 3), dtype=np.uint16) * 128
 
     raw = MagicMock()
@@ -150,7 +150,7 @@ def test_load_linear_preview_hq_demosaic_xtrans_vs_bayer(cfa_block: int) -> None
         PreviewManager().load_linear_preview("/fake/path.dng", full_resolution=True)
 
     _, kwargs = raw.postprocess.call_args
-    expected = rawpy.DemosaicAlgorithm.VNG if cfa_block == 6 else rawpy.DemosaicAlgorithm.AHD
+    expected = rawpy.DemosaicAlgorithm.DHT if cfa_block == 6 else rawpy.DemosaicAlgorithm.AHD
     assert kwargs["demosaic_algorithm"] == expected
 
 

--- a/tests/test_raw_handlers.py
+++ b/tests/test_raw_handlers.py
@@ -1,6 +1,14 @@
 import unittest
 import numpy as np
+import rawpy
 from negpy.infrastructure.loaders.tiff_loader import NonStandardFileWrapper
+from negpy.infrastructure.loaders.helpers import get_best_demosaic_algorithm
+
+
+class _FakeRaw:
+    def __init__(self, raw_type: rawpy.RawType, block_size: int) -> None:
+        self.raw_type = raw_type
+        self.raw_pattern = np.zeros((block_size, block_size), dtype=np.uint8)
 
 
 class TestRawHandlers(unittest.TestCase):
@@ -15,6 +23,20 @@ class TestRawHandlers(unittest.TestCase):
             processed = raw.postprocess(output_bps=16)
             self.assertEqual(processed.dtype, np.uint16)
             self.assertAlmostEqual(np.mean(processed), 32767, delta=100)
+
+    def test_xtrans_full_res_uses_dht_not_vng(self):
+        # VNG produces dot/maze artifacts on X-Trans's 6x6 CFA in high-contrast
+        # regions (see issue #272). DHT is the LGPL-clean algorithm built for X-Trans.
+        raw = _FakeRaw(rawpy.RawType.Flat, block_size=6)
+        self.assertEqual(get_best_demosaic_algorithm(raw, for_preview=False), rawpy.DemosaicAlgorithm.DHT)
+
+    def test_xtrans_preview_uses_linear(self):
+        raw = _FakeRaw(rawpy.RawType.Flat, block_size=6)
+        self.assertEqual(get_best_demosaic_algorithm(raw, for_preview=True), rawpy.DemosaicAlgorithm.LINEAR)
+
+    def test_bayer_full_res_uses_ahd(self):
+        raw = _FakeRaw(rawpy.RawType.Flat, block_size=2)
+        self.assertEqual(get_best_demosaic_algorithm(raw, for_preview=False), rawpy.DemosaicAlgorithm.AHD)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Fixes #272 — Fuji X-Trans RAF files showing dot/maze-like demosaicing artifacts in high-contrast regions during HQ preview and full-resolution export.
- Root cause: `get_best_demosaic_algorithm()` selected `rawpy.DemosaicAlgorithm.VNG` for X-Trans sensors (6x6 CFA block) at full resolution. VNG is designed for standard Bayer CFAs and is known to produce dot/worm artifacts on X-Trans's pattern, especially in high-contrast areas.
- Switched to `DHT` (Dcraw Hue Transit), which was added to dcraw/LibRaw specifically to handle X-Trans correctly, and remains part of the permissive/LGPL rawpy build (no licensing change needed). Preview-mode (downsampled) still uses fast `LINEAR`, unaffected.
- This single helper is used by both HQ preview (`preview_manager.py`) and full-resolution export (`image_processor.py`), so both paths are fixed.

## Test plan
- [x] `make all` passes (lint, type check, full test suite: 761 passed)
- [x] Added unit tests in `tests/test_raw_handlers.py` pinning algorithm choice for X-Trans vs. Bayer, preview vs. full-res
- [x] Updated existing `tests/test_preview_manager.py` expectation from VNG to DHT
- [x] Cannot speak for the original reporters, but my Fuji raw files look better (?) when pixel peeping