### PR TITLE
fix(preview): drop stale async decode in _on_preview_loaded

### DIFF
--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -45,8 +45,8 @@ from negpy.features.local.models import LocalAdjustmentsConfig
 from negpy.features.process.models import ProcessMode, invalidate_local_bounds
 from negpy.features.retouch.models import RetouchConfig
 from negpy.features.toning.models import ToningConfig
-from negpy.infrastructure.filesystem.watcher import FolderWatchService
 from negpy.infrastructure.display.color_spaces import ColorSpaceRegistry
+from negpy.infrastructure.filesystem.watcher import FolderWatchService
 from negpy.infrastructure.gpu.device import GPUDevice
 from negpy.infrastructure.gpu.resources import GPUTexture
 from negpy.infrastructure.storage.local_asset_store import LocalAssetStore
@@ -523,6 +523,8 @@ class AppController(QObject):
         self.request_render()
 
     def _on_preview_loaded(self, file_path: str, raw: Any, dims: Any, source_cs: str, ir_preview: Any, detected_mode: str) -> None:
+        if self._requested_file_path != file_path:
+            return
         logger.debug(
             "preview e2e (load request to decoded buffer) %.3fs for %s",
             time.perf_counter() - self._preview_load_t0,

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -96,6 +96,7 @@ class TestAppController(unittest.TestCase):
         mock_slot = MagicMock()
         self.controller.preview_loaded.connect(mock_slot)
         self.controller.request_render = MagicMock()
+        self.controller._requested_file_path = "dummy.dng"
 
         raw = object()
         dims = (1234, 5678)
@@ -109,6 +110,19 @@ class TestAppController(unittest.TestCase):
         self.assertIsNone(self.controller.state.preview_ir)
         mock_slot.assert_called_once_with()
         self.controller.request_render.assert_called_once_with()
+
+    def test_stale_preview_decode_is_dropped(self):
+        """A decode that lands after the user switched files must not be applied —
+        accepting it pairs the old buffer with the new file's hash and poisons the
+        per-source analysis cache (green/red cast on the new file)."""
+        self.controller.request_render = MagicMock()
+        self.controller._requested_file_path = "current.dng"
+        self.controller.state.preview_raw = None
+
+        self.controller._on_preview_loaded("stale.dng", object(), (10, 20), "", None, "")
+
+        self.assertIsNone(self.controller.state.preview_raw)
+        self.controller.request_render.assert_not_called()
 
     def test_apply_auto_crop_enables_auto_crop_and_clears_manual_rect(self):
         geometry = replace(self.controller.state.config.geometry, manual_crop_rect=(0.1, 0.1, 0.9, 0.9), auto_crop_enabled=False)


### PR DESCRIPTION
On a rapid file switch, a decode that finishes after the user moved on was applied unconditionally: it set preview_raw to the old file's buffer while current_file_hash already pointed at the new file. The render then paired the stale buffer with the new file's hash, so the GPU analysis cache stored the old file's bounds under the new file's key — the new file later rendered with those stale per-channel bounds (heavy green/red cast), fixed only by forcing a recompute (Reset, or cropping).

Guard _on_preview_loaded with `if self._requested_file_path != file_path: return`, mirroring _on_splash_preview, so a stale decode (and its IR / detected-mode) is dropped. Both real preview_raw writers are now guarded, keeping buffer↔hash consistent so the analysis cache key reliably identifies the buffer.