### PR TITLE
Add VISION3 500T crosstalk matrix

### DIFF
--- a/crosstalk/vision3_500t.toml
+++ b/crosstalk/vision3_500t.toml
@@ -1,0 +1,9 @@
+name = "Kodak VISION3 500T 5219/7219"
+
+# 3x3 row-major density unmixing matrix (out R/G/B × in R/G/B)
+# Derived analytically from spectral dye-density curves (datasheet H-1-5219)
+matrix = [
+  [ 1.000, -0.099, -0.006 ],
+  [-0.170,  1.000, -0.040 ],
+  [-0.090, -0.201,  1.000 ]
+]


### PR DESCRIPTION
Adds a spectral-crosstalk matrix for **Kodak VISION3 500T (5219/7219)** to the gallery.

Derived via the `crosstalk-from-datasheet` skill from datasheet **H-1-5219** (March 2022), page 4 — separated Yellow/Magenta/Cyan dye-density curves (peak-normalized), Tier 1.

Readings (Status M, R650/G550/B450):

| band | Cyan | Magenta | Yellow |
|---|---|---|---|
| R 650 | 0.80 | 0.10 | 0.01 |
| G 550 | 0.14 | 1.00 | 0.04 |
| B 450 | 0.10 | 0.21 | 0.97 |

Dominant corrections: magenta-unwanted-blue `B,-0.201`, cyan-unwanted-green `G,-0.170`. Anchored to the analytically-derived 250D sibling (`-0.186/-0.140`) since Vision3 shares dye chemistry; 500T reads marginally hotter. Validated it loads via `CrosstalkProfiles._parse_file`.