### PR TITLE
Add flat master as a per-preset export option 

### DIFF
--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -33,6 +33,7 @@ from negpy.domain.models import (
     flat_export_config,
     flat_master_config,
     preset_from_export_config,
+    resolve_preset_export,
 )
 from negpy.services.assets.sidecar import load_or_promote, write_sidecar
 from negpy.features.exposure.logic import (
@@ -1347,15 +1348,13 @@ class AppController(QObject):
     ) -> List[ExportTask]:
         tasks = []
         for preset in presets:
-            from copy import copy
-
-            p = copy(preset)
-            p.icc_input_path = self.state.icc_input_path
+            task_params, export_settings = resolve_preset_export(preset, params)
+            export_settings.icc_input_path = self.state.icc_input_path
             tasks.append(
                 ExportTask(
                     file_info=file_info,
-                    params=params,
-                    export_settings=p,
+                    params=task_params,
+                    export_settings=export_settings,
                     gpu_enabled=self.state.gpu_enabled,
                     bounds_override=bounds_override,
                     source_exif=source_exif,

--- a/negpy/desktop/view/sidebar/export.py
+++ b/negpy/desktop/view/sidebar/export.py
@@ -24,6 +24,7 @@ from negpy.desktop.view.styles.theme import THEME
 from negpy.desktop.view.widgets.collapsible import CollapsibleSection
 from negpy.desktop.view.widgets.export_settings_form import ExportSettingsForm, constrain_combo
 from negpy.domain.models import ColorSpace
+from negpy.features.exposure.models import RenderIntent
 from negpy.services.export.contact_sheet_templates import ContactSheetLayout, ContactSheetTemplates
 
 
@@ -650,7 +651,10 @@ class ExportSidebar(BaseSidebar):
         self._no_presets_label.setVisible(not presets)
 
         for i, preset in enumerate(presets):
-            cb = QCheckBox(preset.name)
+            label = preset.name
+            if preset.render_intent == RenderIntent.FLAT:
+                label = f"{preset.name} (flat)"
+            cb = QCheckBox(label)
             cb.setChecked(preset.enabled)
             cb.setStyleSheet(f"color: {THEME.text_primary};")
             cb.stateChanged.connect(lambda state, idx=i: self._on_preset_toggled(idx, state))

--- a/negpy/desktop/view/widgets/export_presets_dialog.py
+++ b/negpy/desktop/view/widgets/export_presets_dialog.py
@@ -10,6 +10,7 @@ from PyQt6.QtWidgets import (
     QLineEdit,
     QListWidget,
     QListWidgetItem,
+    QMenu,
     QPushButton,
     QScrollArea,
     QVBoxLayout,
@@ -18,7 +19,8 @@ from PyQt6.QtWidgets import (
 
 from negpy.desktop.view.styles.theme import THEME
 from negpy.desktop.view.widgets.export_settings_form import ExportSettingsForm
-from negpy.domain.models import ExportPreset
+from negpy.domain.models import ColorSpace, ExportFormat, ExportPreset, ExportResolutionMode
+from negpy.features.exposure.models import RenderIntent
 
 
 class ExportPresetsDialog(QDialog):
@@ -71,9 +73,9 @@ class ExportPresetsDialog(QDialog):
         btn_row = QHBoxLayout()
         self.add_btn = QPushButton()
         self.add_btn.setIcon(qta.icon("fa5s.plus", color=THEME.text_primary))
-        self.add_btn.setToolTip("Add preset")
+        self.add_btn.setToolTip("Add print or flat master preset")
         self.add_btn.setFixedWidth(36)
-        self.add_btn.clicked.connect(self._add_preset)
+        self.add_btn.clicked.connect(self._show_add_menu)
 
         self.dup_btn = QPushButton()
         self.dup_btn.setIcon(qta.icon("fa5s.copy", color=THEME.text_primary))
@@ -148,6 +150,10 @@ class ExportPresetsDialog(QDialog):
         row.addWidget(self.enabled_check)
         form.addLayout(row)
 
+        self.intent_label = QLabel()
+        self.intent_label.setStyleSheet(f"color: {THEME.text_muted}; font-size: 10px; border: none;")
+        form.addWidget(self.intent_label)
+
         # Shared FORMAT / SIZE / COLOR / DESTINATION rows.
         self.form = ExportSettingsForm()
         self.form.changed.connect(self._on_form_changed)
@@ -163,7 +169,10 @@ class ExportPresetsDialog(QDialog):
         self.preset_list.blockSignals(True)
         self.preset_list.clear()
         for p in self._presets:
-            item = QListWidgetItem(p.name)
+            label = p.name
+            if p.render_intent == RenderIntent.FLAT:
+                label = f"{p.name} (flat)"
+            item = QListWidgetItem(label)
             item.setCheckState(Qt.CheckState.Checked if p.enabled else Qt.CheckState.Unchecked)
             item.setFlags(item.flags() | Qt.ItemFlag.ItemIsUserCheckable)
             self.preset_list.addItem(item)
@@ -202,6 +211,13 @@ class ExportPresetsDialog(QDialog):
     def _populate_form(self, preset: ExportPreset) -> None:
         self._updating_form = True
         try:
+            is_flat = preset.render_intent == RenderIntent.FLAT
+            self.intent_label.setText(
+                "Flat master — exports a neutral log intermediate (16-bit TIFF or linear DNG)."
+                if is_flat
+                else "Print — exports the full in-app photographic look."
+            )
+            self.form.set_flat_mode(is_flat, preset_editor=True)
             self.name_edit.setText(preset.name)
             self.enabled_check.setChecked(preset.enabled)
             self.form.load(preset.to_dict())
@@ -214,7 +230,10 @@ class ExportPresetsDialog(QDialog):
         self._presets[self._selected_idx].name = text
         item = self.preset_list.item(self._selected_idx)
         if item:
-            item.setText(text)
+            label = text
+            if self._presets[self._selected_idx].render_intent == RenderIntent.FLAT:
+                label = f"{text} (flat)"
+            item.setText(label)
         self._emit_changed()
 
     def _on_enabled_changed(self, _state: int) -> None:
@@ -257,12 +276,36 @@ class ExportPresetsDialog(QDialog):
     # Preset actions
     # ------------------------------------------------------------------
 
-    def _add_preset(self) -> None:
-        preset = ExportPreset(id=str(uuid.uuid4()), name="New Preset")
+    def _show_add_menu(self) -> None:
+        menu = QMenu(self)
+        menu.addAction("Print preset", self._add_print_preset)
+        menu.addAction("Flat master preset", self._add_flat_preset)
+        menu.exec(self.add_btn.mapToGlobal(self.add_btn.rect().bottomLeft()))
+
+    def _append_preset(self, preset: ExportPreset) -> None:
         self._presets.append(preset)
         self._rebuild_list()
         self._select_row(len(self._presets) - 1)
         self._emit_changed()
+
+    def _add_print_preset(self) -> None:
+        self._append_preset(ExportPreset(id=str(uuid.uuid4()), name="New Preset"))
+
+    def _add_flat_preset(self) -> None:
+        self._append_preset(
+            ExportPreset(
+                id=str(uuid.uuid4()),
+                name="Flat Master",
+                render_intent=RenderIntent.FLAT,
+                export_fmt=ExportFormat.TIFF,
+                export_resolution_mode=ExportResolutionMode.ORIGINAL.value,
+                export_color_space=ColorSpace.PROPHOTO.value,
+                filename_pattern="{{ original_name }}_flat",
+            )
+        )
+
+    def _add_preset(self) -> None:
+        self._add_print_preset()
 
     def _duplicate_preset(self) -> None:
         if self._selected_idx < 0:

--- a/negpy/desktop/view/widgets/export_settings_form.py
+++ b/negpy/desktop/view/widgets/export_settings_form.py
@@ -435,12 +435,39 @@ class ExportSettingsForm(QWidget):
         else:
             self._ratio_row_widget.setVisible(True)
 
-    def set_flat_mode(self, enabled: bool) -> None:
-        """Toggle flat-master export UI: hide delivery formats, adjust size rows."""
+    def set_flat_mode(self, enabled: bool, *, preset_editor: bool = False) -> None:
+        """Toggle flat-master export UI: hide delivery formats, adjust size rows.
+
+        When ``preset_editor`` is True (Manage Presets dialog), the format row stays
+        visible but limited to TIFF/DNG instead of hiding entirely.
+        """
         enabled = bool(enabled)
-        if enabled == self._flat_mode:
+        if not preset_editor and enabled == self._flat_mode:
             return
         self._flat_mode = enabled
+
+        if preset_editor:
+            self._format_section.setVisible(True)
+            current = self.fmt_combo.currentText()
+            self.fmt_combo.blockSignals(True)
+            self.fmt_combo.clear()
+            if enabled:
+                flat_formats = [ExportFormat.TIFF.value, ExportFormat.DNG.value]
+                self.fmt_combo.addItems(flat_formats)
+                self.fmt_combo.setCurrentText(current if current in flat_formats else ExportFormat.TIFF.value)
+                self._quality_container.setVisible(False)
+                self._jxl_container.setVisible(False)
+                self._webp_container.setVisible(False)
+            else:
+                all_formats = [f.value for f in ExportFormat]
+                self.fmt_combo.addItems(all_formats)
+                self.fmt_combo.setCurrentText(current if current in all_formats else ExportFormat.JPEG.value)
+            self.fmt_combo.blockSignals(False)
+            if not enabled:
+                self._on_fmt_changed(self.fmt_combo.currentText())
+            self._update_ratio_visibility()
+            return
+
         self._format_section.setVisible(not enabled)
         if enabled:
             self._update_ratio_visibility()

--- a/negpy/domain/models.py
+++ b/negpy/domain/models.py
@@ -145,6 +145,7 @@ class ExportPreset:
     id: str = field(default_factory=lambda: str(uuid.uuid4()))
     name: str = "Untitled Preset"
     enabled: bool = True
+    render_intent: str = RenderIntent.PRINT
 
     # Format
     export_fmt: str = ExportFormat.JPEG
@@ -180,6 +181,7 @@ class ExportPreset:
             "id": self.id,
             "name": self.name,
             "enabled": self.enabled,
+            "render_intent": self.render_intent,
             "export_fmt": self.export_fmt,
             "jpeg_quality": self.jpeg_quality,
             "jxl_lossless": self.jxl_lossless,
@@ -388,6 +390,40 @@ def flat_master_config(config: WorkspaceConfig) -> WorkspaceConfig:
         shoulder=0.0,
     )
     return replace(config, exposure=flat_exposure)
+
+
+def flat_export_preset(preset: ExportPreset) -> ExportPreset:
+    """Apply flat-master delivery rules to a preset copy (TIFF/DNG, default full-res)."""
+    from copy import copy
+
+    fmt = preset.export_fmt if preset.export_fmt in (ExportFormat.TIFF, ExportFormat.DNG) else ExportFormat.TIFF
+    stub = ExportConfig(
+        export_fmt=fmt,
+        export_resolution_mode=preset.export_resolution_mode,
+        paper_aspect_ratio=preset.paper_aspect_ratio,
+        export_print_size=preset.export_print_size,
+        export_dpi=preset.export_dpi,
+        export_target_long_edge_px=preset.export_target_long_edge_px,
+    )
+    flat = flat_export_config(stub, fmt=fmt)
+    out = copy(preset)
+    out.export_fmt = flat.export_fmt
+    out.export_resolution_mode = flat.export_resolution_mode
+    out.paper_aspect_ratio = flat.paper_aspect_ratio
+    return out
+
+
+def resolve_preset_export(
+    preset: ExportPreset,
+    params: WorkspaceConfig,
+) -> tuple[WorkspaceConfig, ExportPreset]:
+    """Return (pipeline_config, delivery_preset) for one preset-driven export task."""
+    from copy import copy
+
+    delivery = copy(preset)
+    if preset.render_intent != RenderIntent.FLAT:
+        return params, delivery
+    return flat_master_config(params), flat_export_preset(preset)
 
 
 def flat_export_config(export: ExportConfig, fmt: str = ExportFormat.TIFF) -> ExportConfig:

--- a/tests/test_export_presets.py
+++ b/tests/test_export_presets.py
@@ -7,6 +7,7 @@ import uuid
 import numpy as np
 import pytest
 import tifffile
+from dataclasses import replace
 from PIL import Image
 
 from negpy.domain.models import (
@@ -18,8 +19,11 @@ from negpy.domain.models import (
     AspectRatio,
     ColorSpace,
     WorkspaceConfig,
+    flat_master_config,
     preset_from_export_config,
+    resolve_preset_export,
 )
+from negpy.features.exposure.models import RenderIntent
 from negpy.infrastructure.display.color_spaces import WORKING_COLOR_SPACE
 from negpy.infrastructure.storage.repository import StorageRepository
 from negpy.services.rendering.image_processor import ImageProcessor
@@ -101,6 +105,47 @@ def test_preset_unknown_keys_dropped():
     d["unknown_future_field"] = "should be ignored"
     p = ExportPreset.from_dict(d)
     assert not hasattr(p, "unknown_future_field")
+
+
+def test_preset_flat_render_intent_round_trip():
+    p = _make_preset(name="Flat Master", render_intent=RenderIntent.FLAT, export_fmt=ExportFormat.DNG)
+    p2 = ExportPreset.from_dict(p.to_dict())
+    assert p2.render_intent == RenderIntent.FLAT
+    assert p2.export_fmt == ExportFormat.DNG
+
+
+def test_preset_render_intent_defaults_to_print():
+    p = ExportPreset.from_dict(_make_preset().to_dict())
+    assert p.render_intent == RenderIntent.PRINT
+
+
+def test_resolve_preset_export_flat_applies_master_pipeline():
+    loud = replace(
+        WorkspaceConfig(),
+        lab=replace(WorkspaceConfig().lab, saturation=2.0, color_separation=1.5),
+        toning=replace(WorkspaceConfig().toning, sepia_strength=1.0),
+    )
+    preset = _make_preset(render_intent=RenderIntent.FLAT, export_fmt=ExportFormat.TIFF)
+    params, delivery = resolve_preset_export(preset, loud)
+    assert params.exposure.render_intent == RenderIntent.FLAT
+    assert params.exposure.auto_exposure is False
+    assert delivery.export_fmt == ExportFormat.TIFF
+    assert delivery.export_resolution_mode == ExportResolutionMode.ORIGINAL.value
+
+
+def test_resolve_preset_export_print_passthrough():
+    preset = _make_preset(export_fmt=ExportFormat.JPEG)
+    params = WorkspaceConfig()
+    out_params, delivery = resolve_preset_export(preset, params)
+    assert out_params is params
+    assert delivery.export_fmt == ExportFormat.JPEG
+    assert delivery.render_intent == RenderIntent.PRINT
+
+
+def test_flat_export_preset_coerces_delivery_format():
+    preset = _make_preset(render_intent=RenderIntent.FLAT, export_fmt=ExportFormat.JPEG)
+    _, delivery = resolve_preset_export(preset, WorkspaceConfig())
+    assert delivery.export_fmt == ExportFormat.TIFF
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_export_presets.py
+++ b/tests/test_export_presets.py
@@ -19,7 +19,6 @@ from negpy.domain.models import (
     AspectRatio,
     ColorSpace,
     WorkspaceConfig,
-    flat_master_config,
     preset_from_export_config,
     resolve_preset_export,
 )

--- a/tests/test_export_settings_form.py
+++ b/tests/test_export_settings_form.py
@@ -156,3 +156,15 @@ def test_flat_mode_skips_jxl_export_block(qapp):
     form.set_flat_mode(False)
     form.set_flat_mode(True)
     assert not form.is_export_blocked()
+
+
+def test_flat_preset_editor_limits_format_choices(qapp):
+    form = ExportSettingsForm()
+    form.load(_values(export_fmt=ExportFormat.JPEG))
+    form.set_flat_mode(True, preset_editor=True)
+    assert [form.fmt_combo.itemText(i) for i in range(form.fmt_combo.count())] == [
+        ExportFormat.TIFF.value,
+        ExportFormat.DNG.value,
+    ]
+    form.set_flat_mode(False, preset_editor=True)
+    assert ExportFormat.JPEG.value in [form.fmt_combo.itemText(i) for i in range(form.fmt_combo.count())]


### PR DESCRIPTION
## Summary

- Adds **`render_intent`** (`print` | `flat`) to `ExportPreset`, so each preset can declare whether it exports the full print look or a flat log master.
- **Manage Presets → +** now offers **Print preset** and **Flat master preset**; flat presets configure **16-bit TIFF** or **Linear DNG**, plus size, color space, and destination like other presets.
- **Export Presets** runs each enabled preset independently — e.g. JPEG + PNG + Flat Master in one click — without using the main panel Print/Flat toggle (that toggle still only affects **Export** / **Export All**).
- Existing presets default to `print`; no new flat preset is shipped enabled by default.

## Test plan

- [x] Open **Export → Presets → Manage**, click **+**, add a **Flat master preset**; confirm Format is limited to TIFF/DNG and intent label reads “Flat master”.
- [x] Enable **JPEG**, **PNG**, and **Flat Master (flat)**; **Export Presets** on one frame → three files (print JPEG, print PNG, flat TIFF/DNG).
- [x] Duplicate a flat preset; confirm `(flat)` label and settings copy correctly.
- [x] Confirm **Export** / **Export All** still follow the panel **Print / Flat** toggle, not preset intent.
- [x] Run `uv run pytest tests/test_export_presets.py tests/test_export_settings_form.py -q`