### PR TITLE
Fixed a small bug in new gear library/gear metadata presets, which resulted in the values for the first selected gear preset did not get displayed when opening manage->gear presets

### DIFF
--- a/negpy/desktop/view/widgets/gear_library_dialog.py
+++ b/negpy/desktop/view/widgets/gear_library_dialog.py
@@ -263,8 +263,6 @@ class GearLibraryDialog(QDialog):
         self._category = _CATEGORIES[row][0]
         self._rebuild_item_list()
         self._show_form_for_category(self._category)
-        if self._category == "gear_presets":
-            self._refresh_preset_combos()
 
     def _rebuild_item_list(self) -> None:
         self.item_list.blockSignals(True)


### PR DESCRIPTION
## Summary

Fixes gear preset camera/lens/film combos showing `— None —` when first opening **Manage… → Gear Presets**.

Switching categories triggered `_populate_form()` (which set the correct combo values) and then an extra `_refresh_preset_combos()` that cleared the combos without re-applying the preset’s IDs.

## Test plan

- [x] Open **Manage… → Gear Presets** — first preset shows linked camera, lens, and film stock
- [x] Switch between presets — selections stay correct
- [x] Switch to Cameras/Lenses/Film Stocks and back — preset combos still populate correctly