### PR TITLE
added nikon bodies and lenses to the bundled gear library

### DIFF
--- a/gear/cameras.json
+++ b/gear/cameras.json
@@ -70,11 +70,207 @@
     "notes": "35mm SLR, 1981-1987, FD mount."
   },
   {
+    "id": "cam-nikon-s2",
+    "make": "Nikon",
+    "model": "S2",
+    "displayName": "Nikon S2",
+    "notes": "35mm rangefinder, S-mount."
+  },
+  {
+    "id": "cam-nikon-sp",
+    "make": "Nikon",
+    "model": "SP",
+    "displayName": "Nikon SP",
+    "notes": "35mm rangefinder, S-mount."
+  },
+  {
+    "id": "cam-nikon-f",
+    "make": "Nikon",
+    "model": "F",
+    "displayName": "Nikon F",
+    "notes": "35mm SLR, F-mount."
+  },
+  {
+    "id": "cam-nikon-f-photomic",
+    "make": "Nikon",
+    "model": "F Photomic",
+    "displayName": "Nikon F Photomic",
+    "notes": "35mm SLR with Photomic meter, F-mount."
+  },
+  {
+    "id": "cam-nikkormat-ftn",
+    "make": "Nikon",
+    "model": "Nikkormat FTn",
+    "displayName": "Nikkormat FT / FTn",
+    "notes": "35mm SLR, F-mount (Nikkormat body)."
+  },
+  {
+    "id": "cam-nikon-f-apollo",
+    "make": "Nikon",
+    "model": "F Apollo",
+    "displayName": "Nikon F Apollo",
+    "notes": "Late-production Nikon F, F-mount."
+  },
+  {
+    "id": "cam-nikon-f2",
+    "make": "Nikon",
+    "model": "F2",
+    "displayName": "Nikon F2",
+    "notes": "35mm professional SLR, F-mount."
+  },
+  {
+    "id": "cam-nikkormat-ft2",
+    "make": "Nikon",
+    "model": "Nikkormat FT2",
+    "displayName": "Nikkormat FT2",
+    "notes": "35mm SLR, F-mount (Nikkormat body)."
+  },
+  {
+    "id": "cam-nikkormat-ft3",
+    "make": "Nikon",
+    "model": "Nikkormat FT3",
+    "displayName": "Nikkormat FT3",
+    "notes": "35mm SLR, F-mount (Nikkormat body)."
+  },
+  {
+    "id": "cam-nikon-el2",
+    "make": "Nikon",
+    "model": "EL2",
+    "displayName": "Nikon EL2",
+    "notes": "35mm electronic SLR, F-mount."
+  },
+  {
+    "id": "cam-nikon-fm",
+    "make": "Nikon",
+    "model": "FM",
+    "displayName": "Nikon FM",
+    "notes": "35mm mechanical SLR, F-mount."
+  },
+  {
+    "id": "cam-nikon-fe",
+    "make": "Nikon",
+    "model": "FE",
+    "displayName": "Nikon FE",
+    "notes": "35mm electronic SLR, F-mount."
+  },
+  {
+    "id": "cam-nikon-f3",
+    "make": "Nikon",
+    "model": "F3",
+    "displayName": "Nikon F3",
+    "notes": "35mm professional SLR, F-mount."
+  },
+  {
+    "id": "cam-nikon-fe2",
+    "make": "Nikon",
+    "model": "FE2",
+    "displayName": "Nikon FE2",
+    "notes": "35mm electronic SLR, F-mount."
+  },
+  {
     "id": "cam-nikon-fm2",
     "make": "Nikon",
     "model": "FM2",
     "displayName": "Nikon FM2",
     "notes": "35mm fully mechanical SLR, F-mount."
+  },
+  {
+    "id": "cam-nikon-f301",
+    "make": "Nikon",
+    "model": "F-301",
+    "displayName": "Nikon F-301 / N2000",
+    "notes": "35mm autofocus SLR, F-mount."
+  },
+  {
+    "id": "cam-nikon-f501",
+    "make": "Nikon",
+    "model": "F-501",
+    "displayName": "Nikon F-501 / N2020",
+    "notes": "35mm autofocus SLR, F-mount."
+  },
+  {
+    "id": "cam-nikon-f4",
+    "make": "Nikon",
+    "model": "F4",
+    "displayName": "Nikon F4",
+    "notes": "35mm professional autofocus SLR, F-mount."
+  },
+  {
+    "id": "cam-nikon-f801",
+    "make": "Nikon",
+    "model": "F-801",
+    "displayName": "Nikon F-801 / N8008",
+    "notes": "35mm autofocus SLR, F-mount."
+  },
+  {
+    "id": "cam-nikon-f801s",
+    "make": "Nikon",
+    "model": "F-801s",
+    "displayName": "Nikon F-801s / N8008s",
+    "notes": "35mm autofocus SLR, F-mount."
+  },
+  {
+    "id": "cam-nikon-f90",
+    "make": "Nikon",
+    "model": "F90",
+    "displayName": "Nikon F90 / N90",
+    "notes": "35mm autofocus SLR, F-mount."
+  },
+  {
+    "id": "cam-nikon-f90x",
+    "make": "Nikon",
+    "model": "F90X",
+    "displayName": "Nikon F90X / N90s",
+    "notes": "35mm autofocus SLR, F-mount."
+  },
+  {
+    "id": "cam-nikon-f5",
+    "make": "Nikon",
+    "model": "F5",
+    "displayName": "Nikon F5",
+    "notes": "35mm professional autofocus SLR, F-mount."
+  },
+  {
+    "id": "cam-nikon-pronea-600i",
+    "make": "Nikon",
+    "model": "Pronea 600i",
+    "displayName": "Nikon Pronea 600i / S",
+    "notes": "APS IX240 autofocus SLR, Pronea mount."
+  },
+  {
+    "id": "cam-nikon-f100",
+    "make": "Nikon",
+    "model": "F100",
+    "displayName": "Nikon F100",
+    "notes": "35mm autofocus SLR, F-mount."
+  },
+  {
+    "id": "cam-nikon-fm3a",
+    "make": "Nikon",
+    "model": "FM3A",
+    "displayName": "Nikon FM3A",
+    "notes": "35mm mechanical/electronic hybrid SLR, F-mount."
+  },
+  {
+    "id": "cam-nikon-f80",
+    "make": "Nikon",
+    "model": "F80",
+    "displayName": "Nikon F80 / N80",
+    "notes": "35mm autofocus SLR, F-mount."
+  },
+  {
+    "id": "cam-nikon-f75",
+    "make": "Nikon",
+    "model": "F75",
+    "displayName": "Nikon F75 / N75",
+    "notes": "35mm autofocus SLR, F-mount."
+  },
+  {
+    "id": "cam-nikon-f6",
+    "make": "Nikon",
+    "model": "F6",
+    "displayName": "Nikon F6",
+    "notes": "35mm professional autofocus SLR, F-mount."
   },
   {
     "id": "cam-pentax-k1000",

--- a/gear/gear_presets.json
+++ b/gear/gear_presets.json
@@ -17,7 +17,7 @@
     "id": "preset-fm2-50-trix",
     "displayName": "FM2 / Nikkor 50 f/1.8 / Tri-X 400",
     "cameraId": "cam-nikon-fm2",
-    "lensId": "lens-leica-summicron-50-2.0",
+    "lensId": "lens-nikon-ais-nikkor-50-18",
     "filmStockId": "film-tri-x-400"
   }
 ]

--- a/gear/lenses.json
+++ b/gear/lenses.json
@@ -40,12 +40,535 @@
     "maxAperture": 2.0
   },
   {
-    "id": "lens-nikkor-50-1.8",
+    "id": "lens-nikon-ai-nikkor-18-4",
+    "displayName": "Nikkor 18mm f/4 AI",
+    "lensModel": "Nikkor 18mm f/4 AI",
+    "make": "Nikon",
+    "focalLength": 18.0,
+    "maxAperture": 4.0,
+    "notes": "Manual-focus F-mount."
+  },
+  {
+    "id": "lens-nikon-ais-nikkor-18-35",
+    "displayName": "Nikkor 18mm f/3.5 AI-S",
+    "lensModel": "Nikkor 18mm f/3.5 AI-S",
+    "make": "Nikon",
+    "focalLength": 18.0,
+    "maxAperture": 3.5,
+    "notes": "Manual-focus F-mount."
+  },
+  {
+    "id": "lens-nikon-ai-nikkor-20-35",
+    "displayName": "Nikkor 20mm f/3.5 AI",
+    "lensModel": "Nikkor 20mm f/3.5 AI",
+    "make": "Nikon",
+    "focalLength": 20.0,
+    "maxAperture": 3.5,
+    "notes": "Manual-focus F-mount."
+  },
+  {
+    "id": "lens-nikon-ais-nikkor-20-35",
+    "displayName": "Nikkor 20mm f/3.5 AI-S",
+    "lensModel": "Nikkor 20mm f/3.5 AI-S",
+    "make": "Nikon",
+    "focalLength": 20.0,
+    "maxAperture": 3.5,
+    "notes": "Manual-focus F-mount."
+  },
+  {
+    "id": "lens-nikon-ais-nikkor-20-28",
+    "displayName": "Nikkor 20mm f/2.8 AI-S",
+    "lensModel": "Nikkor 20mm f/2.8 AI-S",
+    "make": "Nikon",
+    "focalLength": 20.0,
+    "maxAperture": 2.8,
+    "notes": "Manual-focus F-mount."
+  },
+  {
+    "id": "lens-nikon-ai-nikkor-24-28",
+    "displayName": "Nikkor 24mm f/2.8 AI",
+    "lensModel": "Nikkor 24mm f/2.8 AI",
+    "make": "Nikon",
+    "focalLength": 24.0,
+    "maxAperture": 2.8,
+    "notes": "Manual-focus F-mount."
+  },
+  {
+    "id": "lens-nikon-ais-nikkor-24-28",
+    "displayName": "Nikkor 24mm f/2.8 AI-S",
+    "lensModel": "Nikkor 24mm f/2.8 AI-S",
+    "make": "Nikon",
+    "focalLength": 24.0,
+    "maxAperture": 2.8,
+    "notes": "Manual-focus F-mount."
+  },
+  {
+    "id": "lens-nikon-ai-nikkor-24-2",
+    "displayName": "Nikkor 24mm f/2 AI",
+    "lensModel": "Nikkor 24mm f/2 AI",
+    "make": "Nikon",
+    "focalLength": 24.0,
+    "maxAperture": 2.0,
+    "notes": "Manual-focus F-mount."
+  },
+  {
+    "id": "lens-nikon-ais-nikkor-24-2",
+    "displayName": "Nikkor 24mm f/2 AI-S",
+    "lensModel": "Nikkor 24mm f/2 AI-S",
+    "make": "Nikon",
+    "focalLength": 24.0,
+    "maxAperture": 2.0,
+    "notes": "Manual-focus F-mount."
+  },
+  {
+    "id": "lens-nikon-ai-nikkor-28-35",
+    "displayName": "Nikkor 28mm f/3.5 AI",
+    "lensModel": "Nikkor 28mm f/3.5 AI",
+    "make": "Nikon",
+    "focalLength": 28.0,
+    "maxAperture": 3.5,
+    "notes": "Manual-focus F-mount."
+  },
+  {
+    "id": "lens-nikon-ais-nikkor-28-35",
+    "displayName": "Nikkor 28mm f/3.5 AI-S",
+    "lensModel": "Nikkor 28mm f/3.5 AI-S",
+    "make": "Nikon",
+    "focalLength": 28.0,
+    "maxAperture": 3.5,
+    "notes": "Manual-focus F-mount."
+  },
+  {
+    "id": "lens-nikon-ai-nikkor-28-28",
+    "displayName": "Nikkor 28mm f/2.8 AI",
+    "lensModel": "Nikkor 28mm f/2.8 AI",
+    "make": "Nikon",
+    "focalLength": 28.0,
+    "maxAperture": 2.8,
+    "notes": "Manual-focus F-mount."
+  },
+  {
+    "id": "lens-nikon-ais-nikkor-28-28",
+    "displayName": "Nikkor 28mm f/2.8 AI-S",
+    "lensModel": "Nikkor 28mm f/2.8 AI-S",
+    "make": "Nikon",
+    "focalLength": 28.0,
+    "maxAperture": 2.8,
+    "notes": "Manual-focus F-mount."
+  },
+  {
+    "id": "lens-nikon-ai-nikkor-28-2",
+    "displayName": "Nikkor 28mm f/2 AI",
+    "lensModel": "Nikkor 28mm f/2 AI",
+    "make": "Nikon",
+    "focalLength": 28.0,
+    "maxAperture": 2.0,
+    "notes": "Manual-focus F-mount."
+  },
+  {
+    "id": "lens-nikon-ais-nikkor-28-2",
+    "displayName": "Nikkor 28mm f/2 AI-S",
+    "lensModel": "Nikkor 28mm f/2 AI-S",
+    "make": "Nikon",
+    "focalLength": 28.0,
+    "maxAperture": 2.0,
+    "notes": "Manual-focus F-mount."
+  },
+  {
+    "id": "lens-nikon-ai-nikkor-35-28",
+    "displayName": "Nikkor 35mm f/2.8 AI",
+    "lensModel": "Nikkor 35mm f/2.8 AI",
+    "make": "Nikon",
+    "focalLength": 35.0,
+    "maxAperture": 2.8,
+    "notes": "Manual-focus F-mount."
+  },
+  {
+    "id": "lens-nikon-ais-nikkor-35-28",
+    "displayName": "Nikkor 35mm f/2.8 AI-S",
+    "lensModel": "Nikkor 35mm f/2.8 AI-S",
+    "make": "Nikon",
+    "focalLength": 35.0,
+    "maxAperture": 2.8,
+    "notes": "Manual-focus F-mount."
+  },
+  {
+    "id": "lens-nikon-ai-nikkor-35-2",
+    "displayName": "Nikkor 35mm f/2 AI",
+    "lensModel": "Nikkor 35mm f/2 AI",
+    "make": "Nikon",
+    "focalLength": 35.0,
+    "maxAperture": 2.0,
+    "notes": "Manual-focus F-mount."
+  },
+  {
+    "id": "lens-nikon-ais-nikkor-35-2",
+    "displayName": "Nikkor 35mm f/2 AI-S",
+    "lensModel": "Nikkor 35mm f/2 AI-S",
+    "make": "Nikon",
+    "focalLength": 35.0,
+    "maxAperture": 2.0,
+    "notes": "Manual-focus F-mount."
+  },
+  {
+    "id": "lens-nikon-ai-nikkor-35-14",
+    "displayName": "Nikkor 35mm f/1.4 AI",
+    "lensModel": "Nikkor 35mm f/1.4 AI",
+    "make": "Nikon",
+    "focalLength": 35.0,
+    "maxAperture": 1.4,
+    "notes": "Manual-focus F-mount."
+  },
+  {
+    "id": "lens-nikon-ais-nikkor-35-14",
+    "displayName": "Nikkor 35mm f/1.4 AI-S",
+    "lensModel": "Nikkor 35mm f/1.4 AI-S",
+    "make": "Nikon",
+    "focalLength": 35.0,
+    "maxAperture": 1.4,
+    "notes": "Manual-focus F-mount."
+  },
+  {
+    "id": "lens-nikon-ai-nikkor-45-28-gn",
+    "displayName": "Nikkor 45mm f/2.8 GN AI",
+    "lensModel": "Nikkor 45mm f/2.8 GN AI",
+    "make": "Nikon",
+    "focalLength": 45.0,
+    "maxAperture": 2.8,
+    "notes": "Manual-focus F-mount."
+  },
+  {
+    "id": "lens-nikon-ai-nikkor-50-2",
+    "displayName": "Nikkor 50mm f/2 AI",
+    "lensModel": "Nikkor 50mm f/2 AI",
+    "make": "Nikon",
+    "focalLength": 50.0,
+    "maxAperture": 2.0,
+    "notes": "Manual-focus F-mount."
+  },
+  {
+    "id": "lens-nikon-ai-nikkor-50-18",
+    "displayName": "Nikkor 50mm f/1.8 AI",
+    "lensModel": "Nikkor 50mm f/1.8 AI",
+    "make": "Nikon",
+    "focalLength": 50.0,
+    "maxAperture": 1.8,
+    "notes": "Manual-focus F-mount."
+  },
+  {
+    "id": "lens-nikon-ais-nikkor-50-18",
     "displayName": "Nikkor 50mm f/1.8 AI-S",
     "lensModel": "Nikkor 50mm f/1.8 AI-S",
     "make": "Nikon",
-    "focalLength": 50,
-    "maxAperture": 1.8
+    "focalLength": 50.0,
+    "maxAperture": 1.8,
+    "notes": "Manual-focus F-mount."
+  },
+  {
+    "id": "lens-nikon-ai-nikkor-50-14",
+    "displayName": "Nikkor 50mm f/1.4 AI",
+    "lensModel": "Nikkor 50mm f/1.4 AI",
+    "make": "Nikon",
+    "focalLength": 50.0,
+    "maxAperture": 1.4,
+    "notes": "Manual-focus F-mount."
+  },
+  {
+    "id": "lens-nikon-ais-nikkor-50-14",
+    "displayName": "Nikkor 50mm f/1.4 AI-S",
+    "lensModel": "Nikkor 50mm f/1.4 AI-S",
+    "make": "Nikon",
+    "focalLength": 50.0,
+    "maxAperture": 1.4,
+    "notes": "Manual-focus F-mount."
+  },
+  {
+    "id": "lens-nikon-ais-nikkor-50-12",
+    "displayName": "Nikkor 50mm f/1.2 AI-S",
+    "lensModel": "Nikkor 50mm f/1.2 AI-S",
+    "make": "Nikon",
+    "focalLength": 50.0,
+    "maxAperture": 1.2,
+    "notes": "Manual-focus F-mount."
+  },
+  {
+    "id": "lens-nikon-ai-micro-nikkor-55-35",
+    "displayName": "Micro-Nikkor 55mm f/3.5 AI",
+    "lensModel": "Micro-Nikkor 55mm f/3.5 AI",
+    "make": "Nikon",
+    "focalLength": 55.0,
+    "maxAperture": 3.5,
+    "notes": "Manual-focus F-mount."
+  },
+  {
+    "id": "lens-nikon-ai-micro-nikkor-55-28",
+    "displayName": "Micro-Nikkor 55mm f/2.8 AI",
+    "lensModel": "Micro-Nikkor 55mm f/2.8 AI",
+    "make": "Nikon",
+    "focalLength": 55.0,
+    "maxAperture": 2.8,
+    "notes": "Manual-focus F-mount."
+  },
+  {
+    "id": "lens-nikon-ais-micro-nikkor-55-28",
+    "displayName": "Micro-Nikkor 55mm f/2.8 AI-S",
+    "lensModel": "Micro-Nikkor 55mm f/2.8 AI-S",
+    "make": "Nikon",
+    "focalLength": 55.0,
+    "maxAperture": 2.8,
+    "notes": "Manual-focus F-mount."
+  },
+  {
+    "id": "lens-nikon-ai-nikkor-85-2",
+    "displayName": "Nikkor 85mm f/2 AI",
+    "lensModel": "Nikkor 85mm f/2 AI",
+    "make": "Nikon",
+    "focalLength": 85.0,
+    "maxAperture": 2.0,
+    "notes": "Manual-focus F-mount."
+  },
+  {
+    "id": "lens-nikon-ais-nikkor-85-2",
+    "displayName": "Nikkor 85mm f/2 AI-S",
+    "lensModel": "Nikkor 85mm f/2 AI-S",
+    "make": "Nikon",
+    "focalLength": 85.0,
+    "maxAperture": 2.0,
+    "notes": "Manual-focus F-mount."
+  },
+  {
+    "id": "lens-nikon-ais-nikkor-85-14",
+    "displayName": "Nikkor 85mm f/1.4 AI-S",
+    "lensModel": "Nikkor 85mm f/1.4 AI-S",
+    "make": "Nikon",
+    "focalLength": 85.0,
+    "maxAperture": 1.4,
+    "notes": "Manual-focus F-mount."
+  },
+  {
+    "id": "lens-nikon-ai-nikkor-105-25",
+    "displayName": "Nikkor 105mm f/2.5 AI",
+    "lensModel": "Nikkor 105mm f/2.5 AI",
+    "make": "Nikon",
+    "focalLength": 105.0,
+    "maxAperture": 2.5,
+    "notes": "Manual-focus F-mount."
+  },
+  {
+    "id": "lens-nikon-ais-nikkor-105-25",
+    "displayName": "Nikkor 105mm f/2.5 AI-S",
+    "lensModel": "Nikkor 105mm f/2.5 AI-S",
+    "make": "Nikon",
+    "focalLength": 105.0,
+    "maxAperture": 2.5,
+    "notes": "Manual-focus F-mount."
+  },
+  {
+    "id": "lens-nikon-ai-nikkor-105-18",
+    "displayName": "Nikkor 105mm f/1.8 AI",
+    "lensModel": "Nikkor 105mm f/1.8 AI",
+    "make": "Nikon",
+    "focalLength": 105.0,
+    "maxAperture": 1.8,
+    "notes": "Manual-focus F-mount."
+  },
+  {
+    "id": "lens-nikon-ais-nikkor-105-18",
+    "displayName": "Nikkor 105mm f/1.8 AI-S",
+    "lensModel": "Nikkor 105mm f/1.8 AI-S",
+    "make": "Nikon",
+    "focalLength": 105.0,
+    "maxAperture": 1.8,
+    "notes": "Manual-focus F-mount."
+  },
+  {
+    "id": "lens-nikon-ai-micro-nikkor-105-4",
+    "displayName": "Micro-Nikkor 105mm f/4 AI",
+    "lensModel": "Micro-Nikkor 105mm f/4 AI",
+    "make": "Nikon",
+    "focalLength": 105.0,
+    "maxAperture": 4.0,
+    "notes": "Manual-focus F-mount."
+  },
+  {
+    "id": "lens-nikon-ais-micro-nikkor-105-28",
+    "displayName": "Micro-Nikkor 105mm f/2.8 AI-S",
+    "lensModel": "Micro-Nikkor 105mm f/2.8 AI-S",
+    "make": "Nikon",
+    "focalLength": 105.0,
+    "maxAperture": 2.8,
+    "notes": "Manual-focus F-mount."
+  },
+  {
+    "id": "lens-nikon-ai-nikkor-135-35",
+    "displayName": "Nikkor 135mm f/3.5 AI",
+    "lensModel": "Nikkor 135mm f/3.5 AI",
+    "make": "Nikon",
+    "focalLength": 135.0,
+    "maxAperture": 3.5,
+    "notes": "Manual-focus F-mount."
+  },
+  {
+    "id": "lens-nikon-ais-nikkor-135-35",
+    "displayName": "Nikkor 135mm f/3.5 AI-S",
+    "lensModel": "Nikkor 135mm f/3.5 AI-S",
+    "make": "Nikon",
+    "focalLength": 135.0,
+    "maxAperture": 3.5,
+    "notes": "Manual-focus F-mount."
+  },
+  {
+    "id": "lens-nikon-ai-nikkor-135-28",
+    "displayName": "Nikkor 135mm f/2.8 AI",
+    "lensModel": "Nikkor 135mm f/2.8 AI",
+    "make": "Nikon",
+    "focalLength": 135.0,
+    "maxAperture": 2.8,
+    "notes": "Manual-focus F-mount."
+  },
+  {
+    "id": "lens-nikon-ais-nikkor-135-28",
+    "displayName": "Nikkor 135mm f/2.8 AI-S",
+    "lensModel": "Nikkor 135mm f/2.8 AI-S",
+    "make": "Nikon",
+    "focalLength": 135.0,
+    "maxAperture": 2.8,
+    "notes": "Manual-focus F-mount."
+  },
+  {
+    "id": "lens-nikon-ai-nikkor-135-2",
+    "displayName": "Nikkor 135mm f/2 AI",
+    "lensModel": "Nikkor 135mm f/2 AI",
+    "make": "Nikon",
+    "focalLength": 135.0,
+    "maxAperture": 2.0,
+    "notes": "Manual-focus F-mount."
+  },
+  {
+    "id": "lens-nikon-ais-nikkor-135-2",
+    "displayName": "Nikkor 135mm f/2 AI-S",
+    "lensModel": "Nikkor 135mm f/2 AI-S",
+    "make": "Nikon",
+    "focalLength": 135.0,
+    "maxAperture": 2.0,
+    "notes": "Manual-focus F-mount."
+  },
+  {
+    "id": "lens-nikon-ai-nikkor-180-28-ed",
+    "displayName": "Nikkor 180mm f/2.8 ED AI",
+    "lensModel": "Nikkor 180mm f/2.8 ED AI",
+    "make": "Nikon",
+    "focalLength": 180.0,
+    "maxAperture": 2.8,
+    "notes": "Manual-focus F-mount."
+  },
+  {
+    "id": "lens-nikon-ais-nikkor-180-28-ed",
+    "displayName": "Nikkor 180mm f/2.8 ED AI-S",
+    "lensModel": "Nikkor 180mm f/2.8 ED AI-S",
+    "make": "Nikon",
+    "focalLength": 180.0,
+    "maxAperture": 2.8,
+    "notes": "Manual-focus F-mount."
+  },
+  {
+    "id": "lens-nikon-ai-nikkor-200-4",
+    "displayName": "Nikkor 200mm f/4 AI",
+    "lensModel": "Nikkor 200mm f/4 AI",
+    "make": "Nikon",
+    "focalLength": 200.0,
+    "maxAperture": 4.0,
+    "notes": "Manual-focus F-mount."
+  },
+  {
+    "id": "lens-nikon-ais-nikkor-200-4",
+    "displayName": "Nikkor 200mm f/4 AI-S",
+    "lensModel": "Nikkor 200mm f/4 AI-S",
+    "make": "Nikon",
+    "focalLength": 200.0,
+    "maxAperture": 4.0,
+    "notes": "Manual-focus F-mount."
+  },
+  {
+    "id": "lens-nikon-ai-zoom-nikkor-25-50-4",
+    "displayName": "Zoom-Nikkor 25-50mm f/4 AI",
+    "lensModel": "Zoom-Nikkor 25-50mm f/4 AI",
+    "make": "Nikon",
+    "focalLength": 25.0,
+    "maxAperture": 4.0,
+    "notes": "Manual-focus F-mount."
+  },
+  {
+    "id": "lens-nikon-ais-zoom-nikkor-25-50-4",
+    "displayName": "Zoom-Nikkor 25-50mm f/4 AI-S",
+    "lensModel": "Zoom-Nikkor 25-50mm f/4 AI-S",
+    "make": "Nikon",
+    "focalLength": 25.0,
+    "maxAperture": 4.0,
+    "notes": "Manual-focus F-mount."
+  },
+  {
+    "id": "lens-nikon-ai-zoom-nikkor-35-70-35",
+    "displayName": "Zoom-Nikkor 35-70mm f/3.5 AI",
+    "lensModel": "Zoom-Nikkor 35-70mm f/3.5 AI",
+    "make": "Nikon",
+    "focalLength": 35.0,
+    "maxAperture": 3.5,
+    "notes": "Manual-focus F-mount."
+  },
+  {
+    "id": "lens-nikon-ais-zoom-nikkor-35-70-35",
+    "displayName": "Zoom-Nikkor 35-70mm f/3.5 AI-S",
+    "lensModel": "Zoom-Nikkor 35-70mm f/3.5 AI-S",
+    "make": "Nikon",
+    "focalLength": 35.0,
+    "maxAperture": 3.5,
+    "notes": "Manual-focus F-mount."
+  },
+  {
+    "id": "lens-nikon-ais-zoom-nikkor-50-135-35",
+    "displayName": "Zoom-Nikkor 50-135mm f/3.5 AI-S",
+    "lensModel": "Zoom-Nikkor 50-135mm f/3.5 AI-S",
+    "make": "Nikon",
+    "focalLength": 50.0,
+    "maxAperture": 3.5,
+    "notes": "Manual-focus F-mount."
+  },
+  {
+    "id": "lens-nikon-ai-zoom-nikkor-80-200-4",
+    "displayName": "Zoom-Nikkor 80-200mm f/4 AI",
+    "lensModel": "Zoom-Nikkor 80-200mm f/4 AI",
+    "make": "Nikon",
+    "focalLength": 80.0,
+    "maxAperture": 4.0,
+    "notes": "Manual-focus F-mount."
+  },
+  {
+    "id": "lens-nikon-ais-zoom-nikkor-80-200-4",
+    "displayName": "Zoom-Nikkor 80-200mm f/4 AI-S",
+    "lensModel": "Zoom-Nikkor 80-200mm f/4 AI-S",
+    "make": "Nikon",
+    "focalLength": 80.0,
+    "maxAperture": 4.0,
+    "notes": "Manual-focus F-mount."
+  },
+  {
+    "id": "lens-nikon-ai-zoom-nikkor-50-300-45-ed",
+    "displayName": "Zoom-Nikkor 50-300mm f/4.5 ED AI",
+    "lensModel": "Zoom-Nikkor 50-300mm f/4.5 ED AI",
+    "make": "Nikon",
+    "focalLength": 50.0,
+    "maxAperture": 4.5,
+    "notes": "Manual-focus F-mount."
+  },
+  {
+    "id": "lens-nikon-ais-zoom-nikkor-50-300-45-ed",
+    "displayName": "Zoom-Nikkor 50-300mm f/4.5 ED AI-S",
+    "lensModel": "Zoom-Nikkor 50-300mm f/4.5 ED AI-S",
+    "make": "Nikon",
+    "focalLength": 50.0,
+    "maxAperture": 4.5,
+    "notes": "Manual-focus F-mount."
   },
   {
     "id": "lens-pentax-smc-50-1.7",


### PR DESCRIPTION
## Summary

Expands the bundled gear library with Nikon bodies and manual-focus F-mount lenses for the Metadata tab.

- **29 Nikon cameras** — S2/SP through F6, including Nikkormat and Pronea variants
- **59 Nikon lenses** — AI/AI-S primes, Micro-Nikkors, and manual zooms; names use suffix style (`Nikkor 28mm f/2.8 AI-S`)
- Fixes bundled **FM2 / Tri-X** preset to reference the correct Nikkor 50mm f/1.8 AI-S lens

## Test plan

- [x] Fresh install or re-seed `~/NegPy/gear/` — cameras and lenses appear in Metadata **Manage…** dropdowns
- [x] select a few Nikon bodies and lenses by name
- [x] Bundled FM2 preset resolves camera + lens correctly