### PR TITLE
feat(crop): rule-of-thirds on crop, denser fine-rotation grid (#320)

### DIFF
--- a/negpy/desktop/view/canvas/overlay.py
+++ b/negpy/desktop/view/canvas/overlay.py
@@ -16,6 +16,13 @@ from negpy.services.view.coordinate_mapping import CoordinateMapping
 _LASSO_SNAP_PX = 12.0
 _CROP_HANDLE_PX = 10.0
 _CROP_MIN_SCREEN_PX = 24.0
+_ROTATION_GRID_DIVISIONS = 10
+_GRID_ALPHA = 70
+
+
+def grid_interior_fractions(divisions: int) -> List[float]:
+    """Interior division fractions, e.g. 3 -> [1/3, 2/3], 10 -> [.1 .. .9]."""
+    return [i / divisions for i in range(1, divisions)]
 
 
 class CanvasOverlay(QWidget):
@@ -263,17 +270,21 @@ class CanvasOverlay(QWidget):
         if getattr(self.state, "compare_mode", False):
             self._draw_compare_badge(painter, visible_rect)
 
-    def _draw_rotation_grid(self, painter: QPainter, visible_rect: QRectF) -> None:
-        """Rule-of-thirds grid: 2 horizontal + 2 vertical screen-aligned reference lines."""
-        pen = QPen(QColor(255, 255, 255, 90), 1, Qt.PenStyle.SolidLine)
+    def _draw_grid(self, painter: QPainter, rect: QRectF, divisions: int, alpha: int) -> None:
+        """Even N×N reference grid (interior lines only) across `rect`, screen-aligned."""
+        pen = QPen(QColor(255, 255, 255, alpha), 1, Qt.PenStyle.SolidLine)
         pen.setCosmetic(True)
         painter.setBrush(Qt.BrushStyle.NoBrush)
         painter.setPen(pen)
-        for i in (1, 2):
-            x = visible_rect.left() + visible_rect.width() * i / 3.0
-            y = visible_rect.top() + visible_rect.height() * i / 3.0
-            painter.drawLine(QPointF(x, visible_rect.top()), QPointF(x, visible_rect.bottom()))
-            painter.drawLine(QPointF(visible_rect.left(), y), QPointF(visible_rect.right(), y))
+        for f in grid_interior_fractions(divisions):
+            x = rect.left() + rect.width() * f
+            y = rect.top() + rect.height() * f
+            painter.drawLine(QPointF(x, rect.top()), QPointF(x, rect.bottom()))
+            painter.drawLine(QPointF(rect.left(), y), QPointF(rect.right(), y))
+
+    def _draw_rotation_grid(self, painter: QPainter, visible_rect: QRectF) -> None:
+        """Dense leveling grid shown while Fine Rot is adjusted (Lightroom-style)."""
+        self._draw_grid(painter, visible_rect, _ROTATION_GRID_DIVISIONS, _GRID_ALPHA)
 
     def _draw_compare_badge(self, painter: QPainter, visible_rect: QRectF) -> None:
         badge = QRectF(visible_rect.x() + 12, visible_rect.y() + 12, 78, 22)
@@ -426,6 +437,7 @@ class CanvasOverlay(QWidget):
             painter.setBrush(Qt.BrushStyle.NoBrush)
             painter.setPen(pen)
             painter.drawRect(rect)
+            self._draw_grid(painter, rect, 3, _GRID_ALPHA)
             return
 
         corners = self._crop_corner_screen_points()
@@ -447,6 +459,8 @@ class CanvasOverlay(QWidget):
         painter.setBrush(Qt.BrushStyle.NoBrush)
         painter.setPen(pen)
         painter.drawPolygon(poly)
+
+        self._draw_grid(painter, QRectF(corners["tl"], corners["br"]), 3, _GRID_ALPHA)
 
         handle_pen = QPen(Qt.GlobalColor.white, 1.5, Qt.PenStyle.SolidLine)
         handle_pen.setCosmetic(True)

--- a/tests/test_rotation_guide.py
+++ b/tests/test_rotation_guide.py
@@ -1,5 +1,8 @@
+from PyQt6.QtCore import QRectF
+from PyQt6.QtGui import QImage, QPainter
+
 from negpy.desktop.session import AppState
-from negpy.desktop.view.canvas.overlay import CanvasOverlay
+from negpy.desktop.view.canvas.overlay import CanvasOverlay, grid_interior_fractions
 
 
 def test_rotation_grid_toggles_with_timer() -> None:
@@ -12,3 +15,18 @@ def test_rotation_grid_toggles_with_timer() -> None:
 
     overlay._hide_rotation_grid()
     assert overlay._rotation_grid_visible is False
+
+
+def test_grid_interior_fractions() -> None:
+    assert grid_interior_fractions(3) == [1 / 3, 2 / 3]
+    assert len(grid_interior_fractions(10)) == 9
+
+
+def test_draw_rotation_grid_paints_without_error() -> None:
+    overlay = CanvasOverlay(AppState())
+    img = QImage(64, 64, QImage.Format.Format_ARGB32)
+    painter = QPainter(img)
+    try:
+        overlay._draw_rotation_grid(painter, QRectF(0, 0, 64, 64))
+    finally:
+        painter.end()


### PR DESCRIPTION
Crop overlay now draws a rule-of-thirds composition grid inside the crop rect (both fresh-draw and resize/move). The fine-rotation overlay switches from a 3x3 thirds grid to a dense 10x10 leveling grid, Lightroom-style. Both share a new _draw_grid primitive.

resolves https://github.com/marcinz606/NegPy/issues/320