### PR TITLE
fix(loaders): skip Pakon .raw 16-byte header (#249)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@
 - **VISION3 500T crosstalk matrix** added to the bundled Lab Crosstalk profiles.
 - Fix: main window now fits small (1368×768) screens, and remembers its size/position.
 - Fix: long monitor ICC profile names no longer force a horizontal scrollbar in the Export panel.
+- Fix: Pakon `.raw` files no longer show a thin strip of garbage pixels along the left edge (and process a touch darker) — the loader now skips the file's small header.
 
 ## 0.29.1
 

--- a/negpy/infrastructure/loaders/pakon_loader.py
+++ b/negpy/infrastructure/loaders/pakon_loader.py
@@ -38,7 +38,10 @@ class PakonLoader(IImageLoader):
             h, w = spec["res"]
             expected_pixels = h * w * 3
 
+            # Skip optional 16-byte header by anchoring pixels to file end.
+            byte_offset = max(0, file_size - expected_pixels * 2)
             with open(file_path, "rb") as f:
+                f.seek(byte_offset)
                 data = np.fromfile(f, dtype="<u2", count=expected_pixels)
 
             if len(data) < expected_pixels:

--- a/tests/test_pakon_loader.py
+++ b/tests/test_pakon_loader.py
@@ -1,0 +1,41 @@
+import numpy as np
+
+from negpy.infrastructure.loaders.pakon_loader import PakonLoader
+
+# Smallest valid Pakon spec: 1000x1500 ("F135 Plus Low Res").
+H, W = 1000, 1500
+
+
+def _planar_ramp() -> np.ndarray:
+    """Planar (3, H, W) buffer with a per-column ramp so column 0 is distinct."""
+    col = np.arange(W, dtype="<u2")
+    plane = np.broadcast_to(col, (H, W))
+    return np.stack([plane, plane + 100, plane + 200], axis=0).astype("<u2")
+
+
+def _load_col0(path) -> np.ndarray:
+    wrapper, _ = PakonLoader().load(str(path))
+    img = wrapper.data  # NonStandardFileWrapper exposes .data
+    return img[:, 0, :]  # (H, 3) leftmost column
+
+
+def test_skips_16_byte_header(tmp_path):
+    p = tmp_path / "headered.raw"
+    with open(p, "wb") as f:
+        np.array([16, W, H, 48], dtype="<u4").tofile(f)
+        _planar_ramp().tofile(f)
+
+    col0 = _load_col0(p)
+    # Leaked header would shift column/channel alignment and break this.
+    expected = np.array([0, 100, 200], dtype="<u2").astype(np.float32) / 65535.0
+    np.testing.assert_allclose(col0, np.broadcast_to(expected, (H, 3)), atol=1e-6)
+
+
+def test_headerless_still_decodes(tmp_path):
+    p = tmp_path / "headerless.raw"
+    with open(p, "wb") as f:
+        _planar_ramp().tofile(f)  # exactly 9_000_000 bytes, no header
+
+    col0 = _load_col0(p)
+    expected = np.array([0, 100, 200], dtype="<u2").astype(np.float32) / 65535.0
+    np.testing.assert_allclose(col0, np.broadcast_to(expected, (H, 3)), atol=1e-6)


### PR DESCRIPTION
## Problem

Closes #249. Pakon `.raw` files render with ~2px of non-image data at the left edge and process slightly darker than the same scan converted to `.tiff`.

## Root cause

Pakon planar RAWs carry a **16-byte leading header** — four `<u4` words `[header_size=16, width, height, bit_depth=48]`. `PakonLoader.load()` read pixels starting at byte 0, so the header's 8 uint16 words were consumed as the first 8 pixels. This shifts the entire planar buffer by 8 samples (the left-edge junk) and feeds header values into the histogram (the darker skew).

The `abs(file_size - spec.size) < 1024` tolerance in `can_handle` already absorbed the extra 16 bytes, masking the problem.

## Fix

Anchor pixel data to the **end** of the file: `byte_offset = max(0, file_size - expected_pixels*2)`, then `seek` past it. Handles headered (offset 16) and headerless (offset 0) files alike.

## Tests

New `tests/test_pakon_loader.py` synthesizes 1000×1500 raws with and without the header and asserts column 0 decodes correctly in both. `make all` green.