### PR TITLE
fix: refresh outgoing thumbnail when switching away from edited image

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@
 - **History panel (new)** — a **History** tab in the right panel lists every edit step for the current photo. Click any step to jump back to that intermediate state (the preview updates instantly), carry on editing from there, or right-click to **Export this version**. Surfaces the existing per-file undo history (last 100 steps) as a scrollable list.
 - **Expanded interactive tutorial** — the first-run walkthrough now covers the newer features too: RGB Scan, Flat-Field correction, the crop/straighten tools, paper profiles, toning, Dodge & Burn, the History panel and the Flat master export, alongside refreshed Exposure (ISO-R grade, H&D curve) and Process (Luma/Colour clip) steps.
 - File pickers now reopen at your last folder instead of the system root.
+- Fix: **thumbnails now update when you switch away** — editing a photo and moving to the next one refreshes the edited frame's thumbnail in the grid, instead of leaving it stale until you re-open or explicitly save it.
 - Fix: **X-Trans full-res demosaic** uses DHT instead of VNG, removing dot/maze artifacts on Fujifilm sensors. @reederphill
 
 ## 0.28.0

--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -299,6 +299,7 @@ class AppController(QObject):
         self.scan_worker.error.connect(self.scan_error.emit)
         self.scan_requested.connect(self.scan_worker.run_scan)
 
+        self.session.active_file_changing.connect(lambda: self._update_thumbnail_from_state(force_readback=True))
         self.session.file_selected.connect(self.load_file)
         self.session.state_changed.connect(self.config_updated.emit)
         self.session.state_changed.connect(self._render_debounce.start)

--- a/negpy/desktop/session.py
+++ b/negpy/desktop/session.py
@@ -232,6 +232,7 @@ class DesktopSessionManager(QObject):
     files_changed = pyqtSignal()  # File list additions only — does not trigger sidebar sync
     history_changed = pyqtSignal()  # Emitted when undo/redo/persist happens
     settings_saved = pyqtSignal()
+    active_file_changing = pyqtSignal()  # Outgoing file about to be replaced — last chance to snapshot it
     settings_copied = pyqtSignal()
     settings_pasted = pyqtSignal()
     file_selected = pyqtSignal(str)  # Emits file path when active file changes
@@ -507,6 +508,7 @@ class DesktopSessionManager(QObject):
             if self.state.current_file_hash and self._config_dirty:
                 self.repo.save_file_settings(self.state.current_file_hash, self.state.config)
                 self.settings_saved.emit()
+                self.active_file_changing.emit()
             self._config_dirty = False
 
             file_info = self.state.uploaded_files[index]

--- a/tests/test_desktop_session.py
+++ b/tests/test_desktop_session.py
@@ -242,6 +242,23 @@ class TestDesktopSessionSync(unittest.TestCase):
         self.assertEqual(paths, ["path1", "path2"])
         self.assertEqual(active, "path2")
 
+    def test_active_file_changing_snapshots_outgoing_when_dirty(self):
+        # Fires before state mutates to the new file, carrying the outgoing identity.
+        self.session.state.current_file_hash = "hash1"
+        self.session.state.is_dirty = True
+        seen = []
+        self.session.active_file_changing.connect(lambda: seen.append(self.session.state.current_file_hash))
+        self.session.select_file(1)
+        self.assertEqual(seen, ["hash1"])
+
+    def test_active_file_changing_not_emitted_when_clean(self):
+        self.session.state.current_file_hash = "hash1"
+        self.session.state.is_dirty = False
+        fired = []
+        self.session.active_file_changing.connect(lambda: fired.append(True))
+        self.session.select_file(1)
+        self.assertEqual(fired, [])
+
     def test_clear_files_persists_empty_manifest(self):
         self.session.clear_files()
         paths, active = self._last_session_manifest()


### PR DESCRIPTION
Emit active_file_changing before select_file mutates state, snapshotting the outgoing frame's thumbnail (gated on dirty, same as the auto-save).