### PR TITLE
feat(export): optional edit sidecars + sidecar-fallback load

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,8 @@ NegPy is a film negative processing desktop app (PyQt6 + WebGPU). Images flow th
 
 `WorkspaceConfig` (`negpy/domain/models.py`) is a **frozen dataclass** composed of per-feature configs (`ExposureConfig`, `LabConfig`, etc.). It is the single source of truth for an edit. Changes are always made via `dataclasses.replace(config, ...)` — never mutated in place. `to_dict`/`from_flat_dict` handle serialization to/from a flat key namespace.
 
+**Edit storage & sidecars.** Edits live primarily in SQLite (`edits.db`, keyed by content hash — `StorageRepository.save/load_file_settings`). Optionally they're mirrored to plain-file **sidecars** for archival: `negpy/services/assets/sidecar.py` writes `<source-basename>.negpy` **next to the source** (JSON = `WorkspaceConfig.to_dict()`, the full edit). On load, `select_file` calls `load_or_promote` — DB first, else a sidecar beside the source, and a loaded sidecar is **promoted into the DB** so the DB wins thereafter. Sidecars are written only on real export when `ExportConfig.export_sidecars_enabled` is on (not the contact sheet), or via the Export panel's "Export Edits Sidecars" section button (`AppController.export_edit_sidecars`).
+
 ### Feature pattern
 
 Every feature under `negpy/features/<name>/` follows this structure:

--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -34,6 +34,7 @@ from negpy.domain.models import (
     flat_master_config,
     preset_from_export_config,
 )
+from negpy.services.assets.sidecar import load_or_promote, write_sidecar
 from negpy.features.exposure.logic import (
     calculate_wb_shifts,
     calculate_wb_shifts_from_log,
@@ -1457,6 +1458,9 @@ class AppController(QObject):
         if files is None:
             files = [self.state.uploaded_files[i] for i in self.session.asset_model.visible_actual_indices_ordered()]
 
+        if self.state.config.export.export_sidecars_enabled:
+            self._write_edit_sidecars(files)
+
         flat = self.state.flat_output
         flat_fmt = self._flat_export_format()
 
@@ -1520,6 +1524,8 @@ class AppController(QObject):
             "path": self.state.current_file_path,
             "hash": self.state.current_file_hash,
         }
+        if self.state.config.export.export_sidecars_enabled:
+            self._write_edit_sidecars([file_info])
         tasks = self._tasks_for_file(
             file_info,
             self.state.config,
@@ -1542,6 +1548,9 @@ class AppController(QObject):
 
         sync_metadata = self.state.config.metadata.sync_to_batch
         visible_files = [self.state.uploaded_files[i] for i in self.session.asset_model.visible_actual_indices_ordered()]
+
+        if self.state.config.export.export_sidecars_enabled:
+            self._write_edit_sidecars(visible_files)
 
         tasks = []
         for f in visible_files:
@@ -1615,6 +1624,27 @@ class AppController(QObject):
             Q_ARG(int, cs.contact_sheet_margin),
             Q_ARG(int, cs.contact_sheet_max_tiles),
         )
+
+    def _write_edit_sidecars(self, files: list[dict]) -> int:
+        """Write a .negpy edit sidecar next to each source (each frame's own saved edits). Returns count written."""
+        repo = self.session.repo
+        written = 0
+        for f in files:
+            params = load_or_promote(repo, f["hash"], f["path"]) or self.state.config
+            try:
+                write_sidecar(f["path"], params)
+                written += 1
+            except Exception as exc:
+                logger.warning("Sidecar write failed for %s: %s", f.get("path"), exc)
+        return written
+
+    def export_edit_sidecars(self) -> None:
+        """Explicit batch sidecar export for all visible files (ignores the on-export toggle)."""
+        visible_files = [self.state.uploaded_files[i] for i in self.session.asset_model.visible_actual_indices_ordered()]
+        if not visible_files:
+            return
+        written = self._write_edit_sidecars(visible_files)
+        self.set_status(f"Wrote {written} edit sidecar(s)", 4000)
 
     def _run_export_tasks(self, tasks: List[ExportTask]) -> None:
         self._export_start_time = time.time()

--- a/negpy/desktop/session.py
+++ b/negpy/desktop/session.py
@@ -10,6 +10,7 @@ from PyQt6.QtCore import QAbstractListModel, QModelIndex, QObject, Qt, pyqtSigna
 from negpy.domain.models import ExportPreset, WorkspaceConfig
 from negpy.infrastructure.storage.repository import StorageRepository
 from negpy.kernel.system.config import APP_CONFIG
+from negpy.services.assets.sidecar import load_or_promote
 
 
 class ToolMode(Enum):
@@ -540,7 +541,7 @@ class DesktopSessionManager(QObject):
             self.state.undo_index = self.repo.get_max_history_index(file_info["hash"])
             self.state.max_history_index = self.state.undo_index
 
-            saved_config = self.repo.load_file_settings(file_info["hash"])
+            saved_config = load_or_promote(self.repo, file_info["hash"], file_info["path"])
             self.state.current_file_is_new = saved_config is None
 
             if saved_config:

--- a/negpy/desktop/view/sidebar/export.py
+++ b/negpy/desktop/view/sidebar/export.py
@@ -53,6 +53,7 @@ class ExportSidebar(BaseSidebar):
         self._add_batch_section()
 
         self._add_presets_section()
+        self._add_sidecars_section()
         self._add_contact_sheet_section()
         self._add_preview_section()
         self._sync_flat_enabled()
@@ -89,6 +90,9 @@ class ExportSidebar(BaseSidebar):
         self.contact_sheet_btn.clicked.connect(self.controller.request_contact_sheet)
         self.cs_save_template_btn.clicked.connect(self._on_save_contact_sheet_template)
         self.cs_template_combo.currentTextChanged.connect(self._on_contact_sheet_template_changed)
+
+        self.sidecars_enabled_btn.toggled.connect(lambda _: self.update_timer.start())
+        self.export_sidecars_btn.clicked.connect(self.controller.export_edit_sidecars)
 
     # --- Presets -------------------------------------------------------------
 
@@ -574,6 +578,46 @@ class ExportSidebar(BaseSidebar):
         section.expanded_changed.connect(lambda checked: repo.save_global_setting("section_expanded_export_preview", checked))
         self.layout.addWidget(section)
 
+    # --- Edit sidecars -------------------------------------------------------
+
+    def _add_sidecars_section(self) -> None:
+        """Collapsible EXPORT EDITS SIDECARS section: on-export toggle + manual export, side by side."""
+        conf = self.state.config.export
+
+        content = QWidget()
+        content_layout = QVBoxLayout(content)
+        content_layout.setContentsMargins(0, 0, 0, 0)
+        content_layout.setSpacing(6)
+
+        btn_row = QHBoxLayout()
+
+        self.sidecars_enabled_btn = QPushButton(" Save on export")
+        self.sidecars_enabled_btn.setCheckable(True)
+        self.sidecars_enabled_btn.setChecked(conf.export_sidecars_enabled)
+        self.sidecars_enabled_btn.setFixedHeight(40)
+        self.sidecars_enabled_btn.setIcon(qta.icon("fa5s.file-export", color=THEME.text_primary))
+        self.sidecars_enabled_btn.setToolTip(
+            "When on, every export also writes a .negpy edit sidecar next to each source frame. Edits stay in the database too."
+        )
+        btn_row.addWidget(self.sidecars_enabled_btn)
+
+        self.export_sidecars_btn = QPushButton(" Export sidecars")
+        self.export_sidecars_btn.setObjectName("export_sidecars_btn")
+        self.export_sidecars_btn.setFixedHeight(40)
+        self.export_sidecars_btn.setIcon(qta.icon("fa5s.file-code", color=THEME.text_primary))
+        self.export_sidecars_btn.setToolTip("Write edit sidecars for all visible frames now")
+        btn_row.addWidget(self.export_sidecars_btn)
+
+        content_layout.addLayout(btn_row)
+
+        repo = self.controller.session.repo
+        expanded = bool(repo.get_global_setting("section_expanded_export_sidecars", default=False))
+        section = CollapsibleSection("Sidecars", expanded=expanded, icon=qta.icon("fa5s.file-export", color="#aaa"))
+        section.setToolTip("Optional plain-file copies of edits next to your sources, for archival. SQLite stays primary.")
+        section.set_content(content)
+        section.expanded_changed.connect(lambda checked: repo.save_global_setting("section_expanded_export_sidecars", checked))
+        self.layout.addWidget(section)
+
     # --- Batch ---------------------------------------------------------------
 
     def _add_batch_section(self) -> None:
@@ -714,6 +758,7 @@ class ExportSidebar(BaseSidebar):
             export_path=vals["output_path"],
             filename_pattern=vals["filename_pattern"],
             overwrite=vals["overwrite"],
+            export_sidecars_enabled=self.sidecars_enabled_btn.isChecked(),
             **cs_kwargs,
         )
 
@@ -769,6 +814,7 @@ class ExportSidebar(BaseSidebar):
             self.cs_margin_input.setValue(layout.margin)
             self.cs_max_tiles_input.setValue(layout.max_tiles)
             self.cs_output_path_edit.setText(conf.contact_sheet_output_path)
+            self.sidecars_enabled_btn.setChecked(conf.export_sidecars_enabled)
             self._refresh_contact_sheet_templates()
             saved_template = conf.contact_sheet_template.strip()
             if saved_template and saved_template in ContactSheetTemplates.list_templates():
@@ -801,6 +847,7 @@ class ExportSidebar(BaseSidebar):
             self.cs_max_tiles_input,
             self.cs_output_path_edit,
             self.cs_template_combo,
+            self.sidecars_enabled_btn,
             self.flat_format_combo,
             self.flat_peek_btn,
         ]

--- a/negpy/domain/models.py
+++ b/negpy/domain/models.py
@@ -131,6 +131,8 @@ class ExportConfig:
     contact_sheet_default_margin: int = 32
     contact_sheet_default_max_tiles: int = 38
 
+    export_sidecars_enabled: bool = False
+
 
 @dataclass
 class ExportPreset:

--- a/negpy/services/assets/sidecar.py
+++ b/negpy/services/assets/sidecar.py
@@ -1,0 +1,61 @@
+import json
+import os
+import tempfile
+from typing import Optional
+
+from negpy.domain.models import WorkspaceConfig
+from negpy.kernel.system.logging import get_logger
+
+logger = get_logger(__name__)
+
+SIDECAR_EXT = ".negpy"
+
+
+def sidecar_path_for(source_path: str) -> str:
+    """Sidecar path next to the source file: ``<basename>.negpy``."""
+    base = os.path.splitext(os.path.basename(source_path))[0]
+    return os.path.join(os.path.dirname(source_path), base + SIDECAR_EXT)
+
+
+def write_sidecar(source_path: str, config: WorkspaceConfig) -> str:
+    """Write the full edit (``config.to_dict()``) as JSON next to the source. Returns the path written."""
+    path = sidecar_path_for(source_path)
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    payload = json.dumps(config.to_dict(), default=str, indent=2)
+    tmp_path = None
+    try:
+        with tempfile.NamedTemporaryFile("w", dir=os.path.dirname(path), delete=False, suffix=".part", encoding="utf-8") as tmp:
+            tmp_path = tmp.name
+            tmp.write(payload)
+        os.replace(tmp_path, path)
+    except Exception:
+        if tmp_path is not None and os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+        raise
+    return path
+
+
+def load_sidecar(source_path: str) -> Optional[WorkspaceConfig]:
+    """Load edits from a sidecar next to the source file. None if absent or malformed."""
+    path = sidecar_path_for(source_path)
+    if not os.path.exists(path):
+        return None
+    try:
+        with open(path, "r", encoding="utf-8") as f_in:
+            data = json.load(f_in)
+        if not isinstance(data, dict):
+            return None
+        return WorkspaceConfig.from_flat_dict(data)
+    except Exception as exc:
+        logger.warning("Failed to load sidecar %s: %s", path, exc)
+        return None
+
+
+def load_or_promote(repo, file_hash: str, source_path: str) -> Optional[WorkspaceConfig]:
+    """DB first; on miss, load a beside-source sidecar and write it into the DB (promote)."""
+    cfg = repo.load_file_settings(file_hash)
+    if cfg is None:
+        cfg = load_sidecar(source_path)
+        if cfg is not None:
+            repo.save_file_settings(file_hash, cfg)
+    return cfg

--- a/tests/test_sidecar.py
+++ b/tests/test_sidecar.py
@@ -1,0 +1,101 @@
+import json
+import os
+from dataclasses import replace
+
+import pytest
+
+from negpy.domain.models import WorkspaceConfig
+from negpy.features.exposure.models import ExposureConfig
+from negpy.features.geometry.models import GeometryConfig
+from negpy.features.local.models import LocalAdjustmentsConfig, PolygonMask
+from negpy.infrastructure.storage.repository import StorageRepository
+from negpy.services.assets.sidecar import load_or_promote, load_sidecar, sidecar_path_for, write_sidecar
+
+
+def _rich_config() -> WorkspaceConfig:
+    """A config exercising scalar + crop + local-mask paths, so the round trip is meaningful."""
+    return WorkspaceConfig(
+        exposure=ExposureConfig(density=0.42, grade=130.0),
+        geometry=GeometryConfig(fine_rotation=1.5, manual_crop_rect=(0.1, 0.2, 0.8, 0.9)),
+        local=LocalAdjustmentsConfig(masks=(PolygonMask(vertices=((0.0, 0.0), (0.5, 0.5)), strength=0.7, feather=0.05),)),
+    )
+
+
+def test_sidecar_path_for_next_to_source():
+    assert sidecar_path_for("/photos/IMG_001.NEF") == os.path.join("/photos", "IMG_001.negpy")
+
+
+def test_roundtrip_next_to_source(tmp_path):
+    src = str(tmp_path / "IMG_001.NEF")
+    cfg = _rich_config()
+    path = write_sidecar(src, cfg)
+
+    assert path == str(tmp_path / "IMG_001.negpy")
+    assert os.path.exists(path)
+
+    loaded = load_sidecar(src)
+    assert loaded is not None
+    d = loaded.to_dict()
+    assert d["density"] == 0.42
+    assert d["grade"] == 130.0
+    assert tuple(d["manual_crop_rect"]) == (0.1, 0.2, 0.8, 0.9)
+    masks = d["local_masks"]["masks"]
+    assert len(masks) == 1
+    assert masks[0]["strength"] == 0.7
+    assert masks[0]["feather"] == 0.05
+
+
+def test_load_missing_returns_none(tmp_path):
+    assert load_sidecar(str(tmp_path / "nope.NEF")) is None
+
+
+def test_load_malformed_returns_none(tmp_path):
+    src = str(tmp_path / "IMG_003.NEF")
+    with open(sidecar_path_for(src), "w", encoding="utf-8") as f:
+        f.write("{ not valid json")
+    assert load_sidecar(src) is None
+
+
+@pytest.fixture()
+def repo(tmp_path):
+    r = StorageRepository(str(tmp_path / "edits.db"), str(tmp_path / "settings.db"))
+    r.initialize()
+    return r
+
+
+def test_load_or_promote_promotes_sidecar_to_db(tmp_path, repo):
+    src = str(tmp_path / "IMG_004.NEF")
+    write_sidecar(src, _rich_config())
+
+    assert repo.load_file_settings("h4") is None  # DB starts empty
+    loaded = load_or_promote(repo, "h4", src)
+    assert loaded is not None
+    assert loaded.exposure.density == 0.42
+
+    # Promotion: the DB now holds it, so a later load never needs the sidecar.
+    promoted = repo.load_file_settings("h4")
+    assert promoted is not None
+    assert promoted.exposure.density == 0.42
+
+
+def test_load_or_promote_db_wins(tmp_path, repo):
+    src = str(tmp_path / "IMG_005.NEF")
+    write_sidecar(src, replace(_rich_config(), exposure=ExposureConfig(density=0.11)))
+    repo.save_file_settings("h5", replace(_rich_config(), exposure=ExposureConfig(density=0.99)))
+
+    loaded = load_or_promote(repo, "h5", src)
+    assert loaded is not None
+    assert loaded.exposure.density == 0.99  # DB value, sidecar ignored
+
+
+def test_load_or_promote_none_when_neither(tmp_path, repo):
+    assert load_or_promote(repo, "h6", str(tmp_path / "IMG_006.NEF")) is None
+
+
+def test_write_payload_is_to_dict_json(tmp_path):
+    src = str(tmp_path / "IMG_007.NEF")
+    cfg = _rich_config()
+    write_sidecar(src, cfg)
+    with open(sidecar_path_for(src), "r", encoding="utf-8") as f:
+        data = json.load(f)
+    assert data == json.loads(json.dumps(cfg.to_dict(), default=str))


### PR DESCRIPTION
Mirror SQLite edits to plain-file .negpy sidecars next to the source, for archival. SQLite stays primary; on load, DB-first then beside-source sidecar, promoting a loaded sidecar into the DB.

- sidecar.py: write/load + load_or_promote (DB->sidecar->promote)
- ExportConfig.export_sidecars_enabled toggle (off by default)
- written on real export when enabled, or via "Sidecars" panel button
- tests for round-trip, promote, malformed