### PR TITLE
feat(desktop): Apply-to-selected dropdown + per-aspect bulk sync

### DIFF
--- a/negpy/desktop/session.py
+++ b/negpy/desktop/session.py
@@ -224,6 +224,116 @@ class AssetListModel(QAbstractListModel):
         self.layoutChanged.emit()
 
 
+_SYNC_MODES = (
+    "everything",
+    "edits",
+    "edits_with_geometry",
+    "geometry_only",
+    "crop_only",
+    "rotation_only",
+    "bounds_luma",
+    "bounds_colour",
+    "bounds_both",
+)
+
+_SYNC_LABELS = {
+    "everything": "Everything",
+    "edits": "Edits",
+    "edits_with_geometry": "Edits + crop",
+    "geometry_only": "Crop & rotation",
+    "crop_only": "Crop",
+    "rotation_only": "Rotation",
+    "bounds_luma": "Bounds (tonal)",
+    "bounds_colour": "Bounds (colour)",
+    "bounds_both": "Bounds (both)",
+}
+
+
+def _source_effective_bounds(process) -> Optional[tuple]:
+    """The floors/ceils a source frame is currently rendering with.
+
+    Roll baseline when the source is on one, else its per-frame meter. Returns
+    None when the source was never analysed (all-zero) — nothing to broadcast.
+    """
+    if process.is_locked_initialized and (process.use_luma_average or process.use_colour_average):
+        return process.locked_floors, process.locked_ceils
+    if process.is_local_initialized:
+        return process.local_floors, process.local_ceils
+    return None
+
+
+def build_synced_config(
+    source: WorkspaceConfig,
+    target: WorkspaceConfig,
+    mode: str,
+    src_bounds: Optional[tuple],
+) -> WorkspaceConfig:
+    """Pure per-target merge for a bulk "Apply to selected" action.
+
+    `src_bounds` is (floors, ceils) from _source_effective_bounds, used by the
+    bounds_* modes (and "everything"). Dust spots and per-frame local bounds are
+    frame-specific, so they're always preserved on the target.
+    """
+    if mode == "geometry_only":
+        return replace(target, geometry=source.geometry)
+
+    if mode == "rotation_only":
+        sg = source.geometry
+        new_geo = replace(
+            target.geometry,
+            rotation=sg.rotation,
+            fine_rotation=sg.fine_rotation,
+            flip_horizontal=sg.flip_horizontal,
+            flip_vertical=sg.flip_vertical,
+        )
+        return replace(target, geometry=new_geo)
+
+    if mode == "crop_only":
+        sg = source.geometry
+        new_geo = replace(
+            target.geometry,
+            auto_crop_enabled=sg.auto_crop_enabled,
+            autocrop_offset=sg.autocrop_offset,
+            autocrop_ratio=sg.autocrop_ratio,
+            autocrop_mode=sg.autocrop_mode,
+            manual_crop_rect=sg.manual_crop_rect,
+        )
+        return replace(target, geometry=new_geo)
+
+    if mode in ("bounds_luma", "bounds_colour", "bounds_both"):
+        floors, ceils = src_bounds
+        # locked_* is one shared pair feeding both axes; a single-axis sync forces
+        # the other axis back to each frame's own meter to avoid an unintended shift.
+        new_process = replace(
+            target.process,
+            locked_floors=floors,
+            locked_ceils=ceils,
+            use_luma_average=mode in ("bounds_luma", "bounds_both"),
+            use_colour_average=mode in ("bounds_colour", "bounds_both"),
+        )
+        return replace(target, process=new_process)
+
+    # "edits" / "edits_with_geometry" / "everything": copy creative config; keep
+    # target geometry unless asked; always keep target dust + per-frame bounds.
+    merged_geo = source.geometry if mode in ("edits_with_geometry", "everything") else target.geometry
+    merged_retouch = replace(source.retouch, manual_dust_spots=target.retouch.manual_dust_spots)
+    merged_process = replace(
+        source.process,
+        local_floors=target.process.local_floors,
+        local_ceils=target.process.local_ceils,
+    )
+    if mode == "everything" and src_bounds is not None:
+        floors, ceils = src_bounds
+        merged_process = replace(
+            merged_process,
+            locked_floors=floors,
+            locked_ceils=ceils,
+            use_luma_average=True,
+            use_colour_average=True,
+        )
+    return replace(source, geometry=merged_geo, retouch=merged_retouch, process=merged_process)
+
+
 class DesktopSessionManager(QObject):
     """
     Manages application state, file list, and configuration persistence.
@@ -236,6 +346,7 @@ class DesktopSessionManager(QObject):
     active_file_changing = pyqtSignal()  # Outgoing file about to be replaced — last chance to snapshot it
     settings_copied = pyqtSignal()
     settings_pasted = pyqtSignal()
+    settings_synced = pyqtSignal(str)  # Bulk "Apply to selected" done — carries a status message
     file_selected = pyqtSignal(str)  # Emits file path when active file changes
 
     @property
@@ -568,60 +679,46 @@ class DesktopSessionManager(QObject):
         self.state.selected_indices = indices
         self.state_changed.emit()
 
-    def sync_selected_settings(self, mode: str = "edits") -> None:
+    def sync_selected_settings(self, mode: str = "edits", scope: str = "selection") -> int:
         """
-        Synchronizes current settings to all other selected files.
+        Apply the active frame's settings to other frames. Returns the count changed.
 
-        Modes:
-            "edits"               — sync everything except crop, fine_rotation, dust spots, local bounds.
-            "edits_with_geometry" — also sync manual_crop_rect and fine_rotation.
-            "geometry_only"       — sync only the GeometryConfig; leave other configs untouched.
+        mode:  everything | edits | edits_with_geometry | geometry_only |
+               crop_only | rotation_only | bounds_luma | bounds_colour | bounds_both
+        scope: "selection" (the multi-selected frames) or "roll" (all loaded frames).
         """
-        if not self.state.selected_indices or self.state.selected_file_idx == -1:
-            return
-        if mode not in ("edits", "edits_with_geometry", "geometry_only"):
-            return
+        if self.state.selected_file_idx == -1 or mode not in _SYNC_MODES:
+            return 0
 
         source_config = self.state.config
 
-        for idx in self.state.selected_indices:
-            if idx == self.state.selected_file_idx:
+        src_bounds = None
+        if mode in ("bounds_luma", "bounds_colour", "bounds_both", "everything"):
+            src_bounds = _source_effective_bounds(source_config.process)
+            if src_bounds is None and mode != "everything":
+                self.settings_synced.emit("Render the source frame before syncing bounds")
+                return 0
+
+        target_indices = range(len(self.state.uploaded_files)) if scope == "roll" else self.state.selected_indices
+
+        count = 0
+        for idx in target_indices:
+            if idx == self.state.selected_file_idx or not (0 <= idx < len(self.state.uploaded_files)):
                 continue
+            target_hash = self.state.uploaded_files[idx]["hash"]
+            target_config = self.repo.load_file_settings(target_hash) or WorkspaceConfig()
+            self.repo.save_file_settings(target_hash, build_synced_config(source_config, target_config, mode, src_bounds))
+            count += 1
 
-            if 0 <= idx < len(self.state.uploaded_files):
-                target_info = self.state.uploaded_files[idx]
-                target_hash = target_info["hash"]
-
-                target_config = self.repo.load_file_settings(target_hash)
-                if not target_config:
-                    target_config = WorkspaceConfig()
-
-                if mode == "geometry_only":
-                    new_config = replace(target_config, geometry=source_config.geometry)
-                else:
-                    if mode == "edits_with_geometry":
-                        merged_geo = source_config.geometry
-                    else:
-                        merged_geo = target_config.geometry
-
-                    merged_retouch = replace(source_config.retouch, manual_dust_spots=target_config.retouch.manual_dust_spots)
-
-                    merged_process = replace(
-                        source_config.process,
-                        local_floors=target_config.process.local_floors,
-                        local_ceils=target_config.process.local_ceils,
-                    )
-
-                    new_config = replace(
-                        source_config,
-                        geometry=merged_geo,
-                        retouch=merged_retouch,
-                        process=merged_process,
-                    )
-
-                self.repo.save_file_settings(target_hash, new_config)
-
-        self.settings_saved.emit()
+        if count:
+            label = _SYNC_LABELS.get(mode, mode)
+            if scope == "roll":
+                msg = f"{label} synced to whole roll ({count} frames)"
+            else:
+                msg = f"{label} synced to {count} frame{'s' if count != 1 else ''}"
+            self.settings_synced.emit(msg)
+            self.settings_saved.emit()
+        return count
 
     def next_file(self) -> None:
         display_idx = self.asset_model.actual_to_display(self.state.selected_file_idx)

--- a/negpy/desktop/view/main_window.py
+++ b/negpy/desktop/view/main_window.py
@@ -334,6 +334,7 @@ class MainWindow(QMainWindow):
         self.controller.export_finished.connect(self._on_export_finished)
         self.controller.session.settings_copied.connect(lambda: self.top_status.showMessage("settings copied", timeout=1500))
         self.controller.session.settings_pasted.connect(lambda: self.top_status.showMessage("settings pasted", timeout=1500))
+        self.controller.session.settings_synced.connect(lambda msg: self.top_status.showMessage(msg, timeout=2500))
         self.controller.tool_sync_requested.connect(self._sync_tool_buttons)
         self.controller.config_updated.connect(self.canvas.overlay.update)
         self.controller.compare_changed.connect(lambda _on: self.canvas.overlay.update())

--- a/negpy/desktop/view/sidebar/files.py
+++ b/negpy/desktop/view/sidebar/files.py
@@ -202,13 +202,13 @@ class FileBrowser(QWidget):
         self.rgb_scan_btn.setChecked(bool(self.session.repo.get_global_setting("rgbscan_mode", False)))
         self._update_rgb_scan_style(self.rgb_scan_btn.isChecked())
 
-        self.sync_btn = QToolButton()
-        self.sync_btn.setIcon(qta.icon("fa5s.sync", color=THEME.text_primary))
-        self.sync_btn.setToolTip("Sync Edits — apply exposure / lab / toning to selected images (preserves their crop and rotation)")
-
-        self.sync_crop_btn = QToolButton()
-        self.sync_crop_btn.setIcon(qta.icon("fa5s.crop", color=THEME.text_primary))
-        self.sync_crop_btn.setToolTip("Sync Crop — apply current crop and rotation to selected images")
+        self.apply_btn = QToolButton()
+        self.apply_btn.setIcon(qta.icon("fa5s.clone", color=THEME.text_primary))
+        self.apply_btn.setToolTip("Apply settings from the current frame to selected frames or the whole roll")
+        self.apply_btn.setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
+        self.apply_menu = QMenu(self.apply_btn)
+        self.apply_menu.aboutToShow.connect(self._rebuild_apply_menu)
+        self.apply_btn.setMenu(self.apply_menu)
 
         # Sort dropdown
         self.sort_btn = QToolButton()
@@ -244,8 +244,7 @@ class FileBrowser(QWidget):
             self.unload_btn,
             self.hot_folder_btn,
             self.rgb_scan_btn,
-            self.sync_btn,
-            self.sync_crop_btn,
+            self.apply_btn,
             self.sort_btn,
         ):
             btn.setIconSize(icon_size)
@@ -258,8 +257,7 @@ class FileBrowser(QWidget):
         toolbar_row.addWidget(self._create_separator())
         toolbar_row.addWidget(self.hot_folder_btn)
         toolbar_row.addWidget(self.rgb_scan_btn)
-        toolbar_row.addWidget(self.sync_btn)
-        toolbar_row.addWidget(self.sync_crop_btn)
+        toolbar_row.addWidget(self.apply_btn)
         toolbar_row.addStretch()
         toolbar_row.addWidget(self._create_separator())
         toolbar_row.addWidget(self.sort_btn)
@@ -306,8 +304,6 @@ class FileBrowser(QWidget):
         self.list_view.selectionModel().selectionChanged.connect(self._on_selection_changed)
         self.hot_folder_btn.toggled.connect(self._on_hot_folder_toggled)
         self.rgb_scan_btn.toggled.connect(self._on_rgb_scan_toggled)
-        self.sync_btn.clicked.connect(lambda *_: self.session.sync_selected_settings("edits"))
-        self.sync_crop_btn.clicked.connect(lambda *_: self.session.sync_selected_settings("geometry_only"))
         self.session.state_changed.connect(self.sync_ui)
         self.session.files_changed.connect(self.sync_ui)
         self.search_input.textChanged.connect(lambda _: self.filter_timer.start())
@@ -499,6 +495,48 @@ class FileBrowser(QWidget):
         menu = self._build_context_menu()
         menu.exec(self.list_view.viewport().mapToGlobal(pos))
 
+    def _source_name(self) -> str:
+        idx = self.session.state.selected_file_idx
+        files = self.session.state.uploaded_files
+        return os.path.basename(files[idx]["path"]) if 0 <= idx < len(files) else ""
+
+    def _build_apply_aspects(self, menu: QMenu, scope: str, enabled: bool = True) -> None:
+        """Adds the aspect actions (+ Bounds submenu) that push the active frame's
+        settings to `scope` ("selection" or "roll")."""
+        for label, mode in (("Everything", "everything"), ("Edits only", "edits"), ("Crop", "crop_only"), ("Rotation", "rotation_only")):
+            act = menu.addAction(label)
+            act.setEnabled(enabled)
+            act.triggered.connect(lambda _=False, m=mode, s=scope: self.session.sync_selected_settings(m, s))
+        bounds = menu.addMenu("Bounds")
+        bounds.menuAction().setEnabled(enabled)
+        for label, mode in (("Tonal span", "bounds_luma"), ("Colour balance", "bounds_colour"), ("Both", "bounds_both")):
+            bounds.addAction(label).triggered.connect(lambda _=False, m=mode, s=scope: self.session.sync_selected_settings(m, s))
+
+    def _populate_apply_menu(self, menu: QMenu, with_header: bool = True) -> None:
+        state = self.session.state
+        n_files = len(state.uploaded_files)
+        src = state.selected_file_idx
+        sel_targets = len([i for i in set(state.selected_indices) if i != src and 0 <= i < n_files])
+        roll_targets = max(0, n_files - 1)
+
+        if with_header:
+            name = self._source_name()
+            header = menu.addAction(f'From "{name}"' if name else "No frame loaded")
+            header.setEnabled(False)
+            menu.addSeparator()
+
+        # Top level targets the current selection (the common case after multi-select).
+        self._build_apply_aspects(menu, "selection", enabled=sel_targets > 0)
+        menu.addSeparator()
+        roll_menu = menu.addMenu(f"Whole roll ({roll_targets})")
+        roll_menu.menuAction().setEnabled(roll_targets > 0)
+        if roll_targets > 0:
+            self._build_apply_aspects(roll_menu, "roll")
+
+    def _rebuild_apply_menu(self) -> None:
+        self.apply_menu.clear()
+        self._populate_apply_menu(self.apply_menu, with_header=True)
+
     def _build_context_menu(self) -> QMenu:
         state = self.session.state
         multi = len(state.selected_indices) > 1
@@ -515,9 +553,8 @@ class FileBrowser(QWidget):
         act_paste.triggered.connect(self.session.paste_settings)
         act_paste.setEnabled(state.clipboard is not None)
         menu.addAction("Reset Settings").triggered.connect(self.session.reset_settings)
-        if multi:
-            menu.addSeparator()
-            menu.addAction("Sync Edits to Selection").triggered.connect(lambda: self.session.sync_selected_settings("edits"))
+        menu.addSeparator()
+        self._populate_apply_menu(menu.addMenu("Apply settings…"), with_header=False)
         if not multi:
             menu.addSeparator()
             menu.addAction("Edit RGB Triplet…").triggered.connect(self._on_edit_triplet)

--- a/tests/test_file_browser_widget.py
+++ b/tests/test_file_browser_widget.py
@@ -111,7 +111,7 @@ def test_context_menu_single_selection_items(browser, session):
     assert "Export Selected" not in labels
     assert "Reset Settings" in labels
     assert "Unload" in labels
-    assert "Sync Edits to Selection" not in labels
+    assert "Apply settings…" in labels
 
 
 def test_context_menu_multi_selection_uses_export_selected(browser, session):
@@ -122,13 +122,35 @@ def test_context_menu_multi_selection_uses_export_selected(browser, session):
     assert "Export" not in labels
 
 
-def test_context_menu_multi_selection_adds_sync_and_remove_selected(browser, session):
+def test_context_menu_multi_selection_adds_apply_and_remove_selected(browser, session):
     session.state.selected_indices = [0, 1]
     session.state.selected_file_idx = 0
     labels = _action_labels(browser._build_context_menu())
-    assert "Sync Edits to Selection" in labels
+    assert "Apply settings…" in labels
     assert "Unload Selected" in labels
     assert "Unload" not in labels
+
+
+def test_apply_dropdown_menu_has_header_aspects_and_roll_scope(browser, session):
+    session.state.selected_indices = [0, 1]
+    session.state.selected_file_idx = 0
+    browser._rebuild_apply_menu()
+    labels = _action_labels(browser.apply_menu)
+    assert 'From "IMG_0001.cr2"' in labels
+    assert {"Everything", "Edits only", "Crop", "Rotation", "Bounds"} <= set(labels)
+    assert "Whole roll (3)" in labels  # 4 loaded − source
+    header = next(a for a in browser.apply_menu.actions() if a.text().startswith("From "))
+    assert not header.isEnabled()
+
+
+def test_apply_dropdown_disables_selection_aspects_when_nothing_selected(browser, session):
+    session.state.selected_indices = [0]
+    session.state.selected_file_idx = 0
+    browser._rebuild_apply_menu()
+    everything = next(a for a in browser.apply_menu.actions() if a.text() == "Everything")
+    assert not everything.isEnabled()  # no targets in the selection
+    roll = next(a for a in browser.apply_menu.actions() if a.text() == "Whole roll (3)")
+    assert roll.isEnabled()
 
 
 def test_context_menu_paste_disabled_without_clipboard(browser, session):

--- a/tests/test_sync_settings.py
+++ b/tests/test_sync_settings.py
@@ -1,0 +1,128 @@
+"""Pure-merge logic for the Files sidebar "Apply to selected" bulk action."""
+
+from dataclasses import replace
+
+from negpy.desktop.session import _source_effective_bounds, build_synced_config
+from negpy.domain.models import WorkspaceConfig
+
+_BOUNDS = ((0.11, 0.22, 0.33), (0.88, 0.77, 0.66))
+
+
+def _source() -> WorkspaceConfig:
+    c = WorkspaceConfig()
+    return replace(
+        c,
+        exposure=replace(c.exposure, density=2.0, grade=130.0),
+        lab=replace(c.lab, saturation=1.5),
+        geometry=replace(c.geometry, rotation=90, flip_horizontal=True, manual_crop_rect=(0.1, 0.1, 0.9, 0.9)),
+        retouch=replace(c.retouch, dust_threshold=0.5, manual_dust_spots=[(0.5, 0.5, 0.01)]),
+        process=replace(c.process, local_floors=(0.1, 0.2, 0.3), local_ceils=(0.9, 0.8, 0.7)),
+    )
+
+
+def _target() -> WorkspaceConfig:
+    c = WorkspaceConfig()
+    return replace(
+        c,
+        geometry=replace(c.geometry, rotation=270, manual_crop_rect=(0.2, 0.2, 0.8, 0.8)),
+        retouch=replace(c.retouch, manual_dust_spots=[(0.1, 0.1, 0.02)]),
+        process=replace(c.process, local_floors=(0.05, 0.05, 0.05), local_ceils=(0.95, 0.95, 0.95)),
+    )
+
+
+def test_geometry_only_touches_only_geometry():
+    src, tgt = _source(), _target()
+    out = build_synced_config(src, tgt, "geometry_only", None)
+    assert out.geometry == src.geometry
+    assert out.exposure == tgt.exposure
+    assert out.lab == tgt.lab
+    assert out.process == tgt.process
+
+
+def test_crop_only_copies_crop_keeps_rotation_and_flips():
+    src, tgt = _source(), _target()
+    out = build_synced_config(src, tgt, "crop_only", None)
+    assert out.geometry.manual_crop_rect == src.geometry.manual_crop_rect
+    assert out.geometry.rotation == tgt.geometry.rotation  # rotation preserved
+    assert out.geometry.flip_horizontal == tgt.geometry.flip_horizontal  # flip preserved
+    assert out.exposure == tgt.exposure
+
+
+def test_rotation_only_copies_rotation_and_flips_keeps_crop():
+    src, tgt = _source(), _target()
+    out = build_synced_config(src, tgt, "rotation_only", None)
+    assert out.geometry.rotation == src.geometry.rotation
+    assert out.geometry.flip_horizontal == src.geometry.flip_horizontal  # flips ride with rotation
+    assert out.geometry.manual_crop_rect == tgt.geometry.manual_crop_rect  # crop preserved
+    assert out.exposure == tgt.exposure
+
+
+def test_edits_copies_creative_keeps_geometry_dust_local_bounds():
+    src, tgt = _source(), _target()
+    out = build_synced_config(src, tgt, "edits", None)
+    assert out.exposure == src.exposure
+    assert out.lab == src.lab
+    assert out.retouch.dust_threshold == src.retouch.dust_threshold  # creative retouch fields copied
+    # frame-specific things stay on the target
+    assert out.geometry == tgt.geometry
+    assert out.retouch.manual_dust_spots == tgt.retouch.manual_dust_spots
+    assert out.process.local_floors == tgt.process.local_floors
+    assert out.process.local_ceils == tgt.process.local_ceils
+
+
+def test_everything_copies_geometry_plus_bounds_baseline_keeps_frame_specifics():
+    src, tgt = _source(), _target()
+    out = build_synced_config(src, tgt, "everything", _BOUNDS)
+    assert out.geometry == src.geometry
+    assert out.exposure == src.exposure
+    assert out.retouch.manual_dust_spots == tgt.retouch.manual_dust_spots
+    assert out.process.local_floors == tgt.process.local_floors  # per-frame meter preserved
+    assert out.process.locked_floors == _BOUNDS[0]
+    assert out.process.locked_ceils == _BOUNDS[1]
+    assert out.process.use_luma_average and out.process.use_colour_average
+
+
+def test_bounds_both_only_changes_baseline():
+    src, tgt = _source(), _target()
+    out = build_synced_config(src, tgt, "bounds_both", _BOUNDS)
+    assert out.exposure == tgt.exposure
+    assert out.lab == tgt.lab
+    assert out.geometry == tgt.geometry
+    assert out.process.local_floors == tgt.process.local_floors  # per-frame meter untouched
+    assert out.process.locked_floors == _BOUNDS[0]
+    assert out.process.locked_ceils == _BOUNDS[1]
+    assert out.process.use_luma_average is True
+    assert out.process.use_colour_average is True
+
+
+def test_bounds_luma_forces_other_axis_off():
+    out = build_synced_config(_source(), _target(), "bounds_luma", _BOUNDS)
+    assert out.process.locked_floors == _BOUNDS[0]
+    assert out.process.use_luma_average is True
+    assert out.process.use_colour_average is False
+
+
+def test_bounds_colour_forces_other_axis_off():
+    out = build_synced_config(_source(), _target(), "bounds_colour", _BOUNDS)
+    assert out.process.locked_ceils == _BOUNDS[1]
+    assert out.process.use_colour_average is True
+    assert out.process.use_luma_average is False
+
+
+def test_source_effective_bounds_prefers_per_frame_meter():
+    p = replace(WorkspaceConfig().process, local_floors=(0.1, 0.2, 0.3), local_ceils=(0.9, 0.8, 0.7))
+    assert _source_effective_bounds(p) == ((0.1, 0.2, 0.3), (0.9, 0.8, 0.7))
+
+
+def test_source_effective_bounds_uses_roll_baseline_when_active():
+    p = replace(
+        WorkspaceConfig().process,
+        locked_floors=(0.4, 0.5, 0.6),
+        locked_ceils=(0.7, 0.6, 0.5),
+        use_luma_average=True,
+    )
+    assert _source_effective_bounds(p) == ((0.4, 0.5, 0.6), (0.7, 0.6, 0.5))
+
+
+def test_source_effective_bounds_none_when_unanalysed():
+    assert _source_effective_bounds(WorkspaceConfig().process) is None


### PR DESCRIPTION
Replace the cryptic Sync Edits / Sync Crop icon buttons with one labelled "Apply" dropdown (Files sidebar + context menu) that names the source frame, shows target counts, and toasts a result count via a new settings_synced signal. Granular aspects: Everything / Edits / Crop / Rotation / Bounds, each applied to the current selection or the whole roll.

Add Sync Bounds (Tonal span / Colour balance / Both): broadcasts the source frame's effective normalization bounds to targets as a locked roll baseline (use_*_average on) so they invert from the same floors/ceils -- a single-frame version of Batch Normalization. Crop and Rotation are independent geometry subsets (flips ride with rotation).

Merge logic extracted to a pure build_synced_config() with unit tests.