### PR TITLE
Feature: set contact sheet location and contact sheet presets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,7 @@ Passed through every stage. Carries `scale_factor` (preview downsample ratio), `
 - **`AppController`** (`negpy/desktop/controller.py`) — single controller; all UI interactions call methods here; emits `config_updated` and `image_updated` signals
 - **Workers** — heavy work (render, export, thumbnails) runs in `QThread`-backed worker objects in `negpy/desktop/workers/`; communicate via Qt signals
 - **Sidebars** — each feature has a `negpy/desktop/view/sidebar/<name>.py` that reads from `AppState` and calls controller methods; all synced via `ControlsPanel._sync_all_sidebars()` on `config_updated`
+- **Contact sheet output** — `ExportConfig.contact_sheet_output_path` (persisted via `last_export_config` sticky). Empty = follow export destination rules (same-as-source → first visible frame's folder; absolute → `export_path`). Non-empty path wins on export.
 
 ### Adding a new feature
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,7 @@ Passed through every stage. Carries `scale_factor` (preview downsample ratio), `
 - **Workers** — heavy work (render, export, thumbnails) runs in `QThread`-backed worker objects in `negpy/desktop/workers/`; communicate via Qt signals
 - **Sidebars** — each feature has a `negpy/desktop/view/sidebar/<name>.py` that reads from `AppState` and calls controller methods; all synced via `ControlsPanel._sync_all_sidebars()` on `config_updated`
 - **Contact sheet output** — `ExportConfig.contact_sheet_output_path` (persisted via `last_export_config` sticky). Empty = follow export destination rules (same-as-source → first visible frame's folder; absolute → `export_path`). Non-empty path wins on export.
+- **Contact sheet templates** — `.toml` files in `~/NegPy/contact_sheets/` (`ContactSheetTemplates`). `ExportConfig.contact_sheet_template` stores the selected name; **Default** uses `contact_sheet_default_*` snapshot fields. Edits to layout spinboxes write back to the active template. See `docs/CONTACT_SHEET_TEMPLATES.md`.
 
 ### Adding a new feature
 

--- a/docs/CONTACT_SHEET_TEMPLATES.md
+++ b/docs/CONTACT_SHEET_TEMPLATES.md
@@ -1,0 +1,94 @@
+# Contact Sheet Templates
+
+The **Contact Sheet** section in the Export sidebar can load layout presets from plain
+`.toml` files. **Default** is your in-app baseline layout (factory 600 / 16 / 32 / 38 until
+you change it).
+
+---
+
+## Folder
+
+Place template files here:
+
+```
+~/NegPy/contact_sheets/
+```
+
+On Windows this is typically:
+
+```
+C:\Users\<you>\NegPy\contact_sheets\
+```
+
+NegPy creates the folder on startup. You can also click **Save as template** in the app
+to write a file from the current layout settings.
+
+---
+
+## File format
+
+Each template is a UTF-8 TOML file with a display name and a `[layout]` table:
+
+```toml
+name = "Tight 35mm"
+
+[layout]
+cell_px = 400
+gap = 8
+margin = 16
+max_tiles = 48
+```
+
+| Key | Meaning | Allowed range |
+|---|---|---|
+| `cell_px` | Long edge of each tile cell (pixels) | 100–4000 |
+| `gap` | Space between cells (pixels) | 0–200 |
+| `margin` | Black border around the grid (pixels) | 0–500 |
+| `max_tiles` | Frames per sheet before pagination | 1–200 |
+
+Omitted keys fall back to the built-in defaults (600 / 16 / 32 / 38).
+
+The optional top-level `name` field is what appears in the **Template** dropdown. If
+omitted, the filename stem is used (without `.toml`).
+
+---
+
+## Examples
+
+**NegPy factory default (reference — not required as a file)**
+
+```toml
+name = "NegPy default"
+
+[layout]
+cell_px = 600
+gap = 16
+margin = 32
+max_tiles = 38
+```
+
+**Large cells, fewer per page**
+
+```toml
+name = "Large cells"
+
+[layout]
+cell_px = 900
+gap = 20
+margin = 40
+max_tiles = 12
+```
+
+---
+
+## Behaviour in the app
+
+- **Default** selected → loads your saved Default layout (starts at factory 600 / 16 / 32 / 38).
+- **Named template** selected → loads that `.toml` file into the spinboxes.
+- **Editing spinboxes** while a template is selected updates that template automatically
+  (Default → saved in app settings; named → rewritten `.toml` file). Changes debounce ~500 ms.
+- **Save as template** creates a **new** named file from the current spinbox values.
+- Invalid or unreadable files are ignored when building the list.
+- If a saved template file is deleted, the app falls back to **Default** on next launch.
+
+Output folder, tile rendering, and JPEG naming are unchanged — templates only control grid layout.

--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -1569,19 +1569,24 @@ class AppController(QObject):
         if tasks:
             self._run_export_tasks(tasks)
 
+    def _contact_sheet_output_dir(self, visible_files: list) -> Optional[str]:
+        """Resolve the contact sheet output folder (custom path or export destination rules)."""
+        custom = self.state.config.export.contact_sheet_output_path.strip()
+        if custom:
+            return custom
+        if self.state.config.export.output_mode == ExportPresetOutputMode.SAME_AS_SOURCE:
+            return os.path.dirname(visible_files[0]["path"])
+        return self._ensure_valid_export_path()
+
     def request_contact_sheet(self) -> None:
         """Renders all visible files small and writes darkroom contact sheet(s)."""
         visible_files = [self.state.uploaded_files[i] for i in self.session.asset_model.visible_actual_indices_ordered()]
         if not visible_files:
             return
 
-        if self.state.config.export.output_mode == ExportPresetOutputMode.SAME_AS_SOURCE:
-            out_dir = os.path.dirname(visible_files[0]["path"])
-        else:
-            resolved = self._ensure_valid_export_path()
-            if not resolved:
-                return
-            out_dir = resolved
+        out_dir = self._contact_sheet_output_dir(visible_files)
+        if not out_dir:
+            return
 
         tasks = []
         for f in visible_files:

--- a/negpy/desktop/main.py
+++ b/negpy/desktop/main.py
@@ -50,6 +50,7 @@ def _bootstrap_environment() -> None:
         APP_CONFIG.cache_dir,
         APP_CONFIG.user_icc_dir,
         APP_CONFIG.crosstalk_dir,
+        APP_CONFIG.contact_sheet_templates_dir,
         APP_CONFIG.default_export_dir,
     ]
     for d in dirs:

--- a/negpy/desktop/view/sidebar/export.py
+++ b/negpy/desktop/view/sidebar/export.py
@@ -1,3 +1,5 @@
+import os
+
 import qtawesome as qta
 from PyQt6.QtCore import Qt, QTimer
 from PyQt6.QtWidgets import (
@@ -6,8 +8,10 @@ from PyQt6.QtWidgets import (
     QComboBox,
     QFileDialog,
     QHBoxLayout,
+    QInputDialog,
     QLabel,
     QLineEdit,
+    QMessageBox,
     QPushButton,
     QSpinBox,
     QVBoxLayout,
@@ -20,6 +24,7 @@ from negpy.desktop.view.styles.theme import THEME
 from negpy.desktop.view.widgets.collapsible import CollapsibleSection
 from negpy.desktop.view.widgets.export_settings_form import ExportSettingsForm, constrain_combo
 from negpy.domain.models import ColorSpace
+from negpy.services.export.contact_sheet_templates import ContactSheetLayout, ContactSheetTemplates
 
 
 class ExportSidebar(BaseSidebar):
@@ -77,6 +82,8 @@ class ExportSidebar(BaseSidebar):
             lambda: self.controller.request_batch_export(override_settings=self.apply_all_btn.isChecked())
         )
         self.contact_sheet_btn.clicked.connect(self.controller.request_contact_sheet)
+        self.cs_save_template_btn.clicked.connect(self._on_save_contact_sheet_template)
+        self.cs_template_combo.currentTextChanged.connect(self._on_contact_sheet_template_changed)
 
     # --- Presets -------------------------------------------------------------
 
@@ -124,11 +131,32 @@ class ExportSidebar(BaseSidebar):
     def _add_contact_sheet_section(self) -> None:
         """Collapsible CONTACT SHEET section: layout settings + the render button."""
         conf = self.state.config.export
+        self._cs_syncing = False
 
         content = QWidget()
         content_layout = QVBoxLayout(content)
         content_layout.setContentsMargins(0, 0, 0, 0)
         content_layout.setSpacing(6)
+
+        template_row = QHBoxLayout()
+        template_label = QLabel("Template")
+        template_label.setFixedWidth(90)
+        template_row.addWidget(template_label)
+        self.cs_template_combo = QComboBox()
+        constrain_combo(self.cs_template_combo)
+        self.cs_template_combo.setToolTip(
+            "Layout preset from .toml files in NegPy/contact_sheets (see docs/CONTACT_SHEET_TEMPLATES.md). "
+            "Edits to the spinboxes below are saved to the active template."
+        )
+        template_row.addWidget(self.cs_template_combo)
+        content_layout.addLayout(template_row)
+
+        self.cs_save_template_btn = QPushButton(" Save as template")
+        self.cs_save_template_btn.setIcon(qta.icon("fa5s.save", color=THEME.text_primary))
+        self.cs_save_template_btn.setToolTip("Save the current layout as a new named template file")
+        content_layout.addWidget(self.cs_save_template_btn)
+
+        initial_layout = self._contact_sheet_layout_for_config(conf)
 
         def _labeled_spinbox(label: str, value: int, lo: int, hi: int) -> QSpinBox:
             row = QHBoxLayout()
@@ -136,15 +164,22 @@ class ExportSidebar(BaseSidebar):
             spin = QSpinBox()
             spin.setRange(lo, hi)
             spin.setValue(value)
-            spin.valueChanged.connect(lambda _: self.update_timer.start())
+            spin.valueChanged.connect(self._on_contact_sheet_layout_changed)
             row.addWidget(spin)
             content_layout.addLayout(row)
             return spin
 
-        self.cs_cell_px_input = _labeled_spinbox("Cell px", conf.contact_sheet_cell_px, 100, 4000)
-        self.cs_gap_input = _labeled_spinbox("Gap px", conf.contact_sheet_gap, 0, 200)
-        self.cs_margin_input = _labeled_spinbox("Margin px", conf.contact_sheet_margin, 0, 500)
-        self.cs_max_tiles_input = _labeled_spinbox("Max tiles", conf.contact_sheet_max_tiles, 1, 200)
+        self.cs_cell_px_input = _labeled_spinbox("Cell px", initial_layout.cell_px, 100, 4000)
+        self.cs_gap_input = _labeled_spinbox("Gap px", initial_layout.gap, 0, 200)
+        self.cs_margin_input = _labeled_spinbox("Margin px", initial_layout.margin, 0, 500)
+        self.cs_max_tiles_input = _labeled_spinbox("Max tiles", initial_layout.max_tiles, 1, 200)
+
+        self._refresh_contact_sheet_templates()
+        saved_template = conf.contact_sheet_template.strip()
+        if saved_template and saved_template in ContactSheetTemplates.list_templates():
+            self.cs_template_combo.setCurrentText(saved_template)
+        else:
+            self.cs_template_combo.setCurrentText(ContactSheetTemplates.DEFAULT_NAME)
 
         cs_path_row = QHBoxLayout()
         cs_path_label = QLabel("Path")
@@ -186,7 +221,153 @@ class ExportSidebar(BaseSidebar):
         if path:
             self.cs_output_path_edit.setText(path)
 
-    # --- Flat master ("for editing elsewhere") -------------------------------
+    def _contact_sheet_layout_for_config(self, conf) -> ContactSheetLayout:
+        saved_template = conf.contact_sheet_template.strip()
+        if saved_template and saved_template in ContactSheetTemplates.list_templates():
+            layout = ContactSheetTemplates.get_layout(saved_template)
+            if layout is not None:
+                return layout
+        return ContactSheetTemplates.default_layout_from_export(conf)
+
+    def _refresh_contact_sheet_templates(self) -> None:
+        profiles = ContactSheetTemplates.list_templates()
+        if profiles != [self.cs_template_combo.itemText(i) for i in range(self.cs_template_combo.count())]:
+            current = self.cs_template_combo.currentText()
+            self.cs_template_combo.blockSignals(True)
+            self.cs_template_combo.clear()
+            self.cs_template_combo.addItems(profiles)
+            idx = self.cs_template_combo.findText(current)
+            self.cs_template_combo.setCurrentIndex(idx if idx >= 0 else 0)
+            self.cs_template_combo.blockSignals(False)
+
+    def _current_contact_sheet_layout(self) -> ContactSheetLayout:
+        return ContactSheetLayout(
+            cell_px=self.cs_cell_px_input.value(),
+            gap=self.cs_gap_input.value(),
+            margin=self.cs_margin_input.value(),
+            max_tiles=self.cs_max_tiles_input.value(),
+        )
+
+    def _apply_contact_sheet_layout(self, layout: ContactSheetLayout) -> None:
+        self._cs_syncing = True
+        try:
+            self.cs_cell_px_input.setValue(layout.cell_px)
+            self.cs_gap_input.setValue(layout.gap)
+            self.cs_margin_input.setValue(layout.margin)
+            self.cs_max_tiles_input.setValue(layout.max_tiles)
+        finally:
+            self._cs_syncing = False
+
+    def _contact_sheet_template_name(self) -> str:
+        name = self.cs_template_combo.currentText()
+        if name == ContactSheetTemplates.DEFAULT_NAME:
+            return ""
+        return name
+
+    def _on_contact_sheet_layout_changed(self, _value: int) -> None:
+        if self._cs_syncing:
+            return
+        self.update_timer.start()
+
+    def _sync_active_contact_sheet_template(self) -> None:
+        """Write spinbox layout back to the active template (Default snapshot or .toml file)."""
+        if self._cs_syncing:
+            return
+        layout = self._current_contact_sheet_layout()
+        template_name = self._contact_sheet_template_name()
+        if template_name:
+            try:
+                ContactSheetTemplates.save(template_name, layout)
+            except OSError as exc:
+                QMessageBox.critical(
+                    self,
+                    "Contact Sheet Template",
+                    f'Could not update template "{template_name}":\n{exc}',
+                )
+                return
+
+    def _contact_sheet_persist_kwargs(self) -> dict:
+        layout = self._current_contact_sheet_layout()
+        template_name = self._contact_sheet_template_name()
+        kwargs = {
+            **ContactSheetTemplates.active_layout_field_updates(layout),
+            "contact_sheet_output_path": self.cs_output_path_edit.text(),
+            "contact_sheet_template": template_name,
+        }
+        if not template_name:
+            kwargs.update(ContactSheetTemplates.default_layout_field_updates(layout))
+        return kwargs
+
+    def _on_contact_sheet_template_changed(self, name: str) -> None:
+        if self._cs_syncing:
+            return
+        if name == ContactSheetTemplates.DEFAULT_NAME:
+            layout = ContactSheetTemplates.default_layout_from_export(self.state.config.export)
+            self._apply_contact_sheet_layout(layout)
+            self.update_config_section(
+                "export",
+                persist=True,
+                render=False,
+                contact_sheet_template="",
+                **ContactSheetTemplates.active_layout_field_updates(layout),
+                **ContactSheetTemplates.default_layout_field_updates(layout),
+            )
+            return
+        layout = ContactSheetTemplates.get_layout(name)
+        if layout is None:
+            return
+        self._apply_contact_sheet_layout(layout)
+        self.update_config_section(
+            "export",
+            persist=True,
+            render=False,
+            contact_sheet_template=name,
+            **ContactSheetTemplates.active_layout_field_updates(layout),
+        )
+
+    def _on_save_contact_sheet_template(self) -> None:
+        current = self.cs_template_combo.currentText()
+        default_text = current if current != ContactSheetTemplates.DEFAULT_NAME else ""
+        name, ok = QInputDialog.getText(self, "Save Contact Sheet Template", "Template name:", text=default_text)
+        if not ok:
+            return
+        name = name.strip()
+        if not name:
+            return
+        if name == ContactSheetTemplates.DEFAULT_NAME:
+            QMessageBox.warning(self, "Save Contact Sheet Template", '"Default" is reserved. Choose another name.')
+            return
+
+        path = ContactSheetTemplates.path_for_name(name)
+        if os.path.exists(path) or ContactSheetTemplates.template_exists(name):
+            reply = QMessageBox.question(
+                self,
+                "Overwrite Template",
+                f'A template named "{name}" already exists. Replace it?',
+                QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+                QMessageBox.StandardButton.No,
+            )
+            if reply != QMessageBox.StandardButton.Yes:
+                return
+
+        layout = self._current_contact_sheet_layout()
+        try:
+            ContactSheetTemplates.save(name, layout)
+        except OSError as exc:
+            QMessageBox.critical(self, "Save Contact Sheet Template", f"Could not write template:\n{exc}")
+            return
+
+        self._refresh_contact_sheet_templates()
+        self.cs_template_combo.blockSignals(True)
+        self.cs_template_combo.setCurrentText(name)
+        self.cs_template_combo.blockSignals(False)
+        self.update_config_section(
+            "export",
+            persist=True,
+            render=False,
+            contact_sheet_template=name,
+            **ContactSheetTemplates.active_layout_field_updates(layout),
+        )
 
     def _add_flat_master_section(self) -> None:
         """Output-intent override: Print (default) or Flat digital intermediate."""
@@ -471,6 +652,9 @@ class ExportSidebar(BaseSidebar):
         self.state.icc_output_path = vals["icc_output_path"]
         self.controller.session.save_icc_prefs()
 
+        self._sync_active_contact_sheet_template()
+        cs_kwargs = self._contact_sheet_persist_kwargs()
+
         self.update_config_section(
             "export",
             persist=True,
@@ -494,11 +678,7 @@ class ExportSidebar(BaseSidebar):
             export_path=vals["output_path"],
             filename_pattern=vals["filename_pattern"],
             overwrite=vals["overwrite"],
-            contact_sheet_cell_px=self.cs_cell_px_input.value(),
-            contact_sheet_gap=self.cs_gap_input.value(),
-            contact_sheet_margin=self.cs_margin_input.value(),
-            contact_sheet_max_tiles=self.cs_max_tiles_input.value(),
-            contact_sheet_output_path=self.cs_output_path_edit.text(),
+            **cs_kwargs,
         )
 
     def _on_display_changed(self, index: int) -> None:
@@ -547,11 +727,18 @@ class ExportSidebar(BaseSidebar):
             override = self.state.monitor_profile_override
             self.display_combo.setCurrentText(override if override in self.display_spaces else "As detected")
             self._refresh_display_info()
-            self.cs_cell_px_input.setValue(conf.contact_sheet_cell_px)
-            self.cs_gap_input.setValue(conf.contact_sheet_gap)
-            self.cs_margin_input.setValue(conf.contact_sheet_margin)
-            self.cs_max_tiles_input.setValue(conf.contact_sheet_max_tiles)
+            layout = self._contact_sheet_layout_for_config(conf)
+            self.cs_cell_px_input.setValue(layout.cell_px)
+            self.cs_gap_input.setValue(layout.gap)
+            self.cs_margin_input.setValue(layout.margin)
+            self.cs_max_tiles_input.setValue(layout.max_tiles)
             self.cs_output_path_edit.setText(conf.contact_sheet_output_path)
+            self._refresh_contact_sheet_templates()
+            saved_template = conf.contact_sheet_template.strip()
+            if saved_template and saved_template in ContactSheetTemplates.list_templates():
+                self.cs_template_combo.setCurrentText(saved_template)
+            else:
+                self.cs_template_combo.setCurrentText(ContactSheetTemplates.DEFAULT_NAME)
             if self.state.flat_output:
                 self.intent_flat_btn.setChecked(True)
             else:
@@ -577,6 +764,7 @@ class ExportSidebar(BaseSidebar):
             self.cs_margin_input,
             self.cs_max_tiles_input,
             self.cs_output_path_edit,
+            self.cs_template_combo,
             self.flat_format_combo,
             self.flat_peek_btn,
         ]

--- a/negpy/desktop/view/sidebar/export.py
+++ b/negpy/desktop/view/sidebar/export.py
@@ -4,8 +4,10 @@ from PyQt6.QtWidgets import (
     QButtonGroup,
     QCheckBox,
     QComboBox,
+    QFileDialog,
     QHBoxLayout,
     QLabel,
+    QLineEdit,
     QPushButton,
     QSpinBox,
     QVBoxLayout,
@@ -144,6 +146,26 @@ class ExportSidebar(BaseSidebar):
         self.cs_margin_input = _labeled_spinbox("Margin px", conf.contact_sheet_margin, 0, 500)
         self.cs_max_tiles_input = _labeled_spinbox("Max tiles", conf.contact_sheet_max_tiles, 1, 200)
 
+        cs_path_row = QHBoxLayout()
+        cs_path_label = QLabel("Path")
+        cs_path_label.setFixedWidth(90)
+        cs_path_row.addWidget(cs_path_label)
+        self.cs_output_path_edit = QLineEdit(conf.contact_sheet_output_path)
+        self.cs_output_path_edit.setPlaceholderText("Uses export destination")
+        self.cs_output_path_edit.setToolTip(
+            "Folder for contact sheet JPEGs. Leave empty to follow the export destination "
+            "(same as source or absolute export path)."
+        )
+        self.cs_output_path_edit.textChanged.connect(lambda _: self.update_timer.start())
+        self.cs_output_path_browse_btn = QPushButton()
+        self.cs_output_path_browse_btn.setIcon(qta.icon("fa5s.folder-open", color=THEME.text_primary))
+        self.cs_output_path_browse_btn.setFixedWidth(40)
+        self.cs_output_path_browse_btn.setToolTip("Choose contact sheet output folder")
+        self.cs_output_path_browse_btn.clicked.connect(self._browse_contact_sheet_output_path)
+        cs_path_row.addWidget(self.cs_output_path_edit)
+        cs_path_row.addWidget(self.cs_output_path_browse_btn)
+        content_layout.addLayout(cs_path_row)
+
         self.contact_sheet_btn = QPushButton(" Export contact sheet")
         self.contact_sheet_btn.setObjectName("contact_sheet_btn")
         self.contact_sheet_btn.setFixedHeight(40)
@@ -157,6 +179,12 @@ class ExportSidebar(BaseSidebar):
         section.set_content(content)
         section.expanded_changed.connect(lambda checked: repo.save_global_setting("section_expanded_contact_sheet", checked))
         self.layout.addWidget(section)
+
+    def _browse_contact_sheet_output_path(self) -> None:
+        start = self.cs_output_path_edit.text().strip() or self.state.config.export.export_path
+        path = QFileDialog.getExistingDirectory(self, "Select Contact Sheet Output Folder", start)
+        if path:
+            self.cs_output_path_edit.setText(path)
 
     # --- Flat master ("for editing elsewhere") -------------------------------
 
@@ -470,6 +498,7 @@ class ExportSidebar(BaseSidebar):
             contact_sheet_gap=self.cs_gap_input.value(),
             contact_sheet_margin=self.cs_margin_input.value(),
             contact_sheet_max_tiles=self.cs_max_tiles_input.value(),
+            contact_sheet_output_path=self.cs_output_path_edit.text(),
         )
 
     def _on_display_changed(self, index: int) -> None:
@@ -522,6 +551,7 @@ class ExportSidebar(BaseSidebar):
             self.cs_gap_input.setValue(conf.contact_sheet_gap)
             self.cs_margin_input.setValue(conf.contact_sheet_margin)
             self.cs_max_tiles_input.setValue(conf.contact_sheet_max_tiles)
+            self.cs_output_path_edit.setText(conf.contact_sheet_output_path)
             if self.state.flat_output:
                 self.intent_flat_btn.setChecked(True)
             else:
@@ -546,6 +576,7 @@ class ExportSidebar(BaseSidebar):
             self.cs_gap_input,
             self.cs_margin_input,
             self.cs_max_tiles_input,
+            self.cs_output_path_edit,
             self.flat_format_combo,
             self.flat_peek_btn,
         ]

--- a/negpy/domain/models.py
+++ b/negpy/domain/models.py
@@ -124,6 +124,7 @@ class ExportConfig:
     contact_sheet_gap: int = 16
     contact_sheet_margin: int = 32
     contact_sheet_max_tiles: int = 38
+    contact_sheet_output_path: str = ""  # empty = follow export destination rules
 
 
 @dataclass

--- a/negpy/domain/models.py
+++ b/negpy/domain/models.py
@@ -125,6 +125,11 @@ class ExportConfig:
     contact_sheet_margin: int = 32
     contact_sheet_max_tiles: int = 38
     contact_sheet_output_path: str = ""  # empty = follow export destination rules
+    contact_sheet_template: str = ""  # empty = Default template active
+    contact_sheet_default_cell_px: int = 600
+    contact_sheet_default_gap: int = 16
+    contact_sheet_default_margin: int = 32
+    contact_sheet_default_max_tiles: int = 38
 
 
 @dataclass

--- a/negpy/domain/types.py
+++ b/negpy/domain/types.py
@@ -35,6 +35,7 @@ class AppConfig:
     cache_dir: str
     user_icc_dir: str
     crosstalk_dir: str
+    contact_sheet_templates_dir: str
     default_export_dir: str
     adobe_rgb_profile: str
     use_gpu: bool = True

--- a/negpy/kernel/system/config.py
+++ b/negpy/kernel/system/config.py
@@ -29,6 +29,7 @@ APP_CONFIG = AppConfig(
     cache_dir=os.path.join(BASE_USER_DIR, "cache"),
     user_icc_dir=os.path.join(BASE_USER_DIR, "icc"),
     crosstalk_dir=os.path.join(BASE_USER_DIR, "crosstalk"),
+    contact_sheet_templates_dir=os.path.join(BASE_USER_DIR, "contact_sheets"),
     default_export_dir=os.path.join(BASE_USER_DIR, "export"),
     adobe_rgb_profile=get_resource_path("icc/AdobeCompat-v4.icc"),
     use_gpu=True,

--- a/negpy/services/export/contact_sheet_templates.py
+++ b/negpy/services/export/contact_sheet_templates.py
@@ -1,0 +1,181 @@
+import os
+import re
+import tomllib
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+from negpy.kernel.system.config import APP_CONFIG
+from negpy.services.export.contact_sheet import CELL_PX, GAP, MARGIN, MAX_TILES_PER_SHEET
+
+DEFAULT_NAME = "Default"
+
+_CELL_PX_RANGE = (100, 4000)
+_GAP_RANGE = (0, 200)
+_MARGIN_RANGE = (0, 500)
+_MAX_TILES_RANGE = (1, 200)
+
+
+@dataclass(frozen=True)
+class ContactSheetLayout:
+    cell_px: int = CELL_PX
+    gap: int = GAP
+    margin: int = MARGIN
+    max_tiles: int = MAX_TILES_PER_SHEET
+
+
+def _slugify(name: str) -> str:
+    slug = re.sub(r"[^\w\s-]", "", name.lower())
+    slug = re.sub(r"[-\s]+", "_", slug).strip("_")
+    return slug or "template"
+
+
+def _escape_toml_string(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _clamp_int(value: object, lo: int, hi: int, default: int) -> int:
+    if not isinstance(value, int) or isinstance(value, bool):
+        return default
+    return max(lo, min(hi, value))
+
+
+class ContactSheetTemplates:
+    """
+    TOML I/O for user contact sheet layout presets.
+
+    Files live in APP_CONFIG.contact_sheet_templates_dir. The built-in layout
+    is exposed as "Default" (no file). Disk I/O happens on folder scan and save.
+    """
+
+    DEFAULT_NAME = DEFAULT_NAME
+
+    @staticmethod
+    def _templates_dir() -> str:
+        return APP_CONFIG.contact_sheet_templates_dir
+
+    @staticmethod
+    def _scan() -> Dict[str, ContactSheetLayout]:
+        """Maps display name -> layout for valid custom .toml files."""
+        result: Dict[str, ContactSheetLayout] = {}
+        templates_dir = ContactSheetTemplates._templates_dir()
+        if not os.path.isdir(templates_dir):
+            return result
+        for fname in os.listdir(templates_dir):
+            if not fname.endswith(".toml"):
+                continue
+            path = os.path.join(templates_dir, fname)
+            parsed = ContactSheetTemplates._parse_file(path)
+            if parsed is None:
+                continue
+            name, layout = parsed
+            name = name or fname[:-5]
+            if name != DEFAULT_NAME:
+                result[name] = layout
+        return result
+
+    @staticmethod
+    def _parse_file(path: str) -> Optional[tuple[str, ContactSheetLayout]]:
+        try:
+            with open(path, "rb") as f:
+                data = tomllib.load(f)
+            layout_data = data.get("layout")
+            if not isinstance(layout_data, dict):
+                return None
+            layout = ContactSheetLayout(
+                cell_px=_clamp_int(layout_data.get("cell_px"), *_CELL_PX_RANGE, CELL_PX),
+                gap=_clamp_int(layout_data.get("gap"), *_GAP_RANGE, GAP),
+                margin=_clamp_int(layout_data.get("margin"), *_MARGIN_RANGE, MARGIN),
+                max_tiles=_clamp_int(layout_data.get("max_tiles"), *_MAX_TILES_RANGE, MAX_TILES_PER_SHEET),
+            )
+            raw_name = data.get("name")
+            name = raw_name.strip() if isinstance(raw_name, str) and raw_name.strip() else None
+            return name, layout
+        except Exception:
+            return None
+
+    @staticmethod
+    def list_templates() -> list[str]:
+        """["Default", *sorted custom display names]."""
+        return [DEFAULT_NAME, *sorted(ContactSheetTemplates._scan().keys())]
+
+    @staticmethod
+    def default_layout() -> ContactSheetLayout:
+        """Built-in NegPy contact sheet layout (factory defaults)."""
+        return ContactSheetLayout()
+
+    @staticmethod
+    def default_layout_from_export(export) -> ContactSheetLayout:
+        """User's Default template snapshot, with legacy fallback from active layout fields."""
+        factory = ContactSheetTemplates.default_layout()
+        stored = ContactSheetLayout(
+            cell_px=export.contact_sheet_default_cell_px,
+            gap=export.contact_sheet_default_gap,
+            margin=export.contact_sheet_default_margin,
+            max_tiles=export.contact_sheet_default_max_tiles,
+        )
+        if stored != factory:
+            return stored
+        if not export.contact_sheet_template.strip():
+            active = ContactSheetLayout(
+                cell_px=export.contact_sheet_cell_px,
+                gap=export.contact_sheet_gap,
+                margin=export.contact_sheet_margin,
+                max_tiles=export.contact_sheet_max_tiles,
+            )
+            if active != factory:
+                return active
+        return factory
+
+    @staticmethod
+    def default_layout_field_updates(layout: ContactSheetLayout) -> dict[str, int]:
+        return {
+            "contact_sheet_default_cell_px": layout.cell_px,
+            "contact_sheet_default_gap": layout.gap,
+            "contact_sheet_default_margin": layout.margin,
+            "contact_sheet_default_max_tiles": layout.max_tiles,
+        }
+
+    @staticmethod
+    def active_layout_field_updates(layout: ContactSheetLayout) -> dict[str, int]:
+        return {
+            "contact_sheet_cell_px": layout.cell_px,
+            "contact_sheet_gap": layout.gap,
+            "contact_sheet_margin": layout.margin,
+            "contact_sheet_max_tiles": layout.max_tiles,
+        }
+
+    @staticmethod
+    def get_layout(name: str) -> Optional[ContactSheetLayout]:
+        """Layout for a named template, or None for Default / missing / invalid."""
+        if not name or name == DEFAULT_NAME:
+            return None
+        return ContactSheetTemplates._scan().get(name)
+
+    @staticmethod
+    def path_for_name(name: str) -> str:
+        """Filesystem path a template with this display name would use."""
+        return os.path.join(ContactSheetTemplates._templates_dir(), f"{_slugify(name)}.toml")
+
+    @staticmethod
+    def template_exists(name: str) -> bool:
+        if not name or name == DEFAULT_NAME:
+            return False
+        return name in ContactSheetTemplates._scan()
+
+    @staticmethod
+    def save(name: str, layout: ContactSheetLayout) -> str:
+        """Write a template TOML and return its path."""
+        templates_dir = ContactSheetTemplates._templates_dir()
+        os.makedirs(templates_dir, exist_ok=True)
+        path = ContactSheetTemplates.path_for_name(name)
+        content = (
+            f'name = "{_escape_toml_string(name)}"\n\n'
+            "[layout]\n"
+            f"cell_px = {layout.cell_px}\n"
+            f"gap = {layout.gap}\n"
+            f"margin = {layout.margin}\n"
+            f"max_tiles = {layout.max_tiles}\n"
+        )
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(content)
+        return path

--- a/negpy/services/export/contact_sheet_templates.py
+++ b/negpy/services/export/contact_sheet_templates.py
@@ -68,7 +68,6 @@ class ContactSheetTemplates:
             if parsed is None:
                 continue
             name, layout = parsed
-            name = name or fname[:-5]
             if name != DEFAULT_NAME:
                 result[name] = layout
         return result
@@ -88,7 +87,10 @@ class ContactSheetTemplates:
                 max_tiles=_clamp_int(layout_data.get("max_tiles"), *_MAX_TILES_RANGE, MAX_TILES_PER_SHEET),
             )
             raw_name = data.get("name")
-            name = raw_name.strip() if isinstance(raw_name, str) and raw_name.strip() else None
+            if isinstance(raw_name, str) and raw_name.strip():
+                name = raw_name.strip()
+            else:
+                name = os.path.splitext(os.path.basename(path))[0]
             return name, layout
         except Exception:
             return None

--- a/tests/test_contact_sheet_templates.py
+++ b/tests/test_contact_sheet_templates.py
@@ -1,0 +1,119 @@
+import os
+
+from negpy.domain.models import ExportConfig
+from negpy.kernel.system.config import APP_CONFIG
+from negpy.services.export.contact_sheet_templates import (
+    ContactSheetLayout,
+    ContactSheetTemplates,
+)
+
+
+def _write(path, content):
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(content)
+
+
+def test_list_and_get_custom(tmp_path, monkeypatch):
+    monkeypatch.setattr(APP_CONFIG, "contact_sheet_templates_dir", str(tmp_path))
+
+    _write(
+        os.path.join(tmp_path, "tight.toml"),
+        'name = "Tight 35mm"\n\n[layout]\ncell_px = 400\ngap = 8\nmargin = 16\nmax_tiles = 48\n',
+    )
+
+    assert ContactSheetTemplates.list_templates() == ["Default", "Tight 35mm"]
+    layout = ContactSheetTemplates.get_layout("Tight 35mm")
+    assert layout == ContactSheetLayout(cell_px=400, gap=8, margin=16, max_tiles=48)
+
+
+def test_name_falls_back_to_stem(tmp_path, monkeypatch):
+    monkeypatch.setattr(APP_CONFIG, "contact_sheet_templates_dir", str(tmp_path))
+    _write(
+        os.path.join(tmp_path, "my_layout.toml"),
+        "[layout]\ncell_px = 500\ngap = 10\nmargin = 20\nmax_tiles = 30\n",
+    )
+    assert "my_layout" in ContactSheetTemplates.list_templates()
+
+
+def test_default_returns_none(tmp_path, monkeypatch):
+    monkeypatch.setattr(APP_CONFIG, "contact_sheet_templates_dir", str(tmp_path))
+    assert ContactSheetTemplates.get_layout("Default") is None
+    assert ContactSheetTemplates.get_layout("") is None
+    assert ContactSheetTemplates.get_layout("nonexistent") is None
+
+
+def test_malformed_skipped(tmp_path, monkeypatch):
+    monkeypatch.setattr(APP_CONFIG, "contact_sheet_templates_dir", str(tmp_path))
+    _write(os.path.join(tmp_path, "bad_toml.toml"), "[layout]\ncell_px = not_int\n")
+    _write(os.path.join(tmp_path, "no_layout.toml"), 'name = "x"\n')
+    assert ContactSheetTemplates.list_templates() == ["Default"]
+
+
+def test_partial_layout_uses_defaults(tmp_path, monkeypatch):
+    monkeypatch.setattr(APP_CONFIG, "contact_sheet_templates_dir", str(tmp_path))
+    _write(
+        os.path.join(tmp_path, "partial.toml"),
+        'name = "Partial"\n\n[layout]\ncell_px = 700\n',
+    )
+    layout = ContactSheetTemplates.get_layout("Partial")
+    assert layout.cell_px == 700
+    assert layout.gap == 16
+    assert layout.margin == 32
+    assert layout.max_tiles == 38
+
+
+def test_save_writes_readable_template(tmp_path, monkeypatch):
+    monkeypatch.setattr(APP_CONFIG, "contact_sheet_templates_dir", str(tmp_path))
+    layout = ContactSheetLayout(cell_px=450, gap=12, margin=24, max_tiles=40)
+    path = ContactSheetTemplates.save("My Roll", layout)
+    assert path.endswith("my_roll.toml")
+    assert os.path.isfile(path)
+    assert ContactSheetTemplates.list_templates() == ["Default", "My Roll"]
+    assert ContactSheetTemplates.get_layout("My Roll") == layout
+
+
+def test_default_layout_matches_service_defaults():
+    layout = ContactSheetTemplates.default_layout()
+    assert layout == ContactSheetLayout()
+
+
+def test_default_layout_from_export_uses_stored_default():
+    export = ExportConfig(
+        contact_sheet_default_cell_px=450,
+        contact_sheet_default_gap=10,
+        contact_sheet_default_margin=20,
+        contact_sheet_default_max_tiles=24,
+    )
+    assert ContactSheetTemplates.default_layout_from_export(export) == ContactSheetLayout(
+        cell_px=450, gap=10, margin=20, max_tiles=24
+    )
+
+
+def test_default_layout_from_export_legacy_active_fields():
+    export = ExportConfig(
+        contact_sheet_cell_px=650,
+        contact_sheet_gap=20,
+        contact_sheet_margin=40,
+        contact_sheet_max_tiles=20,
+        contact_sheet_template="",
+    )
+    assert ContactSheetTemplates.default_layout_from_export(export) == ContactSheetLayout(
+        cell_px=650, gap=20, margin=40, max_tiles=20
+    )
+
+
+def test_default_layout_from_export_named_template_ignores_active_fields():
+    export = ExportConfig(
+        contact_sheet_cell_px=650,
+        contact_sheet_default_cell_px=500,
+        contact_sheet_template="Other",
+    )
+    assert ContactSheetTemplates.default_layout_from_export(export).cell_px == 500
+
+
+def test_template_exists(tmp_path, monkeypatch):
+    monkeypatch.setattr(APP_CONFIG, "contact_sheet_templates_dir", str(tmp_path))
+    ContactSheetTemplates.save("Existing", ContactSheetLayout())
+    assert ContactSheetTemplates.template_exists("Existing")
+    assert not ContactSheetTemplates.template_exists("Default")
+    assert not ContactSheetTemplates.template_exists("Missing")

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -7,6 +7,7 @@ from PyQt6.QtWidgets import QApplication
 
 from negpy.desktop.controller import AppController
 from negpy.desktop.session import DesktopSessionManager, AppState, ToolMode
+from negpy.domain.models import ExportConfig, ExportPresetOutputMode, WorkspaceConfig
 from negpy.services.rendering.preview_manager import PreviewManager
 
 if not QApplication.instance():
@@ -619,6 +620,83 @@ class TestBatchAnalysisFiltering(unittest.TestCase):
             mock_box.question.return_value = 1
             self.controller.request_batch_normalization()
         self.assertEqual(self.emitted, [])
+
+
+class TestContactSheetOutputDir(unittest.TestCase):
+    def setUp(self):
+        self.mock_session_manager = MagicMock(spec=DesktopSessionManager)
+        self.mock_session_manager.state = AppState()
+        self.mock_session_manager.repo = MagicMock()
+        self.mock_session_manager.asset_model = MagicMock()
+
+        with (
+            patch("negpy.desktop.controller.RenderWorker") as mock_rw_class,
+            patch("negpy.desktop.controller.PreviewManager") as mock_pm_class,
+        ):
+            mock_rw_class.return_value = MagicMock()
+            mock_pm_class.return_value = MagicMock(spec=PreviewManager)
+            mock_pm_class.return_value.load_linear_preview.return_value = (None, (0, 0), {})
+            self.controller = AppController(self.mock_session_manager)
+
+        self.visible_files = [
+            {"name": "a.cr2", "path": "/rolls/frame/a.cr2", "hash": "h1"},
+            {"name": "b.cr2", "path": "/rolls/frame/b.cr2", "hash": "h2"},
+        ]
+
+    def tearDown(self):
+        import gc
+
+        for thread in [
+            self.controller.render_thread,
+            self.controller.export_thread,
+            self.controller.thumb_thread,
+            self.controller.norm_thread,
+            self.controller.discovery_thread,
+            self.controller.preview_load_thread,
+            self.controller.scan_thread,
+        ]:
+            if thread is not None and thread.isRunning():
+                thread.quit()
+                thread.wait()
+        del self.controller
+        gc.collect()
+
+    def test_custom_path_wins_over_export_destination(self):
+        export = ExportConfig(
+            contact_sheet_output_path="/custom/contact",
+            output_mode=ExportPresetOutputMode.SAME_AS_SOURCE,
+        )
+        self.controller.state.config = replace(self.controller.state.config, export=export)
+        out = self.controller._contact_sheet_output_dir(self.visible_files)
+        self.assertEqual(out, "/custom/contact")
+
+    def test_empty_path_uses_source_folder_when_same_as_source(self):
+        export = ExportConfig(
+            contact_sheet_output_path="",
+            output_mode=ExportPresetOutputMode.SAME_AS_SOURCE,
+        )
+        self.controller.state.config = replace(self.controller.state.config, export=export)
+        out = self.controller._contact_sheet_output_dir(self.visible_files)
+        self.assertEqual(out, "/rolls/frame")
+
+    def test_empty_path_uses_export_path_when_absolute(self):
+        export = ExportConfig(
+            contact_sheet_output_path="",
+            output_mode=ExportPresetOutputMode.ABSOLUTE,
+            export_path="/home/user/NegPy/export",
+        )
+        self.controller.state.config = replace(self.controller.state.config, export=export)
+        out = self.controller._contact_sheet_output_dir(self.visible_files)
+        self.assertEqual(out, "/home/user/NegPy/export")
+
+    def test_whitespace_only_path_falls_back_to_export_rules(self):
+        export = ExportConfig(
+            contact_sheet_output_path="   ",
+            output_mode=ExportPresetOutputMode.SAME_AS_SOURCE,
+        )
+        self.controller.state.config = replace(self.controller.state.config, export=export)
+        out = self.controller._contact_sheet_output_dir(self.visible_files)
+        self.assertEqual(out, "/rolls/frame")
 
 
 if __name__ == "__main__":

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -7,7 +7,7 @@ from PyQt6.QtWidgets import QApplication
 
 from negpy.desktop.controller import AppController
 from negpy.desktop.session import DesktopSessionManager, AppState, ToolMode
-from negpy.domain.models import ExportConfig, ExportPresetOutputMode, WorkspaceConfig
+from negpy.domain.models import ExportConfig, ExportPresetOutputMode
 from negpy.services.rendering.preview_manager import PreviewManager
 
 if not QApplication.instance():

--- a/tests/test_desktop_session.py
+++ b/tests/test_desktop_session.py
@@ -88,6 +88,20 @@ class TestDesktopSessionSync(unittest.TestCase):
         self.assertEqual(config.export.contact_sheet_output_path, "/saved/contact")
         self.assertEqual(config.export.contact_sheet_cell_px, 800)
 
+    def test_contact_sheet_template_in_sticky_export(self):
+        sticky = {
+            "last_export_config": {
+                "contact_sheet_template": "Tight 35mm",
+                "contact_sheet_cell_px": 400,
+                "contact_sheet_default_cell_px": 550,
+            },
+        }
+        self.mock_repo.get_global_setting.side_effect = lambda key, default=None: sticky.get(key, default)
+        config = self.session._apply_sticky_settings(WorkspaceConfig(), only_global=False)
+        self.assertEqual(config.export.contact_sheet_template, "Tight 35mm")
+        self.assertEqual(config.export.contact_sheet_cell_px, 400)
+        self.assertEqual(config.export.contact_sheet_default_cell_px, 550)
+
     def test_sync_selected_settings_exclusions(self):
         source_config = WorkspaceConfig(
             exposure=replace(WorkspaceConfig().exposure, density=1.5),

--- a/tests/test_desktop_session.py
+++ b/tests/test_desktop_session.py
@@ -77,6 +77,17 @@ class TestDesktopSessionSync(unittest.TestCase):
         config = self.session._apply_sticky_settings(base, only_global=True)
         self.assertFalse(config.exposure.auto_exposure)
 
+    def test_contact_sheet_output_path_in_sticky_export(self):
+        from negpy.domain.models import ExportConfig
+
+        sticky = {
+            "last_export_config": {"contact_sheet_output_path": "/saved/contact", "contact_sheet_cell_px": 800},
+        }
+        self.mock_repo.get_global_setting.side_effect = lambda key, default=None: sticky.get(key, default)
+        config = self.session._apply_sticky_settings(WorkspaceConfig(), only_global=False)
+        self.assertEqual(config.export.contact_sheet_output_path, "/saved/contact")
+        self.assertEqual(config.export.contact_sheet_cell_px, 800)
+
     def test_sync_selected_settings_exclusions(self):
         source_config = WorkspaceConfig(
             exposure=replace(WorkspaceConfig().exposure, density=1.5),

--- a/tests/test_desktop_session.py
+++ b/tests/test_desktop_session.py
@@ -78,8 +78,6 @@ class TestDesktopSessionSync(unittest.TestCase):
         self.assertFalse(config.exposure.auto_exposure)
 
     def test_contact_sheet_output_path_in_sticky_export(self):
-        from negpy.domain.models import ExportConfig
-
         sticky = {
             "last_export_config": {"contact_sheet_output_path": "/saved/contact", "contact_sheet_cell_px": 800},
         }

--- a/tests/test_override_config.py
+++ b/tests/test_override_config.py
@@ -29,6 +29,7 @@ def _make_app_config(**kwargs) -> AppConfig:
         cache_dir="/tmp/cache",
         user_icc_dir="/tmp/icc",
         crosstalk_dir="/tmp/crosstalk",
+        contact_sheet_templates_dir="/tmp/contact_sheets",
         default_export_dir="/tmp/export",
         adobe_rgb_profile="/tmp/adobe.icc",
         override_toml_path="/tmp/override.toml",


### PR DESCRIPTION
## Summary

Extends the Export **Contact Sheet** section with a dedicated output folder, a file-based template system, and live-editable layout presets. Addresses #305 .

### Output folder

- Adds a **Path** row (text field + browse) in the Contact Sheet collapsible section, matching the export destination folder picker pattern.
- Empty path → unchanged behavior (follows export **Destination**: same-as-source or absolute export path).
- Non-empty path → always used for contact sheet JPEGs, independent of batch export destination.
- Persisted via `ExportConfig.contact_sheet_output_path` and `last_export_config` sticky settings.

### Layout templates

- User-authored `.toml` templates in `~/NegPy/contact_sheets/` (folder created on startup).
- **Template** dropdown lists `Default` plus discovered templates; selection persists across restarts.
- **Save as template** writes the current spinbox layout to a new named file (overwrite confirm if the name exists).
- **Live editing**: changing Cell px / Gap / Margin / Max tiles updates the active template automatically (~500 ms debounce):
  - **Default** → saved to `contact_sheet_default_*` in app config.
  - **Named template** → rewritten to its `.toml` file on disk.
- Switching templates loads the correct snapshot; Default and named templates keep separate saved layouts.
- Authoring docs: `docs/CONTACT_SHEET_TEMPLATES.md`.

### Unchanged

- Contact sheet rendering pipeline (`ContactSheetService`, export worker) — still driven by the four layout spinboxes at export time.

## Test plan

- [x] **Output folder — empty**: Leave Path blank; export contact sheet with Destination set to same-as-source and absolute path; confirm output matches existing behavior.
- [x] **Output folder — custom**: Pick a folder via browse; restart NegPy; confirm path persists and contact sheets write there (not batch export destination).
- [x] **Templates — Default**: Fresh install shows factory layout (600 / 16 / 32 / 38); edit spinboxes; restart; confirm Default retains edits.
- [x] **Templates — named**: Create or drop a `.toml` in `~/NegPy/contact_sheets/`; select it; confirm spinboxes load; edit a value; confirm the file updates on disk after debounce.
- [x] **Templates — switching**: Customize Default, select a named template, switch back to Default; confirm each restores its own layout (not the other’s values).
- [x] **Save as template**: Save current layout under a new name; confirm new file appears in dropdown and is selected.
- [x] **Missing template**: Delete a selected template file externally; restart; confirm app falls back to Default gracefully.
- [x] `uv run pytest tests/test_contact_sheet_templates.py tests/test_controller.py::TestContactSheetOutputDir tests/test_desktop_session.py -k contact_sheet -v`

Fixes: #305 