### PR TITLE
Feature/exclude image option

### DIFF
--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -1325,6 +1325,12 @@ class AppController(QObject):
     def _enabled_presets(self) -> List[ExportPreset]:
         return [p for p in self.state.export_presets if p.enabled]
 
+    def _exportable_visible_files(self) -> list[dict]:
+        return [
+            self.state.uploaded_files[i]
+            for i in self.session.asset_model.exportable_visible_indices_ordered()
+        ]
+
     def _validate_preset_paths(self, presets: List[ExportPreset]) -> bool:
         """Returns True if all absolute-path presets have a valid directory configured."""
         from PyQt6.QtWidgets import QFileDialog
@@ -1456,7 +1462,11 @@ class AppController(QObject):
 
     def request_export_selected(self) -> None:
         """Batch-exports the currently selected files using each file's own saved settings."""
-        selected = [self.state.uploaded_files[i] for i in self.state.selected_indices if 0 <= i < len(self.state.uploaded_files)]
+        selected = [
+            self.state.uploaded_files[i]
+            for i in self.state.selected_indices
+            if 0 <= i < len(self.state.uploaded_files) and not self.state.uploaded_files[i].get("excluded")
+        ]
         self.request_batch_export(files=selected)
 
     def request_batch_export(self, override_settings: bool = False, files: list[dict] | None = None) -> None:
@@ -1471,7 +1481,12 @@ class AppController(QObject):
         sync_metadata = self.state.config.metadata.sync_to_batch
 
         if files is None:
-            files = [self.state.uploaded_files[i] for i in self.session.asset_model.visible_actual_indices_ordered()]
+            files = self._exportable_visible_files()
+        else:
+            files = [f for f in files if not f.get("excluded")]
+
+        if not files:
+            return
 
         if self.state.config.export.export_sidecars_enabled:
             self._write_edit_sidecars(files)
@@ -1562,8 +1577,13 @@ class AppController(QObject):
             return
 
         sync_metadata = self.state.config.metadata.sync_to_batch
-        visible_files = [self.state.uploaded_files[i] for i in self.session.asset_model.visible_actual_indices_ordered()]
+        visible_files = self._exportable_visible_files()
         if not visible_files:
+            QMessageBox.information(
+                None,
+                "No files to export",
+                "All visible frames are excluded from batch export.",
+            )
             return
 
         n_frames = len(visible_files)
@@ -1622,7 +1642,7 @@ class AppController(QObject):
 
     def request_contact_sheet(self) -> None:
         """Renders all visible files small and writes darkroom contact sheet(s)."""
-        visible_files = [self.state.uploaded_files[i] for i in self.session.asset_model.visible_actual_indices_ordered()]
+        visible_files = self._exportable_visible_files()
         if not visible_files:
             return
 
@@ -1673,7 +1693,7 @@ class AppController(QObject):
 
     def export_edit_sidecars(self) -> None:
         """Explicit batch sidecar export for all visible files (ignores the on-export toggle)."""
-        visible_files = [self.state.uploaded_files[i] for i in self.session.asset_model.visible_actual_indices_ordered()]
+        visible_files = self._exportable_visible_files()
         if not visible_files:
             return
         written = self._write_edit_sidecars(visible_files)

--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -1563,6 +1563,24 @@ class AppController(QObject):
 
         sync_metadata = self.state.config.metadata.sync_to_batch
         visible_files = [self.state.uploaded_files[i] for i in self.session.asset_model.visible_actual_indices_ordered()]
+        if not visible_files:
+            return
+
+        n_frames = len(visible_files)
+        n_presets = len(presets)
+        n_files = n_frames * n_presets
+        frame_word = "frame" if n_frames == 1 else "frames"
+        preset_word = "preset" if n_presets == 1 else "presets"
+        file_word = "file" if n_files == 1 else "files"
+        reply = QMessageBox.question(
+            None,
+            "Export All Presets",
+            f"Export {n_frames} {frame_word} through {n_presets} {preset_word} ({n_files} {file_word})?",
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.Cancel,
+            QMessageBox.StandardButton.Cancel,
+        )
+        if reply != QMessageBox.StandardButton.Yes:
+            return
 
         if self.state.config.export.export_sidecars_enabled:
             self._write_edit_sidecars(visible_files)

--- a/negpy/desktop/session.py
+++ b/negpy/desktop/session.py
@@ -10,7 +10,7 @@ from PyQt6.QtCore import QAbstractListModel, QModelIndex, QObject, Qt, pyqtSigna
 from negpy.domain.models import ExportPreset, WorkspaceConfig
 from negpy.infrastructure.storage.repository import StorageRepository
 from negpy.kernel.system.config import APP_CONFIG
-from negpy.services.assets.sidecar import load_or_promote
+from negpy.services.assets.sidecar import load_or_promote, sidecar_path_for, write_sidecar
 
 
 class ToolMode(Enum):
@@ -108,6 +108,8 @@ class AssetListModel(QAbstractListModel):
     Model for the uploaded files list with thumbnail support.
     """
 
+    ExcludedRole = Qt.ItemDataRole.UserRole + 1
+
     def __init__(self, state: AppState):
         super().__init__()
         self._state = state
@@ -188,6 +190,19 @@ class AssetListModel(QAbstractListModel):
     def visible_actual_indices_ordered(self) -> list[int]:
         return list(self._sorted_indices)
 
+    def exportable_visible_indices_ordered(self) -> list[int]:
+        files = self._state.uploaded_files
+        return [i for i in self._sorted_indices if not files[i].get("excluded")]
+
+    def notify_exclusion_changed(self, actual_indices: list[int]) -> None:
+        roles = [AssetListModel.ExcludedRole, Qt.ItemDataRole.DecorationRole]
+        for actual in actual_indices:
+            display = self.actual_to_display(actual)
+            if display < 0:
+                continue
+            idx = self.index(display, 0)
+            self.dataChanged.emit(idx, idx, roles)
+
     def display_to_actual(self, display_row: int) -> int:
         if display_row < 0 or display_row >= len(self._sorted_indices):
             return -1
@@ -216,6 +231,9 @@ class AssetListModel(QAbstractListModel):
 
         if role == Qt.ItemDataRole.ToolTipRole:
             return file_info["path"]
+
+        if role == AssetListModel.ExcludedRole:
+            return bool(file_info.get("excluded"))
 
         return None
 
@@ -675,6 +693,8 @@ class DesktopSessionManager(QObject):
                     self.state.config, rgbscan=RgbScanConfig(enabled=True, green_path=green, blue_path=blue, align=align)
                 )
 
+            file_info["excluded"] = self.state.config.excluded_from_batch
+
             self.file_selected.emit(file_info["path"])
             self.state_changed.emit()
             self._persist_session()
@@ -683,6 +703,44 @@ class DesktopSessionManager(QObject):
         """Updates the list of currently selected indices."""
         self.state.selected_indices = indices
         self.state_changed.emit()
+
+    def _hydrate_file_excluded(self, file_info: dict) -> None:
+        cfg = load_or_promote(self.repo, file_info["hash"], file_info["path"])
+        file_info["excluded"] = bool(cfg.excluded_from_batch) if cfg else False
+
+    def set_frames_excluded(self, indices: List[int], excluded: bool) -> None:
+        """Mark frames included/excluded from batch export; persists to DB and existing sidecars."""
+        from negpy.kernel.system.logging import get_logger
+
+        logger = get_logger(__name__)
+        changed: list[int] = []
+        for idx in sorted(set(indices)):
+            if not (0 <= idx < len(self.state.uploaded_files)):
+                continue
+            file_info = self.state.uploaded_files[idx]
+            path = file_info["path"]
+            f_hash = file_info["hash"]
+
+            if idx == self.state.selected_file_idx:
+                params = replace(self.state.config, excluded_from_batch=excluded)
+                self.state.config = params
+            else:
+                params = self.repo.load_file_settings(f_hash) or WorkspaceConfig()
+                params = replace(params, excluded_from_batch=excluded)
+
+            self.repo.save_file_settings(f_hash, params)
+            if os.path.exists(sidecar_path_for(path)):
+                try:
+                    write_sidecar(path, params)
+                except OSError as exc:
+                    logger.warning("Sidecar write failed for %s: %s", path, exc)
+
+            file_info["excluded"] = excluded
+            changed.append(idx)
+
+        if changed:
+            self.asset_model.notify_exclusion_changed(changed)
+            self.state_changed.emit()
 
     def sync_selected_settings(self, aspects: frozenset, scope: str = "selection") -> int:
         """
@@ -909,6 +967,7 @@ class DesktopSessionManager(QObject):
             for info in validated_info:
                 if any(f["hash"] == info["hash"] for f in self.state.uploaded_files):
                     continue
+                self._hydrate_file_excluded(info)
                 self.state.uploaded_files.append(info)
         else:
             for path in file_paths:
@@ -920,7 +979,9 @@ class DesktopSessionManager(QObject):
                     if any(f["hash"] == f_hash for f in self.state.uploaded_files):
                         continue
 
-                    self.state.uploaded_files.append({"name": os.path.basename(path), "path": path, "hash": f_hash})
+                    info = {"name": os.path.basename(path), "path": path, "hash": f_hash}
+                    self._hydrate_file_excluded(info)
+                    self.state.uploaded_files.append(info)
                 except Exception as e:
                     from negpy.kernel.system.logging import get_logger
 

--- a/negpy/desktop/view/sidebar/export.py
+++ b/negpy/desktop/view/sidebar/export.py
@@ -1,7 +1,7 @@
 import os
 
 import qtawesome as qta
-from PyQt6.QtCore import Qt, QTimer
+from PyQt6.QtCore import Qt, QSize, QTimer
 from PyQt6.QtWidgets import (
     QButtonGroup,
     QCheckBox,
@@ -11,9 +11,12 @@ from PyQt6.QtWidgets import (
     QInputDialog,
     QLabel,
     QLineEdit,
+    QMenu,
     QMessageBox,
     QPushButton,
+    QSizePolicy,
     QSpinBox,
+    QToolButton,
     QVBoxLayout,
     QWidget,
 )
@@ -75,6 +78,7 @@ class ExportSidebar(BaseSidebar):
 
         self.manage_presets_btn.clicked.connect(self._open_presets_dialog)
         self.export_presets_btn.clicked.connect(self.controller.request_preset_export)
+        self.export_presets_menu_btn.clicked.connect(self._show_export_presets_menu)
 
         self.intent_btn_group.idToggled.connect(self._on_flat_output_toggled)
         self.flat_format_combo.currentIndexChanged.connect(self._on_flat_format_changed)
@@ -120,12 +124,46 @@ class ExportSidebar(BaseSidebar):
         self.manage_presets_btn = QPushButton(" Manage")
         self.manage_presets_btn.setObjectName("manage_presets_btn")
         self.manage_presets_btn.setIcon(qta.icon("fa5s.sliders-h", color=THEME.text_primary))
+        self.manage_presets_btn.setSizePolicy(QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Fixed)
+        preset_scope_tooltip = (
+            "Export the current file with every enabled preset. "
+            "Use the menu arrow for other scopes."
+        )
+        self.export_presets_group = QWidget()
+        export_presets_row = QHBoxLayout(self.export_presets_group)
+        export_presets_row.setContentsMargins(0, 0, 0, 0)
+        export_presets_row.setSpacing(0)
+
         self.export_presets_btn = QPushButton(" Export Presets")
         self.export_presets_btn.setObjectName("export_presets_btn")
         self.export_presets_btn.setIcon(qta.icon("fa5s.layer-group", color=THEME.text_primary))
-        self.export_presets_btn.setToolTip("Export the current file with every enabled preset")
-        preset_btn_row.addWidget(self.manage_presets_btn)
-        preset_btn_row.addWidget(self.export_presets_btn)
+        self.export_presets_btn.setToolTip(preset_scope_tooltip)
+        self.export_presets_btn.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+
+        preset_menu = QMenu(self)
+        export_current_action = preset_menu.addAction("Export current frame")
+        export_current_action.setToolTip("Export the current file with every enabled preset")
+        export_current_action.triggered.connect(self.controller.request_preset_export)
+        export_all_presets_action = preset_menu.addAction("Export all visible frames…")
+        export_all_presets_action.setToolTip(
+            "Export every visible frame in the filmstrip with every enabled preset"
+        )
+        export_all_presets_action.triggered.connect(self.controller.request_preset_batch_export)
+
+        self.export_presets_menu_btn = QToolButton()
+        self.export_presets_menu_btn.setObjectName("export_presets_menu_btn")
+        self.export_presets_menu_btn.setAutoRaise(False)
+        self.export_presets_menu_btn.setIcon(qta.icon("fa5s.chevron-down", color=THEME.text_primary))
+        self.export_presets_menu_btn.setIconSize(QSize(18, 18))
+        self.export_presets_menu_btn.setFixedWidth(36)
+        self.export_presets_menu_btn.setToolTip(preset_scope_tooltip)
+        self._export_presets_menu = preset_menu
+
+        export_presets_row.addWidget(self.export_presets_btn, 1)
+        export_presets_row.addWidget(self.export_presets_menu_btn, 0)
+        self.export_presets_group.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+        preset_btn_row.addWidget(self.manage_presets_btn, 0)
+        preset_btn_row.addWidget(self.export_presets_group, 1)
         content_layout.addLayout(preset_btn_row)
 
         repo = self.controller.session.repo
@@ -664,6 +702,10 @@ class ExportSidebar(BaseSidebar):
         if 0 <= idx < len(presets):
             presets[idx].enabled = state == Qt.CheckState.Checked.value
             self.controller.session.save_export_presets()
+
+    def _show_export_presets_menu(self) -> None:
+        btn = self.export_presets_menu_btn
+        self._export_presets_menu.exec(btn.mapToGlobal(btn.rect().bottomLeft()))
 
     def _open_presets_dialog(self) -> None:
         from negpy.desktop.view.widgets.export_presets_dialog import ExportPresetsDialog

--- a/negpy/desktop/view/sidebar/files.py
+++ b/negpy/desktop/view/sidebar/files.py
@@ -2,7 +2,7 @@ import os
 
 import qtawesome as qta
 from PyQt6.QtCore import Qt, QItemSelectionModel, QModelIndex, QRect, QSize, QTimer, pyqtSignal
-from PyQt6.QtGui import QActionGroup, QColor, QPainter, QPen
+from PyQt6.QtGui import QActionGroup, QColor, QImage, QPainter, QPen, QPixmap
 from PyQt6.QtWidgets import (
     QCheckBox,
     QDialog,
@@ -24,6 +24,7 @@ from PyQt6.QtWidgets import (
 )
 
 from negpy.desktop.controller import AppController
+from negpy.desktop.session import AssetListModel
 from negpy.desktop.view.styles.theme import THEME
 from negpy.desktop.view.widgets.sync_settings_dialog import SyncSettingsDialog
 from negpy.infrastructure.filesystem.watcher import FolderWatchService
@@ -37,6 +38,11 @@ class _ThumbnailDelegate(QStyledItemDelegate):
     dirty active file gets an accent line along the image's bottom edge."""
 
     _MARGIN = 3
+
+    @staticmethod
+    def _grayscale_pixmap(pixmap: QPixmap) -> QPixmap:
+        gray = pixmap.toImage().convertToFormat(QImage.Format.Format_Grayscale8)
+        return QPixmap.fromImage(gray)
 
     def paint(self, painter: QPainter, option: QStyleOptionViewItem, index: QModelIndex) -> None:
         icon = index.data(Qt.ItemDataRole.DecorationRole)
@@ -60,6 +66,10 @@ class _ThumbnailDelegate(QStyledItemDelegate):
         y = area.y() + (area.height() - scaled.height()) // 2
         img_rect = QRect(x, y, scaled.width(), scaled.height())
 
+        excluded = bool(index.data(AssetListModel.ExcludedRole))
+        if excluded:
+            scaled = self._grayscale_pixmap(scaled)
+
         # Selected image full-brightness with a white frame; others dimmed.
         selected = bool(option.state & QStyle.StateFlag.State_Selected)
         hover = bool(option.state & QStyle.StateFlag.State_MouseOver)
@@ -77,6 +87,14 @@ class _ThumbnailDelegate(QStyledItemDelegate):
         painter.setPen(pen)
         painter.setBrush(Qt.BrushStyle.NoBrush)
         painter.drawRect(img_rect.adjusted(0, 0, -1, -1))
+
+        if excluded:
+            dot_r = max(3, min(img_rect.width(), img_rect.height()) // 16)
+            cx = img_rect.right() - dot_r - 2
+            cy = img_rect.top() + dot_r + 2
+            painter.setPen(Qt.PenStyle.NoPen)
+            painter.setBrush(QColor(THEME.excluded_marker))
+            painter.drawEllipse(cx - dot_r, cy - dot_r, dot_r * 2, dot_r * 2)
 
         painter.restore()
 
@@ -520,6 +538,20 @@ class FileBrowser(QWidget):
             menu.addAction("Export Selected").triggered.connect(lambda: self.controller.request_export_selected())
         else:
             menu.addAction("Export").triggered.connect(lambda: self.controller.request_export())
+        menu.addSeparator()
+        if multi:
+            menu.addAction("Exclude selected").triggered.connect(
+                lambda: self.session.set_frames_excluded(list(state.selected_indices), True)
+            )
+            menu.addAction("Include selected").triggered.connect(
+                lambda: self.session.set_frames_excluded(list(state.selected_indices), False)
+            )
+        else:
+            idx = state.selected_file_idx
+            if 0 <= idx < len(state.uploaded_files) and state.uploaded_files[idx].get("excluded"):
+                menu.addAction("Include image").triggered.connect(lambda: self.session.set_frames_excluded([idx], False))
+            else:
+                menu.addAction("Exclude image").triggered.connect(lambda: self.session.set_frames_excluded([idx], True))
         menu.addSeparator()
         menu.addAction("Copy Settings  Ctrl+C").triggered.connect(self.session.copy_settings)
         menu.addAction("Copy Settings + Bounds  Ctrl+Shift+C").triggered.connect(self.session.copy_settings_with_bounds)

--- a/negpy/desktop/view/styles/modern_dark.qss
+++ b/negpy/desktop/view/styles/modern_dark.qss
@@ -259,3 +259,29 @@ QLabel#update_label {
     font-weight: bold;
     padding: 5px;
 }
+
+QPushButton#export_presets_btn {
+    text-align: center;
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+    border-right: none;
+}
+
+QToolButton#export_presets_menu_btn {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+    border-left: 1px solid #3A3A3A;
+    padding: 6px 4px;
+}
+
+QToolButton#export_presets_menu_btn::menu-button {
+    width: 0px;
+    border: none;
+    padding: 0px;
+}
+
+QToolButton#export_presets_menu_btn::menu-arrow {
+    image: none;
+    width: 0px;
+    height: 0px;
+}

--- a/negpy/desktop/view/styles/theme.py
+++ b/negpy/desktop/view/styles/theme.py
@@ -63,6 +63,7 @@ class ThemeConfig:
 
     # Channel colors (histogram)
     channel_red: str = "#D32F2F"
+    excluded_marker: str = "#6E2C2C"
     channel_green: str = "#388E3C"
     channel_blue: str = "#1976D2"
 

--- a/negpy/desktop/view/widgets/tutorial_steps.py
+++ b/negpy/desktop/view/widgets/tutorial_steps.py
@@ -358,7 +358,9 @@ def build(window: "MainWindow") -> list[TutorialStep]:
                 "Choose a format (<b>JPEG</b>, high-bit-depth <b>TIFF</b>, PNG, WebP, JPEG XL, DNG), "
                 "pick a colour space, and set resolution or print size. The <b>ICC</b> section adds "
                 "monitor-profile display and soft-proofing.<br><br>"
-                "<b>Export Presets</b> save named configurations for one-click batch output, and "
+                "<b>Export Presets</b> save named configurations for one-click batch output — "
+                "the main button exports the current frame through every enabled preset; "
+                "the menu arrow exports all visible frames the same way. "
                 "<b>Contact Sheet</b> renders all frames into one sheet. Export always runs at full "
                 "RAW resolution; <b>Export All</b> processes every loaded file."
             ),

--- a/negpy/domain/models.py
+++ b/negpy/domain/models.py
@@ -267,6 +267,7 @@ class WorkspaceConfig:
     finish: FinishConfig = field(default_factory=FinishConfig)
     metadata: MetadataConfig = field(default_factory=MetadataConfig)
     export: ExportConfig = field(default_factory=ExportConfig)
+    excluded_from_batch: bool = False
 
     def to_dict(self) -> Dict[str, Any]:
         """
@@ -285,6 +286,7 @@ class WorkspaceConfig:
         res.update(asdict(self.finish))
         res.update(asdict(self.metadata))
         res.update(asdict(self.export))
+        res["excluded_from_batch"] = self.excluded_from_batch
         return res
 
     @classmethod
@@ -326,6 +328,8 @@ class WorkspaceConfig:
             data["output_mode"] = ExportPresetOutputMode.SAME_AS_SOURCE if data.pop("same_as_source") else ExportPresetOutputMode.ABSOLUTE
         else:
             data.pop("same_as_source", None)
+
+        excluded_from_batch = bool(data.pop("excluded_from_batch", False))
 
         config_classes = [
             ProcessConfig,
@@ -378,6 +382,7 @@ class WorkspaceConfig:
             finish=FinishConfig(**filter_keys(FinishConfig, data)),
             metadata=MetadataConfig(**filter_keys(MetadataConfig, data)),
             export=ExportConfig(**filter_keys(ExportConfig, data)),
+            excluded_from_batch=excluded_from_batch,
         )
 
 

--- a/tests/test_config_deserialization.py
+++ b/tests/test_config_deserialization.py
@@ -147,6 +147,12 @@ class TestConfigDeserialization(unittest.TestCase):
         config = WorkspaceConfig.from_flat_dict({"autocrop_mode": "banana"})
         self.assertEqual(config.geometry.autocrop_mode, "image")
 
+    def test_excluded_from_batch_roundtrip(self):
+        config = replace(WorkspaceConfig(), excluded_from_batch=True)
+        reloaded = WorkspaceConfig.from_flat_dict(config.to_dict())
+        self.assertTrue(reloaded.excluded_from_batch)
+        self.assertFalse(WorkspaceConfig.from_flat_dict({}).excluded_from_batch)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -7,7 +7,7 @@ from PyQt6.QtWidgets import QApplication
 
 from negpy.desktop.controller import AppController
 from negpy.desktop.session import DesktopSessionManager, AppState, ToolMode
-from negpy.domain.models import ExportConfig, ExportPresetOutputMode
+from negpy.domain.models import ExportConfig, ExportFormat, ExportPreset, ExportPresetOutputMode
 from negpy.services.rendering.preview_manager import PreviewManager
 
 if not QApplication.instance():
@@ -407,6 +407,101 @@ class TestBatchExportFiltering(unittest.TestCase):
         tasks = self._captured_tasks()
         for t in tasks:
             self.assertEqual(t.params.export.export_path, "/tmp/out")
+
+
+class TestPresetBatchExport(unittest.TestCase):
+    def setUp(self):
+        self.mock_session_manager = MagicMock(spec=DesktopSessionManager)
+        self.mock_session_manager.state = AppState()
+        self.mock_session_manager.repo = MagicMock()
+        self.mock_session_manager.repo.load_file_settings.return_value = None
+
+        self.mock_session_manager.state.uploaded_files = [
+            {"name": "IMG_0001.cr2", "path": "/tmp/IMG_0001.cr2", "hash": "h1"},
+            {"name": "IMG_0002.cr2", "path": "/tmp/IMG_0002.cr2", "hash": "h2"},
+            {"name": "scan.tif", "path": "/tmp/scan.tif", "hash": "h3"},
+        ]
+        self.mock_session_manager.state.export_presets = [
+            ExportPreset(name="JPEG", enabled=True, export_fmt=ExportFormat.JPEG),
+            ExportPreset(name="TIFF", enabled=True, export_fmt=ExportFormat.TIFF),
+        ]
+
+        self.visible_indices = [0, 1, 2]
+        self.mock_session_manager.asset_model = MagicMock()
+        self.mock_session_manager.asset_model.visible_actual_indices_ordered.side_effect = lambda: list(self.visible_indices)
+
+        with (
+            patch("negpy.desktop.controller.RenderWorker") as mock_rw_class,
+            patch("negpy.desktop.controller.PreviewManager") as mock_pm_class,
+        ):
+            mock_rw_class.return_value = MagicMock()
+            mock_pm_class.return_value = MagicMock(spec=PreviewManager)
+            mock_pm_class.return_value.load_linear_preview.return_value = (None, (0, 0), {})
+            self.controller = AppController(self.mock_session_manager)
+
+        self.controller._validate_preset_paths = MagicMock(return_value=True)
+        self.controller._run_export_tasks = MagicMock()
+
+    def tearDown(self):
+        import gc
+
+        for thread in [
+            self.controller.render_thread,
+            self.controller.export_thread,
+            self.controller.thumb_thread,
+            self.controller.norm_thread,
+            self.controller.discovery_thread,
+            self.controller.preview_load_thread,
+            self.controller.scan_thread,
+        ]:
+            if thread is not None and thread.isRunning():
+                thread.quit()
+                thread.wait()
+        del self.controller
+        gc.collect()
+
+    def _captured_tasks(self):
+        self.controller._run_export_tasks.assert_called_once()
+        return self.controller._run_export_tasks.call_args.args[0]
+
+    @patch("negpy.desktop.controller.QMessageBox.question")
+    def test_preset_batch_export_respects_filter(self, mock_question):
+        from PyQt6.QtWidgets import QMessageBox
+
+        mock_question.return_value = QMessageBox.StandardButton.Yes
+        self.visible_indices = [0, 1]
+        self.controller.request_preset_batch_export()
+        tasks = self._captured_tasks()
+        self.assertEqual(len(tasks), 4)
+        self.assertEqual([t.file_info["name"] for t in tasks], ["IMG_0001.cr2"] * 2 + ["IMG_0002.cr2"] * 2)
+
+    @patch("negpy.desktop.controller.QMessageBox.question")
+    def test_preset_batch_export_zero_visible_does_not_dispatch(self, mock_question):
+        self.visible_indices = []
+        self.controller.request_preset_batch_export()
+        self.controller._run_export_tasks.assert_not_called()
+        mock_question.assert_not_called()
+
+    @patch("negpy.desktop.controller.QMessageBox.question")
+    def test_preset_batch_export_cancel_does_not_dispatch(self, mock_question):
+        from PyQt6.QtWidgets import QMessageBox
+
+        mock_question.return_value = QMessageBox.StandardButton.Cancel
+        self.controller.request_preset_batch_export()
+        self.controller._run_export_tasks.assert_not_called()
+
+    @patch("negpy.desktop.controller.QMessageBox.question")
+    def test_preset_batch_export_confirmation_message(self, mock_question):
+        from PyQt6.QtWidgets import QMessageBox
+
+        mock_question.return_value = QMessageBox.StandardButton.Yes
+        self.visible_indices = [0, 1, 2]
+        self.controller.request_preset_batch_export()
+        mock_question.assert_called_once()
+        message = mock_question.call_args.args[2]
+        self.assertIn("3 frames", message)
+        self.assertIn("2 presets", message)
+        self.assertIn("6 files", message)
 
 
 class TestSessionRestore(unittest.TestCase):

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -338,7 +338,7 @@ class TestBatchExportFiltering(unittest.TestCase):
 
         self.visible_indices = [0, 1, 2]
         self.mock_session_manager.asset_model = MagicMock()
-        self.mock_session_manager.asset_model.visible_actual_indices_ordered.side_effect = lambda: list(self.visible_indices)
+        self.mock_session_manager.asset_model.exportable_visible_indices_ordered.side_effect = lambda: list(self.visible_indices)
 
         with (
             patch("negpy.desktop.controller.RenderWorker") as mock_rw_class,
@@ -409,6 +409,67 @@ class TestBatchExportFiltering(unittest.TestCase):
             self.assertEqual(t.params.export.export_path, "/tmp/out")
 
 
+class TestBatchExportExclusion(unittest.TestCase):
+    def setUp(self):
+        self.mock_session_manager = MagicMock(spec=DesktopSessionManager)
+        self.mock_session_manager.state = AppState()
+        self.mock_session_manager.repo = MagicMock()
+        self.mock_session_manager.repo.load_file_settings.return_value = None
+
+        self.mock_session_manager.state.uploaded_files = [
+            {"name": "IMG_0001.cr2", "path": "/tmp/IMG_0001.cr2", "hash": "h1"},
+            {"name": "IMG_0002.cr2", "path": "/tmp/IMG_0002.cr2", "hash": "h2", "excluded": True},
+            {"name": "scan.tif", "path": "/tmp/scan.tif", "hash": "h3"},
+        ]
+
+        self.exportable_indices = [0, 2]
+        self.mock_session_manager.asset_model = MagicMock()
+        self.mock_session_manager.asset_model.exportable_visible_indices_ordered.side_effect = (
+            lambda: list(self.exportable_indices)
+        )
+
+        with (
+            patch("negpy.desktop.controller.RenderWorker") as mock_rw_class,
+            patch("negpy.desktop.controller.PreviewManager") as mock_pm_class,
+        ):
+            mock_rw_class.return_value = MagicMock()
+            mock_pm_class.return_value = MagicMock(spec=PreviewManager)
+            mock_pm_class.return_value.load_linear_preview.return_value = (None, (0, 0), {})
+            self.controller = AppController(self.mock_session_manager)
+
+        self.controller._ensure_valid_export_path = MagicMock(return_value="/tmp/out")
+        self.controller._run_export_tasks = MagicMock()
+
+    def tearDown(self):
+        import gc
+
+        for thread in [
+            self.controller.render_thread,
+            self.controller.export_thread,
+            self.controller.thumb_thread,
+            self.controller.norm_thread,
+            self.controller.discovery_thread,
+            self.controller.preview_load_thread,
+            self.controller.scan_thread,
+        ]:
+            if thread is not None and thread.isRunning():
+                thread.quit()
+                thread.wait()
+        del self.controller
+        gc.collect()
+
+    def test_batch_export_skips_excluded_via_exportable_indices(self):
+        self.controller.request_batch_export()
+        tasks = self.controller._run_export_tasks.call_args.args[0]
+        self.assertEqual([t.file_info["name"] for t in tasks], ["IMG_0001.cr2", "scan.tif"])
+
+    def test_export_selected_skips_excluded_even_when_selected(self):
+        self.controller.state.selected_indices = [0, 1, 2]
+        self.controller.request_export_selected()
+        tasks = self.controller._run_export_tasks.call_args.args[0]
+        self.assertEqual([t.file_info["name"] for t in tasks], ["IMG_0001.cr2", "scan.tif"])
+
+
 class TestPresetBatchExport(unittest.TestCase):
     def setUp(self):
         self.mock_session_manager = MagicMock(spec=DesktopSessionManager)
@@ -428,7 +489,7 @@ class TestPresetBatchExport(unittest.TestCase):
 
         self.visible_indices = [0, 1, 2]
         self.mock_session_manager.asset_model = MagicMock()
-        self.mock_session_manager.asset_model.visible_actual_indices_ordered.side_effect = lambda: list(self.visible_indices)
+        self.mock_session_manager.asset_model.exportable_visible_indices_ordered.side_effect = lambda: list(self.visible_indices)
 
         with (
             patch("negpy.desktop.controller.RenderWorker") as mock_rw_class,
@@ -475,12 +536,14 @@ class TestPresetBatchExport(unittest.TestCase):
         self.assertEqual(len(tasks), 4)
         self.assertEqual([t.file_info["name"] for t in tasks], ["IMG_0001.cr2"] * 2 + ["IMG_0002.cr2"] * 2)
 
+    @patch("negpy.desktop.controller.QMessageBox.information")
     @patch("negpy.desktop.controller.QMessageBox.question")
-    def test_preset_batch_export_zero_visible_does_not_dispatch(self, mock_question):
+    def test_preset_batch_export_zero_visible_does_not_dispatch(self, mock_question, mock_info):
         self.visible_indices = []
         self.controller.request_preset_batch_export()
         self.controller._run_export_tasks.assert_not_called()
         mock_question.assert_not_called()
+        mock_info.assert_called_once()
 
     @patch("negpy.desktop.controller.QMessageBox.question")
     def test_preset_batch_export_cancel_does_not_dispatch(self, mock_question):
@@ -716,7 +779,7 @@ class TestBatchAnalysisFiltering(unittest.TestCase):
 
         self.visible_indices = [0, 1, 2]
         self.mock_session_manager.asset_model = MagicMock()
-        self.mock_session_manager.asset_model.visible_actual_indices_ordered.side_effect = lambda: list(self.visible_indices)
+        self.mock_session_manager.asset_model.exportable_visible_indices_ordered.side_effect = lambda: list(self.visible_indices)
 
         with (
             patch("negpy.desktop.controller.RenderWorker") as mock_rw_class,

--- a/tests/test_desktop_session.py
+++ b/tests/test_desktop_session.py
@@ -1,4 +1,5 @@
 import unittest
+import os
 from unittest.mock import MagicMock
 from dataclasses import replace
 
@@ -447,6 +448,13 @@ class TestAssetListModelFilter(unittest.TestCase):
         self.assertEqual(self.model.visible_actual_indices_ordered(), self.model._sorted_indices)
         self.assertEqual(self.model.visible_actual_indices(), set(self.model._sorted_indices))
 
+    def test_exportable_visible_indices_ordered_skips_excluded(self):
+        self.state.uploaded_files[1]["excluded"] = True
+        self.model.refresh()
+        names = [self.state.uploaded_files[i]["name"] for i in self.model.exportable_visible_indices_ordered()]
+        self.assertNotIn("IMG_0002.cr2", names)
+        self.assertEqual(len(names), 4)
+
     def test_filter_persists_through_refresh(self):
         self.model.set_filter("IMG", regex=False)
         self.state.uploaded_files.append({"name": "extra.txt", "path": "/tmp/extra.txt", "hash": "h6"})
@@ -458,6 +466,69 @@ class TestAssetListModelFilter(unittest.TestCase):
         self.model.set_filter("IMG", regex=False)
         self.model.set_filter("", regex=False)
         self.assertEqual(len(self.model._sorted_indices), 5)
+
+
+class TestFrameExclusion(unittest.TestCase):
+    def setUp(self):
+        import tempfile
+
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.repo = StorageRepository(
+            os.path.join(self._tmpdir.name, "edits.db"),
+            os.path.join(self._tmpdir.name, "settings.db"),
+        )
+        self.repo.initialize()
+
+        def mock_get_global(key, default=None):
+            if key == "last_export_config":
+                return {}
+            if key == "process_mode":
+                return "C41"
+            return default
+
+        self.repo.get_global_setting = MagicMock(side_effect=mock_get_global)
+        self.repo.get_max_history_index = MagicMock(return_value=0)
+
+        self.session = DesktopSessionManager(self.repo)
+        self.session.state.uploaded_files = [
+            {"name": "file1.dng", "path": os.path.join(self._tmpdir.name, "file1.dng"), "hash": "hash1"},
+            {"name": "file2.dng", "path": os.path.join(self._tmpdir.name, "file2.dng"), "hash": "hash2"},
+        ]
+
+    def tearDown(self):
+        self._tmpdir.cleanup()
+
+    def test_set_frames_excluded_persists_to_db(self):
+        self.session.set_frames_excluded([0], True)
+        saved = self.repo.load_file_settings("hash1")
+        self.assertIsNotNone(saved)
+        self.assertTrue(saved.excluded_from_batch)
+        self.assertTrue(self.session.state.uploaded_files[0]["excluded"])
+
+    def test_set_frames_excluded_writes_existing_sidecar_only(self):
+        from negpy.services.assets.sidecar import load_sidecar, sidecar_path_for, write_sidecar
+
+        path = self.session.state.uploaded_files[1]["path"]
+        open(path, "wb").close()
+        write_sidecar(path, WorkspaceConfig())
+
+        self.session.set_frames_excluded([1], True)
+
+        loaded = load_sidecar(path)
+        self.assertIsNotNone(loaded)
+        self.assertTrue(loaded.excluded_from_batch)
+        self.assertFalse(os.path.exists(sidecar_path_for(self.session.state.uploaded_files[0]["path"])))
+
+    def test_hydrate_file_excluded_from_sidecar(self):
+        from negpy.services.assets.sidecar import write_sidecar
+
+        path = self.session.state.uploaded_files[0]["path"]
+        open(path, "wb").close()
+        write_sidecar(path, replace(WorkspaceConfig(), excluded_from_batch=True))
+
+        info = {"name": "file1.dng", "path": path, "hash": "hash1"}
+        self.session._hydrate_file_excluded(info)
+        self.assertTrue(info["excluded"])
 
 
 if __name__ == "__main__":

--- a/tests/test_sidecar.py
+++ b/tests/test_sidecar.py
@@ -99,3 +99,12 @@ def test_write_payload_is_to_dict_json(tmp_path):
     with open(sidecar_path_for(src), "r", encoding="utf-8") as f:
         data = json.load(f)
     assert data == json.loads(json.dumps(cfg.to_dict(), default=str))
+
+
+def test_excluded_from_batch_roundtrip(tmp_path):
+    src = str(tmp_path / "IMG_008.NEF")
+    cfg = replace(WorkspaceConfig(), excluded_from_batch=True)
+    write_sidecar(src, cfg)
+    loaded = load_sidecar(src)
+    assert loaded is not None
+    assert loaded.excluded_from_batch is True


### PR DESCRIPTION
## Summary

Adds a per-frame **Exclude from batch export** workflow: mark frames in the filmstrip to skip them from batch output while keeping them editable and still exportable one-off.

Excluded frames show a muted red dot and grayscale thumbnail, the flag persists in the DB and is mirrored into an existing `.negpy` sidecar when present.

## Changes

### Data model
- **`WorkspaceConfig.excluded_from_batch`** — serialized in DB and sidecar JSON (`to_dict` / `from_flat_dict`).

### Session & persistence
- **`set_frames_excluded(indices, excluded)`** — saves to DB for every toggle; updates `.negpy` **only if a sidecar already exists** (does not create one).
- Exclusion hydrated on **add files** and **select file** into `file_info["excluded"]`.
- **`AssetListModel.exportable_visible_indices_ordered()`** — single filter for batch-eligible frames.

### Filmstrip UI
- Context menu:
  - Single selection: **Exclude image** / **Include image**
  - Multi selection: **Exclude selected** / **Include selected**
- Thumbnail delegate: grayscale image + small muted dark-red dot (top-right).

### Batch export filtering
Excluded frames are skipped for:
- **Export All**
- **Export Selected**
- **Export all visible presets** (confirmation counts exportable frames only; info dialog if all visible are excluded)
- **Contact sheet**
- **Export sidecars**

**Still exported when excluded:** toolbar **Export**, context **Export**, and **Export Presets** (current frame).

### Tests
- Config/sidecar round-trip for `excluded_from_batch`
- DB persistence and conditional sidecar write
- Batch export / export selected skip excluded frames
- Exportable index filtering in `AssetListModel`

## Test plan

- [x] Right-click → **Exclude image** → grayscale + red dot; menu toggles to **Include image**
- [x] Multi-select → **Exclude selected** / **Include selected** behave correctly
- [x] **Export All**, **Export Selected**, preset batch, contact sheet, sidecars skip excluded frames
- [x] Single-frame **Export** and **Export Presets** (main click) still work on excluded frames
- [x] Restart app → exclusion restored from DB
- [x] Frame with existing `.negpy` → exclude updates sidecar; frame without sidecar → no new sidecar created
- [x] `uv run pytest tests/test_controller.py::TestBatchExportExclusion tests/test_desktop_session.py::TestFrameExclusion tests/test_sidecar.py::test_excluded_from_batch_roundtrip -v`
- [x] `uv run ruff check`