### PR TITLE
fix(exposure): re-meter on Linear RAW toggle to clear stale magenta cast

### DIFF
--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -1083,7 +1083,7 @@ class AppController(QObject):
         """
         Per-image toggle to enable/disable flat-field correction for the current frame.
         """
-        new_ff = replace(self.state.config.flatfield, enabled=enabled)
+        new_ff = replace(self.state.config.flatfield, apply=enabled)
         self.session.update_config(replace(self.state.config, flatfield=new_ff), persist=True)
         self.request_render()
 

--- a/negpy/desktop/session.py
+++ b/negpy/desktop/session.py
@@ -364,7 +364,7 @@ class DesktopSessionManager(QObject):
         if only_global:
             return config
 
-        config = replace(config, flatfield=replace(config.flatfield, enabled=bool(ff_path)))
+        config = replace(config, flatfield=replace(config.flatfield, apply=bool(ff_path)))
 
         # Workflow settings — safe to carry across all files on a roll
         sticky_mode = self.repo.get_global_setting("last_process_mode")

--- a/negpy/desktop/view/sidebar/flatfield.py
+++ b/negpy/desktop/view/sidebar/flatfield.py
@@ -106,7 +106,7 @@ class FlatFieldSidebar(BaseSidebar):
             idx = self.profile_combo.findData(active)
             self.profile_combo.setCurrentIndex(idx if idx >= 0 else 0)
 
-            self.enable_btn.setChecked(conf.enabled)
+            self.enable_btn.setChecked(conf.apply)
             self.enable_btn.setEnabled(bool(conf.reference_path))
         finally:
             self.block_signals(False)

--- a/negpy/features/exposure/logic.py
+++ b/negpy/features/exposure/logic.py
@@ -4,8 +4,15 @@ import numpy as np
 from numba import njit  # type: ignore
 
 from negpy.domain.types import ImageBuffer
+from negpy.features.exposure.models import ExposureConfig
 from negpy.features.exposure.papers import PaperProfile, effective_constants
 from negpy.kernel.image.validation import ensure_image
+
+
+def linear_raw_token(exposure: ExposureConfig) -> str:
+    """Decode-mode identity, folded into the render source hash so the auto-meter
+    re-runs when Linear RAW toggles (the decode changes the source pixels)."""
+    return f"|lr:{int(exposure.linear_raw)}"
 
 
 def _expit(x: Any) -> Any:

--- a/negpy/features/flatfield/logic.py
+++ b/negpy/features/flatfield/logic.py
@@ -68,7 +68,7 @@ def load_reference_gain(path: str) -> Optional[np.ndarray]:
 
 def flatfield_token(config: FlatFieldConfig) -> str:
     """Identity of the active correction, folded into the render source hash. Empty when inactive."""
-    if not config.enabled or not config.reference_path:
+    if not config.apply or not config.reference_path:
         return ""
     try:
         mtime = os.path.getmtime(config.reference_path)
@@ -79,7 +79,7 @@ def flatfield_token(config: FlatFieldConfig) -> str:
 
 def apply_flatfield(image: ImageBuffer, config: FlatFieldConfig) -> ImageBuffer:
     """Multiply the linear source by the reference gain map. No-op when inactive or unreadable."""
-    if not config.enabled or not config.reference_path:
+    if not config.apply or not config.reference_path:
         return image
     gain = load_reference_gain(config.reference_path)
     if gain is None:

--- a/negpy/features/flatfield/models.py
+++ b/negpy/features/flatfield/models.py
@@ -5,7 +5,8 @@ from dataclasses import dataclass
 class FlatFieldConfig:
     """Flat-field (illumination falloff) correction."""
 
-    # Per-image toggle.
-    enabled: bool = False
+    # Per-image toggle. Named 'apply', not 'enabled', to stay unique in the flat
+    # config dict (WorkspaceConfig.to_dict) where RgbScanConfig.enabled also lives.
+    apply: bool = False
     # Resolved path of the globally active reference profile (seeded on file load).
     reference_path: str = ""

--- a/negpy/services/rendering/image_processor.py
+++ b/negpy/services/rendering/image_processor.py
@@ -16,6 +16,7 @@ from negpy.domain.models import (
     ColorSpace,
 )
 from negpy.features.process.models import ProcessMode
+from negpy.features.exposure.logic import linear_raw_token
 from negpy.features.exposure.models import RenderIntent
 from negpy.features.flatfield.logic import apply_flatfield, flatfield_token
 from negpy.features.rgbscan.logic import merge_rgb_triplet, rgbscan_token
@@ -105,7 +106,12 @@ class ImageProcessor:
         # Flat-field is a source pre-correction (before geometry/crop); folding its token
         # into source_hash invalidates the engine cache when it changes.
         img = apply_flatfield(img, settings.flatfield)
-        source_hash = source_hash + flatfield_token(settings.flatfield) + rgbscan_token(settings.rgbscan)
+        source_hash = (
+            source_hash
+            + flatfield_token(settings.flatfield)
+            + rgbscan_token(settings.rgbscan)
+            + linear_raw_token(settings.exposure)
+        )
 
         h_orig, w_cols = img.shape[:2]
         scale_factor = max(h_orig, w_cols) / float(APP_CONFIG.preview_render_size)

--- a/tests/test_config_deserialization.py
+++ b/tests/test_config_deserialization.py
@@ -62,6 +62,24 @@ class TestConfigDeserialization(unittest.TestCase):
         config = WorkspaceConfig.from_flat_dict(data)
         self.assertEqual(config.export.export_resolution_mode, ExportResolutionMode.TARGET_PX.value)
 
+    def test_flatfield_apply_does_not_collide_with_rgbscan_enabled(self):
+        """flatfield.apply and rgbscan.enabled must round-trip independently (#356)."""
+        cfg = WorkspaceConfig(
+            flatfield=replace(WorkspaceConfig().flatfield, apply=True, reference_path="/r.dng"),
+            rgbscan=replace(WorkspaceConfig().rgbscan, enabled=False),
+        )
+        back = WorkspaceConfig.from_flat_dict(cfg.to_dict())
+        self.assertTrue(back.flatfield.apply)
+        self.assertFalse(back.rgbscan.enabled)
+
+        cfg2 = WorkspaceConfig(
+            flatfield=replace(WorkspaceConfig().flatfield, apply=False),
+            rgbscan=replace(WorkspaceConfig().rgbscan, enabled=True),
+        )
+        back2 = WorkspaceConfig.from_flat_dict(cfg2.to_dict())
+        self.assertFalse(back2.flatfield.apply)
+        self.assertTrue(back2.rgbscan.enabled)
+
     def test_legacy_use_original_res_does_not_warn(self):
         data = {"use_original_res": False}
         with self.assertNoLogs("negpy.domain.models", level=logging.WARNING):

--- a/tests/test_exposure_logic.py
+++ b/tests/test_exposure_logic.py
@@ -6,8 +6,9 @@ from negpy.features.exposure.logic import (
     apply_characteristic_curve,
     cmy_to_density,
     density_to_cmy,
+    linear_raw_token,
 )
-from negpy.features.exposure.models import EXPOSURE_CONSTANTS
+from negpy.features.exposure.models import EXPOSURE_CONSTANTS, ExposureConfig
 
 
 class TestExposureLogic(unittest.TestCase):
@@ -120,6 +121,15 @@ class TestAdaptiveMeteringStrength(unittest.TestCase):
         self.assertGreater(dev_large, dev_slight)
         a_extreme = _anchor_for_luminance(assumed + 0.5)
         self.assertLessEqual(abs(a_extreme - assumed), float(c["anchor_meter_band"]) + 1e-6)
+
+
+class TestLinearRawToken(unittest.TestCase):
+    def test_token_differs_by_mode(self):
+        """Toggling Linear RAW must change the source identity, else the per-source
+        auto-meter cache (bounds + neutral-axis cast) goes stale across the toggle (#355)."""
+        on = linear_raw_token(ExposureConfig(linear_raw=True))
+        off = linear_raw_token(ExposureConfig(linear_raw=False))
+        self.assertNotEqual(on, off)
 
 
 if __name__ == "__main__":

--- a/tests/test_flatfield_logic.py
+++ b/tests/test_flatfield_logic.py
@@ -17,13 +17,13 @@ def _radial_falloff(h: int, w: int) -> np.ndarray:
 
 def test_disabled_is_noop():
     img = np.full((16, 16, 3), 0.5, dtype=np.float32)
-    out = ff.apply_flatfield(img, FlatFieldConfig(enabled=False, reference_path="/nope.dng"))
+    out = ff.apply_flatfield(img, FlatFieldConfig(apply=False, reference_path="/nope.dng"))
     assert out is img
 
 
 def test_empty_path_is_noop():
     img = np.full((16, 16, 3), 0.5, dtype=np.float32)
-    out = ff.apply_flatfield(img, FlatFieldConfig(enabled=True, reference_path=""))
+    out = ff.apply_flatfield(img, FlatFieldConfig(apply=True, reference_path=""))
     assert out is img
 
 
@@ -41,7 +41,7 @@ def test_correction_flattens_uneven_illumination(tmp_path):
     path = str(ref_file)
     ff._GAIN_CACHE[(path, os.path.getmtime(path))] = ff._compute_gain(falloff)
 
-    cfg = FlatFieldConfig(enabled=True, reference_path=path)
+    cfg = FlatFieldConfig(apply=True, reference_path=path)
     corrected = ff.apply_flatfield(captured, cfg)
 
     # Before: clearly uneven. After: near-flat across the field.
@@ -59,5 +59,5 @@ def test_gain_resized_to_image(tmp_path):
     ff._GAIN_CACHE[(path, os.path.getmtime(path))] = ff._compute_gain(falloff)
 
     img = np.full((100, 140, 3), 0.5, dtype=np.float32)
-    out = ff.apply_flatfield(img, FlatFieldConfig(enabled=True, reference_path=path))
+    out = ff.apply_flatfield(img, FlatFieldConfig(apply=True, reference_path=path))
     assert out.shape == img.shape


### PR DESCRIPTION
The preview GPUEngine's per-source auto-meter cache (_analysis_cache) is keyed by analysis_source_hash, which folded in flat-field and RGB-scan identity but not exposure.linear_raw. Toggling Linear RAW re-decodes the source pixels (camera-WB vs neutral multipliers) without changing the hash, so the engine reused the neutral-axis/cast and bounds metered under the previous decode -> magenta cast in the UI preview (export was unaffected; its path bypasses the analysis cache).

Fold a linear_raw_token into source_hash, mirroring flatfield_token/ rgbscan_token, so the auto-meter (and the CPU base cache) invalidate on toggle. Fixes #355.

fix(flatfield): persist per-image toggle (rename enabled->apply, drop key collision)
WorkspaceConfig.to_dict() flattens every sub-config into one flat key
namespace. FlatFieldConfig.enabled and RgbScanConfig.enabled both mapped
to the bare key 'enabled'; rgbscan is serialized last and clobbered
flatfield's value, so flatfield's toggle was never persisted (saved as
rgbscan's False) and lost on reload -> Flatfield Correction deactivated
when switching away and back, and 'Sync Edits' wrote the target with the
toggle off too. rgbscan dodged its own half because select_file rebuilds
it from the asset dict.

Rename the field to FlatFieldConfig.apply so it is unique in the flat
namespace; to_dict/from_flat_dict stay fully generic. Matches the UI
wording ("Apply the active flat-field reference"). Fixes https://github.com/marcinz606/NegPy/issues/356.