### PR TITLE
Unify manual crop into a single draggable/resizable tool

### DIFF
--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -524,8 +524,13 @@ class AppController(QObject):
             self._handle_dust_pick(nx, ny)
 
     def set_active_tool(self, mode: ToolMode) -> None:
+        crop_tool_changed = ToolMode.CROP_MANUAL in (self.state.active_tool, mode)
         self.state.active_tool = mode
         self.tool_sync_requested.emit()
+        if crop_tool_changed:
+            # Entering/leaving the crop tool swaps between the full uncropped preview
+            # and the normal cropped preview, so the canvas must re-render immediately.
+            self.request_render()
 
     def cancel_active_tool(self) -> None:
         if self.state.active_tool != ToolMode.NONE:
@@ -535,39 +540,28 @@ class AppController(QObject):
         """Request the canvas show the fine-rotation alignment grid."""
         self.rotation_guide_requested.emit()
 
-    def handle_crop_completed(self, nx1: float, ny1: float, nx2: float, ny2: float) -> None:
+    def handle_crop_rect_changed(self, nx1: float, ny1: float, nx2: float, ny2: float, persist: bool) -> None:
+        """Live-updates (persist=False) or commits (persist=True) the manual crop rect
+        while the crop tool is open. The tool stays active afterwards — darktable-style
+        continuous adjustment, not a one-shot drag-then-close."""
         if self.state.active_tool != ToolMode.CROP_MANUAL:
             return
-        with self.state.metrics_lock:
-            uv_grid = self.state.last_metrics.get("uv_grid")
-        if uv_grid is None:
-            return
-
-        rx1, ry1 = CoordinateMapping.map_click_to_raw(nx1, ny1, uv_grid)
-        rx2, ry2 = CoordinateMapping.map_click_to_raw(nx2, ny2, uv_grid)
-
         new_geo = replace(
             self.state.config.geometry,
             manual_crop_rect=(
-                min(rx1, rx2),
-                min(ry1, ry2),
-                max(rx1, rx2),
-                max(ry1, ry2),
+                min(nx1, nx2),
+                min(ny1, ny2),
+                max(nx1, nx2),
+                max(ny1, ny2),
             ),
             auto_crop_enabled=False,
         )
         new_proc = replace(self.state.config.process, **invalidate_local_bounds(self.state.config.process))
-        self.session.update_config(replace(self.state.config, geometry=new_geo, process=new_proc))
-        self.state.active_tool = ToolMode.NONE
-        self.tool_sync_requested.emit()
-        self.request_render()
-
-    def handle_crop_translated(self, nx1: float, ny1: float, nx2: float, ny2: float) -> None:
-        if self.state.config.geometry.manual_crop_rect is None:
-            return
-        new_geo = replace(self.state.config.geometry, manual_crop_rect=(nx1, ny1, nx2, ny2))
-        self.session.update_config(replace(self.state.config, geometry=new_geo))
-        self.request_render()
+        self.session.update_config(replace(self.state.config, geometry=new_geo, process=new_proc), persist=persist)
+        if persist:
+            self.request_render()
+        else:
+            self._render_debounce.start()
 
     def reset_crop(self) -> None:
         new_proc = replace(self.state.config.process, **invalidate_local_bounds(self.state.config.process))
@@ -1114,6 +1108,7 @@ class AppController(QObject):
             readback_metrics=readback_metrics,
             ir_buffer=self.state.preview_ir,
             monitor_icc_bytes=self.state.monitor_icc_bytes,
+            crop_preview_full=self.state.active_tool == ToolMode.CROP_MANUAL,
         )
 
         if self._is_rendering:

--- a/negpy/desktop/session.py
+++ b/negpy/desktop/session.py
@@ -16,7 +16,6 @@ class ToolMode(Enum):
     NONE = auto()
     WB_PICK = auto()
     CROP_MANUAL = auto()
-    CROP_MOVE = auto()
     DUST_PICK = auto()
     LOCAL_DRAW = auto()
 

--- a/negpy/desktop/view/canvas/overlay.py
+++ b/negpy/desktop/view/canvas/overlay.py
@@ -1,5 +1,5 @@
 import sys
-from typing import List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import numpy as np
 from PyQt6.QtCore import QPointF, QRectF, QSize, Qt, QTimer, pyqtSignal
@@ -14,6 +14,8 @@ from negpy.kernel.system.config import APP_CONFIG
 from negpy.services.view.coordinate_mapping import CoordinateMapping
 
 _LASSO_SNAP_PX = 12.0
+_CROP_HANDLE_PX = 10.0
+_CROP_MIN_SCREEN_PX = 24.0
 
 
 class CanvasOverlay(QWidget):
@@ -22,8 +24,7 @@ class CanvasOverlay(QWidget):
     """
 
     clicked = pyqtSignal(float, float)
-    crop_completed = pyqtSignal(float, float, float, float)
-    crop_translated = pyqtSignal(float, float, float, float)
+    crop_rect_changed = pyqtSignal(float, float, float, float, bool)
     cursor_moved = pyqtSignal(float, float)
     cursor_left = pyqtSignal()
     lasso_completed = pyqtSignal(list)
@@ -36,15 +37,16 @@ class CanvasOverlay(QWidget):
         self._current_size: Optional[Tuple[int, int]] = None
         self._content_rect: Optional[Tuple[int, int, int, int]] = None
 
-        # Interaction State
-        self._crop_active: bool = False
-        self._crop_p1: Optional[QPointF] = None
-        self._crop_p2: Optional[QPointF] = None
-        self._move_active: bool = False
-        self._move_press_raw: Optional[Tuple[float, float]] = None
-        self._move_orig_rect: Optional[Tuple[float, float, float, float]] = None
-        self._move_last_emitted: Optional[Tuple[float, float, float, float]] = None
-        self._move_uv_grid: Optional[np.ndarray] = None
+        # Crop tool interaction state: corner-resize, interior move, or fresh draw
+        # (when the click lands outside the existing rect).
+        self._crop_rect_raw: Optional[Tuple[float, float, float, float]] = None
+        self._crop_drag_mode: Optional[str] = None  # "corner" | "move" | "draw"
+        self._crop_anchor_screen: Optional[QPointF] = None
+        self._crop_press_raw: Optional[Tuple[float, float]] = None
+        self._crop_orig_rect: Optional[Tuple[float, float, float, float]] = None
+        self._crop_uv_grid: Optional[np.ndarray] = None
+        self._crop_draw_p1: Optional[QPointF] = None
+        self._crop_draw_p2: Optional[QPointF] = None
         self._tool_mode: ToolMode = ToolMode.NONE
         self._mouse_pos: QPointF = QPointF()
 
@@ -109,19 +111,24 @@ class CanvasOverlay(QWidget):
 
     def set_tool_mode(self, mode: ToolMode) -> None:
         self._tool_mode = mode
-        if mode != ToolMode.CROP_MANUAL:
-            self._crop_p1 = None
-            self._crop_p2 = None
-        if mode != ToolMode.CROP_MOVE:
-            self._move_active = False
-            self._move_press_raw = None
-            self._move_orig_rect = None
-            self._move_last_emitted = None
-            self._move_uv_grid = None
+        if mode == ToolMode.CROP_MANUAL:
+            self._crop_rect_raw = self.state.config.geometry.manual_crop_rect or (0.0, 0.0, 1.0, 1.0)
+        else:
+            self._crop_rect_raw = None
+            self._end_crop_drag()
         if mode != ToolMode.LOCAL_DRAW:
             self._lasso_pts = []
             self._lasso_drawing = False
         self.update()
+
+    def _end_crop_drag(self) -> None:
+        self._crop_drag_mode = None
+        self._crop_anchor_screen = None
+        self._crop_press_raw = None
+        self._crop_orig_rect = None
+        self._crop_uv_grid = None
+        self._crop_draw_p1 = None
+        self._crop_draw_p2 = None
 
     def _cancel_lasso(self) -> None:
         if self._tool_mode == ToolMode.LOCAL_DRAW and self._lasso_drawing:
@@ -144,6 +151,9 @@ class CanvasOverlay(QWidget):
         else:
             self._qimage = None
             self._current_size = gpu_size
+
+        if self._tool_mode == ToolMode.CROP_MANUAL and self._crop_drag_mode is None:
+            self._crop_rect_raw = self.state.config.geometry.manual_crop_rect or (0.0, 0.0, 1.0, 1.0)
 
         self._recalc_view_rect()
         self.update()
@@ -209,31 +219,10 @@ class CanvasOverlay(QWidget):
 
         visible_rect = self._view_rect
 
-        if (
-            self._crop_active
-            and self._crop_p1 is not None
-            and not self._crop_p1.isNull()
-            and self._crop_p2 is not None
-            and not self._crop_p2.isNull()
-        ):
-            rect = QRectF(self._crop_p1, self._crop_p2).normalized().intersected(visible_rect)
+        if self._tool_mode == ToolMode.CROP_MANUAL:
+            self._draw_crop_tool(painter)
 
-            painter.setBrush(QColor(0, 0, 0, 180))
-            painter.setPen(Qt.PenStyle.NoPen)
-            d = visible_rect
-
-            painter.drawRect(d.intersected(QRectF(d.x(), d.y(), d.width(), rect.y() - d.y())))
-            painter.drawRect(d.intersected(QRectF(d.x(), rect.bottom(), d.width(), d.bottom() - rect.bottom())))
-            painter.drawRect(d.intersected(QRectF(d.x(), rect.y(), rect.x() - d.x(), rect.height())))
-            painter.drawRect(d.intersected(QRectF(rect.right(), rect.y(), d.right() - rect.right(), rect.height())))
-
-            pen = QPen(Qt.GlobalColor.white, 1, Qt.PenStyle.DashLine)
-            pen.setCosmetic(True)
-            painter.setBrush(Qt.BrushStyle.NoBrush)
-            painter.setPen(pen)
-            painter.drawRect(rect)
-
-        if self._buffer_overlay_visible and self._buffer_overlay_ratio > 1e-4 and not self._crop_active:
+        if self._buffer_overlay_visible and self._buffer_overlay_ratio > 1e-4 and self._tool_mode != ToolMode.CROP_MANUAL:
             d = visible_rect
             margin_w = d.width() * self._buffer_overlay_ratio
             margin_h = d.height() * self._buffer_overlay_ratio
@@ -311,16 +300,19 @@ class CanvasOverlay(QWidget):
         painter.setPen(Qt.PenStyle.NoPen)
         painter.drawEllipse(self._mouse_pos, radius, radius)
 
-    def _raw_to_screen(self, rx: float, ry: float, uv_grid: np.ndarray) -> QPointF:
+    def _raw_to_screen(self, rx: float, ry: float, uv_grid: np.ndarray, buckets: int = 100) -> QPointF:
         """
         Inverse UV-grid lookup: raw-normalised (0-1) -> screen position.
 
         Downsamples the grid before the nearest-neighbour search so this stays
-        fast even for large preview buffers; precision loss is sub-pixel at
-        screen scale.
+        fast even for large preview buffers. `buckets` trades precision for
+        speed: the default is fine for one-shot mask-vertex rendering, but
+        anything redrawn continuously while being dragged (e.g. crop handles)
+        needs a much finer grid or the on-screen point visibly snaps between
+        buckets instead of tracking the cursor.
         """
         h_uv, w_uv = uv_grid.shape[:2]
-        step = max(1, h_uv // 100)
+        step = max(1, h_uv // buckets)
         small = uv_grid[::step, ::step]
         dist = (small[..., 0] - rx) ** 2 + (small[..., 1] - ry) ** 2
         idx = int(np.argmin(dist))
@@ -332,6 +324,136 @@ class CanvasOverlay(QWidget):
             self._view_rect.x() + nx * self._view_rect.width(),
             self._view_rect.y() + ny * self._view_rect.height(),
         )
+
+    def _crop_corner_screen_points(self) -> Optional[Dict[str, QPointF]]:
+        """Maps the current raw crop rect to its on-screen axis-aligned bounding box.
+
+        The actual crop (`get_manual_rect_coords` / `CropProcessor`) always takes the
+        axis-aligned bounding box of the rect's transformed corners - it's a plain
+        array slice, never a rotated one. So under fine rotation the 4 raw corners
+        land at a tilted quadrilateral, but we deliberately collapse that to its AABB
+        here rather than drawing the tilt, so the overlay shows what will actually be
+        cropped instead of a shape the pipeline can't produce.
+        """
+        if self._crop_rect_raw is None:
+            return None
+        with self.state.metrics_lock:
+            uv_grid = self.state.last_metrics.get("uv_grid")
+        if uv_grid is None:
+            return None
+        x1, y1, x2, y2 = self._crop_rect_raw
+        h_uv, w_uv = uv_grid.shape[:2]
+        buckets = max(h_uv, w_uv)
+        pts = [
+            self._raw_to_screen(x1, y1, uv_grid, buckets),
+            self._raw_to_screen(x2, y1, uv_grid, buckets),
+            self._raw_to_screen(x2, y2, uv_grid, buckets),
+            self._raw_to_screen(x1, y2, uv_grid, buckets),
+        ]
+        left = min(p.x() for p in pts)
+        right = max(p.x() for p in pts)
+        top = min(p.y() for p in pts)
+        bottom = max(p.y() for p in pts)
+        return {
+            "tl": QPointF(left, top),
+            "tr": QPointF(right, top),
+            "br": QPointF(right, bottom),
+            "bl": QPointF(left, bottom),
+        }
+
+    def _hit_test_crop_corner(self, pos: QPointF, corners: Dict[str, QPointF]) -> Optional[str]:
+        for name, pt in corners.items():
+            dx, dy = pos.x() - pt.x(), pos.y() - pt.y()
+            if dx * dx + dy * dy <= _CROP_HANDLE_PX * _CROP_HANDLE_PX:
+                return name
+        return None
+
+    def _apply_aspect_and_min(self, anchor_screen: QPointF, cur_screen: QPointF, uv_grid: np.ndarray) -> Tuple[float, float, float, float]:
+        """Resizes a rect anchored at `anchor_screen` towards `cur_screen`, honoring the
+        configured aspect ratio (if any) and a minimum rect size.
+
+        Done entirely in screen-pixel space: raw-normalised (0-1) fractions only equal
+        physical aspect ratio when the source image is square, so applying a target
+        ratio to raw-space deltas distorts it by the image's actual width/height ratio.
+        Screen pixels reflect the image as displayed, so ratios computed there are correct.
+        """
+        ax, ay = anchor_screen.x(), anchor_screen.y()
+        nx, ny = cur_screen.x(), cur_screen.y()
+
+        ratio_str = self.state.config.geometry.autocrop_ratio
+        target_ratio: Optional[float] = None
+        if ratio_str != "Free":
+            try:
+                w_r, h_r = map(float, ratio_str.split(":"))
+                target_ratio = w_r / h_r
+            except Exception:
+                target_ratio = None
+
+        dx = nx - ax
+        dy = ny - ay
+
+        if target_ratio:
+            if abs(dx) > abs(dy) * target_ratio:
+                dx = abs(dy) * target_ratio * (1 if dx >= 0 else -1)
+            else:
+                dy = abs(dx) / target_ratio * (1 if dy >= 0 else -1)
+            # Enforce the minimum size by scaling dx/dy up together so the
+            # locked ratio survives even on the tiny first move of a drag
+            # (clamping each axis independently here would distort the ratio).
+            scale = max(_CROP_MIN_SCREEN_PX / max(abs(dx), 1e-6), _CROP_MIN_SCREEN_PX / max(abs(dy), 1e-6), 1.0)
+            dx *= scale
+            dy *= scale
+        else:
+            if abs(dx) < _CROP_MIN_SCREEN_PX:
+                dx = _CROP_MIN_SCREEN_PX if dx >= 0 else -_CROP_MIN_SCREEN_PX
+            if abs(dy) < _CROP_MIN_SCREEN_PX:
+                dy = _CROP_MIN_SCREEN_PX if dy >= 0 else -_CROP_MIN_SCREEN_PX
+
+        end_screen = QPointF(ax + dx, ay + dy)
+        c1 = self._raw_from_screen_with_grid(anchor_screen, uv_grid)
+        c2 = self._raw_from_screen_with_grid(end_screen, uv_grid)
+        if c1 is None or c2 is None:
+            return self._crop_rect_raw or (0.0, 0.0, 1.0, 1.0)
+        x1, x2 = sorted((c1[0], c2[0]))
+        y1, y2 = sorted((c1[1], c2[1]))
+        return (max(0.0, x1), max(0.0, y1), min(1.0, x2), min(1.0, y2))
+
+    def _draw_crop_tool(self, painter: QPainter) -> None:
+        if self._crop_drag_mode == "draw" and self._crop_draw_p1 is not None:
+            rect = QRectF(self._crop_draw_p1, self._crop_draw_p2 or self._crop_draw_p1).normalized().intersected(self._view_rect)
+            pen = QPen(Qt.GlobalColor.white, 1, Qt.PenStyle.DashLine)
+            pen.setCosmetic(True)
+            painter.setBrush(Qt.BrushStyle.NoBrush)
+            painter.setPen(pen)
+            painter.drawRect(rect)
+            return
+
+        corners = self._crop_corner_screen_points()
+        if corners is None:
+            return
+        poly = QPolygonF([corners["tl"], corners["tr"], corners["br"], corners["bl"]])
+
+        # Dim everything outside the crop rect: full view rect minus the crop polygon.
+        outer = QPainterPath()
+        outer.addRect(self._view_rect)
+        inner = QPainterPath()
+        inner.addPolygon(poly)
+        painter.setBrush(QColor(0, 0, 0, 180))
+        painter.setPen(Qt.PenStyle.NoPen)
+        painter.drawPath(outer.subtracted(inner))
+
+        pen = QPen(Qt.GlobalColor.white, 1, Qt.PenStyle.DashLine)
+        pen.setCosmetic(True)
+        painter.setBrush(Qt.BrushStyle.NoBrush)
+        painter.setPen(pen)
+        painter.drawPolygon(poly)
+
+        handle_pen = QPen(Qt.GlobalColor.white, 1.5, Qt.PenStyle.SolidLine)
+        handle_pen.setCosmetic(True)
+        painter.setPen(handle_pen)
+        painter.setBrush(QColor(THEME.accent_primary))
+        for pt in corners.values():
+            painter.drawRect(QRectF(pt.x() - 5, pt.y() - 5, 10, 10))
 
     def _draw_local_masks(self, painter: QPainter) -> None:
         if self._view_rect.isEmpty():
@@ -429,25 +551,42 @@ class CanvasOverlay(QWidget):
         if coords:
             self.clicked.emit(*coords)
             if self._tool_mode == ToolMode.CROP_MANUAL:
-                self._crop_active = True
-                px = np.clip(event.position().x(), self._view_rect.left(), self._view_rect.right())
-                py = np.clip(event.position().y(), self._view_rect.top(), self._view_rect.bottom())
-                self._crop_p1 = QPointF(px, py)
-                self._crop_p2 = QPointF(px, py)
-            elif self._tool_mode == ToolMode.CROP_MOVE:
-                orig_rect = self.state.config.geometry.manual_crop_rect
-                with self.state.metrics_lock:
-                    uv_grid = self.state.last_metrics.get("uv_grid")
-                if orig_rect is not None and uv_grid is not None:
-                    self._move_uv_grid = uv_grid
-                    press_raw = self._raw_from_screen_with_grid(event.position(), uv_grid)
-                    if press_raw is not None:
-                        self._move_active = True
-                        self._move_press_raw = press_raw
-                        self._move_orig_rect = orig_rect
-                        self._move_last_emitted = orig_rect
-                        self.setCursor(Qt.CursorShape.ClosedHandCursor)
+                self._start_crop_drag(event.position())
             self.update()
+
+    def _start_crop_drag(self, pos: QPointF) -> None:
+        with self.state.metrics_lock:
+            uv_grid = self.state.last_metrics.get("uv_grid")
+        if uv_grid is None or self._crop_rect_raw is None:
+            return
+
+        corners = self._crop_corner_screen_points()
+        corner = self._hit_test_crop_corner(pos, corners) if corners else None
+        if corner is not None and corners is not None:
+            anchor_name = {"tl": "br", "tr": "bl", "br": "tl", "bl": "tr"}[corner]
+            self._crop_drag_mode = "corner"
+            self._crop_anchor_screen = corners[anchor_name]
+            self._crop_uv_grid = uv_grid
+            self.setCursor(Qt.CursorShape.SizeFDiagCursor if corner in ("tl", "br") else Qt.CursorShape.SizeBDiagCursor)
+            return
+
+        if corners is not None and QPolygonF(list(corners.values())).containsPoint(pos, Qt.FillRule.OddEvenFill):
+            press_raw = self._raw_from_screen_with_grid(pos, uv_grid)
+            if press_raw is not None:
+                self._crop_drag_mode = "move"
+                self._crop_press_raw = press_raw
+                self._crop_orig_rect = self._crop_rect_raw
+                self._crop_uv_grid = uv_grid
+                self.setCursor(Qt.CursorShape.ClosedHandCursor)
+            return
+
+        # Clicked outside the existing rect: draw a fresh one from scratch.
+        px = np.clip(pos.x(), self._view_rect.left(), self._view_rect.right())
+        py = np.clip(pos.y(), self._view_rect.top(), self._view_rect.bottom())
+        self._crop_drag_mode = "draw"
+        self._crop_draw_p1 = QPointF(px, py)
+        self._crop_draw_p2 = QPointF(px, py)
+        self._crop_uv_grid = uv_grid
 
     def mouseMoveEvent(self, event: QMouseEvent) -> None:
         self._mouse_pos = event.position()
@@ -466,46 +605,65 @@ class CanvasOverlay(QWidget):
             event.accept()
             return
 
-        if self._move_active and self._move_press_raw is not None and self._move_orig_rect is not None and self._move_uv_grid is not None:
-            curr_raw = self._raw_from_screen_with_grid(event.position(), self._move_uv_grid)
-            if curr_raw is not None:
-                fine = bool(event.modifiers() & Qt.KeyboardModifier.ShiftModifier)
-                sensitivity = 0.2 if fine else 0.5
-                dx = (curr_raw[0] - self._move_press_raw[0]) * sensitivity
-                dy = (curr_raw[1] - self._move_press_raw[1]) * sensitivity
-                new_rect = translate_manual_crop_rect(self._move_orig_rect, dx, dy)
-                if self._move_last_emitted is None or any(abs(a - b) > 5e-4 for a, b in zip(new_rect, self._move_last_emitted)):
-                    self._move_last_emitted = new_rect
-                    self.crop_translated.emit(*new_rect)
+        if self._crop_drag_mode == "corner" and self._crop_anchor_screen is not None and self._crop_uv_grid is not None:
+            cur_screen = QPointF(
+                float(np.clip(event.position().x(), self._view_rect.left(), self._view_rect.right())),
+                float(np.clip(event.position().y(), self._view_rect.top(), self._view_rect.bottom())),
+            )
+            rect = self._apply_aspect_and_min(self._crop_anchor_screen, cur_screen, self._crop_uv_grid)
+            self._crop_rect_raw = rect
+            self.crop_rect_changed.emit(*rect, False)
+            self.update()
             event.accept()
             return
 
-        if self._crop_active:
+        if (
+            self._crop_drag_mode == "move"
+            and self._crop_press_raw is not None
+            and self._crop_orig_rect is not None
+            and self._crop_uv_grid is not None
+        ):
+            curr_raw = self._raw_from_screen_with_grid(event.position(), self._crop_uv_grid)
+            if curr_raw is not None:
+                fine = bool(event.modifiers() & Qt.KeyboardModifier.ShiftModifier)
+                sensitivity = 0.2 if fine else 0.5
+                dx = (curr_raw[0] - self._crop_press_raw[0]) * sensitivity
+                dy = (curr_raw[1] - self._crop_press_raw[1]) * sensitivity
+                new_rect = translate_manual_crop_rect(self._crop_orig_rect, dx, dy)
+                if any(abs(a - b) > 5e-4 for a, b in zip(new_rect, self._crop_rect_raw or new_rect)):
+                    self._crop_rect_raw = new_rect
+                    self.crop_rect_changed.emit(*new_rect, False)
+                    self.update()
+            event.accept()
+            return
+
+        if self._crop_drag_mode == "draw" and self._crop_draw_p1 is not None:
             mx = np.clip(event.position().x(), self._view_rect.left(), self._view_rect.right())
             my = np.clip(event.position().y(), self._view_rect.top(), self._view_rect.bottom())
 
             ratio_str = self.state.config.geometry.autocrop_ratio
             if ratio_str == "Free":
-                self._crop_p2 = QPointF(mx, my)
+                self._crop_draw_p2 = QPointF(mx, my)
             else:
                 try:
                     w_r, h_r = map(float, ratio_str.split(":"))
                     target_ratio = w_r / h_r
 
-                    dx = mx - self._crop_p1.x()
-                    dy = my - self._crop_p1.y()
+                    dx = mx - self._crop_draw_p1.x()
+                    dy = my - self._crop_draw_p1.y()
 
                     if abs(dx) > abs(dy) * target_ratio:
                         dx = abs(dy) * target_ratio * (1 if dx >= 0 else -1)
                     else:
                         dy = abs(dx) / target_ratio * (1 if dy >= 0 else -1)
 
-                    self._crop_p2 = QPointF(self._crop_p1.x() + dx, self._crop_p1.y() + dy)
+                    self._crop_draw_p2 = QPointF(self._crop_draw_p1.x() + dx, self._crop_draw_p1.y() + dy)
                 except Exception:
-                    self._crop_p2 = QPointF(mx, my)
+                    self._crop_draw_p2 = QPointF(mx, my)
             self.update()
-        else:
-            self.update()
+            return
+
+        self.update()
 
     def _handle_lasso_press(self, pos: QPointF) -> None:
         if not self._view_rect.contains(pos):
@@ -562,27 +720,26 @@ class CanvasOverlay(QWidget):
             event.accept()
             return
 
-        if self._move_active:
-            self._move_active = False
-            self._move_press_raw = None
-            self._move_orig_rect = None
-            self._move_last_emitted = None
-            self._move_uv_grid = None
+        if self._crop_drag_mode in ("corner", "move"):
+            if self._crop_rect_raw is not None:
+                self.crop_rect_changed.emit(*self._crop_rect_raw, True)
+            self._end_crop_drag()
             self.unsetCursor()
             event.accept()
             return
 
-        if self._crop_active:
-            r = QRectF(self._crop_p1, self._crop_p2).normalized()
+        if self._crop_drag_mode == "draw":
+            r = QRectF(self._crop_draw_p1, self._crop_draw_p2 or self._crop_draw_p1).normalized()
             r = r.intersected(self._view_rect)
-
-            if r.width() > 5 and r.height() > 5:
-                c1 = self._map_to_image_coords(r.topLeft())
-                c2 = self._map_to_image_coords(r.bottomRight())
+            uv_grid = self._crop_uv_grid
+            if r.width() > 5 and r.height() > 5 and uv_grid is not None:
+                c1 = self._raw_from_screen_with_grid(r.topLeft(), uv_grid)
+                c2 = self._raw_from_screen_with_grid(r.bottomRight(), uv_grid)
                 if c1 and c2:
-                    self.crop_completed.emit(c1[0], c1[1], c2[0], c2[1])
-            self._crop_active = False
-            self._crop_p1, self._crop_p2 = None, None
+                    rect = (min(c1[0], c2[0]), min(c1[1], c2[1]), max(c1[0], c2[0]), max(c1[1], c2[1]))
+                    self._crop_rect_raw = rect
+                    self.crop_rect_changed.emit(*rect, True)
+            self._end_crop_drag()
             self.update()
 
     def leaveEvent(self, event) -> None:

--- a/negpy/desktop/view/canvas/widget.py
+++ b/negpy/desktop/view/canvas/widget.py
@@ -33,7 +33,6 @@ _TOOL_CURSORS: dict[ToolMode, Qt.CursorShape] = {
     ToolMode.NONE: Qt.CursorShape.ArrowCursor,
     ToolMode.WB_PICK: Qt.CursorShape.PointingHandCursor,
     ToolMode.CROP_MANUAL: Qt.CursorShape.CrossCursor,
-    ToolMode.CROP_MOVE: Qt.CursorShape.OpenHandCursor,
     ToolMode.DUST_PICK: Qt.CursorShape.BlankCursor,
     ToolMode.LOCAL_DRAW: Qt.CursorShape.CrossCursor,
 }
@@ -75,8 +74,7 @@ class ImageCanvas(QWidget):
     """
 
     clicked = pyqtSignal(float, float)
-    crop_completed = pyqtSignal(float, float, float, float)
-    crop_translated = pyqtSignal(float, float, float, float)
+    crop_rect_changed = pyqtSignal(float, float, float, float, bool)
     zoom_changed = pyqtSignal(float)
     cursor_position_changed = pyqtSignal(float, float)
     cursor_left_canvas = pyqtSignal()
@@ -122,8 +120,7 @@ class ImageCanvas(QWidget):
         self.root_layout.addWidget(self.overlay)
 
         self.overlay.clicked.connect(self.clicked.emit)
-        self.overlay.crop_completed.connect(self.crop_completed.emit)
-        self.overlay.crop_translated.connect(self.crop_translated.emit)
+        self.overlay.crop_rect_changed.connect(self.crop_rect_changed.emit)
         self.overlay.cursor_moved.connect(self.cursor_position_changed.emit)
         self.overlay.cursor_left.connect(self.cursor_left_canvas.emit)
         self.overlay.lasso_completed.connect(self.lasso_completed.emit)

--- a/negpy/desktop/view/main_window.py
+++ b/negpy/desktop/view/main_window.py
@@ -280,8 +280,7 @@ class MainWindow(QMainWindow):
         self.controller.session.file_selected.connect(lambda _: self._refresh_image_info())
 
         self.canvas.clicked.connect(self.controller.handle_canvas_clicked)
-        self.canvas.crop_completed.connect(self.controller.handle_crop_completed)
-        self.canvas.crop_translated.connect(self.controller.handle_crop_translated)
+        self.canvas.crop_rect_changed.connect(self.controller.handle_crop_rect_changed)
         self.canvas.lasso_completed.connect(self.controller.handle_lasso_completed)
         self.canvas.local_mask_selected.connect(self.controller.select_local_mask)
 

--- a/negpy/desktop/view/sidebar/geometry.py
+++ b/negpy/desktop/view/sidebar/geometry.py
@@ -71,22 +71,16 @@ class GeometrySidebar(BaseSidebar):
 
         # Buttons side by side
         btn_row = QHBoxLayout()
-        self.manual_crop_btn = CropToolButton(" Manual")
+        self.manual_crop_btn = CropToolButton(" Crop")
         self.manual_crop_btn.setCheckable(True)
         self.manual_crop_btn.setIcon(qta.icon("fa5s.crop-alt", color=THEME.text_primary))
-        self.manual_crop_btn.setToolTip(tooltip_with_shortcut("Manual crop", "manual_crop"))
-
-        self.move_crop_btn = QPushButton(" Move")
-        self.move_crop_btn.setCheckable(True)
-        self.move_crop_btn.setIcon(qta.icon("fa5s.arrows-alt", color=THEME.text_primary))
-        self.move_crop_btn.setToolTip("Translate the existing crop rectangle (preserves size)")
+        self.manual_crop_btn.setToolTip(tooltip_with_shortcut("Crop: drag corners to resize, drag inside to move", "manual_crop"))
 
         self.reset_crop_btn = CropToolButton(" Auto")
         self.reset_crop_btn.setCheckable(True)
         self.reset_crop_btn.setIcon(qta.icon("fa5s.magic", color=THEME.text_primary))
         self.reset_crop_btn.setToolTip(tooltip_with_shortcut("Apply automatic crop using the current ratio and offset", "auto_crop"))
         btn_row.addWidget(self.manual_crop_btn)
-        btn_row.addWidget(self.move_crop_btn)
         self.layout.addLayout(btn_row)
 
         # Auto crop toggle + mode: crop to exposed image, or keep full film incl. rebate
@@ -126,7 +120,6 @@ class GeometrySidebar(BaseSidebar):
         self.mode_combo.currentIndexChanged.connect(self._on_mode_changed)
         self.detect_ratio_btn.clicked.connect(self.controller.detect_aspect_ratio)
         self.manual_crop_btn.toggled.connect(self._on_manual_crop_toggled)
-        self.move_crop_btn.toggled.connect(self._on_move_crop_toggled)
         self.reset_crop_btn.toggled.connect(self._on_auto_crop_toggled)
 
         self.offset_slider.valueChanged.connect(
@@ -170,12 +163,7 @@ class GeometrySidebar(BaseSidebar):
         self.controller.request_render()
 
     def _on_manual_crop_toggled(self, checked: bool) -> None:
-        if checked:
-            self.controller.reset_crop()
         self.controller.set_active_tool(ToolMode.CROP_MANUAL if checked else ToolMode.NONE)
-
-    def _on_move_crop_toggled(self, checked: bool) -> None:
-        self.controller.set_active_tool(ToolMode.CROP_MOVE if checked else ToolMode.NONE)
 
     def _on_auto_crop_toggled(self, checked: bool) -> None:
         if checked:
@@ -195,8 +183,6 @@ class GeometrySidebar(BaseSidebar):
             self.fine_rot_slider.setValue(conf.fine_rotation)
 
             self.manual_crop_btn.setChecked(self.state.active_tool == ToolMode.CROP_MANUAL)
-            self.move_crop_btn.setChecked(self.state.active_tool == ToolMode.CROP_MOVE)
-            self.move_crop_btn.setEnabled(conf.manual_crop_rect is not None)
             self.reset_crop_btn.setChecked(conf.auto_crop_enabled)
             self.manual_crop_btn.set_crop_active(conf.manual_crop_rect is not None)
             self.reset_crop_btn.set_crop_active(conf.auto_crop_enabled)
@@ -210,5 +196,4 @@ class GeometrySidebar(BaseSidebar):
         self.offset_slider.blockSignals(blocked)
         self.fine_rot_slider.blockSignals(blocked)
         self.manual_crop_btn.blockSignals(blocked)
-        self.move_crop_btn.blockSignals(blocked)
         self.reset_crop_btn.blockSignals(blocked)

--- a/negpy/desktop/workers/render.py
+++ b/negpy/desktop/workers/render.py
@@ -32,6 +32,9 @@ class RenderTask:
     # Monitor ICC profile bytes (detected on the UI thread); soft proof is shown on
     # this display. None = sRGB display.
     monitor_icc_bytes: Optional[bytes] = None
+    # True while the crop tool is active: show the full uncropped frame instead of
+    # the final crop.
+    crop_preview_full: bool = False
 
 
 @dataclass(frozen=True)
@@ -117,6 +120,7 @@ class RenderWorker(QObject):
                 prefer_gpu=task.gpu_enabled,
                 readback_metrics=task.readback_metrics,
                 ir_buffer=task.ir_buffer,
+                crop_preview_full=task.crop_preview_full,
             )
 
             soft_proof = task.icc_input_path or task.icc_output_path

--- a/negpy/domain/interfaces.py
+++ b/negpy/domain/interfaces.py
@@ -23,6 +23,9 @@ class PipelineContext:
     active_roi: Optional[ROI] = None
     metrics: dict[str, Any] = field(default_factory=dict)
     ir_buffer: Optional[Any] = None  # 2D float32 [0,1] (H,W), RAW (pre-geometry) frame; None if absent
+    # When set, the crop tool is active: the final crop slice and uv_grid are bypassed
+    # so the full uncropped frame is shown, while active_roi still scopes tone analysis.
+    crop_preview_full: bool = False
 
 
 class IImageSource(Protocol):

--- a/negpy/services/rendering/engine.py
+++ b/negpy/services/rendering/engine.py
@@ -95,10 +95,26 @@ class DarkroomEngine:
             img_in = GeometryProcessor(settings.geometry).process(img_in, ctx)
             return NormalizationProcessor(settings.process).process(img_in, ctx)
 
+        # While the crop tool shows the full uncropped frame, the crop-selection
+        # fields (manual_crop_rect, auto_crop_*) only feed context.active_roi, which
+        # is itself unused for output in that mode (CropProcessor and uv_grid ROI
+        # slicing are both bypassed) - keying on them would force a full base/
+        # exposure/retouch/lab/local recompute on every crop-rect drag step.
+        geometry_key = (
+            (
+                settings.geometry.rotation,
+                settings.geometry.fine_rotation,
+                settings.geometry.flip_horizontal,
+                settings.geometry.flip_vertical,
+            )
+            if context.crop_preview_full
+            else settings.geometry
+        )
+
         base_key = (
             settings.process.process_mode,
             settings.process.e6_normalize,
-            settings.geometry,
+            geometry_key,
             settings.process.analysis_buffer,
             settings.process.drange_clip,
             settings.process.use_roll_average,
@@ -158,7 +174,8 @@ class DarkroomEngine:
 
             current_img = ToningProcessor(settings.toning).process(current_img, context)
 
-        current_img = CropProcessor(settings.geometry).process(current_img, context)
+        if not context.crop_preview_full:
+            current_img = CropProcessor(settings.geometry).process(current_img, context)
 
         if not flat_intent:
             current_img = FinishProcessor(settings.finish).process(current_img, context)
@@ -172,7 +189,7 @@ class DarkroomEngine:
                 flip_h=settings.geometry.flip_horizontal,
                 flip_v=settings.geometry.flip_vertical,
                 autocrop=True,
-                autocrop_params={"roi": context.active_roi} if context.active_roi else None,
+                autocrop_params=({"roi": context.active_roi} if context.active_roi and not context.crop_preview_full else None),
             )
             context.metrics["uv_grid"] = uv_grid
         except Exception as e:

--- a/negpy/services/rendering/image_processor.py
+++ b/negpy/services/rendering/image_processor.py
@@ -78,6 +78,7 @@ class ImageProcessor:
         prefer_gpu: bool = True,
         readback_metrics: bool = True,
         ir_buffer: Optional[np.ndarray] = None,
+        crop_preview_full: bool = False,
     ) -> Tuple[Any, Dict[str, Any]]:
         """
         Executes rendering pipeline. Returns result (ndarray/GPUTexture) and metrics.
@@ -95,11 +96,15 @@ class ImageProcessor:
             original_size=(h_orig, w_cols),
             process_mode=settings.process.process_mode,
             ir_buffer=ir_buffer,
+            crop_preview_full=crop_preview_full,
         )
         if metrics:
             context.metrics.update(metrics)
 
-        if self._is_flat(settings):
+        if self._is_flat(settings) or crop_preview_full:
+            # The crop tool's "show full uncropped frame" preview only needs a single
+            # CPU render per settings change (dragging only moves an overlay rect), so
+            # we sidestep the GPU engine's ROI-fused compute dispatch entirely here.
             prefer_gpu = False
 
         if prefer_gpu and self.engine_gpu:

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -134,51 +134,62 @@ class TestAppController(unittest.TestCase):
         self.assertIsNone(saved_config.geometry.manual_crop_rect)
         self.controller.request_render.assert_called_once_with()
 
-    def test_manual_crop_completion_disables_auto_crop(self):
+    def test_manual_crop_rect_changed_disables_auto_crop(self):
         geometry = replace(self.controller.state.config.geometry, auto_crop_enabled=True)
         self.controller.state.config = replace(self.controller.state.config, geometry=geometry)
         self.controller.state.active_tool = ToolMode.CROP_MANUAL
-        self.controller.state.last_metrics = {"uv_grid": (0.0, 1.0, 0.0, 1.0)}
         self.controller.request_render = MagicMock()
 
-        with patch("negpy.desktop.controller.CoordinateMapping.map_click_to_raw", side_effect=[(0.2, 0.3), (0.8, 0.9)]):
-            self.controller.handle_crop_completed(0.2, 0.3, 0.8, 0.9)
+        self.controller.handle_crop_rect_changed(0.2, 0.3, 0.8, 0.9, True)
 
         saved_config = self.mock_session_manager.update_config.call_args.args[0]
         self.assertFalse(saved_config.geometry.auto_crop_enabled)
         self.assertEqual(saved_config.geometry.manual_crop_rect, (0.2, 0.3, 0.8, 0.9))
         self.controller.request_render.assert_called_once_with()
 
-    def test_handle_crop_translated_updates_rect(self):
+    def test_handle_crop_rect_changed_updates_rect(self):
         geometry = replace(self.controller.state.config.geometry, manual_crop_rect=(0.2, 0.2, 0.6, 0.5))
         self.controller.state.config = replace(self.controller.state.config, geometry=geometry)
+        self.controller.state.active_tool = ToolMode.CROP_MANUAL
         self.controller.request_render = MagicMock()
 
-        self.controller.handle_crop_translated(0.3, 0.25, 0.7, 0.55)
+        self.controller.handle_crop_rect_changed(0.3, 0.25, 0.7, 0.55, True)
 
         saved_config = self.mock_session_manager.update_config.call_args.args[0]
         self.assertEqual(saved_config.geometry.manual_crop_rect, (0.3, 0.25, 0.7, 0.55))
         self.controller.request_render.assert_called_once_with()
 
-    def test_handle_crop_translated_noop_when_no_manual_rect(self):
+    def test_handle_crop_rect_changed_noop_when_tool_inactive(self):
         geometry = replace(self.controller.state.config.geometry, manual_crop_rect=None)
         self.controller.state.config = replace(self.controller.state.config, geometry=geometry)
+        self.controller.state.active_tool = ToolMode.NONE
         self.controller.request_render = MagicMock()
 
-        self.controller.handle_crop_translated(0.1, 0.1, 0.5, 0.5)
+        self.controller.handle_crop_rect_changed(0.1, 0.1, 0.5, 0.5, True)
 
         self.mock_session_manager.update_config.assert_not_called()
         self.controller.request_render.assert_not_called()
 
-    def test_handle_crop_translated_does_not_deactivate_tool(self):
+    def test_handle_crop_rect_changed_does_not_deactivate_tool(self):
         geometry = replace(self.controller.state.config.geometry, manual_crop_rect=(0.2, 0.2, 0.6, 0.5))
         self.controller.state.config = replace(self.controller.state.config, geometry=geometry)
-        self.controller.state.active_tool = ToolMode.CROP_MOVE
+        self.controller.state.active_tool = ToolMode.CROP_MANUAL
         self.controller.request_render = MagicMock()
 
-        self.controller.handle_crop_translated(0.3, 0.25, 0.7, 0.55)
+        self.controller.handle_crop_rect_changed(0.3, 0.25, 0.7, 0.55, True)
 
-        self.assertEqual(self.controller.state.active_tool, ToolMode.CROP_MOVE)
+        self.assertEqual(self.controller.state.active_tool, ToolMode.CROP_MANUAL)
+
+    def test_handle_crop_rect_changed_live_drag_does_not_persist(self):
+        geometry = replace(self.controller.state.config.geometry, manual_crop_rect=(0.2, 0.2, 0.6, 0.5))
+        self.controller.state.config = replace(self.controller.state.config, geometry=geometry)
+        self.controller.state.active_tool = ToolMode.CROP_MANUAL
+        self.controller.request_render = MagicMock()
+
+        self.controller.handle_crop_rect_changed(0.3, 0.25, 0.7, 0.55, False)
+
+        self.assertEqual(self.mock_session_manager.update_config.call_args.kwargs.get("persist"), False)
+        self.controller.request_render.assert_not_called()
 
     def test_local_overlay_visible_default_on(self):
         self.assertTrue(AppState().show_local_overlay)

--- a/tests/test_desktop_session.py
+++ b/tests/test_desktop_session.py
@@ -328,13 +328,5 @@ class TestAssetListModelFilter(unittest.TestCase):
         self.assertEqual(len(self.model._sorted_indices), 5)
 
 
-class TestToolMode(unittest.TestCase):
-    def test_crop_move_is_distinct(self):
-        from negpy.desktop.session import ToolMode
-
-        assert ToolMode.CROP_MOVE != ToolMode.CROP_MANUAL
-        assert ToolMode.CROP_MOVE != ToolMode.NONE
-
-
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_lock_bounds.py
+++ b/tests/test_lock_bounds.py
@@ -198,13 +198,11 @@ class TestCropPreservesBoundsWhenLocked(unittest.TestCase):
         self.assertEqual(proc.local_floors, _FLOORS)
         self.assertEqual(proc.local_ceils, _CEILS)
 
-    def test_handle_crop_completed_preserves_bounds(self):
+    def test_handle_crop_rect_changed_preserves_bounds(self):
         from negpy.desktop.session import ToolMode
 
         self.ctrl.state.active_tool = ToolMode.CROP_MANUAL
-        self.ctrl.state.last_metrics = {"uv_grid": (0.0, 1.0, 0.0, 1.0)}
-        with patch("negpy.desktop.controller.CoordinateMapping.map_click_to_raw", side_effect=[(0.1, 0.1), (0.9, 0.9)]):
-            self.ctrl.handle_crop_completed(0.1, 0.1, 0.9, 0.9)
+        self.ctrl.handle_crop_rect_changed(0.1, 0.1, 0.9, 0.9, True)
         proc = _saved_process(self.ctrl)
         self.assertEqual(proc.local_floors, _FLOORS)
         self.assertEqual(proc.local_ceils, _CEILS)


### PR DESCRIPTION
## Summary
- Replaces the separate Manual-draw and Move crop tools with one Crop tool: drag corners to resize, drag inside to move, click outside an existing rect to draw a fresh one. Continuous drag updates render live and the tool stays open afterward (no one-shot draw-then-close).
- While the crop tool is open, the canvas previews the full uncropped frame (`PipelineContext.crop_preview_full`) instead of the already-cropped image, so you can resize the crop without losing context of what's outside it.

## Bugs found and fixed while building this
- Corner handles snapped/jumped while dragging — the inverse raw→screen lookup used a coarse quantized grid search; now exact for the 4 corner points.
- Aspect-ratio locking distorted the rect — ratio math was applied to raw normalized-space deltas, which only matches physical aspect ratio when the source image is square. Moved the ratio/min-size enforcement into screen-pixel space.
- The crop overlay drew the rect's fine-rotation-transformed corners as a tilted parallelogram, but the actual crop (`get_manual_rect_coords`/`CropProcessor`) only ever takes the axis-aligned bounding box of those corners — it's a plain array slice. The overlay now draws that bounding box so what you see matches what gets cropped.
- Dragging the crop rect caused a full CPU recompute of exposure/retouch/lab/local on every mouse-move, because the engine's base-stage cache key bundled the entire `GeometryConfig` (including crop-selection fields that don't affect pixel output while `crop_preview_full` bypasses the final crop). The cache key now excludes those fields in that mode.

## Test plan
- [x] `make all` (format, lint, type check, full test suite) passes
- [ ] Manually verify in the running app: drag corners to resize (with and without a locked aspect ratio), drag inside to move, draw a fresh crop from outside the rect, and adjust fine rotation while the crop tool is open