### PR TITLE
Draft 0.31.0 changelog + Apply Settings dialog

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 0.31.0
+
+- **Lens distortion correction** — the Flat-Field profile gains a **k1** slider for radial (barrel/pincushion) correction from a copy-stand setup, alongside the existing illumination correction. It's a single coefficient folded into the geometry transform (so dragging it doesn't force a RAW re-decode), with scale-to-fill baked in to avoid empty borders, and stays in sync with crop/retouch/dodge-burn placement.
+- **Apply settings dialog** — the Sync Edits / Sync Crop icon buttons are replaced by one **Apply** button (Files sidebar and context menu) that opens a Lightroom-style dialog: pick Selected frames or the whole roll, then check any combination of Process, Crop, Rotation, Exposure, Color, Finish, Tonal span and Colour balance and hit Apply. The bounds checkboxes broadcast the source frame's tonal/colour normalization as a locked roll baseline — a single-frame version of Batch Normalization.
+- **Optional edit sidecars** — SQLite stays the primary edit store, but you can now also mirror edits to plain `.negpy` sidecar files next to the source for archival. Off by default; enable via the new Export panel toggle, or write them on demand from the Sidecars section button. Loading a file falls back to a beside-source sidecar when there's no DB entry, and promotes it into the DB.
+- Fix: toggling **Linear RAW** no longer leaves a stale magenta cast in the preview — the auto-meter cache now invalidates when the RAW decode changes. (#355)
+- Fix: the **Flatfield Correction** toggle is no longer silently reset to off when switching files or using Sync Edits — it was colliding with RGB Scan's toggle in the saved settings. (#356)
+
 ## 0.30.2
 
 - **Cast Removal — cleaner highlights** — the per-channel gray balance now anchors a third (highlight) reference, fitting a curve through highlight/midtone/shadow instead of a line. Fixes highlights occasionally overcorrecting past neutral (toward magenta) under 0.30.1.

--- a/negpy/desktop/session.py
+++ b/negpy/desktop/session.py
@@ -224,29 +224,18 @@ class AssetListModel(QAbstractListModel):
         self.layoutChanged.emit()
 
 
-_SYNC_MODES = (
-    "everything",
-    "edits",
-    "edits_with_geometry",
-    "geometry_only",
-    "crop_only",
-    "rotation_only",
-    "bounds_luma",
-    "bounds_colour",
-    "bounds_both",
-)
-
-_SYNC_LABELS = {
-    "everything": "Everything",
-    "edits": "Edits",
-    "edits_with_geometry": "Edits + crop",
-    "geometry_only": "Crop & rotation",
-    "crop_only": "Crop",
-    "rotation_only": "Rotation",
-    "bounds_luma": "Bounds (tonal)",
-    "bounds_colour": "Bounds (colour)",
-    "bounds_both": "Bounds (both)",
+_ASPECT_LABELS = {
+    "process": "Process",
+    "crop": "Crop",
+    "rotation": "Rotation",
+    "exposure": "Exposure",
+    "color": "Color",
+    "finish": "Finish",
+    "bounds_luma": "Tonal span",
+    "bounds_colour": "Colour balance",
 }
+
+_VALID_ASPECTS = frozenset(_ASPECT_LABELS)
 
 
 def _source_effective_bounds(process) -> Optional[tuple]:
@@ -265,73 +254,90 @@ def _source_effective_bounds(process) -> Optional[tuple]:
 def build_synced_config(
     source: WorkspaceConfig,
     target: WorkspaceConfig,
-    mode: str,
+    aspects: frozenset,
     src_bounds: Optional[tuple],
 ) -> WorkspaceConfig:
     """Pure per-target merge for a bulk "Apply to selected" action.
 
-    `src_bounds` is (floors, ceils) from _source_effective_bounds, used by the
-    bounds_* modes (and "everything"). Dust spots and per-frame local bounds are
-    frame-specific, so they're always preserved on the target.
+    `aspects` is a subset of _VALID_ASPECTS, checked independently in the Sync
+    Settings dialog. `src_bounds` is (floors, ceils) from _source_effective_bounds,
+    needed when bounds_luma/bounds_colour is checked. Builds the result by starting
+    from `target` and overlaying only the checked aspects, so anything not covered
+    by an aspect (flatfield, rgbscan, metadata, export, dust spots, per-frame local
+    bounds) always stays the target's own.
     """
-    if mode == "geometry_only":
-        return replace(target, geometry=source.geometry)
+    out = target
 
-    if mode == "rotation_only":
-        sg = source.geometry
-        new_geo = replace(
-            target.geometry,
-            rotation=sg.rotation,
-            fine_rotation=sg.fine_rotation,
-            flip_horizontal=sg.flip_horizontal,
-            flip_vertical=sg.flip_vertical,
+    if "process" in aspects:
+        out = replace(
+            out,
+            process=replace(
+                source.process,
+                local_floors=out.process.local_floors,
+                local_ceils=out.process.local_ceils,
+                locked_floors=out.process.locked_floors,
+                locked_ceils=out.process.locked_ceils,
+                use_luma_average=out.process.use_luma_average,
+                use_colour_average=out.process.use_colour_average,
+            ),
         )
-        return replace(target, geometry=new_geo)
 
-    if mode == "crop_only":
+    if "crop" in aspects:
         sg = source.geometry
-        new_geo = replace(
-            target.geometry,
-            auto_crop_enabled=sg.auto_crop_enabled,
-            autocrop_offset=sg.autocrop_offset,
-            autocrop_ratio=sg.autocrop_ratio,
-            autocrop_mode=sg.autocrop_mode,
-            manual_crop_rect=sg.manual_crop_rect,
+        out = replace(
+            out,
+            geometry=replace(
+                out.geometry,
+                auto_crop_enabled=sg.auto_crop_enabled,
+                autocrop_offset=sg.autocrop_offset,
+                autocrop_ratio=sg.autocrop_ratio,
+                autocrop_mode=sg.autocrop_mode,
+                manual_crop_rect=sg.manual_crop_rect,
+            ),
         )
-        return replace(target, geometry=new_geo)
 
-    if mode in ("bounds_luma", "bounds_colour", "bounds_both"):
+    if "rotation" in aspects:
+        sg = source.geometry
+        out = replace(
+            out,
+            geometry=replace(
+                out.geometry,
+                rotation=sg.rotation,
+                fine_rotation=sg.fine_rotation,
+                flip_horizontal=sg.flip_horizontal,
+                flip_vertical=sg.flip_vertical,
+            ),
+        )
+
+    if "exposure" in aspects:
+        out = replace(out, exposure=source.exposure)
+
+    if "color" in aspects:
+        out = replace(out, lab=source.lab, toning=source.toning)
+
+    if "finish" in aspects:
+        out = replace(
+            out,
+            retouch=replace(source.retouch, manual_dust_spots=out.retouch.manual_dust_spots),
+            finish=source.finish,
+        )
+
+    if aspects & {"bounds_luma", "bounds_colour"}:
         floors, ceils = src_bounds
         # locked_* is one shared pair feeding both axes; a single-axis sync forces
         # the other axis back to each frame's own meter to avoid an unintended shift.
-        new_process = replace(
-            target.process,
-            locked_floors=floors,
-            locked_ceils=ceils,
-            use_luma_average=mode in ("bounds_luma", "bounds_both"),
-            use_colour_average=mode in ("bounds_colour", "bounds_both"),
+        out = replace(
+            out,
+            process=replace(
+                out.process,
+                locked_floors=floors,
+                locked_ceils=ceils,
+                use_luma_average="bounds_luma" in aspects,
+                use_colour_average="bounds_colour" in aspects,
+            ),
         )
-        return replace(target, process=new_process)
 
-    # "edits" / "edits_with_geometry" / "everything": copy creative config; keep
-    # target geometry unless asked; always keep target dust + per-frame bounds.
-    merged_geo = source.geometry if mode in ("edits_with_geometry", "everything") else target.geometry
-    merged_retouch = replace(source.retouch, manual_dust_spots=target.retouch.manual_dust_spots)
-    merged_process = replace(
-        source.process,
-        local_floors=target.process.local_floors,
-        local_ceils=target.process.local_ceils,
-    )
-    if mode == "everything" and src_bounds is not None:
-        floors, ceils = src_bounds
-        merged_process = replace(
-            merged_process,
-            locked_floors=floors,
-            locked_ceils=ceils,
-            use_luma_average=True,
-            use_colour_average=True,
-        )
-    return replace(source, geometry=merged_geo, retouch=merged_retouch, process=merged_process)
+    return out
 
 
 class DesktopSessionManager(QObject):
@@ -681,23 +687,25 @@ class DesktopSessionManager(QObject):
         self.state.selected_indices = indices
         self.state_changed.emit()
 
-    def sync_selected_settings(self, mode: str = "edits", scope: str = "selection") -> int:
+    def sync_selected_settings(self, aspects: frozenset, scope: str = "selection") -> int:
         """
         Apply the active frame's settings to other frames. Returns the count changed.
 
-        mode:  everything | edits | edits_with_geometry | geometry_only |
-               crop_only | rotation_only | bounds_luma | bounds_colour | bounds_both
-        scope: "selection" (the multi-selected frames) or "roll" (all loaded frames).
+        aspects: subset of _VALID_ASPECTS (process/crop/rotation/exposure/color/
+                 finish/bounds_luma/bounds_colour), checked independently.
+        scope:   "selection" (the multi-selected frames) or "roll" (all loaded frames).
         """
-        if self.state.selected_file_idx == -1 or mode not in _SYNC_MODES:
+        aspects = frozenset(aspects) & _VALID_ASPECTS
+        if self.state.selected_file_idx == -1 or not aspects:
             return 0
 
         source_config = self.state.config
 
         src_bounds = None
-        if mode in ("bounds_luma", "bounds_colour", "bounds_both", "everything"):
+        needs_bounds = bool(aspects & {"bounds_luma", "bounds_colour"})
+        if needs_bounds:
             src_bounds = _source_effective_bounds(source_config.process)
-            if src_bounds is None and mode != "everything":
+            if src_bounds is None:
                 self.settings_synced.emit("Render the source frame before syncing bounds")
                 return 0
 
@@ -709,11 +717,11 @@ class DesktopSessionManager(QObject):
                 continue
             target_hash = self.state.uploaded_files[idx]["hash"]
             target_config = self.repo.load_file_settings(target_hash) or WorkspaceConfig()
-            self.repo.save_file_settings(target_hash, build_synced_config(source_config, target_config, mode, src_bounds))
+            self.repo.save_file_settings(target_hash, build_synced_config(source_config, target_config, aspects, src_bounds))
             count += 1
 
         if count:
-            label = _SYNC_LABELS.get(mode, mode)
+            label = ", ".join(_ASPECT_LABELS[a] for a in _ASPECT_LABELS if a in aspects)
             if scope == "roll":
                 msg = f"{label} synced to whole roll ({count} frames)"
             else:

--- a/negpy/desktop/view/sidebar/files.py
+++ b/negpy/desktop/view/sidebar/files.py
@@ -25,6 +25,7 @@ from PyQt6.QtWidgets import (
 
 from negpy.desktop.controller import AppController
 from negpy.desktop.view.styles.theme import THEME
+from negpy.desktop.view.widgets.sync_settings_dialog import SyncSettingsDialog
 from negpy.infrastructure.filesystem.watcher import FolderWatchService
 from negpy.infrastructure.loaders.helpers import get_supported_raw_wildcards
 
@@ -205,10 +206,7 @@ class FileBrowser(QWidget):
         self.apply_btn = QToolButton()
         self.apply_btn.setIcon(qta.icon("fa5s.clone", color=THEME.text_primary))
         self.apply_btn.setToolTip("Apply settings from the current frame to selected frames or the whole roll")
-        self.apply_btn.setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
-        self.apply_menu = QMenu(self.apply_btn)
-        self.apply_menu.aboutToShow.connect(self._rebuild_apply_menu)
-        self.apply_btn.setMenu(self.apply_menu)
+        self.apply_btn.clicked.connect(self._open_apply_dialog)
 
         # Sort dropdown
         self.sort_btn = QToolButton()
@@ -500,42 +498,18 @@ class FileBrowser(QWidget):
         files = self.session.state.uploaded_files
         return os.path.basename(files[idx]["path"]) if 0 <= idx < len(files) else ""
 
-    def _build_apply_aspects(self, menu: QMenu, scope: str, enabled: bool = True) -> None:
-        """Adds the aspect actions (+ Bounds submenu) that push the active frame's
-        settings to `scope` ("selection" or "roll")."""
-        for label, mode in (("Everything", "everything"), ("Edits only", "edits"), ("Crop", "crop_only"), ("Rotation", "rotation_only")):
-            act = menu.addAction(label)
-            act.setEnabled(enabled)
-            act.triggered.connect(lambda _=False, m=mode, s=scope: self.session.sync_selected_settings(m, s))
-        bounds = menu.addMenu("Bounds")
-        bounds.menuAction().setEnabled(enabled)
-        for label, mode in (("Tonal span", "bounds_luma"), ("Colour balance", "bounds_colour"), ("Both", "bounds_both")):
-            bounds.addAction(label).triggered.connect(lambda _=False, m=mode, s=scope: self.session.sync_selected_settings(m, s))
-
-    def _populate_apply_menu(self, menu: QMenu, with_header: bool = True) -> None:
+    def _open_apply_dialog(self) -> None:
         state = self.session.state
         n_files = len(state.uploaded_files)
         src = state.selected_file_idx
+        if src == -1:
+            return
         sel_targets = len([i for i in set(state.selected_indices) if i != src and 0 <= i < n_files])
         roll_targets = max(0, n_files - 1)
 
-        if with_header:
-            name = self._source_name()
-            header = menu.addAction(f'From "{name}"' if name else "No frame loaded")
-            header.setEnabled(False)
-            menu.addSeparator()
-
-        # Top level targets the current selection (the common case after multi-select).
-        self._build_apply_aspects(menu, "selection", enabled=sel_targets > 0)
-        menu.addSeparator()
-        roll_menu = menu.addMenu(f"Whole roll ({roll_targets})")
-        roll_menu.menuAction().setEnabled(roll_targets > 0)
-        if roll_targets > 0:
-            self._build_apply_aspects(roll_menu, "roll")
-
-    def _rebuild_apply_menu(self) -> None:
-        self.apply_menu.clear()
-        self._populate_apply_menu(self.apply_menu, with_header=True)
+        dlg = SyncSettingsDialog(self, self._source_name(), sel_targets, roll_targets)
+        if dlg.exec() == QDialog.DialogCode.Accepted:
+            self.session.sync_selected_settings(dlg.aspects(), dlg.scope())
 
     def _build_context_menu(self) -> QMenu:
         state = self.session.state
@@ -554,7 +528,7 @@ class FileBrowser(QWidget):
         act_paste.setEnabled(state.clipboard is not None)
         menu.addAction("Reset Settings").triggered.connect(self.session.reset_settings)
         menu.addSeparator()
-        self._populate_apply_menu(menu.addMenu("Apply settings…"), with_header=False)
+        menu.addAction("Apply settings…").triggered.connect(self._open_apply_dialog)
         if not multi:
             menu.addSeparator()
             menu.addAction("Edit RGB Triplet…").triggered.connect(self._on_edit_triplet)

--- a/negpy/desktop/view/widgets/sync_settings_dialog.py
+++ b/negpy/desktop/view/widgets/sync_settings_dialog.py
@@ -1,0 +1,122 @@
+from PyQt6.QtWidgets import (
+    QButtonGroup,
+    QCheckBox,
+    QDialog,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QRadioButton,
+    QVBoxLayout,
+)
+
+from negpy.desktop.view.styles.theme import THEME
+
+_GROUPS = (
+    ("Setup", (("process", "Process"), ("crop", "Crop"), ("rotation", "Rotation"))),
+    ("Exposure", (("exposure", "Exposure"),)),
+    ("Color", (("color", "Color"),)),
+    ("Finish", (("finish", "Finish"),)),
+    ("Bounds", (("bounds_luma", "Tonal span"), ("bounds_colour", "Colour balance"))),
+)
+
+
+class SyncSettingsDialog(QDialog):
+    """Lightroom-style "Apply Settings" dialog: independent checkboxes + Apply."""
+
+    def __init__(self, parent, source_name: str, sel_count: int, roll_count: int):
+        super().__init__(parent)
+        self._aspects: frozenset = frozenset()
+        self._scope = "selection" if sel_count > 0 else "roll"
+
+        self.setWindowTitle("Apply Settings")
+        self.setStyleSheet(f"QDialog {{ background: {THEME.bg_dark}; }}")
+
+        root = QVBoxLayout(self)
+        root.setContentsMargins(THEME.space_2xl, THEME.space_2xl, THEME.space_2xl, THEME.space_2xl)
+        root.setSpacing(THEME.space_xl)
+
+        header = QLabel(f'From "{source_name}"' if source_name else "No frame loaded")
+        header.setStyleSheet(f"color: {THEME.text_primary}; font-weight: bold;")
+        root.addWidget(header)
+
+        root.addLayout(self._build_scope_row(sel_count, roll_count))
+        root.addLayout(self._build_checks_row())
+        root.addLayout(self._build_groups(), 1)
+        root.addLayout(self._build_footer())
+
+        self._update_apply_enabled()
+
+    def _build_scope_row(self, sel_count: int, roll_count: int) -> QHBoxLayout:
+        row = QHBoxLayout()
+        self.scope_group = QButtonGroup(self)
+
+        self.sel_radio = QRadioButton(f"Selected frames ({sel_count})")
+        self.sel_radio.setEnabled(sel_count > 0)
+        self.roll_radio = QRadioButton(f"Whole roll ({roll_count})")
+        self.roll_radio.setEnabled(roll_count > 0)
+
+        self.scope_group.addButton(self.sel_radio)
+        self.scope_group.addButton(self.roll_radio)
+        if sel_count > 0:
+            self.sel_radio.setChecked(True)
+        else:
+            self.roll_radio.setChecked(True)
+
+        row.addWidget(self.sel_radio)
+        row.addWidget(self.roll_radio)
+        row.addStretch()
+        return row
+
+    def _build_checks_row(self) -> QHBoxLayout:
+        row = QHBoxLayout()
+        check_all = QPushButton("Check All")
+        check_all.clicked.connect(lambda: self._set_all_checked(True))
+        check_none = QPushButton("Check None")
+        check_none.clicked.connect(lambda: self._set_all_checked(False))
+        row.addWidget(check_all)
+        row.addWidget(check_none)
+        row.addStretch()
+        return row
+
+    def _build_groups(self) -> QVBoxLayout:
+        col = QVBoxLayout()
+        self._checkboxes: dict[str, QCheckBox] = {}
+        for group_label, items in _GROUPS:
+            label = QLabel(group_label.upper())
+            label.setStyleSheet(f"color: {THEME.text_muted}; font-size: 10px; font-weight: bold; letter-spacing: 1px;")
+            col.addWidget(label)
+            for key, text in items:
+                box = QCheckBox(text)
+                box.stateChanged.connect(self._update_apply_enabled)
+                self._checkboxes[key] = box
+                col.addWidget(box)
+        return col
+
+    def _build_footer(self) -> QHBoxLayout:
+        row = QHBoxLayout()
+        row.addStretch()
+        cancel_btn = QPushButton("Cancel")
+        cancel_btn.clicked.connect(self.reject)
+        self.apply_btn = QPushButton("Apply")
+        self.apply_btn.clicked.connect(self._on_apply)
+        row.addWidget(cancel_btn)
+        row.addWidget(self.apply_btn)
+        return row
+
+    def _set_all_checked(self, checked: bool) -> None:
+        for box in self._checkboxes.values():
+            box.setChecked(checked)
+
+    def _update_apply_enabled(self) -> None:
+        self.apply_btn.setEnabled(any(box.isChecked() for box in self._checkboxes.values()))
+
+    def _on_apply(self) -> None:
+        self._aspects = frozenset(key for key, box in self._checkboxes.items() if box.isChecked())
+        self._scope = "selection" if self.sel_radio.isChecked() else "roll"
+        self.accept()
+
+    def aspects(self) -> frozenset:
+        return self._aspects
+
+    def scope(self) -> str:
+        return self._scope

--- a/tests/test_desktop_session.py
+++ b/tests/test_desktop_session.py
@@ -120,7 +120,7 @@ class TestDesktopSessionSync(unittest.TestCase):
         self.mock_repo.load_file_settings.return_value = target_config
 
         self.session.update_selection([0, 1])
-        self.session.sync_selected_settings()
+        self.session.sync_selected_settings(frozenset({"process", "exposure", "color", "finish"}))
 
         args, _ = self.mock_repo.save_file_settings.call_args
         self.assertEqual(args[0], "hash2")
@@ -158,7 +158,7 @@ class TestDesktopSessionSync(unittest.TestCase):
         self.mock_repo.load_file_settings.return_value = target_config
 
         self.session.update_selection([0, 1])
-        self.session.sync_selected_settings("edits_with_geometry")
+        self.session.sync_selected_settings(frozenset({"process", "exposure", "color", "finish", "crop", "rotation"}))
 
         args, _ = self.mock_repo.save_file_settings.call_args
         saved_config = args[1]
@@ -188,7 +188,7 @@ class TestDesktopSessionSync(unittest.TestCase):
         self.mock_repo.load_file_settings.return_value = target_config
 
         self.session.update_selection([0, 1])
-        self.session.sync_selected_settings("geometry_only")
+        self.session.sync_selected_settings(frozenset({"crop", "rotation"}))
 
         args, _ = self.mock_repo.save_file_settings.call_args
         saved_config = args[1]
@@ -200,11 +200,11 @@ class TestDesktopSessionSync(unittest.TestCase):
         # Other config preserved from target
         self.assertEqual(saved_config.exposure.density, 0.7)
 
-    def test_sync_selected_settings_invalid_mode_is_noop(self):
+    def test_sync_selected_settings_invalid_aspect_is_noop(self):
         self.session.state.selected_file_idx = 0
         self.session.state.current_file_hash = "hash1"
         self.session.update_selection([0, 1])
-        self.session.sync_selected_settings("bogus")
+        self.session.sync_selected_settings(frozenset({"bogus"}))
         self.mock_repo.save_file_settings.assert_not_called()
 
     def test_undo_redo_persistence(self):

--- a/tests/test_file_browser_widget.py
+++ b/tests/test_file_browser_widget.py
@@ -1,10 +1,12 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
+from PyQt6.QtWidgets import QDialog
 
 from negpy.desktop.session import DesktopSessionManager
 from negpy.desktop.view.sidebar.files import FileBrowser
 from negpy.desktop.view.styles.theme import THEME
+from negpy.desktop.view.widgets.sync_settings_dialog import SyncSettingsDialog
 from negpy.infrastructure.storage.repository import StorageRepository
 
 
@@ -131,26 +133,65 @@ def test_context_menu_multi_selection_adds_apply_and_remove_selected(browser, se
     assert "Unload" not in labels
 
 
-def test_apply_dropdown_menu_has_header_aspects_and_roll_scope(browser, session):
+def test_apply_dialog_shows_header_scope_and_counts():
+    dlg = SyncSettingsDialog(None, "IMG_0001.cr2", sel_count=2, roll_count=3)
+    assert dlg.sel_radio.text() == "Selected frames (2)"
+    assert dlg.sel_radio.isEnabled()
+    assert dlg.sel_radio.isChecked()  # selection preferred when it has targets
+    assert dlg.roll_radio.text() == "Whole roll (3)"
+    assert dlg.roll_radio.isEnabled()
+
+
+def test_apply_dialog_defaults_to_roll_when_selection_empty():
+    dlg = SyncSettingsDialog(None, "IMG_0001.cr2", sel_count=0, roll_count=3)
+    assert not dlg.sel_radio.isEnabled()
+    assert dlg.roll_radio.isChecked()
+
+
+def test_apply_dialog_check_all_and_none():
+    dlg = SyncSettingsDialog(None, "IMG_0001.cr2", sel_count=1, roll_count=3)
+    assert not dlg.apply_btn.isEnabled()
+    dlg._set_all_checked(True)
+    assert all(box.isChecked() for box in dlg._checkboxes.values())
+    assert dlg.apply_btn.isEnabled()
+    dlg._set_all_checked(False)
+    assert not any(box.isChecked() for box in dlg._checkboxes.values())
+    assert not dlg.apply_btn.isEnabled()
+
+
+def test_apply_dialog_apply_collects_checked_aspects_and_scope():
+    dlg = SyncSettingsDialog(None, "IMG_0001.cr2", sel_count=1, roll_count=3)
+    dlg._checkboxes["crop"].setChecked(True)
+    dlg._checkboxes["exposure"].setChecked(True)
+    dlg.roll_radio.setChecked(True)
+    dlg._on_apply()
+    assert dlg.aspects() == frozenset({"crop", "exposure"})
+    assert dlg.scope() == "roll"
+
+
+def test_open_apply_dialog_routes_aspects_and_scope_to_session(browser, session):
     session.state.selected_indices = [0, 1]
     session.state.selected_file_idx = 0
-    browser._rebuild_apply_menu()
-    labels = _action_labels(browser.apply_menu)
-    assert 'From "IMG_0001.cr2"' in labels
-    assert {"Everything", "Edits only", "Crop", "Rotation", "Bounds"} <= set(labels)
-    assert "Whole roll (3)" in labels  # 4 loaded − source
-    header = next(a for a in browser.apply_menu.actions() if a.text().startswith("From "))
-    assert not header.isEnabled()
+    session.sync_selected_settings = MagicMock()
+
+    mock_dlg = MagicMock()
+    mock_dlg.exec.return_value = QDialog.DialogCode.Accepted
+    mock_dlg.aspects.return_value = frozenset({"exposure"})
+    mock_dlg.scope.return_value = "selection"
+    with patch("negpy.desktop.view.sidebar.files.SyncSettingsDialog", return_value=mock_dlg) as ctor:
+        browser._open_apply_dialog()
+
+    assert ctor.call_args.args[1:] == ("IMG_0001.cr2", 1, 3)  # 1 other selected, 3 other on roll
+    session.sync_selected_settings.assert_called_once_with(frozenset({"exposure"}), "selection")
 
 
-def test_apply_dropdown_disables_selection_aspects_when_nothing_selected(browser, session):
-    session.state.selected_indices = [0]
-    session.state.selected_file_idx = 0
-    browser._rebuild_apply_menu()
-    everything = next(a for a in browser.apply_menu.actions() if a.text() == "Everything")
-    assert not everything.isEnabled()  # no targets in the selection
-    roll = next(a for a in browser.apply_menu.actions() if a.text() == "Whole roll (3)")
-    assert roll.isEnabled()
+def test_open_apply_dialog_noop_without_active_file(browser, session):
+    session.state.selected_file_idx = -1
+    session.sync_selected_settings = MagicMock()
+    with patch("negpy.desktop.view.sidebar.files.SyncSettingsDialog") as ctor:
+        browser._open_apply_dialog()
+    ctor.assert_not_called()
+    session.sync_selected_settings.assert_not_called()
 
 
 def test_context_menu_paste_disabled_without_clipboard(browser, session):

--- a/tests/test_sync_settings.py
+++ b/tests/test_sync_settings.py
@@ -14,9 +14,11 @@ def _source() -> WorkspaceConfig:
         c,
         exposure=replace(c.exposure, density=2.0, grade=130.0),
         lab=replace(c.lab, saturation=1.5),
+        toning=replace(c.toning, sepia_strength=0.4),
+        finish=replace(c.finish, vignette_strength=0.3),
+        process=replace(c.process, process_mode="E-6", analysis_buffer=0.2),
         geometry=replace(c.geometry, rotation=90, flip_horizontal=True, manual_crop_rect=(0.1, 0.1, 0.9, 0.9)),
         retouch=replace(c.retouch, dust_threshold=0.5, manual_dust_spots=[(0.5, 0.5, 0.01)]),
-        process=replace(c.process, local_floors=(0.1, 0.2, 0.3), local_ceils=(0.9, 0.8, 0.7)),
     )
 
 
@@ -30,18 +32,9 @@ def _target() -> WorkspaceConfig:
     )
 
 
-def test_geometry_only_touches_only_geometry():
-    src, tgt = _source(), _target()
-    out = build_synced_config(src, tgt, "geometry_only", None)
-    assert out.geometry == src.geometry
-    assert out.exposure == tgt.exposure
-    assert out.lab == tgt.lab
-    assert out.process == tgt.process
-
-
 def test_crop_only_copies_crop_keeps_rotation_and_flips():
     src, tgt = _source(), _target()
-    out = build_synced_config(src, tgt, "crop_only", None)
+    out = build_synced_config(src, tgt, frozenset({"crop"}), None)
     assert out.geometry.manual_crop_rect == src.geometry.manual_crop_rect
     assert out.geometry.rotation == tgt.geometry.rotation  # rotation preserved
     assert out.geometry.flip_horizontal == tgt.geometry.flip_horizontal  # flip preserved
@@ -50,41 +43,83 @@ def test_crop_only_copies_crop_keeps_rotation_and_flips():
 
 def test_rotation_only_copies_rotation_and_flips_keeps_crop():
     src, tgt = _source(), _target()
-    out = build_synced_config(src, tgt, "rotation_only", None)
+    out = build_synced_config(src, tgt, frozenset({"rotation"}), None)
     assert out.geometry.rotation == src.geometry.rotation
     assert out.geometry.flip_horizontal == src.geometry.flip_horizontal  # flips ride with rotation
     assert out.geometry.manual_crop_rect == tgt.geometry.manual_crop_rect  # crop preserved
     assert out.exposure == tgt.exposure
 
 
-def test_edits_copies_creative_keeps_geometry_dust_local_bounds():
+def test_crop_and_rotation_together_cover_full_geometry():
     src, tgt = _source(), _target()
-    out = build_synced_config(src, tgt, "edits", None)
-    assert out.exposure == src.exposure
-    assert out.lab == src.lab
-    assert out.retouch.dust_threshold == src.retouch.dust_threshold  # creative retouch fields copied
-    # frame-specific things stay on the target
-    assert out.geometry == tgt.geometry
-    assert out.retouch.manual_dust_spots == tgt.retouch.manual_dust_spots
+    out = build_synced_config(src, tgt, frozenset({"crop", "rotation"}), None)
+    assert out.geometry == src.geometry
+
+
+def test_process_aspect_copies_setup_keeps_bounds():
+    src, tgt = _source(), _target()
+    out = build_synced_config(src, tgt, frozenset({"process"}), None)
+    assert out.process.process_mode == src.process.process_mode
+    assert out.process.analysis_buffer == src.process.analysis_buffer
+    # bounds-related fields stay the target's own
     assert out.process.local_floors == tgt.process.local_floors
     assert out.process.local_ceils == tgt.process.local_ceils
+    assert out.process.locked_floors == tgt.process.locked_floors
+    assert out.process.locked_ceils == tgt.process.locked_ceils
+    assert out.process.use_luma_average == tgt.process.use_luma_average
+    assert out.process.use_colour_average == tgt.process.use_colour_average
+    assert out.geometry == tgt.geometry
 
 
-def test_everything_copies_geometry_plus_bounds_baseline_keeps_frame_specifics():
+def test_exposure_aspect_copies_exposure_only():
     src, tgt = _source(), _target()
-    out = build_synced_config(src, tgt, "everything", _BOUNDS)
+    out = build_synced_config(src, tgt, frozenset({"exposure"}), None)
+    assert out.exposure == src.exposure
+    assert out.lab == tgt.lab
+    assert out.geometry == tgt.geometry
+
+
+def test_color_aspect_copies_lab_and_toning():
+    src, tgt = _source(), _target()
+    out = build_synced_config(src, tgt, frozenset({"color"}), None)
+    assert out.lab == src.lab
+    assert out.toning == src.toning
+    assert out.exposure == tgt.exposure
+
+
+def test_finish_aspect_copies_retouch_and_finish_keeps_dust_spots():
+    src, tgt = _source(), _target()
+    out = build_synced_config(src, tgt, frozenset({"finish"}), None)
+    assert out.finish == src.finish
+    assert out.retouch.dust_threshold == src.retouch.dust_threshold
+    assert out.retouch.manual_dust_spots == tgt.retouch.manual_dust_spots  # frame-specific, preserved
+    assert out.geometry == tgt.geometry
+
+
+def test_all_aspects_checked_keeps_frame_specifics_and_untouched_fields():
+    src, tgt = _source(), _target()
+    aspects = frozenset({"process", "crop", "rotation", "exposure", "color", "finish", "bounds_luma", "bounds_colour"})
+    out = build_synced_config(src, tgt, aspects, _BOUNDS)
     assert out.geometry == src.geometry
     assert out.exposure == src.exposure
+    assert out.lab == src.lab
+    assert out.toning == src.toning
+    assert out.finish == src.finish
+    assert out.process.process_mode == src.process.process_mode
     assert out.retouch.manual_dust_spots == tgt.retouch.manual_dust_spots
     assert out.process.local_floors == tgt.process.local_floors  # per-frame meter preserved
     assert out.process.locked_floors == _BOUNDS[0]
     assert out.process.locked_ceils == _BOUNDS[1]
     assert out.process.use_luma_average and out.process.use_colour_average
+    # not a sync category: stays the target's own
+    assert out.flatfield == tgt.flatfield
+    assert out.rgbscan == tgt.rgbscan
+    assert out.metadata == tgt.metadata
 
 
 def test_bounds_both_only_changes_baseline():
     src, tgt = _source(), _target()
-    out = build_synced_config(src, tgt, "bounds_both", _BOUNDS)
+    out = build_synced_config(src, tgt, frozenset({"bounds_luma", "bounds_colour"}), _BOUNDS)
     assert out.exposure == tgt.exposure
     assert out.lab == tgt.lab
     assert out.geometry == tgt.geometry
@@ -96,14 +131,14 @@ def test_bounds_both_only_changes_baseline():
 
 
 def test_bounds_luma_forces_other_axis_off():
-    out = build_synced_config(_source(), _target(), "bounds_luma", _BOUNDS)
+    out = build_synced_config(_source(), _target(), frozenset({"bounds_luma"}), _BOUNDS)
     assert out.process.locked_floors == _BOUNDS[0]
     assert out.process.use_luma_average is True
     assert out.process.use_colour_average is False
 
 
 def test_bounds_colour_forces_other_axis_off():
-    out = build_synced_config(_source(), _target(), "bounds_colour", _BOUNDS)
+    out = build_synced_config(_source(), _target(), frozenset({"bounds_colour"}), _BOUNDS)
     assert out.process.locked_ceils == _BOUNDS[1]
     assert out.process.use_colour_average is True
     assert out.process.use_luma_average is False


### PR DESCRIPTION
## Summary
- Draft the 0.31.0 CHANGELOG entry covering everything since 0.30.2: k1 lens distortion, the new Apply Settings dialog, optional edit sidecars, and the Linear RAW re-meter / flatfield-toggle fixes.
- Replace the nested Apply-to-selected QMenu (mutually-exclusive Everything/Edits/Crop/Rotation/Bounds, duplicated for selection vs. whole roll, duplicated again in the context menu) with a single Lightroom-style **Sync Settings** dialog: pick a scope, then check any combination of Process / Crop / Rotation / Exposure / Color / Finish / Tonal span / Colour balance, hit Apply.
- `build_synced_config` now builds the merged config by starting from the target and overlaying only the checked aspects, instead of starting from a full copy of the source — fixes a latent bug where bulk "Edits" sync silently overwrote each target's own RGB-scan triplet paths with the source's.

## Test plan
- [x] `make lint` clean
- [x] `make type` clean
- [x] `uv run pytest -q` — 1023 passed, 4 skipped, 7 deselected, 1 xfailed
- [x] Manual end-to-end run (offscreen Qt + real QSS): opened the real dialog, screenshotted it, checked Exposure, clicked Apply, confirmed the target frame's saved config actually changed in SQLite while untouched aspects (geometry) stayed put