### PR TITLE
fix(ui): stack right-panel collapsibles at content height

### DIFF
--- a/negpy/desktop/view/sidebar/controls_panel.py
+++ b/negpy/desktop/view/sidebar/controls_panel.py
@@ -2,7 +2,7 @@ from PyQt6.QtWidgets import (
     QWidget,
     QVBoxLayout,
 )
-from PyQt6.QtCore import Qt, QTimer, pyqtSignal
+from PyQt6.QtCore import QTimer, pyqtSignal
 import qtawesome as qta
 
 from negpy.desktop.controller import AppController
@@ -210,11 +210,11 @@ class ControlsPanel(QWidget):
         for key, icon_name, tooltip, sections, section_attrs in groups:
             page = QWidget()
             page_layout = QVBoxLayout(page)
-            page_layout.setAlignment(Qt.AlignmentFlag.AlignTop)
             page_layout.setContentsMargins(0, 0, 0, 0)
             page_layout.setSpacing(8)
             for section in sections:
                 page_layout.addWidget(section)
+            page_layout.addStretch(1)
             self.pages.append(
                 {
                     "key": key,


### PR DESCRIPTION
## What

Right-panel workflow tabs (Setup / Geometry / Tone / Color / Finish) split their vertical space evenly across the multiple collapsible sections instead of sizing each to its controls.

## Why

Each tab page relied on `QVBoxLayout.setAlignment(AlignTop)` — a no-op for a layout installed directly on a widget. The page sits in a `setWidgetResizable(True)` scroll area, so it stretches taller than content and the layout hands the surplus height out equally across the `Preferred`-policy sections.

## Fix

Drop the ineffective `setAlignment` (and its now-orphaned `Qt` import) and absorb the extra height with a trailing `addStretch(1)`. Sections now hug their content and stack top-to-bottom; blank space collects at the bottom.

`CollapsibleSection` itself is untouched — the Analysis section still expands in its splitter as before.