### PR TITLE
fix: use each triplet's own exposures in batch export (#382)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 
 
+## 0.33.1
+
+- Fix: **exporting all RGB-scan triplets no longer fails** with "Input/output error" on most frames. Batch export was reusing stale saved paths for each frame's green/blue exposures instead of the ones the triplet was actually built from, so it tried to read files that weren't there; it now uses each frame's own exposures, the same as exporting one at a time.
+
+
 ## 0.33.0
 
 - New: **Temperature slider** — a Kelvin lever above the CMY white balance: drag it and Magenta/Yellow move together along the warm–cool axis in the right ratio, like re-dialing a dichroic filter pack, while your green–magenta tint stays put. Move M/Y (or Pick WB) yourself and the slider reads back the print's temperature instead. Warm sits on the right, travel is mired-linear (equal drag = equal perceived shift), and `T`/`G` nudge it from the keyboard. The thermometer button locks the temperature for the roll: every frame you open gets re-aimed to it — keeping its own tint — and the lock survives restarts.

--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -9,7 +9,7 @@ from PyQt6.QtGui import QIcon, QPixmap
 from PyQt6.QtWidgets import QMessageBox
 
 from negpy.desktop.converters import ImageConverter
-from negpy.desktop.session import AppState, DesktopSessionManager, ToolMode
+from negpy.desktop.session import AppState, DesktopSessionManager, ToolMode, resolve_asset_rgbscan
 from negpy.desktop.workers.export import ExportTask, ExportWorker
 from negpy.desktop.workers.render import (
     AssetDiscoveryTask,
@@ -1338,6 +1338,13 @@ class AppController(QObject):
                 self.session.save_export_presets()
         return True
 
+    def _batch_params_for(self, f: dict) -> WorkspaceConfig:
+        """Resolve a visible frame's export params: its saved DB config (else the current
+        config), with its own RGB-scan green/blue re-injected from the asset dict — the
+        same authoritative source individual export gets via select_file."""
+        params = self.session.repo.load_file_settings(f["hash"]) or self.state.config
+        return resolve_asset_rgbscan(params, f)
+
     def _tasks_for_file(
         self,
         file_info: dict,
@@ -1481,7 +1488,7 @@ class AppController(QObject):
 
         tasks = []
         for f in files:
-            params = self.session.repo.load_file_settings(f["hash"]) or self.state.config
+            params = self._batch_params_for(f)
 
             if override_settings:
                 params = replace(params, export=current_export)
@@ -1587,7 +1594,7 @@ class AppController(QObject):
 
         tasks = []
         for f in visible_files:
-            params = self.session.repo.load_file_settings(f["hash"]) or self.state.config
+            params = self._batch_params_for(f)
 
             bounds_override = None
             if f["hash"] == self.state.current_file_hash:
@@ -1632,7 +1639,7 @@ class AppController(QObject):
 
         tasks = []
         for f in visible_files:
-            params = self.session.repo.load_file_settings(f["hash"]) or self.state.config
+            params = self._batch_params_for(f)
             tasks.append(
                 ExportTask(
                     file_info=f,

--- a/negpy/desktop/session.py
+++ b/negpy/desktop/session.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, List, Optional
 from PyQt6.QtCore import QAbstractListModel, QModelIndex, QObject, Qt, pyqtSignal
 
 from negpy.domain.models import ExportPreset, WorkspaceConfig
+from negpy.features.rgbscan.models import RgbScanConfig
 from negpy.infrastructure.storage.repository import StorageRepository
 from negpy.kernel.system.config import APP_CONFIG
 from negpy.services.assets.sidecar import load_or_promote
@@ -333,6 +334,17 @@ def build_synced_config(
         out = replace(out, process=replace(out.process, **changes))
 
     return out
+
+
+def resolve_asset_rgbscan(params: WorkspaceConfig, asset: dict) -> WorkspaceConfig:
+    """Overlay a frame's own RGB-scan triplet paths (from the asset dict) onto its export
+    params — the authoritative source select_file uses. A non-triplet frame gets rgbscan
+    reset so a batch frame never inherits the currently-open frame's leaked/stale triplet."""
+    green, blue = asset.get("green_path"), asset.get("blue_path")
+    if green and blue:
+        align = bool(asset.get("align", params.rgbscan.align))
+        return replace(params, rgbscan=RgbScanConfig(enabled=True, green_path=green, blue_path=blue, align=align))
+    return replace(params, rgbscan=RgbScanConfig())
 
 
 class DesktopSessionManager(QObject):

--- a/negpy/services/rendering/image_processor.py
+++ b/negpy/services/rendering/image_processor.py
@@ -231,6 +231,10 @@ class ImageProcessor:
         if is_triplet:
             # Assemble one frame from the R/G/B exposures; the primary (red) file is
             # already decoded above, so reuse it and decode only green/blue.
+            for label, path in (("green", rgbcfg.green_path), ("blue", rgbcfg.blue_path)):
+                if not os.path.exists(path):
+                    raise FileNotFoundError(f"RGB-scan {label} exposure not found: {path}")
+
             def _decode(path: str) -> np.ndarray:
                 if path == file_path:
                     return rgb

--- a/tests/test_image_processor.py
+++ b/tests/test_image_processor.py
@@ -94,18 +94,22 @@ def test_load_source_f32_cache_key_separates_fast_decode(monkeypatch) -> None:
     assert calls == [True, False]
 
 
-def test_load_source_f32_never_fast_decodes_rgbscan_triplets(monkeypatch) -> None:
+def test_load_source_f32_never_fast_decodes_rgbscan_triplets(monkeypatch, tmp_path) -> None:
     from dataclasses import replace
 
     from negpy.features.rgbscan.models import RgbScanConfig
+
+    r, g, b = (tmp_path / n for n in ("r.raw", "g.raw", "b.raw"))
+    for f in (r, g, b):
+        f.write_bytes(b"x")
 
     service = ImageProcessor()
     calls: list = []
     monkeypatch.setattr(service, "_decode_sensor_rgb", _fake_decode_recorder(calls))
     cfg = replace(
         WorkspaceConfig(),
-        rgbscan=RgbScanConfig(enabled=True, green_path="/nonexistent/g.raw", blue_path="/nonexistent/b.raw", align=False),
+        rgbscan=RgbScanConfig(enabled=True, green_path=str(g), blue_path=str(b), align=False),
     )
 
-    service._load_source_f32("/nonexistent/r.raw", cfg, fast_decode=True)
+    service._load_source_f32(str(r), cfg, fast_decode=True)
     assert calls and calls[0] is False

--- a/tests/test_rgbscan.py
+++ b/tests/test_rgbscan.py
@@ -1,4 +1,5 @@
 import os
+from dataclasses import replace
 
 import numpy as np
 import pytest
@@ -203,3 +204,30 @@ def test_config_roundtrip_preserves_rgbscan():
     cfg = type(cfg)(**{**cfg.__dict__, "rgbscan": RgbScanConfig(enabled=True, green_path="/g", blue_path="/b")})
     restored = WorkspaceConfig.from_flat_dict(cfg.to_dict())
     assert restored.rgbscan == cfg.rgbscan
+
+
+def test_resolve_asset_rgbscan_injects_from_asset():
+    """Batch export must use the asset dict's own green/blue, overriding a stale DB config."""
+    from negpy.desktop.session import resolve_asset_rgbscan
+
+    stale = replace(WorkspaceConfig(), rgbscan=RgbScanConfig(enabled=True, green_path="/old_g", blue_path="/old_b"))
+    asset = {"path": "/r", "green_path": "/g", "blue_path": "/b"}
+    out = resolve_asset_rgbscan(stale, asset)
+    assert out.rgbscan == RgbScanConfig(enabled=True, green_path="/g", blue_path="/b", align=True)
+
+
+def test_resolve_asset_rgbscan_honors_align():
+    from negpy.desktop.session import resolve_asset_rgbscan
+
+    asset = {"green_path": "/g", "blue_path": "/b", "align": False}
+    out = resolve_asset_rgbscan(WorkspaceConfig(), asset)
+    assert out.rgbscan.align is False
+
+
+def test_resolve_asset_rgbscan_resets_when_not_triplet():
+    """A non-triplet frame must not inherit a leaked/enabled triplet config."""
+    from negpy.desktop.session import resolve_asset_rgbscan
+
+    leaked = replace(WorkspaceConfig(), rgbscan=RgbScanConfig(enabled=True, green_path="/g", blue_path="/b"))
+    out = resolve_asset_rgbscan(leaked, {"path": "/r"})
+    assert out.rgbscan == RgbScanConfig()


### PR DESCRIPTION
Fixes #382.

## Problem

Bulk-exporting RGB-scan (trichrome) triplets fails on most frames with `Export pipeline failed: b'Input/output error'` — only a couple export. Individual export works.

`b'Input/output error'` is rawpy/LibRaw on a nonexistent path (reproduced: `rawpy.imread(missing)` raises exactly this).

## Root cause

- **Individual export** works: `select_file` freshly re-injects each triplet's green/blue exposure paths from the discovery-verified asset dict into `state.config`.
- **Batch export** built each frame's params from the saved **DB config** and never re-injected the asset's own green/blue. A frame whose DB config held a **stale/missing** exposure path (prior session, RGB-mode regroup, or session restore) decoded a file that wasn't there → LibRaw EIO → that frame errored and was skipped.

## Fix

1. `resolve_asset_rgbscan(params, asset)` — pure helper in `session.py`: re-injects a frame's own green/blue/align from the asset dict; resets rgbscan for non-triplet frames so a batch frame never inherits the currently-open frame's config.
2. `_batch_params_for(f)` — routes all three batch task-builders (`request_batch_export`, `request_preset_batch_export`, `request_contact_sheet`) through it, so batch uses the same authoritative source as single-file export.
3. Guard in `_load_source_f32`: a genuinely-missing exposure now raises a clear `FileNotFoundError: RGB-scan green exposure not found: <path>` instead of cryptic LibRaw bytes. The batch worker already continues per-file.

## Tests

- New unit tests (`test_rgbscan.py`): inject-from-asset overrides a stale config, align honored, reset-when-not-triplet.
- Updated one existing test that relied on fake paths (now real temp files).
- `make all` green: lint + type clean, 1109 passed.

Manual repro (real triplet folder + "Export all") still recommended before release.