### PR TITLE
feat(ui): yellow labels for edited controls, grey CMY/hue labels

### DIFF
--- a/negpy/desktop/view/sidebar/controls_panel.py
+++ b/negpy/desktop/view/sidebar/controls_panel.py
@@ -2,7 +2,7 @@ from PyQt6.QtWidgets import (
     QWidget,
     QVBoxLayout,
 )
-from PyQt6.QtCore import Qt, QTimer
+from PyQt6.QtCore import Qt, QTimer, pyqtSignal
 import qtawesome as qta
 
 from negpy.desktop.controller import AppController
@@ -33,6 +33,8 @@ class ControlsPanel(QWidget):
     """
     Right sidebar panel aggregating all tool controls (Exposure, Geometry, etc.).
     """
+
+    modified_synced = pyqtSignal()
 
     def __init__(self, controller: AppController):
         super().__init__()
@@ -585,6 +587,7 @@ class ControlsPanel(QWidget):
         self.retouch_section.set_modified(retouch_count)
         self.local_section.set_modified(len(cfg.local.masks))
         self.finish_section.set_modified(finish_count)
+        self.modified_synced.emit()
 
     def _sync_tool_buttons(self) -> None:
         """Updates toggle button states to match active_tool."""

--- a/negpy/desktop/view/sidebar/exposure.py
+++ b/negpy/desktop/view/sidebar/exposure.py
@@ -45,15 +45,15 @@ class ExposureSidebar(BaseSidebar):
         self.region_btn_group.addButton(self.region_highlight_btn, 2)
         self.layout.addLayout(region_row)
 
-        self.cyan_slider = CompactSlider("Cyan", -1.0, 1.0, conf.wb_cyan, color="#00b1b1", has_neutral=True)
+        self.cyan_slider = CompactSlider("Cyan", -1.0, 1.0, conf.wb_cyan, has_neutral=True)
         self.cyan_slider.slider.setObjectName("cyan_slider")
         self.cyan_slider.setToolTip("Cyan–Red white balance shift; applies to the selected region (Global/Shadows/Highlights)")
-        self.magenta_slider = CompactSlider("Magenta", -1.0, 1.0, conf.wb_magenta, color="#b100b1", has_neutral=True)
+        self.magenta_slider = CompactSlider("Magenta", -1.0, 1.0, conf.wb_magenta, has_neutral=True)
         self.magenta_slider.slider.setObjectName("magenta_slider")
         self.magenta_slider.setToolTip(
             tooltip_with_shortcut("Magenta–Green white balance shift; applies to the selected region  E/D", None)
         )
-        self.yellow_slider = CompactSlider("Yellow", -1.0, 1.0, conf.wb_yellow, color="#b1b100", has_neutral=True)
+        self.yellow_slider = CompactSlider("Yellow", -1.0, 1.0, conf.wb_yellow, has_neutral=True)
         self.yellow_slider.slider.setObjectName("yellow_slider")
         self.yellow_slider.setToolTip(tooltip_with_shortcut("Yellow–Blue white balance shift; applies to the selected region  R/F", None))
         self.layout.addWidget(self.cyan_slider)
@@ -343,21 +343,6 @@ class ExposureSidebar(BaseSidebar):
         if self.state.current_file_path:
             self.controller.load_file(self.state.current_file_path)
 
-    # Base hues per slider; varied by region for visual context
-    _CMY_COLORS = {
-        # region_index: (cyan_color, magenta_color, yellow_color)
-        0: ("#00b1b1", "#b100b1", "#b1b100"),  # Global — full saturation
-        1: ("#007a9c", "#7a009c", "#7a7a00"),  # Shadows — cooler/darker
-        2: ("#00d4c8", "#d400a0", "#d4c800"),  # Highlights — brighter/warmer
-    }
-
-    def _update_cmy_label_colors(self, idx: int) -> None:
-        c, m, y = self._CMY_COLORS.get(idx, self._CMY_COLORS[0])
-        fs = THEME.font_size_base
-        self.cyan_slider.label.setStyleSheet(f"font-size: {fs}px; color: {c};")
-        self.magenta_slider.label.setStyleSheet(f"font-size: {fs}px; color: {m};")
-        self.yellow_slider.label.setStyleSheet(f"font-size: {fs}px; color: {y};")
-
     def sync_ui(self) -> None:
         conf = self.state.config.exposure
 
@@ -374,7 +359,6 @@ class ExposureSidebar(BaseSidebar):
             self.paper_label.setVisible(not hide_paper)
 
             idx = self._region_index()
-            self._update_cmy_label_colors(idx)
             if idx == 0:
                 self.cyan_slider.setValue(conf.wb_cyan)
                 self.magenta_slider.setValue(conf.wb_magenta)

--- a/negpy/desktop/view/sidebar/right_panel.py
+++ b/negpy/desktop/view/sidebar/right_panel.py
@@ -117,6 +117,9 @@ class RightPanel(QWidget):
         self._tab_icons: list[str] = []
         self._tab_tooltips: list[str] = []
         self._section_tab_index: dict[str, int] = {}
+        self._tab_sections: dict[int, list[str]] = {}
+        self._tab_edited: list[bool] = []
+        self._active_index = 0
         self._scan_index = -1
 
         tab_style = """
@@ -151,6 +154,9 @@ class RightPanel(QWidget):
             self._tab_keys.append(key)
             self._tab_icons.append(icon_name)
             self._tab_tooltips.append(tooltip)
+            self._tab_edited.append(False)
+            if section_attrs:
+                self._tab_sections[i] = section_attrs
             for attr in section_attrs:
                 self._section_tab_index[attr] = i
             if key == "scan":
@@ -196,13 +202,30 @@ class RightPanel(QWidget):
         self.controller.image_updated.connect(self._update_analysis)
         self.controller.metrics_available.connect(self._on_metrics_available)
         self.controller.config_updated.connect(self.export_sidebar.sync_ui)
+        self.controls_panel.modified_synced.connect(self._sync_tab_edited)
+
+    def _sync_tab_edited(self) -> None:
+        """Mark control-group tabs whose sections have edits (yellow icon, like edited sliders)."""
+        for i, attrs in self._tab_sections.items():
+            self._tab_edited[i] = any(getattr(getattr(self.controls_panel, a), "modified_count", 0) for a in attrs)
+        self._refresh_tab_icons()
+
+    def _refresh_tab_icons(self) -> None:
+        for i, btn in enumerate(self._tab_buttons):
+            if i == self._active_index:
+                color = "white"
+            elif self._tab_edited[i]:
+                color = THEME.accent_edited
+            else:
+                color = THEME.text_secondary
+            btn.setIcon(qta.icon(self._tab_icons[i], color=color))
 
     def _switch_tab(self, index: int) -> None:
+        self._active_index = index
         self.stack.setCurrentIndex(index)
         for i, btn in enumerate(self._tab_buttons):
-            active = i == index
-            btn.setChecked(active)
-            btn.setIcon(qta.icon(self._tab_icons[i], color="white" if active else THEME.text_secondary))
+            btn.setChecked(i == index)
+        self._refresh_tab_icons()
 
         # Trigger device detection when the Scan tab is selected
         if index == self._scan_index and hasattr(self.scan_sidebar, "on_activated"):

--- a/negpy/desktop/view/styles/templates.py
+++ b/negpy/desktop/view/styles/templates.py
@@ -16,8 +16,8 @@ def section_subheader(text: str) -> QLabel:
 
 
 def slider_label_qss(color: str, edited: bool) -> str:
-    border = f"border-bottom: 1px solid {THEME.accent_edited};" if edited else ""
-    return f"font-size: {THEME.font_size_base}px; color: {color}; {border}"
+    label_color = THEME.accent_edited if edited else color
+    return f"font-size: {THEME.font_size_base}px; color: {label_color};"
 
 
 def hue_handle_qss(color: str) -> str:

--- a/negpy/desktop/view/widgets/collapsible.py
+++ b/negpy/desktop/view/widgets/collapsible.py
@@ -135,6 +135,7 @@ class CollapsibleSection(QWidget):
 
     def set_modified(self, count: int) -> None:
         """Append count to title when non-zero; show reset button."""
+        self.modified_count = count
         visible = count > 0
         self.reset_btn.setVisible(visible)
         if visible:

--- a/negpy/desktop/view/widgets/sliders.py
+++ b/negpy/desktop/view/widgets/sliders.py
@@ -329,11 +329,10 @@ class HueSlider(CompactSlider):
         self._apply_hue(default_val)
 
     def _apply_hue(self, hue_deg: float) -> None:
-        """Update label color and slider handle to match the current hue."""
+        """Update slider handle to match the current hue; label stays grey (yellow when edited)."""
         h = int(hue_deg) % 360
         color = QColor.fromHsv(h, 200, 210)
-        edited = abs(self.spin.value() - self._default) > 1e-6
-        self.label.setStyleSheet(slider_label_qss(color.name(), edited))
+        self._update_edited_state()
         self.slider.setStyleSheet(hue_handle_qss(color.name()))
 
     def _on_slider_changed(self, value: int) -> None:


### PR DESCRIPTION
## What

- Edited sliders now mark with a **yellow label** instead of a yellow underline.
- Workflow tabs (Setup/Tone/Color/Finish) tint **yellow** when any of their sections have edits, matching the slider markers.
- Cyan/Magenta/Yellow white-balance labels and Shadow/Highlight Hue labels are no longer coloured by their channel/hue — labels stay grey; the slider **handle dots** keep their colour.

## Why

Consistent, less noisy edited-state signalling. Colour stays where it carries meaning (the handle), labels reserved for the grey→yellow edited cue.

## Test

`uv run pytest` — 916 passed, 4 skipped, 1 xfailed. lint + ty green.