### PR TITLE
perf(rendering): cache GPU bind groups and hot decode paths

### DIFF
--- a/negpy/desktop/view/sidebar/controls_panel.py
+++ b/negpy/desktop/view/sidebar/controls_panel.py
@@ -15,6 +15,7 @@ from negpy.features.lab.models import LabConfig
 from negpy.features.toning.models import ToningConfig
 from negpy.features.geometry.models import GeometryConfig
 from negpy.features.process.models import ProcessConfig
+from negpy.features.finish.models import FinishConfig
 
 # Sidebar Components
 from negpy.desktop.view.sidebar.presets import PresetsSidebar
@@ -28,6 +29,14 @@ from negpy.desktop.view.sidebar.retouch import RetouchSidebar
 from negpy.desktop.view.sidebar.local import LocalSidebar
 from negpy.desktop.view.sidebar.finish import FinishSidebar
 
+# Constant frozen-dataclass defaults — build once, not per resync.
+_DEFAULT_EXPOSURE = ExposureConfig()
+_DEFAULT_LAB = LabConfig()
+_DEFAULT_TONING = ToningConfig()
+_DEFAULT_GEOMETRY = GeometryConfig()
+_DEFAULT_PROCESS = ProcessConfig()
+_DEFAULT_FINISH = FinishConfig()
+
 
 class ControlsPanel(QWidget):
     """
@@ -39,6 +48,7 @@ class ControlsPanel(QWidget):
     def __init__(self, controller: AppController):
         super().__init__()
         self.controller = controller
+        self._last_histogram_buf = None
 
         self._init_ui()
         self._connect_signals()
@@ -198,6 +208,8 @@ class ControlsPanel(QWidget):
         self._sync_debounce.timeout.connect(self._sync_all_sidebars)
         self.controller.config_updated.connect(self._sync_debounce.start)
         self.controller.tool_sync_requested.connect(self._sync_tool_buttons)
+        # Histogram only changes on render completion — refresh there, not on every resync.
+        self.controller.image_updated.connect(self._update_histogram)
 
         self.exposure_section.reset_requested.connect(lambda: self.controller.session.reset_section("exposure"))
         self.lab_section.reset_requested.connect(lambda: self.controller.session.reset_section("lab"))
@@ -477,17 +489,23 @@ class ControlsPanel(QWidget):
         self.presets_sidebar.sync_ui()
         self.flatfield_sidebar.sync_ui()
         self._sync_modified_dots()
+
+    def _update_histogram(self) -> None:
+        """Repaint only when the render produced a new buffer."""
         buf = self.controller.state.last_metrics.get("histogram_raw")
+        if buf is self._last_histogram_buf:
+            return
+        self._last_histogram_buf = buf
         self.exposure_histogram.update_data(buf)
 
     def _sync_modified_dots(self) -> None:
         """Update modified-indicator dots on collapsible section headers."""
         cfg = self.controller.state.config
-        _exp = ExposureConfig()
-        _lab = LabConfig()
-        _ton = ToningConfig()
-        _geo = GeometryConfig()
-        _proc = ProcessConfig()
+        _exp = _DEFAULT_EXPOSURE
+        _lab = _DEFAULT_LAB
+        _ton = _DEFAULT_TONING
+        _geo = _DEFAULT_GEOMETRY
+        _proc = _DEFAULT_PROCESS
 
         exp = cfg.exposure
         exposure_count = sum(
@@ -566,9 +584,7 @@ class ControlsPanel(QWidget):
         ret = cfg.retouch
         retouch_count = int(ret.dust_remove) + len(ret.manual_dust_spots)
 
-        from negpy.features.finish.models import FinishConfig
-
-        _fin = FinishConfig()
+        _fin = _DEFAULT_FINISH
         fin = cfg.finish
         finish_count = sum(
             [

--- a/negpy/desktop/workers/export.py
+++ b/negpy/desktop/workers/export.py
@@ -164,7 +164,6 @@ class ExportWorker(QObject):
                 )
                 if tile is not None:
                     tiles.append(tile)
-                self._processor.cleanup()
 
             sheets = ContactSheetService.build_sheets(tiles, max_tiles=max_tiles, cell_px=cell_px, gap=gap, margin=margin)
             os.makedirs(out_dir, exist_ok=True)
@@ -191,3 +190,6 @@ class ExportWorker(QObject):
             self.finished.emit()
         except Exception as e:
             self.error.emit(str(e))
+        finally:
+            # Release GPU resources once per batch, not per tile (avoids pool rebuild each frame).
+            self._processor.cleanup()

--- a/negpy/desktop/workers/render.py
+++ b/negpy/desktop/workers/render.py
@@ -406,11 +406,8 @@ class PreviewLoadWorker(QObject):
             if not task.use_camera_wb:
                 scan = raw
             else:
-                scan, _, _ = self._preview_service.load_linear_preview(
-                    task.file_path,
-                    task.workspace_color_space,
-                    use_camera_wb=False,
-                )
+                # Camera WB hides the C41 mask — re-decode no-WB (lean; detect downsamples).
+                scan = self._preview_service.decode_for_detection(task.file_path)
             return str(detect_process_mode(scan))
         except Exception:
             logger.exception(f"Process-mode detection failed: {task.file_path}")

--- a/negpy/services/rendering/gpu_engine.py
+++ b/negpy/services/rendering/gpu_engine.py
@@ -96,6 +96,16 @@ def _downsample_for_analysis(img: np.ndarray, max_size: int) -> np.ndarray:
     return cv2.resize(img, (int(w * scale), int(h * scale)), interpolation=cv2.INTER_AREA)
 
 
+def _binding_identity(idx: int, res: Any) -> tuple:
+    """Hashable identity for the bind-group cache. Pooled views/persistent buffers keep the
+    same object across frames, so id() is stable."""
+    if isinstance(res, dict) and "buffer" in res:
+        return (idx, id(res["buffer"]), res.get("offset", 0), res.get("size"))
+    if isinstance(res, GPUBuffer):
+        return (idx, id(res.buffer))
+    return (idx, id(res))
+
+
 def _analysis_cache_key(settings: WorkspaceConfig, analysis_source_hash: str) -> tuple:
     """Identity of the auto-exposure analysis for a frame. Mirrors the CPU base-stage
     cache key (engine.py) plus the fields that gate refs/anchor/textural, so it survives
@@ -189,6 +199,11 @@ class GPUEngine:
         self._last_scale_factor: float = 1.0
         self._pending_ir_buffer: Optional[np.ndarray] = None
         self._ir_upload_key: Optional[Tuple[int, Any, int, int]] = None
+
+        # Bind groups reference resources, not contents, so they survive across frames;
+        # cache and reuse (cleared in cleanup()). Saves ~28 wgpu calls per frame.
+        self._bind_group_cache: Dict[Tuple, Any] = {}
+        self._bind_layout_cache: Dict[str, Any] = {}
 
         # Persistent staging buffers — avoid create_buffer() on every readback
         self._metrics_staging: Optional[Any] = None
@@ -1351,43 +1366,52 @@ class GPUEngine:
         if pipeline is None:
             raise RuntimeError(f"Pipeline not initialized: {pipeline_name}")
 
-        wg_x, wg_y = (16, 16) if pipeline_name in ["autocrop", "metrics", "clahe_hist"] else (8, 8)
-        entries = []
-        for idx, res in bindings:
-            if res is None:
-                raise ValueError(
-                    f"Binding {idx} in pipeline '{pipeline_name}' is None. "
-                    "This usually means a hardware resource was not properly initialized or has been destroyed."
-                )
-
-            if isinstance(res, dict) and "buffer" in res:
-                if res["buffer"] is None:
-                    raise ValueError(f"Buffer in binding {idx} ({pipeline_name}) is None")
-                entries.append({"binding": idx, "resource": res})
-            elif isinstance(res, GPUBuffer):
-                if res.buffer is None:
-                    raise ValueError(f"GPUBuffer in binding {idx} ({pipeline_name}) is None")
-                entries.append(
-                    {
-                        "binding": idx,
-                        "resource": {
-                            "buffer": res.buffer,
-                            "offset": 0,
-                            "size": res.buffer.size,
-                        },
-                    }
-                )
-            else:
-                entries.append({"binding": idx, "resource": res})
-
         if not self.gpu.device:
             raise RuntimeError("GPU device lost")
 
-        try:
-            bind_group = self.gpu.device.create_bind_group(layout=pipeline.get_bind_group_layout(0), entries=entries)
-        except Exception as e:
-            logger.error(f"Failed to create bind group for {pipeline_name}: {e}")
-            raise
+        wg_x, wg_y = (16, 16) if pipeline_name in ["autocrop", "metrics", "clahe_hist"] else (8, 8)
+
+        cache_key = (pipeline_name, tuple(_binding_identity(idx, res) for idx, res in bindings))
+        bind_group = self._bind_group_cache.get(cache_key)
+        if bind_group is None:
+            entries = []
+            for idx, res in bindings:
+                if res is None:
+                    raise ValueError(
+                        f"Binding {idx} in pipeline '{pipeline_name}' is None. "
+                        "This usually means a hardware resource was not properly initialized or has been destroyed."
+                    )
+
+                if isinstance(res, dict) and "buffer" in res:
+                    if res["buffer"] is None:
+                        raise ValueError(f"Buffer in binding {idx} ({pipeline_name}) is None")
+                    entries.append({"binding": idx, "resource": res})
+                elif isinstance(res, GPUBuffer):
+                    if res.buffer is None:
+                        raise ValueError(f"GPUBuffer in binding {idx} ({pipeline_name}) is None")
+                    entries.append(
+                        {
+                            "binding": idx,
+                            "resource": {
+                                "buffer": res.buffer,
+                                "offset": 0,
+                                "size": res.buffer.size,
+                            },
+                        }
+                    )
+                else:
+                    entries.append({"binding": idx, "resource": res})
+
+            layout = self._bind_layout_cache.get(pipeline_name)
+            if layout is None:
+                layout = pipeline.get_bind_group_layout(0)
+                self._bind_layout_cache[pipeline_name] = layout
+            try:
+                bind_group = self.gpu.device.create_bind_group(layout=layout, entries=entries)
+            except Exception as e:
+                logger.error(f"Failed to create bind group for {pipeline_name}: {e}")
+                raise
+            self._bind_group_cache[cache_key] = bind_group
 
         pass_enc = encoder.begin_compute_pass()
         pass_enc.set_pipeline(pipeline)
@@ -1613,6 +1637,9 @@ class GPUEngine:
         for tex in self._tex_cache.values():
             tex.destroy()
         self._tex_cache.clear()
+        # Bind groups reference the destroyed views — drop them.
+        self._bind_group_cache.clear()
+        self._bind_layout_cache.clear()
         self._ir_upload_key = None
         gc.collect()
         logger.info("GPUEngine: VRAM resources released")

--- a/negpy/services/rendering/image_processor.py
+++ b/negpy/services/rendering/image_processor.py
@@ -62,6 +62,11 @@ class ImageProcessor:
         self.engine_cpu = DarkroomEngine()
         self.engine_gpu: Optional[GPUEngine] = None
 
+        # Last decoded full-res source (decode+flatfield) — skips re-decode on repeat export.
+        # One entry only (full-res buffers are large); treated read-only downstream.
+        self._source_cache_key: Optional[tuple] = None
+        self._source_cache_value: Optional[Tuple[np.ndarray, Optional[np.ndarray], str]] = None
+
         if APP_CONFIG.use_gpu:
             gpu = GPUDevice.get()
             if gpu.is_available:
@@ -190,6 +195,14 @@ class ImageProcessor:
         """
         linear_raw = params.exposure.linear_raw
 
+        try:
+            mtime = os.path.getmtime(file_path)
+        except OSError:
+            mtime = 0.0
+        cache_key = (file_path, mtime, linear_raw, rgbscan_token(params.rgbscan), flatfield_token(params.flatfield))
+        if cache_key == self._source_cache_key and self._source_cache_value is not None:
+            return self._source_cache_value
+
         rgb, metadata = self._decode_sensor_rgb(file_path, linear_raw)
         source_cs = str(metadata.get("color_space", ColorSpace.ADOBE_RGB.value))
         ir_full = metadata.get("ir")
@@ -212,7 +225,10 @@ class ImageProcessor:
         f32_buffer = apply_flatfield(f32_buffer, params.flatfield)
         if ir_full is not None:
             ir_full = apply_exif_orientation(ir_full, orientation)
-        return f32_buffer, ir_full, source_cs
+        result = (f32_buffer, ir_full, source_cs)
+        self._source_cache_key = cache_key
+        self._source_cache_value = result
+        return result
 
     def process_export(
         self,
@@ -708,6 +724,8 @@ class ImageProcessor:
 
     def cleanup(self) -> None:
         """Evacuates transient GPU resources."""
+        self._source_cache_key = None
+        self._source_cache_value = None
         if self.engine_gpu:
             self.engine_gpu.cleanup()
 

--- a/negpy/services/rendering/preview_manager.py
+++ b/negpy/services/rendering/preview_manager.py
@@ -282,6 +282,35 @@ class PreviewManager:
         )
         return out, dims, meta
 
+    def decode_for_detection(self, file_path: str) -> Optional[ImageBuffer]:
+        """No-WB linear decode for autodetect only — skips the preview resize/orient/cache
+        (detect_process_mode downsamples), so it costs just the demosaic. Mirrors the fast path."""
+        try:
+            ctx_mgr, _meta = loader_factory.get_loader(file_path)
+            with ctx_mgr as raw:
+                if isinstance(raw, NonStandardFileWrapper):
+                    demosaic = get_best_demosaic_algorithm(raw)
+                    post_kw: dict = {}
+                else:
+                    demosaic = rawpy.DemosaicAlgorithm.LINEAR
+                    # half_size casts X-Trans channel ratios (skews detection); Bayer is fine.
+                    post_kw = {} if is_xtrans(raw) else {"half_size": True}
+                rgb = raw.postprocess(
+                    gamma=(1, 1),
+                    no_auto_bright=True,
+                    use_camera_wb=False,
+                    user_wb=[1, 1, 1, 1],
+                    output_bps=16,
+                    output_color=rawpy.ColorSpace.raw,
+                    demosaic_algorithm=demosaic,
+                    user_flip=0,
+                    **post_kw,
+                )
+            return uint16_to_float32(ensure_rgb(rgb))
+        except Exception:
+            logger.exception("detection decode failed: %s", file_path)
+            return None
+
     def load_linear_preview_rgb(
         self,
         red_path: str,
@@ -294,8 +323,20 @@ class PreviewManager:
         align: bool = True,
     ) -> Tuple[ImageBuffer, Dimensions, dict]:
         """Merge a narrowband R/G/B triplet into one linear preview: red channel from the
-        red shot, green from green, blue from blue. Each exposure is decoded (and cached)
-        through the normal preview path, then channels are combined."""
+        red shot, green from green, blue from blue. The merged result is cached, so re-visiting
+        a triplet skips the green/blue decode and the phase-correlate align."""
+        merged_key = None
+        if file_hash and color_space is not None:
+            merged_key = PreviewCacheKey(
+                file_hash=f"rgb|{file_hash}|{green_path}|{blue_path}|{align}",
+                use_camera_wb=use_camera_wb,
+                workspace_color_space=color_space,
+                full_resolution=full_resolution,
+            )
+            hit = self._cache.get(merged_key)
+            if hit is not None:
+                return hit  # cache hit — caller must not mutate this buffer
+
         red_out, dims, meta = self.load_linear_preview(red_path, color_space, use_camera_wb, full_resolution, file_hash)
         green_out, _, _ = self.load_linear_preview(green_path, color_space, use_camera_wb, full_resolution, None)
         blue_out, _, _ = self.load_linear_preview(blue_path, color_space, use_camera_wb, full_resolution, None)
@@ -309,7 +350,10 @@ class PreviewManager:
             return arr
 
         merged = assemble_rgb(red, _match(green_out), _match(blue_out), align=align)
-        return ensure_image(merged), dims, meta
+        out = ensure_image(merged)
+        if merged_key is not None:
+            self._cache.put(merged_key, out.copy(), dims, dict(meta))
+        return out, dims, meta
 
     def load_splash_and_linear(
         self,

--- a/tests/test_preview_load_worker_detect_mode.py
+++ b/tests/test_preview_load_worker_detect_mode.py
@@ -5,8 +5,8 @@ The worker previously read task.linear_raw and passed linear_raw=True to
 load_linear_preview; both were renamed to use_camera_wb during the #210 merge.
 A wrong reference here is a silent runtime crash (not a merge conflict), so these
 tests pin the wiring:
-  - camera-WB preview (use_camera_wb=True): re-decode no-WB before classifying,
-    since the C41 orange mask is hidden by camera WB.
+  - camera-WB preview (use_camera_wb=True): a lean no-WB decode (decode_for_detection)
+    before classifying, since the C41 orange mask is hidden by camera WB.
   - no-WB preview (use_camera_wb=False): classify the buffer we already have.
 """
 
@@ -31,7 +31,7 @@ def test_detect_mode_camera_wb_redecodes_no_wb(qapp):
 
     service = MagicMock()
     rescan = np.zeros((4, 4, 3), dtype=np.float32)
-    service.load_linear_preview.return_value = (rescan, (4, 4), {})
+    service.decode_for_detection.return_value = rescan
     worker = PreviewLoadWorker(service)
 
     camera_wb_buf = np.ones((4, 4, 3), dtype=np.float32)
@@ -39,9 +39,9 @@ def test_detect_mode_camera_wb_redecodes_no_wb(qapp):
         result = worker._detect_mode(_task(use_camera_wb=True), camera_wb_buf)
 
     assert result == "c41"
-    service.load_linear_preview.assert_called_once()
-    _, kwargs = service.load_linear_preview.call_args
-    assert kwargs["use_camera_wb"] is False
+    # Camera WB hides the C41 mask → a lean no-WB decode is run for detection.
+    service.decode_for_detection.assert_called_once_with("/fake/path.dng")
+    service.load_linear_preview.assert_not_called()
     # Classified the freshly re-decoded no-WB buffer, not the camera-WB one.
     assert dpm.call_args[0][0] is rescan
 


### PR DESCRIPTION
Performance pass — GPU is the primary path, so most wins target it and the host-side work that bookends every render.

- gpu_engine: cache bind groups + bind-group layouts in _dispatch_pass instead of recreating ~28 per frame (pooled views/buffers are stable across frames); cleared in cleanup(). Frame 2 onward rebuilds zero.
- controls_panel: hoist default configs to module constants (no per-resync churn); drive the histogram off image_updated, gated on buffer identity, instead of repainting on every config-change resync.
- preview_manager: add decode_for_detection (lean no-WB half-size decode for autodetect) replacing a full second preview decode; cache the assembled RGB-scan triplet so re-nav skips the green/blue decode and phaseCorrelate.
- image_processor: single-slot full-res source cache (path+mtime+decode params) so a repeat export skips the RAW decode.
- export: release GPU resources once per contact-sheet batch, not per tile.