### PR TITLE
fix(normalization): stop edits stacking into extremity

### DIFF
--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -1665,17 +1665,15 @@ class AppController(QObject):
         if src is not None and src != self.state.current_file_hash:
             return
 
-        # Persist fresh local bounds; skip only when both axes ride the roll baseline.
+        # Persist the per-frame *base* (not the final mix) — re-feeding a mix as the next
+        # base stacks edits. Skip only when both axes ride the roll baseline.
         proc = self.state.config.process
-        if "log_bounds" in metrics and not (proc.use_luma_average and proc.use_colour_average):
-            bounds = metrics.get("log_bounds")
-
+        bounds = metrics.get("log_bounds_base") or metrics.get("log_bounds")
+        if bounds and not (proc.use_luma_average and proc.use_colour_average):
             changes = {}
-            if bounds and not self.state.config.process.lock_bounds:
-                current = self.state.config.process
-                if bounds.floors != current.local_floors or bounds.ceils != current.local_ceils:
-                    changes["local_floors"] = bounds.floors
-                    changes["local_ceils"] = bounds.ceils
+            if not proc.lock_bounds and (bounds.floors != proc.local_floors or bounds.ceils != proc.local_ceils):
+                changes["local_floors"] = bounds.floors
+                changes["local_ceils"] = bounds.ceils
 
             if changes:
                 new_process = replace(self.state.config.process, **changes)

--- a/negpy/features/exposure/normalization.py
+++ b/negpy/features/exposure/normalization.py
@@ -382,6 +382,10 @@ def mix_luma_colour_bounds(luma_src: LogNegativeBounds, colour_src: LogNegativeB
     Luma centre+span from one bounds, per-channel colour deviation from another.
     Identity when luma_src is colour_src — mirrors analyze_log_exposure_bounds' recombination.
     """
+    # Mean-vs-median centres make a self-mix drift by (mean - median); that gets
+    # persisted and re-fed each render, stacking edits. Short-circuit same source.
+    if luma_src == colour_src:
+        return luma_src
     mlf, mlc = sum(luma_src.floors) / 3.0, sum(luma_src.ceils) / 3.0
     mcf, mcc = sorted(colour_src.floors)[1], sorted(colour_src.ceils)[1]
     floors = tuple(mlf + (colour_src.floors[ch] - mcf) for ch in range(3))
@@ -390,15 +394,23 @@ def mix_luma_colour_bounds(luma_src: LogNegativeBounds, colour_src: LogNegativeB
 
 
 def resolve_bounds(process, analyze_fn) -> LogNegativeBounds:
+    """Final bounds for rendering. See resolve_bounds_detailed for the per-frame base."""
+    return resolve_bounds_detailed(process, analyze_fn)[0]
+
+
+def resolve_bounds_detailed(process, analyze_fn) -> tuple[LogNegativeBounds, LogNegativeBounds]:
     """
-    Pick luma + colour bounds from the roll baseline (locked) or the per-frame
-    local/analyzed base, then mix. analyze_fn() supplies the per-frame base and is
-    called only when it is actually needed.
+    Returns (final, base): the final mixed bounds to render with, and the per-frame
+    base (local/analyzed) to persist. Persist the base, not the mix — re-feeding a
+    mix as the next base stacks edits (mean-vs-median drift; colour-only roll).
+    Picks luma + colour from the roll baseline (locked) or the per-frame base, then
+    mixes. analyze_fn() supplies the base and is called only when actually needed.
     """
     roll_luma = process.use_luma_average and process.is_locked_initialized
     roll_colour = process.use_colour_average and process.is_locked_initialized
     locked = LogNegativeBounds(process.locked_floors, process.locked_ceils)
     if roll_luma and roll_colour:
-        return locked
+        return locked, locked
     base = LogNegativeBounds(process.local_floors, process.local_ceils) if process.is_local_initialized else analyze_fn()
-    return mix_luma_colour_bounds(locked if roll_luma else base, locked if roll_colour else base)
+    final = mix_luma_colour_bounds(locked if roll_luma else base, locked if roll_colour else base)
+    return final, base

--- a/negpy/features/exposure/processor.py
+++ b/negpy/features/exposure/processor.py
@@ -19,7 +19,7 @@ from negpy.features.exposure.normalization import (
     measure_shadow_refs_from_log,
     measure_textural_range_from_log,
     normalize_log_image,
-    resolve_bounds,
+    resolve_bounds_detailed,
 )
 from negpy.features.process.models import ProcessConfig, ProcessMode
 from negpy.kernel.image.logic import get_luminance
@@ -76,7 +76,8 @@ class NormalizationProcessor:
             context.metrics["log_bounds_mode_val"] = context.process_mode
             return analyzed
 
-        bounds = resolve_bounds(self.config, analyze_base)
+        bounds, base_bounds = resolve_bounds_detailed(self.config, analyze_base)
+        context.metrics["log_bounds_base"] = base_bounds
 
         context.metrics["norm_density_range"] = luminance_density_range(bounds)
 

--- a/negpy/services/rendering/gpu_engine.py
+++ b/negpy/services/rendering/gpu_engine.py
@@ -16,6 +16,7 @@ from negpy.features.exposure.normalization import (
     measure_shadow_log_refs,
     measure_textural_range,
     resolve_bounds,
+    resolve_bounds_detailed,
 )
 from negpy.features.geometry.logic import (
     AUTOCROP_DETECT_RES,
@@ -459,9 +460,9 @@ class GPUEngine:
             analysis_source = _downsample_for_analysis(analysis_source, APP_CONFIG.preview_render_size)
 
         if bounds_override:
-            bounds = bounds_override
+            bounds = base_bounds = bounds_override
         else:
-            bounds = resolve_bounds(
+            bounds, base_bounds = resolve_bounds_detailed(
                 settings.process,
                 lambda: analyze_log_exposure_bounds(
                     analysis_source,
@@ -832,6 +833,7 @@ class GPUEngine:
             "normalized_log": tex_norm,
             "content_rect": content_rect,
             "log_bounds": bounds,
+            "log_bounds_base": base_bounds,
             "norm_density_range": luminance_density_range(bounds),
             "metered_anchor": metered_anchor,
             "textural_range": textural_range,

--- a/tests/test_color_luma_split.py
+++ b/tests/test_color_luma_split.py
@@ -9,6 +9,7 @@ from negpy.features.exposure.normalization import (
     analyze_log_exposure_bounds,
     mix_luma_colour_bounds,
     resolve_bounds,
+    resolve_bounds_detailed,
 )
 from negpy.features.process.models import ProcessConfig
 
@@ -98,6 +99,29 @@ class TestResolveBounds(unittest.TestCase):
         """Mixing a bounds with itself is the identity."""
         self._assert_close(mix_luma_colour_bounds(self.LOCKED, self.LOCKED), self.LOCKED)
 
+    def test_mix_identity_asymmetric(self):
+        """Identity must hold for asymmetric channels too (mean != median), else a
+        mix(base, base) drifts and stacks when its result is persisted and re-fed."""
+        # floors mean (-1.45) != median (-1.5); ceils mean (-0.4) != median (-0.5).
+        asym = LogNegativeBounds((-1.5, -1.5, -1.35), (-0.5, -0.5, -0.2))
+        self._assert_close(mix_luma_colour_bounds(asym, asym), asym)
+
+    def test_no_roll_resolve_is_stable_when_fed_back(self):
+        """resolve_bounds with no roll baseline must return the local base unchanged,
+        so persisting it and re-resolving doesn't accumulate (the edit-stacking bug)."""
+        asym = LogNegativeBounds((-1.5, -1.5, -1.35), (-0.5, -0.5, -0.2))
+        proc = replace(
+            ProcessConfig(),
+            use_luma_average=False,
+            use_colour_average=False,
+            local_floors=asym.floors,
+            local_ceils=asym.ceils,
+        )
+        first = resolve_bounds(proc, self._boom)
+        proc2 = replace(proc, local_floors=first.floors, local_ceils=first.ceils)
+        second = resolve_bounds(proc2, self._boom)
+        self._assert_close(first, second)
+
     def test_both_on_uses_locked(self):
         proc = self._proc(use_luma_average=True, use_colour_average=True)
         self._assert_close(resolve_bounds(proc, self._boom), self.LOCKED)
@@ -113,6 +137,33 @@ class TestResolveBounds(unittest.TestCase):
     def test_colour_only_mixes_local_luma_with_locked_colour(self):
         proc = self._proc(use_luma_average=False, use_colour_average=True)
         self._assert_close(resolve_bounds(proc, self._boom), mix_luma_colour_bounds(self.LOCAL, self.LOCKED))
+
+    def test_detailed_returns_per_frame_base(self):
+        """resolve_bounds_detailed exposes the per-frame base alongside the final mix —
+        the base is what must be persisted (persisting the mix drifts)."""
+        proc = self._proc(use_luma_average=False, use_colour_average=True)
+        final, base = resolve_bounds_detailed(proc, self._boom)
+        self._assert_close(base, self.LOCAL)
+        self._assert_close(final, mix_luma_colour_bounds(self.LOCAL, self.LOCKED))
+
+    def test_persisting_base_is_stable_colour_only_roll(self):
+        """Colour-only roll with an asymmetric baseline: persisting the per-frame base
+        and re-feeding it must not accumulate (the residual edit-stacking path)."""
+        locked = LogNegativeBounds((-2.0, -2.0, -1.7), (-0.3, -0.3, -0.05))
+        local = LogNegativeBounds((-1.5, -1.4, -1.2), (-0.6, -0.5, -0.4))
+        proc = replace(
+            ProcessConfig(),
+            use_luma_average=False,
+            use_colour_average=True,
+            locked_floors=locked.floors,
+            locked_ceils=locked.ceils,
+            local_floors=local.floors,
+            local_ceils=local.ceils,
+        )
+        _, base = resolve_bounds_detailed(proc, self._boom)
+        proc2 = replace(proc, local_floors=base.floors, local_ceils=base.ceils)
+        _, base2 = resolve_bounds_detailed(proc2, self._boom)
+        self._assert_close(base, base2)
 
     def test_falls_back_to_analyze_when_locked_uninitialized(self):
         """Flags on but no roll baseline -> the per-frame analyze_fn supplies the base."""

--- a/tests/test_lock_bounds.py
+++ b/tests/test_lock_bounds.py
@@ -321,6 +321,21 @@ class TestRenderWritebackRespectsLock(unittest.TestCase):
         self.assertEqual(proc.local_floors, new_floors)
         self.assertEqual(proc.local_ceils, new_ceils)
 
+    def test_writeback_persists_base_not_mixed(self):
+        # Persist the per-frame base, never the final mix — persisting the mix and
+        # re-feeding it drifts (the colour-only-roll edit-stacking residual).
+        _set_process(self.ctrl, local_floors=(0.0, 0.0, 0.0), local_ceils=(0.0, 0.0, 0.0), lock_bounds=False)
+        base = ((0.05, 0.06, 0.07), (0.91, 0.92, 0.93))
+        self.ctrl._on_metrics_updated(
+            {
+                "log_bounds": FakeBounds((0.5, 0.5, 0.5), (0.5, 0.5, 0.5)),  # mixed — must be ignored
+                "log_bounds_base": FakeBounds(*base),
+            }
+        )
+        proc = _saved_process(self.ctrl)
+        self.assertEqual(proc.local_floors, base[0])
+        self.assertEqual(proc.local_ceils, base[1])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

Changing any setting (exposure, saturation, even toggling cast removal) made the image progressively more extreme — edits "stacked" on every change.

## Root cause

Each render persisted its `log_bounds` back into `local_floors`/`local_ceils`, which became the next render's normalization base. Two non-idempotent paths turned that writeback into a feedback loop:

1. **`mix_luma_colour_bounds(base, base)` is not identity.** The luma centre uses the *mean* but the colour deviation is measured around the *median*, so a self-mix shifts every channel by `(mean − median)` whenever the channels are asymmetric (the normal case). The default no-roll path hits this and drifts by a constant offset every edit → runaway.
2. **GPU emitted the *mixed* bounds as `log_bounds`.** Persisting the mix and re-feeding it as `base` climbs each render under colour-only roll. The CPU engine already persisted the per-frame *base*, so it never drifted — the two engines disagreed on what `log_bounds` meant.

Not PR #330 (analysis cache) as first suspected — introduced in #332 (split roll average into luma + colour).

## Fix

- Short-circuit `mix_luma_colour_bounds` to identity when both sources are equal.
- Split `resolve_bounds` → `resolve_bounds_detailed` returning `(final, base)`. Both engines now emit `log_bounds_base` (the per-frame base); the controller persists that instead of the final mix, making the writeback idempotent.
- `log_bounds` / `final_bounds` (export, display) unchanged.

## Tests

+3 regression tests (mix identity on asymmetric channels, colour-only-roll stability under feedback, controller persists base not mix). Full suite 914 passed, lint + ty clean.