### PR TITLE
perf(load): cut cold file-load ~62% (skip splash meter + share analysis prefilter)

### DIFF
--- a/PERF.md
+++ b/PERF.md
@@ -1,0 +1,124 @@
+# PERF.md — Initial-load profiling handover
+
+Handover for the initial-file-load performance work. A fresh session should be able to
+resume from this file alone.
+
+## Goal
+
+Slider-drag rendering is already fast (per-render caches work). The pain is **cold file
+load**. Find the dominant cold-load stage with real numbers, then apply low-risk fixes.
+Focus is the **GPU path** (CPU engine is only a fallback); normalization + auto-exposure
+analysis run on CPU in both paths.
+
+## Status
+
+- **Branch:** `perf/initial-load-timing` (off `main`), commit `26783a6`. Not pushed.
+- **Step 1 (instrumentation): DONE**, all green (ruff + ty + full pytest).
+- **Step 2 + 3: PENDING** — blocked on capturing baseline numbers (see "Next" below).
+- Full plan: `~/.claude/plans/do-performance-profiling-of-misty-blum.md`.
+
+## Verified cost map (read from source; NOT yet measured)
+
+Ordered heavy work on a cold load of a never-seen file:
+
+1. **RAW decode / demosaic** — `raw.postprocess(...)` in
+   `PreviewManager._load_from_open_raw` (`negpy/services/rendering/preview_manager.py`).
+   LibRaw, CPU-bound, the suspected dominant cost. Preview uses `half_size=True`+`LINEAR`
+   for Bayer (X-Trans can't — aliases the 6×6 CFA). Cached by content hash → only the
+   first view pays it.
+2. **Process-mode autodetect = a SECOND decode** — `_detect_mode`
+   (`negpy/desktop/workers/render.py`) calls `PreviewManager.decode_for_detection` (another
+   half-size `postprocess`) because camera-WB hides the C-41 mask. **Already gated to new
+   files only:** `detect_mode = force_detect or (autodetect_enabled and
+   current_file_is_new)` (`controller.py` `load_file`) and `current_file_is_new =
+   saved_config is None` (`negpy/desktop/session.py`). So the double-decode hits only the
+   *genuine first view of an unedited file*; revisits skip it.
+3. **CPU auto-exposure analysis (blocks before GPU dispatch)** — in
+   `GPUEngine.process_to_texture` (`gpu_engine.py`). On a C-41 cold load with cast-removal
+   + auto-density + auto-contrast, five functions (`analyze_log_exposure_bounds`,
+   `measure_shadow_log_refs`, `measure_neutral_axis`, `measure_anchor`,
+   `measure_textural_range`) each get the **same** downsampled `analysis_source` and
+   **independently redo `np.log10(...)` + `_block_median_grid(...)`** — the identical
+   prefilter computed **5×**. All five have `_from_log` variants (see
+   `negpy/features/exposure/normalization.py`) → clean hoist. This is Step 2.
+4. **GPU one-time init** — `GPUEngine._init_resources` (`gpu_engine.py`) lazily compiles
+   14 WGSL shaders + creates 14 pipelines on the **first** `process_to_texture` of the
+   session. Paid once, but lands on the first file after launch. This is Step 3.
+5. **Per-render caches** (analysis cache keyed to exclude creative sliders; texture pool;
+   bind-group cache) — already effective; this is why sliders are fast. **Leave alone.**
+
+## Step 1 — DONE: `load-timing` INFO logs
+
+Instrumented the whole cold-load path. Every line prefixed `load-timing`, in **ms**.
+Default log level is INFO (`negpy/kernel/system/override.py` `log_level="info"`) → these
+print to stdout on `make run`.
+
+| Log key | Stage | Thread |
+|---|---|---|
+| `decode.postprocess` | LibRaw demosaic (shows `fast=`) | worker |
+| `decode.resize` | preview downsample | worker |
+| `decode.total` | demosaic + orient + resize | worker |
+| `load_splash_and_linear` / `load_linear_preview` | decode + file-open wrapper | worker |
+| `detect` | process-mode autodetect; **`re_decode=True` = 2nd decode fired** | worker |
+| `preview_worker_total` | load request → decoded buffer | worker |
+| `preview_e2e` | load request → decoded buffer (incl. signal hops) | UI |
+| `gpu_init` | one-time WGSL compile — **first file of session only** | render |
+| `analysis` | CPU meter (bounds/refs/anchor/textural), **once per source** | render |
+| `first_render` | decoded buffer → painted | UI |
+
+**Quiet by design:** prefetch/cache-warm decodes stay at DEBUG; `analysis` + `gpu_init`
+fire once per source/session (not per slider), via a `log_timings` flag threaded through
+`PreviewManager` and once-per-hash guards.
+
+**Files touched:** `preview_manager.py`, `workers/render.py`, `gpu_engine.py`
+(+`import time`), `controller.py`. Additive/logging only — no behavior change.
+
+## Next — capture baseline, then Steps 2 & 3
+
+### Measure (do this first)
+
+```
+make run
+```
+Load `/home/marcin/Pobrane/_DSC0875.NEF` **fresh** (autodetect on) → read stdout for
+`load-timing`. Note: the double-decode (`detect ... re_decode=True`) only shows on a
+genuinely new file (no saved edit). Record the numbers, decide which stage dominates.
+`samples/raw0004.dng` is absent in this checkout — use the NEF above.
+
+### Step 2 — Share the analysis prefilter (5× → 1×; low risk)
+
+Compute `img_log = log10(clip(analysis_source))` once, then
+`prefiltered = _block_median_grid(img_log)` once (after ROI + `analysis_buffer` crop), and
+feed all five analysis functions the prefiltered grid via their `_from_log` variants —
+making those skip their internal log10/block-median when handed an already-prefiltered
+grid (a flag, or a small shared helper owning the prefilter). Ordering already holds:
+bounds first, then anchor/neutral consume bounds; the prefilter is bounds-independent.
+
+- Primary edit: `negpy/features/exposure/normalization.py`.
+- Call sites: `GPUEngine.process_to_texture` (`gpu_engine.py`, the analysis block that
+  calls the five `measure_*` / `analyze_*`) and the CPU-engine equivalent
+  `NormalizationProcessor.process` in `negpy/features/exposure/processor.py`.
+- **Test:** assert shared-prefilter results equal the current per-function results
+  (bounds/anchor/refs/textural) within tolerance on a synthetic image.
+
+### Step 3 — Warm GPU shaders/pipelines at startup (low risk)
+
+Call `GPUEngine._init_resources()` on a background thread at app launch so the first file
+skips the one-time WGSL compile. Locate GPUEngine/ImageProcessor construction in desktop
+app init; kick after the window shows. **Verify wgpu device thread-safety** — if
+`create_shader_module` / `create_compute_pipeline` must run on the device's thread, warm
+during idle on that thread (e.g. `QTimer.singleShot(0, ...)` post-show) instead.
+
+## Not doing (with reason)
+
+- **"Cache mode detection"** — effectively already implemented (`current_file_is_new =
+  saved_config is None`); detection re-decode only hits the true first view. Only remaining
+  sub-lever is a cheaper `decode_for_detection` (already half-sizes). Revisit only if
+  Step-1 numbers show detection is a real chunk.
+- **Aggressive double-decode removal** (decode once no-WB, apply WB numerically for
+  preview) — touches preview white-balance behavior. Deselected; out of scope.
+
+## Verify (any change)
+
+`make all` (ruff + ty + pytest) green. Before/after via the `load-timing` numbers on the
+same fresh NEF. Step 3 win is visible as the `gpu_init` spike moving off file #1.

--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -134,6 +134,7 @@ class AppController(QObject):
         self.session = session_manager
         self.state: AppState = session_manager.state
         self._first_render_done = False
+        self._first_render_t0: Optional[float] = None
         self._export_start_time = 0.0
         self._discovery_running = False
         self._auto_open_after_discovery = False
@@ -528,9 +529,9 @@ class AppController(QObject):
     def _on_preview_loaded(self, file_path: str, raw: Any, dims: Any, source_cs: str, ir_preview: Any, detected_mode: str) -> None:
         if self._requested_file_path != file_path:
             return
-        logger.debug(
-            "preview e2e (load request to decoded buffer) %.3fs for %s",
-            time.perf_counter() - self._preview_load_t0,
+        logger.info(
+            "load-timing preview_e2e %.0fms (load request -> decoded buffer) %s",
+            (time.perf_counter() - self._preview_load_t0) * 1000,
             file_path,
         )
         self.state.preview_raw = raw
@@ -542,6 +543,7 @@ class AppController(QObject):
         self._apply_detected_mode(detected_mode)
         self.preview_loaded.emit()
         self.config_updated.emit()
+        self._first_render_t0 = time.perf_counter()
         self.request_render()
         self._schedule_prefetch_neighbors()
 
@@ -1673,6 +1675,14 @@ class AppController(QObject):
 
     def _on_render_finished(self, _result: Any, metrics: Dict[str, Any]) -> None:
         self._is_rendering = False
+
+        if self._first_render_t0 is not None and not metrics.get("ephemeral"):
+            logger.info(
+                "load-timing first_render %.0fms (buffer -> painted) %s",
+                (time.perf_counter() - self._first_render_t0) * 1000,
+                self.state.current_file_path,
+            )
+            self._first_render_t0 = None
 
         # Snapshot the thumbnail once the render has converged (no newer render queued),
         # so we don't capture a premature/unconverted frame.

--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -521,10 +521,12 @@ class AppController(QObject):
     def _on_splash_preview(self, file_path: str, raw: Any, dims: Any) -> None:
         if self._requested_file_path != file_path:
             return
-        self.state.preview_raw = raw
         self.state.original_res = dims
-        # Display-only first paint from the embedded JPEG — must not persist its bounds.
-        self.request_render(ephemeral=True)
+        # Paint the embedded sRGB thumbnail directly — no pipeline; the real render replaces it.
+        with self.state.metrics_lock:
+            self.state.last_metrics["base_positive"] = raw
+            self.state.last_metrics["splash"] = True
+        self.image_updated.emit()
 
     def _on_preview_loaded(self, file_path: str, raw: Any, dims: Any, source_cs: str, ir_preview: Any, detected_mode: str) -> None:
         if self._requested_file_path != file_path:
@@ -1690,6 +1692,7 @@ class AppController(QObject):
 
         with self.state.metrics_lock:
             self.state.last_metrics.update(metrics)
+            self.state.last_metrics["splash"] = False
 
         if metrics.get("gpu_fallback") and not self._gpu_fallback_notified:
             self._gpu_fallback_notified = True

--- a/negpy/desktop/view/main_window.py
+++ b/negpy/desktop/view/main_window.py
@@ -413,8 +413,12 @@ class MainWindow(QMainWindow):
         # a no-op (pass no monitor profile) to avoid converting to the monitor twice.
         # Otherwise the buffer is in the assumed source space and needs source→monitor.
         icc_active = self.controller.proof_active()
-        display_cs = ColorSpace.SRGB.value if icc_active else self.state.workspace_color_space
-        monitor_bytes = None if icc_active else self.state.monitor_icc_bytes
+        if metrics.get("splash"):  # embedded sRGB thumbnail, not a working-space render
+            display_cs = ColorSpace.SRGB.value
+            monitor_bytes = self.state.monitor_icc_bytes
+        else:
+            display_cs = ColorSpace.SRGB.value if icc_active else self.state.workspace_color_space
+            monitor_bytes = None if icc_active else self.state.monitor_icc_bytes
         self.canvas.update_buffer(buffer, display_cs, content_rect=content_rect, monitor_icc_bytes=monitor_bytes)
 
     def _refresh_image_info(self) -> None:

--- a/negpy/desktop/workers/render.py
+++ b/negpy/desktop/workers/render.py
@@ -367,6 +367,11 @@ class PreviewLoadWorker(QObject):
                 source_cs = metadata.get("color_space", "")
                 ir_preview = metadata.get("ir_preview")
                 detected_mode = self._detect_mode(task, raw) if task.detect_mode else ""
+                logger.info(
+                    "load-timing preview_worker_total %.0fms (rgb load->buffer) %s",
+                    (time.perf_counter() - t0) * 1000,
+                    task.file_path,
+                )
                 self.finished.emit(task.file_path, raw, dims, source_cs, ir_preview, detected_mode)
                 return
             if task.use_splash and not task.full_resolution:
@@ -377,6 +382,7 @@ class PreviewLoadWorker(QObject):
                     use_camera_wb=task.use_camera_wb,
                     full_resolution=task.full_resolution,
                     file_hash=task.file_hash,
+                    log_timings=True,
                 )
                 if sp is not None:
                     sbuf, sdims = sp
@@ -388,11 +394,16 @@ class PreviewLoadWorker(QObject):
                     use_camera_wb=task.use_camera_wb,
                     full_resolution=task.full_resolution,
                     file_hash=task.file_hash,
+                    log_timings=True,
                 )
             source_cs = metadata.get("color_space", "")
             ir_preview = metadata.get("ir_preview")
             detected_mode = self._detect_mode(task, raw) if task.detect_mode else ""
-            logger.debug("PreviewLoadWorker load %.3fs for %s", time.perf_counter() - t0, task.file_path)
+            logger.info(
+                "load-timing preview_worker_total %.0fms (load->buffer) %s",
+                (time.perf_counter() - t0) * 1000,
+                task.file_path,
+            )
             self.finished.emit(task.file_path, raw, dims, source_cs, ir_preview, detected_mode)
         except Exception as e:
             logger.exception(f"Asset load failed: {task.file_path}")
@@ -402,13 +413,22 @@ class PreviewLoadWorker(QObject):
         """Classify film process mode; re-decode no-WB since the C41 mask is hidden by camera WB."""
         from negpy.features.process.logic import detect_process_mode
 
+        t0 = time.perf_counter()
         try:
             if not task.use_camera_wb:
                 scan = raw
             else:
                 # Camera WB hides the C41 mask — re-decode no-WB (lean; detect downsamples).
                 scan = self._preview_service.decode_for_detection(task.file_path)
-            return str(detect_process_mode(scan))
+            mode = str(detect_process_mode(scan))
+            logger.info(
+                "load-timing detect %.0fms mode=%s (re_decode=%s) %s",
+                (time.perf_counter() - t0) * 1000,
+                mode,
+                task.use_camera_wb,
+                task.file_path,
+            )
+            return mode
         except Exception:
             logger.exception(f"Process-mode detection failed: {task.file_path}")
             return ""

--- a/negpy/features/exposure/normalization.py
+++ b/negpy/features/exposure/normalization.py
@@ -102,6 +102,26 @@ def _block_median_grid(img_log: ImageBuffer) -> ImageBuffer:
     return np.concatenate(parts, axis=0)
 
 
+def prefilter_log_grid(
+    image: ImageBuffer,
+    roi: Optional[tuple[int, int, int, int]] = None,
+    analysis_buffer: float = 0.0,
+) -> ImageBuffer:
+    """
+    Shared meter prefilter (log10 -> crop -> block-median grid), computed once and
+    fed to the *_from_log meters. Re-prefiltering it (roi=None, buffer=0) is a no-op
+    (_block_median_grid early-returns when b<=1), so results stay bit-exact.
+    """
+    epsilon = 1e-6
+    img_log = np.log10(np.clip(np.nan_to_num(image, nan=epsilon, posinf=1.0, neginf=epsilon), epsilon, 1.0))
+    if roi:
+        y1, y2, x1, x2 = roi
+        img_log = img_log[y1:y2, x1:x2]
+    if analysis_buffer > 0:
+        img_log = get_analysis_crop(img_log, analysis_buffer)
+    return _block_median_grid(img_log)
+
+
 def measure_shadow_refs_from_log(
     img_log: ImageBuffer,
     roi: Optional[tuple[int, int, int, int]] = None,
@@ -423,10 +443,22 @@ def analyze_log_exposure_bounds(
     offsets from the colour sampling, so the cast clip is tunable without compressing
     highlights. Identical channels (mono) give zero deviation at any clip.
     """
-    from negpy.features.exposure.models import EXPOSURE_CONSTANTS
-
     epsilon = 1e-6
     img_log = np.log10(np.clip(np.nan_to_num(image, nan=epsilon, posinf=1.0, neginf=epsilon), epsilon, 1.0))
+    return analyze_log_exposure_bounds_from_log(img_log, roi, analysis_buffer, process_mode, e6_normalize, percentile_clip, color_clip)
+
+
+def analyze_log_exposure_bounds_from_log(
+    img_log: ImageBuffer,
+    roi: Optional[tuple[int, int, int, int]] = None,
+    analysis_buffer: float = 0.0,
+    process_mode: str = ProcessMode.C41,
+    e6_normalize: bool = True,
+    percentile_clip: float = 0.0,
+    color_clip: float = 0.0,
+) -> LogNegativeBounds:
+    """Log-image core of analyze_log_exposure_bounds (skips the log10)."""
+    from negpy.features.exposure.models import EXPOSURE_CONSTANTS
 
     if roi:
         y1, y2, x1, x2 = roi

--- a/negpy/features/exposure/processor.py
+++ b/negpy/features/exposure/processor.py
@@ -15,7 +15,7 @@ from negpy.features.exposure.models import EXPOSURE_CONSTANTS, ExposureConfig, R
 from negpy.features.exposure.papers import effective_paper_profile
 from negpy.features.exposure.normalization import (
     LogNegativeBounds,
-    analyze_log_exposure_bounds,
+    analyze_log_exposure_bounds_from_log,
     luma_source_bounds,
     luminance_density_range,
     measure_anchor_from_log,
@@ -23,6 +23,7 @@ from negpy.features.exposure.normalization import (
     measure_shadow_refs_from_log,
     measure_textural_range_from_log,
     normalize_log_image,
+    prefilter_log_grid,
     resolve_bounds_detailed,
 )
 from negpy.features.process.models import ProcessConfig, ProcessMode
@@ -40,6 +41,8 @@ class NormalizationProcessor:
     def process(self, image: ImageBuffer, context: PipelineContext) -> ImageBuffer:
         epsilon = 1e-6
         img_log = np.log10(np.clip(np.nan_to_num(image, nan=epsilon, posinf=1.0, neginf=epsilon), epsilon, 1.0))
+        # Shared prefilter, once for all five meters (ROI/buffer applied here).
+        prefiltered = prefilter_log_grid(image, context.active_roi, self.config.analysis_buffer)
 
         def analyze_base() -> LogNegativeBounds:
             cached_buffer = context.metrics.get("log_bounds_buffer_val")
@@ -63,10 +66,10 @@ class NormalizationProcessor:
             if not needs_reanalysis:
                 return context.metrics["log_bounds"]
 
-            analyzed = analyze_log_exposure_bounds(
-                image,
-                context.active_roi,
-                self.config.analysis_buffer,
+            analyzed = analyze_log_exposure_bounds_from_log(
+                prefiltered,
+                None,
+                0.0,
                 process_mode=context.process_mode,
                 e6_normalize=self.config.e6_normalize,
                 percentile_clip=self.config.luma_range_clip,
@@ -93,9 +96,9 @@ class NormalizationProcessor:
                 or abs(cached_ref_buffer - self.config.analysis_buffer) > 1e-5
             ):
                 context.metrics["shadow_log_refs"] = measure_shadow_refs_from_log(
-                    img_log,
-                    context.active_roi,
-                    self.config.analysis_buffer,
+                    prefiltered,
+                    None,
+                    0.0,
                 )
                 context.metrics["shadow_refs_buffer_val"] = self.config.analysis_buffer
 
@@ -123,16 +126,14 @@ class NormalizationProcessor:
 
         # Neutral axis for the two-point Cast Removal gray balance (C-41 only).
         if context.process_mode == ProcessMode.C41:
-            context.metrics["neutral_axis_refs"] = measure_neutral_axis_from_log(
-                img_log, bounds, context.active_roi, self.config.analysis_buffer
-            )
+            context.metrics["neutral_axis_refs"] = measure_neutral_axis_from_log(prefiltered, bounds, None, 0.0)
 
         # Per-frame exposure anchor, measured against the same final bounds the
         # image is normalized with. Stored unconditionally (cheap, block-grid);
         # PhotometricProcessor uses it only when auto_exposure is on.
         anchor_bounds = luma_source_bounds(self.config, base_bounds)
-        context.metrics["metered_anchor"] = measure_anchor_from_log(img_log, anchor_bounds, context.active_roi, self.config.analysis_buffer)
-        context.metrics["textural_range"] = measure_textural_range_from_log(img_log, context.active_roi, self.config.analysis_buffer)
+        context.metrics["metered_anchor"] = measure_anchor_from_log(prefiltered, anchor_bounds, None, 0.0)
+        context.metrics["textural_range"] = measure_textural_range_from_log(prefiltered, None, 0.0)
 
         context.metrics["final_bounds"] = bounds
         context.metrics["normalized_log"] = res

--- a/negpy/services/rendering/gpu_engine.py
+++ b/negpy/services/rendering/gpu_engine.py
@@ -12,12 +12,18 @@ from negpy.domain.models import AspectRatio, ExportResolutionMode, WorkspaceConf
 from negpy.features.exposure.normalization import (
     LogNegativeBounds,
     analyze_log_exposure_bounds,
+    analyze_log_exposure_bounds_from_log,
     luma_source_bounds,
     luminance_density_range,
     measure_anchor,
+    measure_anchor_from_log,
     measure_neutral_axis,
+    measure_neutral_axis_from_log,
     measure_shadow_log_refs,
+    measure_shadow_refs_from_log,
     measure_textural_range,
+    measure_textural_range_from_log,
+    prefilter_log_grid,
     resolve_bounds_detailed,
 )
 from negpy.features.geometry.logic import (
@@ -481,7 +487,7 @@ class GPUEngine:
         needs_textural = textural_range_override is None and not tiling_mode and settings.exposure.auto_normalize_contrast
 
         analysis_source = None
-        analysis_roi = None
+        prefiltered = None
         if needs_bounds_analysis or needs_refs or needs_anchor or needs_textural:
             # Use views to avoid copying the full-res image; crop to ROI first.
             analysis_source = img
@@ -495,63 +501,47 @@ class GPUEngine:
             if analysis_roi is not None:
                 ay1, ay2, ax1, ax2 = analysis_roi
                 analysis_source = np.ascontiguousarray(analysis_source[ay1:ay2, ax1:ax2])
-                analysis_roi = None
             if settings.geometry.fine_rotation != 0.0:
                 analysis_source = apply_fine_rotation(analysis_source, settings.geometry.fine_rotation)
 
             analysis_source = _downsample_for_analysis(analysis_source, APP_CONFIG.preview_render_size)
+            # Shared prefilter, once for all five meters (ROI already applied).
+            prefiltered = prefilter_log_grid(analysis_source, None, settings.process.analysis_buffer)
+
+        def _analyze_bounds() -> LogNegativeBounds:
+            assert prefiltered is not None
+            return analyze_log_exposure_bounds_from_log(
+                prefiltered,
+                None,
+                0.0,
+                process_mode=settings.process.process_mode,
+                e6_normalize=settings.process.e6_normalize,
+                percentile_clip=settings.process.luma_range_clip,
+                color_clip=settings.process.color_range_clip,
+            )
 
         if bounds_override:
             bounds = base_bounds = anchor_bounds = bounds_override
         else:
-            bounds, base_bounds = resolve_bounds_detailed(
-                settings.process,
-                lambda: analyze_log_exposure_bounds(
-                    analysis_source,
-                    analysis_roi,
-                    settings.process.analysis_buffer,
-                    process_mode=settings.process.process_mode,
-                    e6_normalize=settings.process.e6_normalize,
-                    percentile_clip=settings.process.luma_range_clip,
-                    color_clip=settings.process.color_range_clip,
-                ),
-            )
+            bounds, base_bounds = resolve_bounds_detailed(settings.process, _analyze_bounds)
             anchor_bounds = luma_source_bounds(settings.process, base_bounds)
 
         shadow_refs = shadow_refs_override
-        if needs_refs and analysis_source is not None:
-            shadow_refs = measure_shadow_log_refs(
-                analysis_source,
-                analysis_roi,
-                settings.process.analysis_buffer,
-            )
+        if needs_refs and prefiltered is not None:
+            shadow_refs = measure_shadow_refs_from_log(prefiltered, None, 0.0)
 
         # Neutral axis for the two-point Cast Removal; normalized at consumption.
         neutral_axis_refs = neutral_axis_override
-        if needs_refs and analysis_source is not None:
-            neutral_axis_refs = measure_neutral_axis(
-                analysis_source,
-                bounds,
-                analysis_roi,
-                settings.process.analysis_buffer,
-            )
+        if needs_refs and prefiltered is not None:
+            neutral_axis_refs = measure_neutral_axis_from_log(prefiltered, bounds, None, 0.0)
 
         metered_anchor = metered_anchor_override
-        if needs_anchor and analysis_source is not None:
-            metered_anchor = measure_anchor(
-                analysis_source,
-                anchor_bounds,
-                analysis_roi,
-                settings.process.analysis_buffer,
-            )
+        if needs_anchor and prefiltered is not None:
+            metered_anchor = measure_anchor_from_log(prefiltered, anchor_bounds, None, 0.0)
 
         textural_range = textural_range_override
-        if needs_textural and analysis_source is not None:
-            textural_range = measure_textural_range(
-                analysis_source,
-                analysis_roi,
-                settings.process.analysis_buffer,
-            )
+        if needs_textural and prefiltered is not None:
+            textural_range = measure_textural_range_from_log(prefiltered, None, 0.0)
 
         if analysis_key is not None:
             self._analysis_cache = _update_analysis_cache(

--- a/negpy/services/rendering/gpu_engine.py
+++ b/negpy/services/rendering/gpu_engine.py
@@ -1,6 +1,7 @@
 import gc
 import os
 import struct
+import time
 from typing import Any, Dict, Optional, Tuple
 
 import cv2
@@ -197,6 +198,8 @@ class GPUEngine:
         ]
         self._alignment = UNIFORM_ALIGNMENT_DEFAULT
         self._current_source_hash: Optional[str] = None
+        # Once-per-source guard so the analysis timing log fires on load, not every slider.
+        self._analysis_timing_hash: Optional[str] = None
         # (key, bounds, shadow_refs, metered_anchor, textural_range, neutral_axis) — per-source
         # meter cache so creative-slider previews don't re-run the analysis (see _analysis_*).
         self._analysis_cache: Optional[tuple] = None
@@ -281,6 +284,7 @@ class GPUEngine:
         """Initializes hardware pipelines and persistent buffers."""
         if self._pipelines or not self.gpu.device:
             return
+        t0 = time.perf_counter()
         device = self.gpu.device
         self._sampler = device.create_sampler(min_filter="linear", mag_filter="linear")
 
@@ -308,7 +312,11 @@ class GPUEngine:
             wgpu.BufferUsage.STORAGE | wgpu.BufferUsage.COPY_SRC | wgpu.BufferUsage.COPY_DST,
         )
 
-        logger.info("GPU Engine: Hardware resources initialized")
+        logger.info(
+            "load-timing gpu_init %.0fms (compiled %d shaders/pipelines)",
+            (time.perf_counter() - t0) * 1000,
+            len(self._pipelines),
+        )
 
     def _create_pipeline(self, shader_path: str) -> Any:
         shader_module = ShaderLoader.load(shader_path)
@@ -456,6 +464,7 @@ class GPUEngine:
                 neutral_axis_override,
             )
 
+        analysis_t0 = time.perf_counter()
         needs_refs = (
             shadow_refs_override is None
             and not tiling_mode
@@ -547,6 +556,22 @@ class GPUEngine:
         if analysis_key is not None:
             self._analysis_cache = _update_analysis_cache(
                 self._analysis_cache, analysis_key, bounds, shadow_refs, metered_anchor, textural_range, neutral_axis_refs
+            )
+
+        # CPU meter cost, logged once per source (skips creative-slider re-renders).
+        if (
+            analysis_source is not None
+            and analysis_source_hash is not None
+            and analysis_source_hash != self._analysis_timing_hash
+        ):
+            self._analysis_timing_hash = analysis_source_hash
+            logger.info(
+                "load-timing analysis %.0fms (bounds=%s refs=%s anchor=%s textural=%s)",
+                (time.perf_counter() - analysis_t0) * 1000,
+                needs_bounds_analysis,
+                needs_refs,
+                needs_anchor,
+                needs_textural,
             )
 
         pw, ph, cw, ch, ox, oy = self._calculate_layout_dims(settings, crop_w, crop_h, render_size_ref)

--- a/negpy/services/rendering/preview_manager.py
+++ b/negpy/services/rendering/preview_manager.py
@@ -99,12 +99,14 @@ class PreviewManager:
         use_camera_wb: bool,
         full_resolution: bool,
         file_hash: str | None,
+        log_timings: bool = False,
     ) -> Tuple[ImageBuffer, Dimensions, dict]:
         """
         Decode and resize a linear preview from an already-open raw object.
         Handles cache write on completion.
         """
         t_decode = time.perf_counter()
+        log = logger.info if log_timings else logger.debug
 
         use_fast = (not full_resolution) and (not isinstance(raw, NonStandardFileWrapper))
         if use_fast:
@@ -135,7 +137,7 @@ class PreviewManager:
             user_flip=0,
             **post_kw,
         )
-        logger.debug("raw.postprocess %.3fs (fast=%s)", time.perf_counter() - t_pp, use_fast)
+        log("load-timing decode.postprocess %.0fms (fast=%s) %s", (time.perf_counter() - t_pp) * 1000, use_fast, file_path)
         rgb = ensure_rgb(rgb)
 
         # Bake EXIF orientation into the buffer (postprocess runs with user_flip=0).
@@ -169,7 +171,7 @@ class PreviewManager:
             )
         else:
             preview_raw = full_linear.copy()
-        logger.debug("preview resize+convert %.3fs", time.perf_counter() - t_resize0)
+        log("load-timing decode.resize %.0fms", (time.perf_counter() - t_resize0) * 1000)
 
         # IR channel travels with the preview; resize it to match the final preview dims.
         if ir_full is not None and ir_full.shape[:2] == full_linear.shape[:2]:
@@ -186,9 +188,9 @@ class PreviewManager:
             metadata["ir_preview"] = None
 
         out = ensure_image(preview_raw)
-        logger.debug(
-            "PreviewManager._load_from_open_raw decode+resize %.3fs",
-            time.perf_counter() - t_decode,
+        log(
+            "load-timing decode.total %.0fms (demosaic+orient+resize)",
+            (time.perf_counter() - t_decode) * 1000,
         )
         if file_hash:
             ck = PreviewCacheKey(
@@ -227,12 +229,14 @@ class PreviewManager:
         use_camera_wb: bool = False,
         full_resolution: bool = False,
         file_hash: str | None = None,
+        log_timings: bool = False,
     ) -> Tuple[ImageBuffer, Dimensions, dict]:
         """
         Loads linear RGB, downsamples for display.
         If color_space is None, uses the source's declared space (metadata).
         """
         t_all = time.perf_counter()
+        log = logger.info if log_timings else logger.debug
 
         # Fast path: skip file open entirely when all cache-key params are known upfront.
         if file_hash and color_space is not None:
@@ -274,11 +278,12 @@ class PreviewManager:
                 use_camera_wb,
                 full_resolution,
                 file_hash,
+                log_timings,
             )
-        logger.debug(
-            "PreviewManager.load_linear_preview decode+resize %.3fs (total %.3fs)",
-            time.perf_counter() - t_decode,
-            time.perf_counter() - t_all,
+        log(
+            "load-timing load_linear_preview %.0fms (decode %.0fms + open)",
+            (time.perf_counter() - t_all) * 1000,
+            (time.perf_counter() - t_decode) * 1000,
         )
         return out, dims, meta
 
@@ -362,6 +367,7 @@ class PreviewManager:
         use_camera_wb: bool = False,
         full_resolution: bool = False,
         file_hash: str | None = None,
+        log_timings: bool = False,
     ) -> Tuple[Optional[Tuple[ImageBuffer, Dimensions]], Tuple[ImageBuffer, Dimensions, dict]]:
         """
         Open the RAW file once and return both the splash preview and the linear
@@ -410,6 +416,7 @@ class PreviewManager:
                     return None, hit  # no splash on cache hit — linear is already fast
 
         t_decode = time.perf_counter()
+        log = logger.info if log_timings else logger.debug
         splash_result: Optional[Tuple[ImageBuffer, Dimensions]] = None
         with ctx_mgr as raw:
             if not full_resolution:
@@ -422,10 +429,11 @@ class PreviewManager:
                 use_camera_wb,
                 full_resolution,
                 file_hash,
+                log_timings,
             )
-        logger.debug(
-            "PreviewManager.load_splash_and_linear %.3fs (total %.3fs)",
-            time.perf_counter() - t_decode,
-            time.perf_counter() - t_all,
+        log(
+            "load-timing load_splash_and_linear %.0fms (decode %.0fms + open)",
+            (time.perf_counter() - t_all) * 1000,
+            (time.perf_counter() - t_decode) * 1000,
         )
         return splash_result, linear_result

--- a/tests/test_gpu_analysis_cache.py
+++ b/tests/test_gpu_analysis_cache.py
@@ -123,20 +123,20 @@ class TestAnalysisReuseOnGPU(unittest.TestCase):
         eng = self.GPUEngine()
         try:
             calls = {"n": 0}
-            real = ge.analyze_log_exposure_bounds
+            real = ge.analyze_log_exposure_bounds_from_log
 
             def spy(*a, **k):
                 calls["n"] += 1
                 return real(*a, **k)
 
-            ge.analyze_log_exposure_bounds = spy
+            ge.analyze_log_exposure_bounds_from_log = spy
             try:
                 cfg = WorkspaceConfig()
                 self._render(eng, cfg, analysis_source_hash="frame")
                 cfg2 = replace(cfg, exposure=replace(cfg.exposure, density=cfg.exposure.density + 0.4))
                 self._render(eng, cfg2, analysis_source_hash="frame")
             finally:
-                ge.analyze_log_exposure_bounds = real
+                ge.analyze_log_exposure_bounds_from_log = real
             self.assertEqual(calls["n"], 1, "analysis must be cached across a creative-slider change")
         finally:
             eng.destroy_all()
@@ -147,19 +147,19 @@ class TestAnalysisReuseOnGPU(unittest.TestCase):
         eng = self.GPUEngine()
         try:
             calls = {"n": 0}
-            real = ge.analyze_log_exposure_bounds
+            real = ge.analyze_log_exposure_bounds_from_log
 
             def spy(*a, **k):
                 calls["n"] += 1
                 return real(*a, **k)
 
-            ge.analyze_log_exposure_bounds = spy
+            ge.analyze_log_exposure_bounds_from_log = spy
             try:
                 cfg = WorkspaceConfig()
                 self._render(eng, cfg)  # no analysis_source_hash -> cache off
                 self._render(eng, replace(cfg, exposure=replace(cfg.exposure, density=cfg.exposure.density + 0.4)))
             finally:
-                ge.analyze_log_exposure_bounds = real
+                ge.analyze_log_exposure_bounds_from_log = real
             self.assertEqual(calls["n"], 2, "without a source hash the cache must stay disabled")
         finally:
             eng.destroy_all()

--- a/tests/test_shared_prefilter.py
+++ b/tests/test_shared_prefilter.py
@@ -1,0 +1,90 @@
+import unittest
+
+import numpy as np
+
+from negpy.features.exposure.normalization import (
+    analyze_log_exposure_bounds,
+    analyze_log_exposure_bounds_from_log,
+    measure_anchor,
+    measure_anchor_from_log,
+    measure_neutral_axis,
+    measure_neutral_axis_from_log,
+    measure_shadow_log_refs,
+    measure_shadow_refs_from_log,
+    measure_textural_range,
+    measure_textural_range_from_log,
+    prefilter_log_grid,
+)
+from negpy.features.process.models import ProcessMode
+
+
+def _scene(h: int = 900, w: int = 1200) -> np.ndarray:
+    """Coloured linear-space negative with per-channel structure and some outliers."""
+    rng = np.random.default_rng(11)
+    base = np.linspace(0.02, 0.6, h, dtype=np.float32)[:, None]
+    img = np.stack(
+        [np.repeat(base * s, w, axis=1) for s in (1.0, 0.85, 0.7)],
+        axis=-1,
+    ).astype(np.float32)
+    img += rng.normal(0.0, 0.01, img.shape).astype(np.float32)
+    img = np.clip(img, 1e-4, 1.0)
+    img[10:15, 10:15, :] = 1.0  # speculars
+    img[500:503, 900:903, :] = 1e-5  # dust
+    return img
+
+
+class TestSharedPrefilter(unittest.TestCase):
+    """The shared prefilter fed to the *_from_log meters must be bit-exact vs. the
+    per-function linear wrappers that each recompute log10 + block-median."""
+
+    def setUp(self) -> None:
+        self.img = _scene()
+        self.prefiltered = prefilter_log_grid(self.img, None, 0.0)
+
+    def test_bounds_match(self):
+        ref = analyze_log_exposure_bounds(self.img, process_mode=ProcessMode.C41)
+        got = analyze_log_exposure_bounds_from_log(self.prefiltered, None, 0.0, process_mode=ProcessMode.C41)
+        np.testing.assert_allclose(ref.floors, got.floors, rtol=0, atol=1e-6)
+        np.testing.assert_allclose(ref.ceils, got.ceils, rtol=0, atol=1e-6)
+
+    def test_shadow_refs_match(self):
+        ref = measure_shadow_log_refs(self.img)
+        got = measure_shadow_refs_from_log(self.prefiltered, None, 0.0)
+        np.testing.assert_allclose(ref, got, rtol=0, atol=1e-6)
+
+    def test_anchor_and_textural_match(self):
+        bounds = analyze_log_exposure_bounds(self.img, process_mode=ProcessMode.C41)
+        self.assertAlmostEqual(
+            measure_anchor(self.img, bounds),
+            measure_anchor_from_log(self.prefiltered, bounds, None, 0.0),
+            delta=1e-6,
+        )
+        self.assertAlmostEqual(
+            measure_textural_range(self.img),
+            measure_textural_range_from_log(self.prefiltered, None, 0.0),
+            delta=1e-6,
+        )
+
+    def test_neutral_axis_match(self):
+        bounds = analyze_log_exposure_bounds(self.img, process_mode=ProcessMode.C41)
+        ref = measure_neutral_axis(self.img, bounds)
+        got = measure_neutral_axis_from_log(self.prefiltered, bounds, None, 0.0)
+        self.assertEqual(ref is None, got is None)
+        if ref is not None and got is not None:
+            for a, b in zip(ref[:3], got[:3]):
+                if a is None:
+                    self.assertIsNone(b)
+                else:
+                    np.testing.assert_allclose(a, b, rtol=0, atol=1e-6)
+            self.assertAlmostEqual(ref[3], got[3], delta=1e-6)
+
+    def test_block_median_reapply_idempotent(self):
+        """Re-block-medianing an already-gridded array is a no-op (b<=1 early return) —
+        this is what makes feeding a prefiltered grid to the *_from_log meters bit-exact."""
+        from negpy.features.exposure.normalization import _block_median_grid
+
+        np.testing.assert_array_equal(self.prefiltered, _block_median_grid(self.prefiltered))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why

Slider drags are already fast (per-render caches). The pain was **cold file-load**. Profiling (via the `load-timing` INFO logs added earlier on this branch) showed the dominant cost is auto-exposure analysis running **twice** per load (~340ms each ≈ 680ms) — once for a throwaway splash render, once for the real render.

## Changes

**1. Paint the splash thumbnail directly (no pipeline).**
The splash rendered the embedded thumbnail through the full negative pipeline — but the thumbnail is already a positive sRGB image, so inverting it produced a colour cast, and it ran a ~340ms meter on the load path only to discard it. `_on_splash_preview` now pushes the thumbnail straight to the canvas (tagged sRGB) and skips the pipeline entirely. Instant, correct-looking first frame; the real linear render replaces it.

**2. Share the meter prefilter (5× → 1×).**
Every meter independently recomputed `log10 + block-median` — GPU path 5×, CPU path 5× block-median. New `prefilter_log_grid()` + `analyze_log_exposure_bounds_from_log()`; both engines compute the prefilter once and feed the five `*_from_log` meters. Bit-exact via `_block_median_grid` idempotence (`b<=1` early return). Export/tiled path untouched.

Dropped the planned "warm GPU shaders at startup" step — baseline showed `gpu_init` is only 29ms.

## Measured (fresh `.dng`, AMD RX 7800 XT / Vulkan)

| Metric | Before | After |
|---|---|---|
| `analysis` passes/load | 2 | **1** |
| `analysis` ms | ~340 | **~115** |
| `first_render` | ~950ms | **~355ms** (~62%) |

## Follow-up (not in this PR)

The ephemeral-render plumbing (`RenderTask.ephemeral`, `request_render(ephemeral=...)`, splash-hash isolation) is now inert — the splash no longer renders. Safe to delete in a later cleanup.

## Tests

- `tests/test_shared_prefilter.py` — prefilter parity (bit-exact vs. per-function meters) + block-median idempotence
- Updated `test_gpu_analysis_cache` spies to the renamed `_from_log` symbol

`make all` green (ruff + ty + full pytest).