### PR TITLE
fix(export): clamp export tab width to stop horizontal scroll (#325)

### DIFF
--- a/negpy/desktop/view/sidebar/export.py
+++ b/negpy/desktop/view/sidebar/export.py
@@ -16,7 +16,7 @@ from negpy.desktop.view.sidebar.base import BaseSidebar
 from negpy.desktop.view.styles.templates import section_subheader
 from negpy.desktop.view.styles.theme import THEME
 from negpy.desktop.view.widgets.collapsible import CollapsibleSection
-from negpy.desktop.view.widgets.export_settings_form import ExportSettingsForm
+from negpy.desktop.view.widgets.export_settings_form import ExportSettingsForm, constrain_combo
 from negpy.domain.models import ColorSpace
 
 
@@ -306,6 +306,7 @@ class ExportSidebar(BaseSidebar):
         self.display_map = [None] + self.display_spaces
         self.display_combo = QComboBox()
         self.display_combo.addItems(["As detected"] + self.display_spaces)
+        constrain_combo(self.display_combo)
         self.display_combo.setToolTip("Monitor profile the preview is displayed on (affects preview only, not export)")
         override = self.state.monitor_profile_override
         self.display_combo.setCurrentText(override if override in self.display_spaces else "As detected")
@@ -317,6 +318,7 @@ class ExportSidebar(BaseSidebar):
         self.layout.addLayout(disp_row)
 
         self.display_detected_label = QLabel()
+        self.display_detected_label.setWordWrap(True)
         self.display_detected_label.setStyleSheet(f"color: {THEME.text_muted}; font-size: 10px;")
         self.layout.addWidget(self.display_detected_label)
         self._refresh_display_info()

--- a/negpy/desktop/view/widgets/export_settings_form.py
+++ b/negpy/desktop/view/widgets/export_settings_form.py
@@ -13,6 +13,7 @@ from PyQt6.QtWidgets import (
     QLabel,
     QLineEdit,
     QPushButton,
+    QSizePolicy,
     QSpinBox,
     QVBoxLayout,
     QWidget,
@@ -32,6 +33,14 @@ from negpy.infrastructure.display.color_mgmt import ColorService
 from negpy.infrastructure.display.color_spaces import ColorSpaceRegistry
 
 _LABEL_WIDTH = 90
+
+
+def constrain_combo(combo: QComboBox, min_chars: int = 6) -> None:
+    """Stop long item text from stretching the panel: size the combo to a small
+    minimum and elide overflow, filling its row via the layout's spare space."""
+    combo.setSizeAdjustPolicy(QComboBox.SizeAdjustPolicy.AdjustToMinimumContentsLengthWithIcon)
+    combo.setMinimumContentsLength(min_chars)
+    combo.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
 
 # Spaces JXL can tag (mirror _JXL_COLOR). Same as Source is allowed — resolved at
 # export time and rejected by the encoder if it lands on an unsupported space.
@@ -82,6 +91,7 @@ class ExportSettingsForm(QWidget):
         fmt_row.addWidget(self._row_label("Format"))
         self.fmt_combo = QComboBox()
         self.fmt_combo.addItems([f.value for f in ExportFormat])
+        constrain_combo(self.fmt_combo)
         self.fmt_combo.currentTextChanged.connect(self._on_fmt_changed)
         fmt_row.addWidget(self.fmt_combo)
         root.addLayout(fmt_row)
@@ -208,6 +218,7 @@ class ExportSettingsForm(QWidget):
         self.ratio_combo = QComboBox()
         ratios = [AspectRatio.ORIGINAL] + [r.value for r in AspectRatio if r != AspectRatio.ORIGINAL]
         self.ratio_combo.addItems(ratios)
+        constrain_combo(self.ratio_combo)
         self.ratio_combo.currentTextChanged.connect(self._on_changed)
         ratio_row.addWidget(self.ratio_combo)
         root.addLayout(ratio_row)
@@ -228,6 +239,7 @@ class ExportSettingsForm(QWidget):
         input_row.addWidget(self._row_label("Input ICC"))
         self.input_combo = QComboBox()
         self.input_combo.addItems([os.path.basename(p) for p in self._icc_input_profiles])
+        constrain_combo(self.input_combo)
         self.input_combo.setToolTip("Source/input ICC profile")
         self.input_combo.currentIndexChanged.connect(self._on_changed)
         input_row.addWidget(self.input_combo)
@@ -237,6 +249,7 @@ class ExportSettingsForm(QWidget):
         cs_row.addWidget(self._row_label("Color space"))
         self.color_space_combo = QComboBox()
         self.color_space_combo.addItems([cs.value for cs in ColorSpace])
+        constrain_combo(self.color_space_combo)
         self.color_space_combo.currentTextChanged.connect(self._on_changed)
         self.color_space_combo.currentTextChanged.connect(self._refresh_jxl_warning)
         cs_row.addWidget(self.color_space_combo)
@@ -247,6 +260,7 @@ class ExportSettingsForm(QWidget):
         output_row.addWidget(self._row_label("Output ICC"))
         self.icc_output_combo = QComboBox()
         self.icc_output_combo.addItems([os.path.basename(p) for p in self._icc_output_profiles])
+        constrain_combo(self.icc_output_combo)
         self.icc_output_combo.setToolTip("Custom output ICC profile (overrides color space)")
         self.icc_output_combo.currentIndexChanged.connect(self._on_changed)
         output_row.addWidget(self.icc_output_combo)
@@ -263,6 +277,7 @@ class ExportSettingsForm(QWidget):
         self.output_mode_combo.addItem("Subfolder of source", ExportPresetOutputMode.SUBFOLDER_OF_SOURCE)
         self.output_mode_combo.addItem("Same as source", ExportPresetOutputMode.SAME_AS_SOURCE)
         self.output_mode_combo.addItem("Absolute path", ExportPresetOutputMode.ABSOLUTE)
+        constrain_combo(self.output_mode_combo)
         self.output_mode_combo.currentIndexChanged.connect(self._on_output_mode_changed)
         mode_row.addWidget(self.output_mode_combo)
         root.addLayout(mode_row)

--- a/tests/test_export_display_warning.py
+++ b/tests/test_export_display_warning.py
@@ -2,10 +2,11 @@
 
 from types import SimpleNamespace
 
-from PyQt6.QtWidgets import QComboBox, QLabel
+from PyQt6.QtWidgets import QComboBox, QLabel, QSizePolicy
 
 from negpy.desktop.view.sidebar.export import ExportSidebar
 from negpy.desktop.view.styles.theme import THEME
+from negpy.desktop.view.widgets.export_settings_form import constrain_combo
 
 
 def _stub(detected_bytes):
@@ -34,3 +35,20 @@ def test_detected_profile_shows_muted_label() -> None:
     assert s.display_detected_label.text().startswith("Detected:")
     assert THEME.text_muted in s.display_detected_label.styleSheet()
     assert THEME.channel_red not in s.display_detected_label.styleSheet()
+
+
+def test_constrain_combo_bounds_width_for_long_items() -> None:
+    """A long item (e.g. a verbose monitor profile / ICC filename) must not
+    blow up the combo's width and stretch the export panel (#325)."""
+    long_item = "As detected (sRGB IEC61966-2.1 Color Space Profile, very verbose)"
+
+    wide = QComboBox()
+    wide.addItem(long_item)
+
+    narrow = QComboBox()
+    narrow.addItem(long_item)
+    constrain_combo(narrow)
+
+    assert narrow.sizeHint().width() < wide.sizeHint().width()
+    assert narrow.sizeAdjustPolicy() == QComboBox.SizeAdjustPolicy.AdjustToMinimumContentsLengthWithIcon
+    assert narrow.sizePolicy().horizontalPolicy() == QSizePolicy.Policy.Expanding


### PR DESCRIPTION
Long detected monitor ICC profile descriptions (Windows) drove the non-wrapped 'Detected:' label and the 'As detected (...)' combo item to a min-width wider than the panel viewport, forcing a horizontal scrollbar in the setWidgetResizable scroll area.

Word-wrap the detection label and add constrain_combo() (small AdjustToMinimumContentsLengthWithIcon + Expanding policy) applied to every export-tab combo so long text elides instead of stretching the panel.

fixes https://github.com/marcinz606/NegPy/issues/325