### PR TITLE
fix(ui): fit window on small (1368x768) screens

### DIFF
--- a/negpy/desktop/view/main_window.py
+++ b/negpy/desktop/view/main_window.py
@@ -5,6 +5,7 @@ import numpy as np
 from PIL import Image
 from PyQt6.QtCore import Qt, QTimer
 from PyQt6.QtWidgets import (
+    QApplication,
     QDockWidget,
     QMainWindow,
     QMessageBox,
@@ -34,6 +35,29 @@ from negpy.kernel.system.logging import get_logger
 from negpy.services.export.print import PrintService
 
 logger = get_logger(__name__)
+
+_DEFAULT_W, _DEFAULT_H = 1400, 900
+
+
+def _clamp_geometry(
+    saved: Optional[tuple[int, int, int, int]],
+    avail: tuple[int, int, int, int],
+) -> tuple[int, int, int, int]:
+    """Fit a window geometry inside the available screen rect.
+
+    ``saved`` is (x, y, w, h) or None (use the default size, centered).
+    ``avail`` is (x, y, w, h) of the screen work area. The result is sized no
+    larger than ``avail`` and positioned fully inside it.
+    """
+    ax, ay, aw, ah = avail
+    if saved is None:
+        w, h = min(_DEFAULT_W, aw), min(_DEFAULT_H, ah)
+        return ax + (aw - w) // 2, ay + (ah - h) // 2, w, h
+    sx, sy, sw, sh = saved
+    w, h = min(sw, aw), min(sh, ah)
+    x = min(max(sx, ax), ax + aw - w)
+    y = min(max(sy, ay), ay + ah - h)
+    return x, y, w, h
 
 
 def _read_screen_icc(screen: object) -> Optional[bytes]:
@@ -107,7 +131,7 @@ class MainWindow(QMainWindow):
         self.controller = controller
         self.state = controller.state
 
-        self.resize(1400, 900)
+        self._restore_window_geometry()
         self.setAcceptDrops(True)
 
         self._init_ui()
@@ -123,6 +147,28 @@ class MainWindow(QMainWindow):
         repo = self.controller.session.repo
         if not repo.get_global_setting("tutorial_seen", False):
             QTimer.singleShot(600, self.show_tutorial)
+
+    def _restore_window_geometry(self) -> None:
+        """Open clamped to the screen work area, restoring the saved size/position if any."""
+        screen = QApplication.primaryScreen()
+        if screen is None:
+            self.resize(_DEFAULT_W, _DEFAULT_H)
+            return
+        raw = self.controller.session.repo.get_global_setting("window_geometry")
+        saved = None
+        if isinstance(raw, list) and len(raw) == 4 and raw[2] > 0 and raw[3] > 0:
+            saved = tuple(int(v) for v in raw)
+        rect = screen.availableGeometry()
+        x, y, w, h = _clamp_geometry(saved, (rect.x(), rect.y(), rect.width(), rect.height()))
+        self.resize(w, h)
+        self.move(x, y)
+
+    def closeEvent(self, event) -> None:
+        try:
+            self.controller.session.repo.save_global_setting("window_geometry", [self.x(), self.y(), self.width(), self.height()])
+        except Exception:
+            logger.exception("Failed to persist window geometry")
+        super().closeEvent(event)
 
     def showEvent(self, event) -> None:
         super().showEvent(event)

--- a/tests/test_window_geometry.py
+++ b/tests/test_window_geometry.py
@@ -1,0 +1,45 @@
+import unittest
+
+from negpy.desktop.view.main_window import _DEFAULT_H, _DEFAULT_W, _clamp_geometry
+
+
+def _inside(geo, avail):
+    x, y, w, h = geo
+    ax, ay, aw, ah = avail
+    return ax <= x and ay <= y and x + w <= ax + aw and y + h <= ay + ah
+
+
+class TestClampGeometry(unittest.TestCase):
+    SMALL = (0, 0, 1366, 728)  # 1368x768 minus a taskbar
+
+    def test_oversized_saved_shrinks_to_fit(self):
+        geo = _clamp_geometry((10, 10, _DEFAULT_W, _DEFAULT_H), self.SMALL)
+        self.assertEqual(geo, (0, 0, 1366, 728))
+        self.assertTrue(_inside(geo, self.SMALL))
+
+    def test_offscreen_position_pulled_inside(self):
+        geo = _clamp_geometry((-50, -30, 800, 600), self.SMALL)
+        self.assertTrue(_inside(geo, self.SMALL))
+        # far-positive position is pulled back so the window stays fully visible
+        geo2 = _clamp_geometry((5000, 5000, 800, 600), self.SMALL)
+        self.assertTrue(_inside(geo2, self.SMALL))
+
+    def test_default_centered_and_clamped(self):
+        geo = _clamp_geometry(None, self.SMALL)
+        self.assertEqual(geo, (0, 0, 1366, 728))  # default exceeds work area -> filled
+        # on a big screen the default size is centered, not stretched
+        big = (0, 0, 2560, 1440)
+        x, y, w, h = _clamp_geometry(None, big)
+        self.assertEqual((w, h), (_DEFAULT_W, _DEFAULT_H))
+        self.assertEqual((x, y), ((2560 - _DEFAULT_W) // 2, (1440 - _DEFAULT_H) // 2))
+
+    def test_screen_offset_respected(self):
+        # second monitor whose work area starts at x=1920
+        avail = (1920, 0, 1366, 728)
+        geo = _clamp_geometry((0, 0, 1000, 700), avail)
+        self.assertTrue(_inside(geo, avail))
+        self.assertGreaterEqual(geo[0], 1920)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The main window opened at a fixed 1400x900, larger than a 1368x768 work area, pushing the bottom toolbar/export buttons and resize handles off-screen. Clamp the opening geometry to the available screen work area and persist/restore window size+position across sessions, re-clamping on restore so moving to a smaller monitor still fits.

Fixes #347