### PR TITLE
fix: handle grayscale BITMAP thumbnails in splash preview

### DIFF
--- a/negpy/services/rendering/preview_manager.py
+++ b/negpy/services/rendering/preview_manager.py
@@ -68,16 +68,16 @@ class PreviewManager:
             return None
         try:
             thumb = raw.extract_thumb()
+            img: Optional[Image.Image] = None
+            if thumb.format == rawpy.ThumbFormat.JPEG:
+                img = Image.open(io.BytesIO(thumb.data))
+            elif thumb.format == rawpy.ThumbFormat.BITMAP:
+                img = Image.fromarray(ensure_rgb(thumb.data))
+            if img is None:
+                return None
+            img = img.convert("RGB")
         except Exception:
             return None
-        img: Optional[Image.Image] = None
-        if thumb.format == rawpy.ThumbFormat.JPEG:
-            img = Image.open(io.BytesIO(thumb.data))
-        elif thumb.format == rawpy.ThumbFormat.BITMAP:
-            img = Image.fromarray(thumb.data)
-        if img is None:
-            return None
-        img = img.convert("RGB")
         arr = np.ascontiguousarray(np.array(img, dtype=np.float32) / 255.0)
         h, w = arr.shape[:2]
         if max(h, w) > APP_CONFIG.preview_render_size:

--- a/tests/test_preview_manager_splash_grayscale.py
+++ b/tests/test_preview_manager_splash_grayscale.py
@@ -1,0 +1,44 @@
+"""Regression: grayscale (H,W,1) BITMAP thumbnails must not break splash/load.
+
+Silverfast-scanned Nikon Coolscan 5000/9000ED DNGs embed a single-channel
+grayscale thumbnail. PIL's Image.fromarray cannot map (H,W,1) uint8, which used
+to abort the whole file load with "cannot handle this data type : (1, 1, 1) |u1".
+"""
+
+from unittest.mock import MagicMock
+
+import numpy as np
+import rawpy
+
+from negpy.services.rendering.preview_manager import PreviewManager
+
+
+def _make_thumb(channels: int, w: int = 64, h: int = 48) -> MagicMock:
+    thumb = MagicMock()
+    thumb.format = rawpy.ThumbFormat.BITMAP
+    thumb.data = np.zeros((h, w, channels), dtype=np.uint8)
+    raw = MagicMock()
+    raw.sizes = MagicMock(iheight=h, iwidth=w)
+    raw.extract_thumb.return_value = thumb
+    return raw
+
+
+def test_grayscale_bitmap_thumb_yields_splash():
+    """A single-channel thumb is broadened to RGB instead of crashing."""
+    raw = _make_thumb(channels=1)
+    result = PreviewManager._try_splash_from_open_raw(raw, "scan.dng")
+    assert result is not None
+    buf, _dims = result
+    assert buf.ndim == 3 and buf.shape[2] == 3
+
+
+def test_malformed_thumb_returns_none_not_raises():
+    """Any thumb conversion failure falls back to None (skip splash), never raises."""
+    raw = MagicMock()
+    raw.sizes = MagicMock(iheight=48, iwidth=64)
+    raw.extract_thumb.side_effect = None
+    bad = MagicMock()
+    bad.format = rawpy.ThumbFormat.BITMAP
+    bad.data = object()  # not array-like -> fromarray raises
+    raw.extract_thumb.return_value = bad
+    assert PreviewManager._try_splash_from_open_raw(raw, "scan.dng") is None


### PR DESCRIPTION
Silverfast-scanned Nikon Coolscan 5000/9000ED DNGs embed a single-channel (H,W,1) thumbnail that PIL.Image.fromarray cannot map, aborting the whole file load with 'cannot handle this data type : (1, 1, 1) |u1'. Broaden the thumb to 3-channel via ensure_rgb and guard the conversion so any malformed thumbnail skips the optional splash instead of failing the load.

fixes https://github.com/marcinz606/NegPy/issues/300