### PR TITLE
fix(normalization): stop colour average shifting brightness/gamma

### DIFF
--- a/negpy/features/exposure/normalization.py
+++ b/negpy/features/exposure/normalization.py
@@ -379,18 +379,27 @@ def analyze_log_exposure_bounds(
 
 def mix_luma_colour_bounds(luma_src: LogNegativeBounds, colour_src: LogNegativeBounds) -> LogNegativeBounds:
     """
-    Luma centre+span from one bounds, per-channel colour deviation from another.
-    Identity when luma_src is colour_src — mirrors analyze_log_exposure_bounds' recombination.
+    Luma-weighted centre+range from one bounds, per-channel colour cast from
+    another. Keeps the colour source's per-channel shape but shifts it so the
+    result's luma-weighted centre and range (the brightness/anchor and the H&D
+    slope drivers — see luminance_density_range) match the luma source. So
+    colour-average moves only the per-channel cast, never contrast/brightness.
+    Identity when luma_src is colour_src (mirrors analyze_log_exposure_bounds'
+    recombination), which also keeps a persisted self-mix from stacking edits.
     """
-    # Mean-vs-median centres make a self-mix drift by (mean - median); that gets
-    # persisted and re-fed each render, stacking edits. Short-circuit same source.
     if luma_src == colour_src:
         return luma_src
-    mlf, mlc = sum(luma_src.floors) / 3.0, sum(luma_src.ceils) / 3.0
-    mcf, mcc = sorted(colour_src.floors)[1], sorted(colour_src.ceils)[1]
-    floors = tuple(mlf + (colour_src.floors[ch] - mcf) for ch in range(3))
-    ceils = tuple(mlc + (colour_src.ceils[ch] - mcc) for ch in range(3))
-    return LogNegativeBounds(floors, ceils)
+    w = (LUMA_R, LUMA_G, LUMA_B)
+    centre = lambda b: sum(w[c] * (b.floors[c] + b.ceils[c]) / 2.0 for c in range(3))  # noqa: E731
+    rng = lambda b: sum(w[c] * (b.ceils[c] - b.floors[c]) for c in range(3))  # noqa: E731
+    dC = centre(luma_src) - centre(colour_src)
+    dR = rng(luma_src) - rng(colour_src)
+    df, dc = dC - dR / 2.0, dC + dR / 2.0
+    cf, cc = colour_src.floors, colour_src.ceils
+    return LogNegativeBounds(
+        (cf[0] + df, cf[1] + df, cf[2] + df),
+        (cc[0] + dc, cc[1] + dc, cc[2] + dc),
+    )
 
 
 def resolve_bounds(process, analyze_fn) -> LogNegativeBounds:
@@ -414,3 +423,16 @@ def resolve_bounds_detailed(process, analyze_fn) -> tuple[LogNegativeBounds, Log
     base = LogNegativeBounds(process.local_floors, process.local_ceils) if process.is_local_initialized else analyze_fn()
     final = mix_luma_colour_bounds(locked if roll_luma else base, locked if roll_colour else base)
     return final, base
+
+
+def luma_source_bounds(process, base: LogNegativeBounds) -> LogNegativeBounds:
+    """
+    Bounds the luma/exposure reading (metered anchor) must come from: the roll
+    baseline when luma-average is on, else the per-frame base. The anchor is a
+    luma-weighted percentile and so reacts non-linearly to the per-channel cast;
+    measuring it here, not on the final mix, keeps brightness independent of the
+    colour-average toggle (mix_luma_colour_bounds already pins centre+range).
+    """
+    if process.use_luma_average and process.is_locked_initialized:
+        return LogNegativeBounds(process.locked_floors, process.locked_ceils)
+    return base

--- a/negpy/features/exposure/processor.py
+++ b/negpy/features/exposure/processor.py
@@ -14,6 +14,7 @@ from negpy.features.exposure.papers import effective_paper_profile
 from negpy.features.exposure.normalization import (
     LogNegativeBounds,
     analyze_log_exposure_bounds,
+    luma_source_bounds,
     luminance_density_range,
     measure_anchor_from_log,
     measure_shadow_refs_from_log,
@@ -120,7 +121,8 @@ class NormalizationProcessor:
         # Per-frame exposure anchor, measured against the same final bounds the
         # image is normalized with. Stored unconditionally (cheap, block-grid);
         # PhotometricProcessor uses it only when auto_exposure is on.
-        context.metrics["metered_anchor"] = measure_anchor_from_log(img_log, bounds, context.active_roi, self.config.analysis_buffer)
+        anchor_bounds = luma_source_bounds(self.config, base_bounds)
+        context.metrics["metered_anchor"] = measure_anchor_from_log(img_log, anchor_bounds, context.active_roi, self.config.analysis_buffer)
         context.metrics["textural_range"] = measure_textural_range_from_log(img_log, context.active_roi, self.config.analysis_buffer)
 
         context.metrics["final_bounds"] = bounds

--- a/negpy/services/rendering/gpu_engine.py
+++ b/negpy/services/rendering/gpu_engine.py
@@ -11,11 +11,11 @@ from negpy.domain.models import AspectRatio, ExportResolutionMode, WorkspaceConf
 from negpy.features.exposure.normalization import (
     LogNegativeBounds,
     analyze_log_exposure_bounds,
+    luma_source_bounds,
     luminance_density_range,
     measure_anchor,
     measure_shadow_log_refs,
     measure_textural_range,
-    resolve_bounds,
     resolve_bounds_detailed,
 )
 from negpy.features.geometry.logic import (
@@ -460,7 +460,7 @@ class GPUEngine:
             analysis_source = _downsample_for_analysis(analysis_source, APP_CONFIG.preview_render_size)
 
         if bounds_override:
-            bounds = base_bounds = bounds_override
+            bounds = base_bounds = anchor_bounds = bounds_override
         else:
             bounds, base_bounds = resolve_bounds_detailed(
                 settings.process,
@@ -474,6 +474,7 @@ class GPUEngine:
                     color_clip=settings.process.color_range_clip,
                 ),
             )
+            anchor_bounds = luma_source_bounds(settings.process, base_bounds)
 
         shadow_refs = shadow_refs_override
         if needs_refs and analysis_source is not None:
@@ -487,7 +488,7 @@ class GPUEngine:
         if needs_anchor and analysis_source is not None:
             metered_anchor = measure_anchor(
                 analysis_source,
-                bounds,
+                anchor_bounds,
                 analysis_roi,
                 settings.process.analysis_buffer,
             )
@@ -1520,9 +1521,10 @@ class GPUEngine:
             )
 
         if bounds_override:
-            global_bounds = bounds_override
+            global_bounds = global_anchor_bounds = bounds_override
         else:
-            global_bounds = resolve_bounds(settings.process, _analyze_global_bounds)
+            global_bounds, global_base_bounds = resolve_bounds_detailed(settings.process, _analyze_global_bounds)
+            global_anchor_bounds = luma_source_bounds(settings.process, global_base_bounds)
 
         global_shadow_refs = None
         if settings.exposure.cast_removal and settings.process.process_mode == ProcessMode.C41:
@@ -1545,7 +1547,7 @@ class GPUEngine:
             analysis_roi = (int(y1 * a_scale), int(y2 * a_scale), int(x1 * a_scale), int(x2 * a_scale))
             global_metered_anchor = measure_anchor(
                 _downsample_for_analysis(img_rot, APP_CONFIG.preview_render_size),
-                global_bounds,
+                global_anchor_bounds,
                 roi=analysis_roi,
                 analysis_buffer=settings.process.analysis_buffer,
             )

--- a/tests/test_color_luma_split.py
+++ b/tests/test_color_luma_split.py
@@ -165,6 +165,40 @@ class TestResolveBounds(unittest.TestCase):
         _, base2 = resolve_bounds_detailed(proc2, self._boom)
         self._assert_close(base, base2)
 
+    def test_colour_source_does_not_move_luma_range_or_centre(self):
+        """The user's bug: swapping the colour source must not change the
+        luma-weighted density range (H&D slope -> gamma) or centre (-> brightness),
+        which only the luma source may set."""
+        from negpy.features.exposure.normalization import LUMA_R, LUMA_G, LUMA_B, luminance_density_range
+
+        w = (LUMA_R, LUMA_G, LUMA_B)
+        centre = lambda b: sum(w[c] * (b.floors[c] + b.ceils[c]) / 2.0 for c in range(3))  # noqa: E731
+        for luma_src, colour_src in ((self.LOCAL, self.LOCKED), (self.LOCKED, self.LOCAL)):
+            mixed = mix_luma_colour_bounds(luma_src, colour_src)
+            self.assertAlmostEqual(luminance_density_range(mixed), luminance_density_range(luma_src), places=6)
+            self.assertAlmostEqual(centre(mixed), centre(luma_src), places=6)
+        # And the cast still differs from the luma source (colour actually applied).
+        self.assertNotAlmostEqual(
+            mix_luma_colour_bounds(self.LOCAL, self.LOCKED).floors[0],
+            self.LOCAL.floors[0],
+            places=4,
+        )
+
+    def test_luma_source_bounds_ignores_colour_average(self):
+        """The metered anchor (brightness) is read off these bounds, so they must
+        depend only on the luma axis — toggling colour-average never moves them."""
+        from negpy.features.exposure.normalization import luma_source_bounds
+
+        off = self._proc(use_luma_average=False, use_colour_average=False)
+        colour_on = self._proc(use_luma_average=False, use_colour_average=True)
+        self._assert_close(luma_source_bounds(off, self.LOCAL), self.LOCAL)
+        self._assert_close(luma_source_bounds(colour_on, self.LOCAL), self.LOCAL)
+        # Luma-average on -> roll baseline, still independent of the colour toggle.
+        luma_both = self._proc(use_luma_average=True, use_colour_average=True)
+        luma_only = self._proc(use_luma_average=True, use_colour_average=False)
+        self._assert_close(luma_source_bounds(luma_both, self.LOCAL), self.LOCKED)
+        self._assert_close(luma_source_bounds(luma_only, self.LOCAL), self.LOCKED)
+
     def test_falls_back_to_analyze_when_locked_uninitialized(self):
         """Flags on but no roll baseline -> the per-frame analyze_fn supplies the base."""
         analyzed = LogNegativeBounds((-1.5, -1.5, -1.5), (-0.4, -0.4, -0.4))


### PR DESCRIPTION
## Problem

After Batch Analysis, toggling **Use Colour Average** visibly shifted contrast and brightness — not just per-channel white balance, as expected.

## Root cause

Two independent leaks let the colour axis perturb the luma axis:

1. **Gamma.** `mix_luma_colour_bounds` extracted the overall level with an equal-weight mean/median, but the H&D slope is driven by `luminance_density_range` — a **luma-weighted** sum of per-channel ranges. The colour source's per-channel span differences therefore moved the slope. (The old `test_color_luma_split` guarded the equal-weight mean span, the wrong metric, so it passed.)

2. **Brightness.** The metered anchor is a luma-weighted percentile of the per-channel normalization — nonlinear in the per-channel floors/ceils — so the colour cast shifted it even with centre/range pinned.

## Fix

- `mix_luma_colour_bounds` now keeps the colour source's per-channel shape but applies two global shifts so the result's luma-weighted **centre** and **range** equal the luma source's. Colour = luma-neutral cast; contrast/brightness owned solely by the luma source. Identity `mix(x,x)==x` preserved, so the edit-stacking guards still hold; E6 reversed bounds handled (sign-agnostic).
- New `luma_source_bounds(process, base)` routes the metered anchor off the luma source (roll baseline when luma-average is on, else the per-frame base) instead of the mix — applied on both CPU (`processor.py`) and GPU (`gpu_engine.py`, including tiled export).

No WGSL change; CPU/GPU share both helpers so parity holds. No-roll / both-off renders are byte-identical (identity mix), so goldens are unaffected.

## Tests

- New `test_colour_source_does_not_move_luma_range_or_centre` — gamma/centre invariant to colour-source swap.
- New `test_luma_source_bounds_ignores_colour_average` — anchor bounds depend only on the luma axis.
- Existing `TestResolveBounds` expressed via the mix function / identity, so they auto-track; `make all` green (916 passed).