### PR TITLE
fix: stop roll-average baseline leaking onto other rolls

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Change: **Lock Bounds** is now a labeled button beside Linear RAW in the Process panel, instead of a small icon squeezed next to the process dropdown.
 - Fix: the **GPU histogram** was binning scene-linear values since the scene-linear pipeline rework (0.30.0), reading darker than the CPU one — both now bin the display-encoded image.
 - Fix: the bundled **RGBScan input ICC profile** used an sRGB TRC instead of the gamma 2.2 curve NegPy's pipeline expects at that stage, lifting the toe and giving a washed-out look — rebuilt to match, same colour transform. @thetalkingdrum
+- Fix: a **roll's Batch Analysis baseline no longer leaks onto other rolls** — the roll-wide bounds and colour balance were being remembered globally and quietly applied to every freshly opened file, so a different film stock (e.g. mask-less Phoenix II) came up with a heavy cast until you hit Reset. The baseline now stays with the roll it was measured on; open a new roll and it meters per frame again.
 
 ## 0.32.1
 

--- a/negpy/desktop/session.py
+++ b/negpy/desktop/session.py
@@ -495,17 +495,8 @@ class DesktopSessionManager(QObject):
         sticky_buffer = self.repo.get_global_setting("last_analysis_buffer")
         sticky_luma_range_clip = self.repo.get_global_setting("last_luma_range_clip")
         sticky_color_range_clip = self.repo.get_global_setting("last_color_range_clip")
-        sticky_legacy_average = self.repo.get_global_setting("last_use_roll_average")
-        sticky_luma_average = self.repo.get_global_setting("last_use_luma_average")
-        sticky_colour_average = self.repo.get_global_setting("last_use_colour_average")
-        # Legacy single roll-average sticky: apply to both axes if the split keys are absent.
-        if sticky_luma_average is None:
-            sticky_luma_average = sticky_legacy_average
-        if sticky_colour_average is None:
-            sticky_colour_average = sticky_legacy_average
-        sticky_floors = self.repo.get_global_setting("last_locked_floors")
-        sticky_ceils = self.repo.get_global_setting("last_locked_ceils")
-        sticky_roll_name = self.repo.get_global_setting("last_roll_name")
+        # Roll-average baseline is roll-scoped (written per-file by Batch Analysis /
+        # a saved roll), never seeded onto fresh files.
         sticky_crosstalk_strength = self.repo.get_global_setting("last_crosstalk_strength")
         sticky_crosstalk_matrix = self.repo.get_global_setting("last_crosstalk_matrix")
         sticky_crosstalk_profile = self.repo.get_global_setting("last_crosstalk_profile")
@@ -519,16 +510,6 @@ class DesktopSessionManager(QObject):
             new_process = replace(new_process, luma_range_clip=float(sticky_luma_range_clip))
         if sticky_color_range_clip is not None:
             new_process = replace(new_process, color_range_clip=float(sticky_color_range_clip))
-        if sticky_luma_average is not None:
-            new_process = replace(new_process, use_luma_average=bool(sticky_luma_average))
-        if sticky_colour_average is not None:
-            new_process = replace(new_process, use_colour_average=bool(sticky_colour_average))
-        if sticky_floors:
-            new_process = replace(new_process, locked_floors=tuple(sticky_floors))
-        if sticky_ceils:
-            new_process = replace(new_process, locked_ceils=tuple(sticky_ceils))
-        if sticky_roll_name:
-            new_process = replace(new_process, roll_name=str(sticky_roll_name))
         if sticky_crosstalk_strength is not None:
             new_process = replace(new_process, crosstalk_strength=float(sticky_crosstalk_strength))
         if sticky_crosstalk_matrix:
@@ -612,11 +593,6 @@ class DesktopSessionManager(QObject):
                 "last_analysis_buffer": config.process.analysis_buffer,
                 "last_luma_range_clip": config.process.luma_range_clip,
                 "last_color_range_clip": config.process.color_range_clip,
-                "last_use_luma_average": config.process.use_luma_average,
-                "last_use_colour_average": config.process.use_colour_average,
-                "last_locked_floors": config.process.locked_floors,
-                "last_locked_ceils": config.process.locked_ceils,
-                "last_roll_name": config.process.roll_name,
                 "last_crosstalk_strength": config.process.crosstalk_strength,
                 "last_crosstalk_matrix": config.process.crosstalk_matrix,
                 "last_crosstalk_profile": config.process.crosstalk_profile,

--- a/tests/test_desktop_session.py
+++ b/tests/test_desktop_session.py
@@ -85,6 +85,60 @@ class TestDesktopSessionSync(unittest.TestCase):
         self.assertTrue(config.exposure.surround)
         self.assertEqual(config.exposure.paper_profile, "ilford_mg_rc")
 
+    def test_roll_average_not_seeded_onto_fresh_files(self):
+        # A roll baseline must not leak onto a fresh (sidecar-less) file.
+        sticky = {
+            "last_export_config": {},
+            "last_use_luma_average": True,
+            "last_use_colour_average": True,
+            "last_locked_floors": [0.1, 0.2, 0.3],
+            "last_locked_ceils": [1.1, 1.2, 1.3],
+            "last_roll_name": "roll-A",
+        }
+        self.mock_repo.get_global_setting.side_effect = lambda key, default=None: sticky.get(key, default)
+        config = self.session._apply_sticky_settings(WorkspaceConfig(), only_global=False)
+        self.assertFalse(config.process.use_luma_average)
+        self.assertFalse(config.process.use_colour_average)
+        self.assertFalse(config.process.is_locked_initialized)
+        self.assertIsNone(config.process.roll_name)
+
+    def test_roll_average_not_persisted_as_global_sticky(self):
+        # The five roll-average keys must no longer be written to global settings.
+        self.session.select_file(0)
+        self.mock_repo.save_global_settings.reset_mock()
+        base = self.session.state.config
+        loaded = replace(
+            base,
+            process=replace(
+                base.process,
+                use_luma_average=True,
+                use_colour_average=True,
+                locked_floors=(0.1, 0.2, 0.3),
+                locked_ceils=(1.1, 1.2, 1.3),
+                roll_name="roll-A",
+            ),
+        )
+        self.session.update_config(loaded, persist=True)
+        saved = self.mock_repo.save_global_settings.call_args.args[0]
+        for key in ("last_use_luma_average", "last_use_colour_average", "last_locked_floors", "last_locked_ceils", "last_roll_name"):
+            self.assertNotIn(key, saved)
+
+    def test_saved_file_keeps_its_own_roll_baseline(self):
+        # A file whose own config carries the baseline (only_global=True) is untouched.
+        base = WorkspaceConfig(
+            process=replace(
+                WorkspaceConfig().process,
+                use_luma_average=True,
+                use_colour_average=True,
+                locked_floors=(0.1, 0.2, 0.3),
+                locked_ceils=(1.1, 1.2, 1.3),
+            )
+        )
+        self.mock_repo.get_global_setting.side_effect = lambda key, default=None: {"last_export_config": {}}.get(key, default)
+        config = self.session._apply_sticky_settings(base, only_global=True)
+        self.assertTrue(config.process.use_luma_average)
+        self.assertTrue(config.process.is_locked_initialized)
+
     def test_processing_toggles_not_applied_to_edited_files(self):
         # only_global=True (file has a sidecar) must not override per-file toggles.
         sticky = {"last_export_config": {}, "last_auto_exposure": True}


### PR DESCRIPTION
## Problem

Fixes #387. On film without an orange mask (e.g. Harman Phoenix II) a freshly opened frame comes up with a heavy red/warm cast. "Reset settings" on one frame snaps it to the correct look, and every frame opened after that comes up correct too.

## Root cause

The roll-average normalization baseline was **global-sticky**. Batch Analysis (`_on_normalization_finished`) sets `use_luma_average` / `use_colour_average` / `locked_floors` / `locked_ceils` / `roll_name`, then `_persist_sticky_settings` wrote those to global settings. Every fresh, never-edited file loaded afterward went through `_apply_sticky_settings(only_global=False)`, which re-seeded them onto the clean config — so a baseline measured on one roll (masked stock) was applied to a different stock (mask-less), which is the wrong normalization → cast.

"Reset settings" happened to persist the off-state back to those global keys, which is why it fixed every file opened afterward (the "3rd state" the reporter saw).

## Fix

Roll-average is roll-scoped, not a global default. Batch Analysis / a saved roll already write the baseline into **every loaded frame's own config**, so a fresh (never-seen) file never needs the global seed. Dropped the global sticky read (`_apply_sticky_settings`) and write (`_persist_sticky_settings`) for those five keys. Fresh files meter per-frame again; stale keys in existing users' DBs simply go unread (no migration needed).

Accepted cost: a same-roll frame loaded *after* Batch Analysis no longer auto-inherits — re-run Batch Analysis or apply a saved roll.

## Tests

- Fresh file rejects the roll-average sticky even when present in global settings.
- The five keys are no longer persisted to global settings.
- A file whose own config carries the baseline still loads it (`only_global=True` untouched).

`make lint` / `make type` / full suite (1102 passed) green.