### PR TITLE
Feature/gear library search filter

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -214,10 +214,10 @@ Archival metadata for the **original analog capture** — gear, process, and sca
 
 ### Original analog gear
 
-Pick gear from your library (or a saved preset). Use **Manage…** to edit cameras, lenses, film stocks, and gear presets. Starter data is seeded into `~/NegPy/gear/` on first launch.
+Pick gear from your library (or a saved preset). Use **Manage…** to edit cameras, lenses, film stocks, and gear presets — the item list and preset link combos support the same type-to-search filtering. Starter data is seeded into `~/NegPy/gear/` on first launch.
 
 *   **Preset**: One-click camera + lens + film combination.
-*   **Camera / Lens / Film stock**: Dropdowns from the gear library. Changing any item clears the preset selection.
+*   **Camera / Lens / Film stock**: Searchable dropdowns — empty fields show a search hint; type to filter the list. An empty field means "not set", so clear the text to remove a selection. Changing any item clears the preset selection.
 *   **Clear**: Clears gear preset and library selections for this frame.
 
 Structured fields for the **original capture** (camera, lens, film ISO) are written to **standard EXIF** when you set gear in the Metadata tab — so Lightroom and other DAMs show your film camera and lens. Scan-only tags from the source file (`FocalLengthIn35mmFormat`, scan exposure/ISO, etc.) are stripped so they do not mix with capture data. The **digitization rig** (DSLR, film scanner, copy-stand setup) is preserved in `negpy:Scan*` XMP tags only.

--- a/gear/gear_presets.json
+++ b/gear/gear_presets.json
@@ -17,7 +17,7 @@
     "id": "preset-fm2-50-trix",
     "displayName": "FM2 / Nikkor 50 f/1.8 / Tri-X 400",
     "cameraId": "cam-nikon-fm2",
-    "lensId": "lens-leica-summicron-50-2.0",
+    "lensId": "lens-nikkor-50-1.8",
     "filmStockId": "film-tri-x-400"
   }
 ]

--- a/negpy/desktop/view/sidebar/metadata.py
+++ b/negpy/desktop/view/sidebar/metadata.py
@@ -18,6 +18,7 @@ from negpy.desktop.view.styles.templates import field_label, section_subheader
 from negpy.desktop.view.styles.theme import THEME
 from negpy.desktop.view.widgets.collapsible import CollapsibleSection
 from negpy.desktop.view.widgets.gear_library_dialog import GearLibraryDialog
+from negpy.desktop.view.widgets.searchable_gear_combo import SearchableGearCombo
 from negpy.features.metadata.gear_logic import metadata_from_gear
 from negpy.features.metadata.gear_models import GearLibrary
 from negpy.features.metadata.payload import build_metadata_payload
@@ -26,8 +27,6 @@ from negpy.services.assets.gear import GearProfiles
 FORMAT_OPTIONS = ["35mm", "120", "4×5", "8×10", "110", "Other"]
 PUSH_PULL_OPTIONS = ["Push +3", "Push +2", "Push +1", "Normal", "Pull -1", "Pull -2", "Pull -3"]
 PUSH_PULL_VALUES = [3, 2, 1, 0, -1, -2, -3]
-
-_NONE = "— None —"
 
 
 class MetadataSidebar(BaseSidebar):
@@ -54,11 +53,15 @@ class MetadataSidebar(BaseSidebar):
         # ── ORIGINAL ANALOG GEAR ─────────────────────────────────────────
         self.layout.addWidget(section_subheader("ORIGINAL ANALOG GEAR"))
 
+        gear_hint = QLabel("Type in any field to search the gear library.")
+        gear_hint.setStyleSheet(f"font-size: {THEME.font_size_xs}px; color: {THEME.text_muted};")
+        self.layout.addWidget(gear_hint)
+
         preset_row = QHBoxLayout()
         preset_row.setSpacing(4)
         self.layout.addWidget(field_label("Preset"))
-        self.preset_combo = QComboBox()
-        self.preset_combo.setToolTip("Reusable camera + lens + film combination")
+        self.preset_combo = SearchableGearCombo(placeholder="Search presets…")
+        self.preset_combo.setToolTip("Reusable camera + lens + film combination. Click and type to search.")
         preset_row.addWidget(self.preset_combo, 1)
         self.preset_clear_btn = QPushButton("Clear")
         self.preset_clear_btn.setToolTip("Clear gear preset selection")
@@ -66,18 +69,18 @@ class MetadataSidebar(BaseSidebar):
         self.layout.addLayout(preset_row)
 
         self.layout.addWidget(field_label("Camera"))
-        self.camera_combo = QComboBox()
-        self.camera_combo.setToolTip("Original film camera body")
+        self.camera_combo = SearchableGearCombo(placeholder="Search cameras…")
+        self.camera_combo.setToolTip("Original film camera body. Click and type to search.")
         self.layout.addWidget(self.camera_combo)
 
         self.layout.addWidget(field_label("Lens"))
-        self.lens_combo = QComboBox()
-        self.lens_combo.setToolTip("Original lens used on the film camera")
+        self.lens_combo = SearchableGearCombo(placeholder="Search lenses…")
+        self.lens_combo.setToolTip("Original lens used on the film camera. Click and type to search.")
         self.layout.addWidget(self.lens_combo)
 
         self.layout.addWidget(field_label("Film stock"))
-        self.film_stock_combo = QComboBox()
-        self.film_stock_combo.setToolTip("Film stock used for the original capture")
+        self.film_stock_combo = SearchableGearCombo(placeholder="Search film stocks…")
+        self.film_stock_combo.setToolTip("Film stock used for the original capture. Click and type to search.")
         self.layout.addWidget(self.film_stock_combo)
 
         self.manage_btn = QPushButton(" Manage…")
@@ -211,11 +214,11 @@ class MetadataSidebar(BaseSidebar):
         self._mark_dirty()
 
     def _connect_signals(self) -> None:
-        self.preset_combo.currentIndexChanged.connect(self._on_preset_changed)
+        self.preset_combo.selection_changed.connect(self._on_preset_changed)
         self.preset_clear_btn.clicked.connect(self._on_preset_clear)
-        self.camera_combo.currentIndexChanged.connect(self._on_gear_changed)
-        self.lens_combo.currentIndexChanged.connect(self._on_gear_changed)
-        self.film_stock_combo.currentIndexChanged.connect(self._on_gear_changed)
+        self.camera_combo.selection_changed.connect(self._on_gear_changed)
+        self.lens_combo.selection_changed.connect(self._on_gear_changed)
+        self.film_stock_combo.selection_changed.connect(self._on_gear_changed)
         self.manage_btn.clicked.connect(self._open_gear_library)
 
         self.format_combo.currentTextChanged.connect(self._on_format_changed)
@@ -231,33 +234,41 @@ class MetadataSidebar(BaseSidebar):
     def _refresh_gear_combos(self) -> None:
         conf = self.state.config.metadata
         self._gear_library = GearProfiles.load_library()
+        library = self._gear_library
 
-        def fill(combo: QComboBox, items, selected_id: str) -> None:
-            combo.blockSignals(True)
-            combo.clear()
-            combo.addItem(_NONE, "")
-            for item in items:
-                label = item.resolved_display_name if hasattr(item, "resolved_display_name") else item.display_name
-                combo.addItem(label, item.id)
-            idx = combo.findData(selected_id or "")
-            combo.setCurrentIndex(idx if idx >= 0 else 0)
-            combo.blockSignals(False)
+        if not self.preset_combo.is_editing():
+            self.preset_combo.blockSignals(True)
+            self.preset_combo.set_gear_items(
+                library.gear_presets,
+                conf.gear_preset_id or "",
+                lambda p: p.display_name or "Unnamed preset",
+                library,
+            )
+            self.preset_combo.blockSignals(False)
 
-        self.preset_combo.blockSignals(True)
-        self.preset_combo.clear()
-        self.preset_combo.addItem(_NONE, "")
-        for p in self._gear_library.gear_presets:
-            self.preset_combo.addItem(p.display_name or "Unnamed preset", p.id)
-        pidx = self.preset_combo.findData(conf.gear_preset_id or "")
-        self.preset_combo.setCurrentIndex(pidx if pidx >= 0 else 0)
-        self.preset_combo.blockSignals(False)
+        if not self.camera_combo.is_editing():
+            self.camera_combo.set_gear_items(
+                library.cameras,
+                conf.camera_id or "",
+                lambda c: c.resolved_display_name,
+            )
 
-        fill(self.camera_combo, self._gear_library.cameras, conf.camera_id)
-        fill(self.lens_combo, self._gear_library.lenses, conf.lens_id)
-        fill(self.film_stock_combo, self._gear_library.film_stocks, conf.film_stock_id)
+        if not self.lens_combo.is_editing():
+            self.lens_combo.set_gear_items(
+                library.lenses,
+                conf.lens_id or "",
+                lambda lens: lens.resolved_display_name,
+            )
+
+        if not self.film_stock_combo.is_editing():
+            self.film_stock_combo.set_gear_items(
+                library.film_stocks,
+                conf.film_stock_id or "",
+                lambda stock: stock.resolved_display_name,
+            )
 
     def _on_preset_changed(self, _idx: int) -> None:
-        preset_id = self.preset_combo.currentData() or ""
+        preset_id = self.preset_combo.selected_id()
         if not preset_id:
             return
         new_meta = metadata_from_gear(
@@ -288,17 +299,27 @@ class MetadataSidebar(BaseSidebar):
         self._apply_metadata_config(cleared)
 
     def _on_gear_changed(self, *_args) -> None:
+        sender = self.sender()
+        kwargs: dict = {}
+        if sender is self.camera_combo:
+            kwargs["gear_preset_id"] = ""
+            kwargs["camera_id"] = self.camera_combo.selected_id()
+        elif sender is self.lens_combo:
+            kwargs["gear_preset_id"] = ""
+            kwargs["lens_id"] = self.lens_combo.selected_id()
+        elif sender is self.film_stock_combo:
+            kwargs["gear_preset_id"] = ""
+            kwargs["film_stock_id"] = self.film_stock_combo.selected_id()
+        else:
+            return
+
         new_meta = metadata_from_gear(
             self.state.config.metadata,
             self._gear_library,
-            gear_preset_id="",
-            camera_id=self.camera_combo.currentData() or "",
-            lens_id=self.lens_combo.currentData() or "",
-            film_stock_id=self.film_stock_combo.currentData() or "",
+            **kwargs,
         )
-        new_meta = replace(new_meta, gear_preset_id="")
         self.preset_combo.blockSignals(True)
-        self.preset_combo.setCurrentIndex(0)
+        self.preset_combo.set_selected_id("")
         self.preset_combo.blockSignals(False)
         self._apply_metadata_config(new_meta, refresh_combos=False)
 
@@ -355,10 +376,10 @@ class MetadataSidebar(BaseSidebar):
             persist=True,
             render=False,
             readback_metrics=False,
-            gear_preset_id=self.preset_combo.currentData() or "",
-            camera_id=self.camera_combo.currentData() or "",
-            lens_id=self.lens_combo.currentData() or "",
-            film_stock_id=self.film_stock_combo.currentData() or "",
+            gear_preset_id=self.preset_combo.selected_id(),
+            camera_id=self.camera_combo.selected_id(),
+            lens_id=self.lens_combo.selected_id(),
+            film_stock_id=self.film_stock_combo.selected_id(),
             format=fmt,
             format_other=self.format_other_edit.text().strip() if fmt == "Other" else "",
             developer=self.developer_edit.text().strip(),

--- a/negpy/desktop/view/sidebar/metadata.py
+++ b/negpy/desktop/view/sidebar/metadata.py
@@ -231,12 +231,15 @@ class MetadataSidebar(BaseSidebar):
 
         self.controller.session.file_selected.connect(self._on_file_selected)
 
-    def _refresh_gear_combos(self) -> None:
+    def _refresh_gear_combos(self, *, force: bool = False) -> None:
         conf = self.state.config.metadata
         self._gear_library = GearProfiles.load_library()
         library = self._gear_library
 
-        if not self.preset_combo.is_editing():
+        def should_refresh(combo: SearchableGearCombo) -> bool:
+            return force or not combo.is_editing()
+
+        if should_refresh(self.preset_combo):
             self.preset_combo.blockSignals(True)
             self.preset_combo.set_gear_items(
                 library.gear_presets,
@@ -246,31 +249,32 @@ class MetadataSidebar(BaseSidebar):
             )
             self.preset_combo.blockSignals(False)
 
-        if not self.camera_combo.is_editing():
+        if should_refresh(self.camera_combo):
             self.camera_combo.set_gear_items(
                 library.cameras,
                 conf.camera_id or "",
                 lambda c: c.resolved_display_name,
             )
 
-        if not self.lens_combo.is_editing():
+        if should_refresh(self.lens_combo):
             self.lens_combo.set_gear_items(
                 library.lenses,
                 conf.lens_id or "",
                 lambda lens: lens.resolved_display_name,
             )
 
-        if not self.film_stock_combo.is_editing():
+        if should_refresh(self.film_stock_combo):
             self.film_stock_combo.set_gear_items(
                 library.film_stocks,
                 conf.film_stock_id or "",
                 lambda stock: stock.resolved_display_name,
             )
 
-    def _on_preset_changed(self, _idx: int) -> None:
+    def _on_preset_changed(self, _preset_id: str = "") -> None:
         preset_id = self.preset_combo.selected_id()
         if not preset_id:
             return
+        self._dirty = False
         new_meta = metadata_from_gear(
             self.state.config.metadata,
             self._gear_library,
@@ -332,7 +336,7 @@ class MetadataSidebar(BaseSidebar):
             **asdict(new_meta),
         )
         if refresh_combos:
-            self._refresh_gear_combos()
+            self._refresh_gear_combos(force=True)
         self.sync_ui()
         self._schedule_preview()
 

--- a/negpy/desktop/view/widgets/gear_library_dialog.py
+++ b/negpy/desktop/view/widgets/gear_library_dialog.py
@@ -23,6 +23,8 @@ from PyQt6.QtWidgets import (
 
 from negpy.desktop.view.styles.templates import field_label
 from negpy.desktop.view.styles.theme import THEME
+from negpy.desktop.view.widgets.searchable_gear_combo import SearchableGearCombo
+from negpy.features.metadata.gear_logic import matches_gear_filter
 from negpy.features.metadata.gear_models import (
     Camera,
     FilmColorType,
@@ -48,6 +50,13 @@ _CATEGORY_FIELDS: dict[str, frozenset[str]] = {
     "gear_presets": frozenset({"display_name", "preset_camera", "preset_lens", "preset_film", "notes"}),
 }
 
+_CATEGORY_SEARCH_PLACEHOLDER = {
+    "cameras": "Search cameras…",
+    "lenses": "Search lenses…",
+    "film_stocks": "Search film stocks…",
+    "gear_presets": "Search presets…",
+}
+
 
 class GearLibraryDialog(QDialog):
     library_changed = pyqtSignal()
@@ -57,6 +66,7 @@ class GearLibraryDialog(QDialog):
         self._library = library or GearProfiles.load_library()
         self._category = "cameras"
         self._selected_idx = -1
+        self._list_items: list = []
         self._updating = False
 
         self.setWindowTitle("Gear Library")
@@ -101,6 +111,11 @@ class GearLibraryDialog(QDialog):
         self.items_label = QLabel("ITEMS")
         self.items_label.setStyleSheet(f"color: {THEME.text_muted}; font-size: 10px; font-weight: bold;")
         mid_layout.addWidget(self.items_label)
+
+        self.item_search = QLineEdit()
+        self.item_search.setPlaceholderText("Search cameras…")
+        self.item_search.textChanged.connect(self._on_item_search_changed)
+        mid_layout.addWidget(self.item_search)
 
         self.item_list = QListWidget()
         self.item_list.currentRowChanged.connect(self._on_item_changed)
@@ -152,9 +167,9 @@ class GearLibraryDialog(QDialog):
         self.color_combo = QComboBox()
         self.color_combo.addItems([e.value for e in FilmColorType])
         self.notes_edit = QLineEdit()
-        self.preset_camera_combo = QComboBox()
-        self.preset_lens_combo = QComboBox()
-        self.preset_film_combo = QComboBox()
+        self.preset_camera_combo = SearchableGearCombo(placeholder="Search cameras…")
+        self.preset_lens_combo = SearchableGearCombo(placeholder="Search lenses…")
+        self.preset_film_combo = SearchableGearCombo(placeholder="Search film stocks…")
 
         for w in (
             self.display_name_edit,
@@ -171,9 +186,9 @@ class GearLibraryDialog(QDialog):
         self.iso_spin.valueChanged.connect(self._on_form_changed)
         self.format_combo.currentIndexChanged.connect(self._on_form_changed)
         self.color_combo.currentIndexChanged.connect(self._on_form_changed)
-        self.preset_camera_combo.currentIndexChanged.connect(self._on_form_changed)
-        self.preset_lens_combo.currentIndexChanged.connect(self._on_form_changed)
-        self.preset_film_combo.currentIndexChanged.connect(self._on_form_changed)
+        self.preset_camera_combo.selection_changed.connect(self._on_form_changed)
+        self.preset_lens_combo.selection_changed.connect(self._on_form_changed)
+        self.preset_film_combo.selection_changed.connect(self._on_form_changed)
 
         self.form_panel = QWidget()
         self.form_layout = QFormLayout(self.form_panel)
@@ -259,42 +274,81 @@ class GearLibraryDialog(QDialog):
         if row < 0:
             return
         self._category = _CATEGORIES[row][0]
+        self.item_search.blockSignals(True)
+        self.item_search.clear()
+        self.item_search.setPlaceholderText(_CATEGORY_SEARCH_PLACEHOLDER.get(self._category, "Search…"))
+        self.item_search.blockSignals(False)
         self._rebuild_item_list()
         self._show_form_for_category(self._category)
 
-    def _rebuild_item_list(self) -> None:
+    def _on_item_search_changed(self, _text: str) -> None:
+        self._rebuild_item_list()
+
+    def _rebuild_item_list(self, *, select_id: str | None = None) -> None:
+        all_items = self._current_items()
+        selected_id = select_id
+        if selected_id is None and 0 <= self._selected_idx < len(all_items):
+            selected_id = all_items[self._selected_idx].id
+
+        query = self.item_search.text().strip()
+        lib = self._library if self._category == "gear_presets" else None
+        visible = [item for item in all_items if matches_gear_filter(item, query, lib)]
+
+        self._list_items = visible
         self.item_list.blockSignals(True)
         self.item_list.clear()
-        for item in self._current_items():
+        for item in visible:
             self.item_list.addItem(QListWidgetItem(self._item_label(item)))
+
+        row = -1
+        if visible:
+            if selected_id:
+                row = next((i for i, item in enumerate(visible) if item.id == selected_id), -1)
+            if row < 0 and select_id is not None:
+                row = next((i for i, item in enumerate(visible) if item.id == select_id), 0)
+            elif row < 0 and not query:
+                row = 0
+        self.item_list.setCurrentRow(row)
         self.item_list.blockSignals(False)
-        if self._current_items():
-            self.item_list.setCurrentRow(0)
-        else:
+
+        if not visible and not query:
             self._selected_idx = -1
             self._clear_form()
+        elif row >= 0:
+            self._on_item_changed(row)
 
-    def _refresh_preset_combos(self) -> None:
-        for combo, items, none_label in (
-            (self.preset_camera_combo, self._library.cameras, "— None —"),
-            (self.preset_lens_combo, self._library.lenses, "— None —"),
-            (self.preset_film_combo, self._library.film_stocks, "— None —"),
-        ):
-            combo.blockSignals(True)
-            combo.clear()
-            combo.addItem(none_label, "")
-            for item in items:
-                combo.addItem(self._item_label(item), item.id)
-            combo.blockSignals(False)
+    def _refresh_preset_combos(
+        self,
+        *,
+        camera_id: str = "",
+        lens_id: str = "",
+        film_id: str = "",
+    ) -> None:
+        self.preset_camera_combo.set_gear_items(
+            self._library.cameras,
+            camera_id,
+            lambda camera: camera.resolved_display_name,
+        )
+        self.preset_lens_combo.set_gear_items(
+            self._library.lenses,
+            lens_id,
+            lambda lens: lens.resolved_display_name,
+        )
+        self.preset_film_combo.set_gear_items(
+            self._library.film_stocks,
+            film_id,
+            lambda stock: stock.resolved_display_name,
+        )
 
     def _on_item_changed(self, row: int) -> None:
-        if row < 0 or row >= len(self._current_items()):
+        if row < 0 or row >= len(self._list_items):
             self._selected_idx = -1
             self._set_form_editable(True)
             self._clear_form()
             return
-        self._selected_idx = row
-        item = self._current_items()[row]
+        item = self._list_items[row]
+        all_items = self._current_items()
+        self._selected_idx = next(i for i, candidate in enumerate(all_items) if candidate.id == item.id)
         self._set_form_editable(not item.is_bundled)
         self._populate_form(item)
 
@@ -331,18 +385,15 @@ class GearLibraryDialog(QDialog):
                     self.color_combo.setCurrentIndex(idx)
                 self.notes_edit.setText(item.notes)
             elif isinstance(item, GearPreset):
-                self._refresh_preset_combos()
+                self._refresh_preset_combos(
+                    camera_id=item.camera_id,
+                    lens_id=item.lens_id,
+                    film_id=item.film_stock_id,
+                )
                 self.display_name_edit.setText(item.display_name)
-                self._set_combo_by_id(self.preset_camera_combo, item.camera_id)
-                self._set_combo_by_id(self.preset_lens_combo, item.lens_id)
-                self._set_combo_by_id(self.preset_film_combo, item.film_stock_id)
                 self.notes_edit.setText(item.notes)
         finally:
             self._updating = False
-
-    def _set_combo_by_id(self, combo: QComboBox, item_id: str) -> None:
-        idx = combo.findData(item_id or "")
-        combo.setCurrentIndex(idx if idx >= 0 else 0)
 
     def _clear_form(self) -> None:
         self._updating = True
@@ -391,14 +442,16 @@ class GearLibraryDialog(QDialog):
             item.notes = self.notes_edit.text().strip()
         elif isinstance(item, GearPreset):
             item.display_name = self.display_name_edit.text().strip()
-            item.camera_id = self.preset_camera_combo.currentData() or ""
-            item.lens_id = self.preset_lens_combo.currentData() or ""
-            item.film_stock_id = self.preset_film_combo.currentData() or ""
+            item.camera_id = self.preset_camera_combo.selected_id()
+            item.lens_id = self.preset_lens_combo.selected_id()
+            item.film_stock_id = self.preset_film_combo.selected_id()
             item.notes = self.notes_edit.text().strip()
 
         items[self._selected_idx] = item
         self._set_current_items(items)
-        self.item_list.item(self._selected_idx).setText(self._item_label(item))
+        list_row = next((i for i, visible in enumerate(self._list_items) if visible.id == item.id), -1)
+        if list_row >= 0:
+            self.item_list.item(list_row).setText(self._item_label(item))
         GearProfiles.save_library(self._library)
         self.library_changed.emit()
 
@@ -415,8 +468,7 @@ class GearLibraryDialog(QDialog):
         items.append(item)
         self._set_current_items(items)
         GearProfiles.save_library(self._library)
-        self._rebuild_item_list()
-        self.item_list.setCurrentRow(len(items) - 1)
+        self._rebuild_item_list(select_id=item.id)
         self.library_changed.emit()
 
     def _duplicate_item(self) -> None:
@@ -433,8 +485,7 @@ class GearLibraryDialog(QDialog):
         items.append(dup)
         self._set_current_items(items)
         GearProfiles.save_library(self._library)
-        self._rebuild_item_list()
-        self.item_list.setCurrentRow(len(items) - 1)
+        self._rebuild_item_list(select_id=dup.id)
         self.library_changed.emit()
 
     def _delete_item(self) -> None:

--- a/negpy/desktop/view/widgets/searchable_gear_combo.py
+++ b/negpy/desktop/view/widgets/searchable_gear_combo.py
@@ -1,0 +1,334 @@
+"""Searchable gear picker — a line edit with a QCompleter dropdown.
+
+Deliberately **not** a ``QComboBox``: editable combos constantly re-sync their
+line-edit text to the current index (on focus-out, popup close, ``setCurrentIndex``),
+which fought every attempt to keep search text / cleared state stable.
+
+The popup is a :class:`QCompleter`, *not* a hand-rolled ``Qt.Popup`` window. A
+``Qt.Popup`` grabs the keyboard when shown, so after the first keystroke typing
+went to the popup instead of the field. ``QCompleter`` is built for this: its popup
+leaves keyboard focus on the line edit, and handles Up/Down/Enter/positioning.
+
+Single source of truth:
+- ``_selected_id`` is the committed selection (``""`` means no selection).
+- the :class:`QLineEdit` owns the visible text; nothing rewrites it behind the
+  user's back, so clearing, re-searching and re-selecting all behave. An empty
+  field *is* "no selection" — clearing the text and leaving the field removes the
+  choice, so there is no separate "— None —" row.
+
+Contract used by callers:
+- ``selection_changed(str)`` — emitted only on a genuine user commit (never on
+  programmatic ``set_gear_items`` / ``set_labeled_items`` / ``set_selected_id``).
+- ``selected_id()`` / ``set_selected_id()`` / ``set_gear_items()`` /
+  ``set_labeled_items()`` / ``is_editing()``.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Optional, Sequence
+
+from PyQt6.QtCore import QEvent, QModelIndex, QSortFilterProxyModel, Qt, QTimer, pyqtSignal
+from PyQt6.QtGui import QStandardItem, QStandardItemModel
+from PyQt6.QtWidgets import QCompleter, QHBoxLayout, QLineEdit, QToolButton, QWidget
+
+from negpy.desktop.view.styles.theme import THEME
+
+_NONE_LABEL = "— None —"
+
+_ID_ROLE = Qt.ItemDataRole.UserRole
+_SEARCH_ROLE = Qt.ItemDataRole.UserRole + 1
+
+
+class _GearFilterProxy(QSortFilterProxyModel):
+    """Filters rows by a hidden search string."""
+
+    def __init__(self, parent=None) -> None:
+        super().__init__(parent)
+        self._query = ""
+
+    def set_query(self, query: str) -> None:
+        needle = (query or "").strip().casefold()
+        if needle == self._query:
+            return
+        self._query = needle
+        self.invalidateFilter()
+
+    def filterAcceptsRow(self, source_row: int, source_parent: QModelIndex) -> bool:  # noqa: N802
+        if not self._query:
+            return True
+        model = self.sourceModel()
+        if model is None:
+            return True
+        index = model.index(source_row, 0, source_parent)
+        search_text = model.data(index, _SEARCH_ROLE) or ""
+        return self._query in search_text
+
+
+class SearchableGearCombo(QWidget):
+    """Line-edit gear picker with a type-to-filter completer dropdown."""
+
+    selection_changed = pyqtSignal(str)
+
+    def __init__(
+        self,
+        *,
+        none_label: str = _NONE_LABEL,
+        placeholder: str = "Search…",
+        parent=None,
+    ) -> None:
+        super().__init__(parent)
+        self._none_label = none_label
+        self._entries: list[tuple[str, str, str]] = []  # (label, id, search_text)
+        self._selected_id = ""
+        self._updating = False
+
+        self._line = QLineEdit(self)
+        self._line.setPlaceholderText(placeholder)
+        self._line.textEdited.connect(self._on_text_edited)
+        self._line.editingFinished.connect(self._on_editing_finished)
+        self._line.installEventFilter(self)
+
+        self._arrow = QToolButton(self)
+        self._arrow.setText("\u25be")
+        self._arrow.setFocusPolicy(Qt.FocusPolicy.NoFocus)
+        self._arrow.setCursor(Qt.CursorShape.ArrowCursor)
+        self._arrow.setFixedWidth(20)
+        self._arrow.clicked.connect(self._toggle_popup)
+        self._arrow.setStyleSheet(
+            f"QToolButton {{ border: none; color: {THEME.text_secondary}; background: transparent; }}"
+            f"QToolButton:hover {{ color: {THEME.text_primary}; }}"
+        )
+
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+        layout.addWidget(self._line, 1)
+        layout.addWidget(self._arrow)
+
+        self._model = QStandardItemModel(self)
+        self._proxy = _GearFilterProxy(self)
+        self._proxy.setSourceModel(self._model)
+
+        self._completer = QCompleter(self._proxy, self)
+        self._completer.setCompletionMode(QCompleter.CompletionMode.UnfilteredPopupCompletion)
+        self._completer.setCaseSensitivity(Qt.CaseSensitivity.CaseInsensitive)
+        self._completer.setCompletionColumn(0)
+        self._completer.setCompletionRole(Qt.ItemDataRole.DisplayRole)
+        self._completer.setWidget(self._line)
+        self._completer.activated[QModelIndex].connect(self._on_completer_activated)
+        popup = self._completer.popup()
+        popup.setStyleSheet(
+            f"QAbstractItemView {{ background: {THEME.bg_header}; color: {THEME.text_primary};"
+            f" border: 1px solid {THEME.border_color}; outline: 0; }}"
+            f"QAbstractItemView::item {{ padding: 4px 6px; }}"
+            f"QAbstractItemView::item:selected {{ background: {THEME.accent_primary}; color: #FFFFFF; }}"
+        )
+
+        self._load_entries([])
+
+    # ── public API ───────────────────────────────────────────────────────
+    def set_gear_items(
+        self,
+        items: Sequence,
+        selected_id: str,
+        label_fn: Callable,
+        library=None,
+    ) -> None:
+        """Replace list contents and selection from gear dataclasses."""
+        from negpy.features.metadata.gear_logic import gear_search_text
+
+        entries: list[tuple[str, str, str]] = []
+        for item in items:
+            item_id = getattr(item, "id", "") or ""
+            entries.append((label_fn(item), item_id, gear_search_text(item, library)))
+        self._selected_id = selected_id or ""
+        self._load_entries(entries)
+
+    def set_labeled_items(
+        self,
+        entries: Sequence[tuple[str, str]],
+        selected_id: str,
+        search_fn: Optional[Callable[[str, str], str]] = None,
+    ) -> None:
+        """Set (label, id) pairs — search text defaults to the label lowercased."""
+        fn = search_fn or (lambda label, _item_id: label.casefold())
+        built = [(label, item_id, fn(label, item_id).casefold()) for label, item_id in entries]
+        self._selected_id = selected_id or ""
+        self._load_entries(built)
+
+    def selected_id(self) -> str:
+        return self._selected_id
+
+    def set_selected_id(self, item_id: str) -> None:
+        self._selected_id = item_id or ""
+        self._proxy.set_query("")
+        self._show_selected_text()
+
+    def is_editing(self) -> bool:
+        """True while the field has focus and shows something other than the committed label."""
+        if not self._line.hasFocus():
+            return False
+        return self._line.text() != self._committed_text()
+
+    def line_edit(self) -> QLineEdit:
+        return self._line
+
+    def setToolTip(self, text: str) -> None:  # noqa: N802
+        super().setToolTip(text)
+        self._line.setToolTip(text)
+
+    # ── model construction ───────────────────────────────────────────────
+    def _load_entries(self, entries: Sequence[tuple[str, str, str]]) -> None:
+        self._entries = [(label, item_id, search.casefold()) for label, item_id, search in entries]
+        self._model.clear()
+        for label, item_id, search in self._entries:
+            row = QStandardItem(label)
+            row.setData(item_id, _ID_ROLE)
+            row.setData(search, _SEARCH_ROLE)
+            row.setEditable(False)
+            self._model.appendRow(row)
+        self._proxy.set_query("")
+        self._show_selected_text()
+
+    def _label_for_id(self, item_id: str) -> str:
+        target = item_id or ""
+        for label, entry_id, _search in self._entries:
+            if entry_id == target:
+                return label
+        return ""
+
+    def _committed_text(self) -> str:
+        return self._label_for_id(self._selected_id) if self._selected_id else ""
+
+    def _show_selected_text(self) -> None:
+        """Reflect the committed selection in the field (blank => placeholder)."""
+        self._updating = True
+        try:
+            self._line.setText(self._committed_text())
+        finally:
+            self._updating = False
+
+    # ── popup ─────────────────────────────────────────────────────────────
+    def _popup_visible(self) -> bool:
+        popup = self._completer.popup()
+        return popup is not None and popup.isVisible()
+
+    def _show_popup(self) -> None:
+        self._completer.complete()
+
+    def _toggle_popup(self) -> None:
+        if self._popup_visible():
+            self._completer.popup().hide()
+            return
+        self._proxy.set_query("")
+        self._line.setFocus()
+        self._line.selectAll()
+        self._completer.complete()
+
+    def _id_from_source_index(self, source_index: QModelIndex) -> str:
+        item = self._model.itemFromIndex(source_index)
+        return (item.data(_ID_ROLE) or "") if item is not None else ""
+
+    def _first_match_id(self) -> Optional[str]:
+        """First real (non-None) row currently passing the filter, if any."""
+        for row in range(self._proxy.rowCount()):
+            source_index = self._proxy.mapToSource(self._proxy.index(row, 0))
+            item_id = self._id_from_source_index(source_index)
+            if item_id:
+                return item_id
+        return None
+
+    def _hide_popup(self) -> None:
+        popup = self._completer.popup()
+        if popup is not None and popup.isVisible():
+            popup.hide()
+
+    def _on_completer_activated(self, index: QModelIndex) -> None:
+        if self._updating:
+            return
+        item_id = ""
+        if index.isValid():
+            completion_model = self._completer.completionModel()
+            proxy_index = completion_model.mapToSource(index)
+            source_index = self._proxy.mapToSource(proxy_index)
+            item_id = self._id_from_source_index(source_index)
+        self._commit_id(item_id)
+
+    # ── user interaction ─────────────────────────────────────────────────
+    def _on_text_edited(self, text: str) -> None:
+        if self._updating:
+            return
+        self._proxy.set_query(text)
+        self._completer.complete()
+
+    def _on_editing_finished(self) -> None:
+        if not self._popup_visible():
+            QTimer.singleShot(0, self._finalize)
+
+    def eventFilter(self, watched, event) -> bool:  # noqa: N802
+        if watched is self._line:
+            etype = event.type()
+            if etype == QEvent.Type.FocusIn:
+                if self._line.text():
+                    QTimer.singleShot(0, self._line.selectAll)
+            elif etype == QEvent.Type.FocusOut:
+                if not self._popup_visible():
+                    QTimer.singleShot(0, self._finalize)
+            elif etype == QEvent.Type.KeyPress and event.key() in (
+                Qt.Key.Key_Return,
+                Qt.Key.Key_Enter,
+            ):
+                # Commit the highlighted/first match ourselves. When the completer
+                # popup is showing it will emit ``activated`` first (and consume the
+                # key), so this only runs when the popup is not intercepting.
+                self._commit_on_return()
+                return True
+        return super().eventFilter(watched, event)
+
+    def _commit_on_return(self) -> None:
+        text = self._line.text().strip()
+        if not text or text.casefold() == self._none_label.casefold():
+            self._commit_id("")
+            return
+        resolved = self._resolve_label(text)
+        if resolved is not None:
+            self._commit_id(resolved)
+            return
+        first = self._first_match_id()
+        if first:
+            self._commit_id(first)
+        else:
+            self._show_selected_text()
+
+    def _finalize(self) -> None:
+        """Settle the field: commit exact matches, clear on empty, else revert."""
+        if self._updating:
+            return
+        text = self._line.text().strip()
+        if not text or text.casefold() == self._none_label.casefold():
+            self._commit_id("")
+            return
+        resolved = self._resolve_label(text)
+        if resolved is not None:
+            self._commit_id(resolved)
+        else:
+            self._show_selected_text()  # partial / unknown text reverts to selection
+
+    def _resolve_label(self, text: str) -> Optional[str]:
+        needle = text.casefold()
+        if needle == self._none_label.casefold():
+            return ""
+        for label, item_id, _search in self._entries:
+            if label.casefold() == needle:
+                return item_id
+        return None
+
+    def _commit_id(self, item_id: str) -> None:
+        new_id = item_id or ""
+        changed = new_id != self._selected_id
+        self._selected_id = new_id
+        self._proxy.set_query("")
+        self._hide_popup()
+        self._show_selected_text()
+        if changed and not self.signalsBlocked():
+            self.selection_changed.emit(new_id)

--- a/negpy/features/metadata/gear_logic.py
+++ b/negpy/features/metadata/gear_logic.py
@@ -84,9 +84,10 @@ def metadata_from_gear(
     if preset_id:
         preset = library.get_gear_preset(preset_id)
         if preset:
-            cam_id = preset.camera_id or cam_id
-            lens_id_val = preset.lens_id or lens_id_val
-            film_id = preset.film_stock_id or film_id
+            # Preset is authoritative: empty preset slots clear manual picks.
+            cam_id = preset.camera_id
+            lens_id_val = preset.lens_id
+            film_id = preset.film_stock_id
 
     camera_make = ""
     camera_model = ""

--- a/negpy/features/metadata/gear_logic.py
+++ b/negpy/features/metadata/gear_logic.py
@@ -3,27 +3,83 @@
 from __future__ import annotations
 
 from dataclasses import replace
-from typing import Optional
+from typing import Optional, Union
 
-from negpy.features.metadata.gear_models import GearLibrary
+from negpy.features.metadata.gear_models import Camera, FilmStock, GearLibrary, GearPreset, Lens
 from negpy.features.metadata.models import MetadataConfig
+
+GearItem = Union[Camera, Lens, FilmStock, GearPreset]
+
+
+def gear_search_text(item: GearItem, library: Optional[GearLibrary] = None) -> str:
+    """Lowercase searchable text for substring filtering."""
+    parts: list[str] = []
+
+    if isinstance(item, Camera):
+        parts = [item.display_name, item.make, item.model, item.notes]
+    elif isinstance(item, Lens):
+        parts = [item.display_name, item.make, item.lens_model, item.notes]
+        if item.focal_length_mm is not None:
+            parts.append(f"{item.focal_length_mm:g}")
+        if item.max_aperture is not None:
+            parts.append(f"{item.max_aperture:g}")
+    elif isinstance(item, FilmStock):
+        parts = [
+            item.display_name,
+            item.manufacturer,
+            item.stock_name,
+            item.notes,
+            str(item.iso),
+            item.format.value,
+            item.color_type.value,
+        ]
+    elif isinstance(item, GearPreset):
+        parts = [item.display_name, item.notes]
+        if library is not None:
+            cam = library.get_camera(item.camera_id)
+            lens = library.get_lens(item.lens_id)
+            stock = library.get_film_stock(item.film_stock_id)
+            if cam:
+                parts.extend([cam.resolved_display_name, cam.make, cam.model])
+            if lens:
+                parts.extend([lens.resolved_display_name, lens.make, lens.lens_model])
+            if stock:
+                parts.extend([stock.resolved_display_name, stock.manufacturer, stock.stock_name])
+
+    return " ".join(p.strip() for p in parts if p and str(p).strip()).lower()
+
+
+def matches_gear_filter(item: GearItem, query: str, library: Optional[GearLibrary] = None) -> bool:
+    needle = query.strip().lower()
+    if not needle:
+        return True
+    return needle in gear_search_text(item, library)
 
 
 def metadata_from_gear(
     config: MetadataConfig,
     library: GearLibrary,
     *,
-    gear_preset_id: str = "",
-    camera_id: str = "",
-    lens_id: str = "",
-    film_stock_id: str = "",
+    gear_preset_id: Optional[str] = None,
+    camera_id: Optional[str] = None,
+    lens_id: Optional[str] = None,
+    film_stock_id: Optional[str] = None,
     clear_preset: bool = False,
 ) -> MetadataConfig:
-    """Build updated MetadataConfig from gear library selections."""
-    preset_id = "" if clear_preset else (gear_preset_id or config.gear_preset_id)
-    cam_id = camera_id if camera_id != "" else config.camera_id
-    lens_id_val = lens_id if lens_id != "" else config.lens_id
-    film_id = film_stock_id if film_stock_id != "" else config.film_stock_id
+    """Build updated MetadataConfig from gear library selections.
+
+    Pass ``None`` (default) to leave an id unchanged; pass ``""`` to clear it.
+    """
+    if clear_preset:
+        preset_id = ""
+    elif gear_preset_id is not None:
+        preset_id = gear_preset_id
+    else:
+        preset_id = config.gear_preset_id
+
+    cam_id = config.camera_id if camera_id is None else camera_id
+    lens_id_val = config.lens_id if lens_id is None else lens_id
+    film_id = config.film_stock_id if film_stock_id is None else film_stock_id
 
     if preset_id:
         preset = library.get_gear_preset(preset_id)

--- a/tests/metadata/test_gear_payload.py
+++ b/tests/metadata/test_gear_payload.py
@@ -283,6 +283,78 @@ def test_metadata_from_gear_clearing_camera_id():
     assert cleared.camera_model == ""
 
 
+def test_bundled_fm2_preset_links_nikkor_lens():
+    library = GearProfiles.load_library()
+    preset = library.get_gear_preset("preset-fm2-50-trix")
+    assert preset is not None
+    lens = library.get_lens(preset.lens_id)
+    assert lens is not None
+    assert "nikkor" in lens.resolved_display_name.casefold()
+    assert "leica" not in lens.resolved_display_name.casefold()
+
+
+def test_metadata_from_gear_preset_overrides_manual_lens():
+    library = GearLibrary(
+        cameras=[
+            Camera(id="c1", make="Canon", model="AE-1 Program"),
+            Camera(id="c2", make="Nikon", model="FM2"),
+        ],
+        lenses=[
+            Lens(id="l1", lens_model="FD 50mm f/1.4", make="Canon"),
+            Lens(id="l2", lens_model="Nikkor 50mm f/1.8 AI-S", make="Nikkor"),
+        ],
+        film_stocks=[
+            FilmStock(id="f1", manufacturer="Kodak", stock_name="Portra 400", iso=400),
+            FilmStock(id="f2", manufacturer="Kodak", stock_name="Tri-X 400", iso=400),
+        ],
+        gear_presets=[
+            GearPreset(
+                id="p1",
+                display_name="FM2 combo",
+                camera_id="c2",
+                lens_id="l2",
+                film_stock_id="f2",
+            ),
+        ],
+    )
+    manual = MetadataConfig(
+        camera_id="c1",
+        lens_id="l1",
+        film_stock_id="f1",
+        camera_make="Canon",
+        camera_model="AE-1 Program",
+        lens_model="FD 50mm f/1.4",
+        film="Kodak Portra 400",
+        film_iso=400,
+    )
+
+    applied = metadata_from_gear(manual, library, gear_preset_id="p1")
+
+    assert applied.gear_preset_id == "p1"
+    assert applied.camera_id == "c2"
+    assert applied.lens_id == "l2"
+    assert applied.film_stock_id == "f2"
+    assert applied.camera_model == "FM2"
+    assert applied.lens_model == "Nikkor 50mm f/1.8 AI-S"
+    assert applied.film == "Kodak Tri-X 400"
+
+
+def test_metadata_from_gear_preset_clears_empty_slots():
+    library = GearLibrary(
+        cameras=[Camera(id="c1", make="Canon", model="AE-1")],
+        lenses=[Lens(id="l1", lens_model="50mm", make="Canon")],
+        film_stocks=[FilmStock(id="f1", manufacturer="Kodak", stock_name="Portra 400", iso=400)],
+        gear_presets=[GearPreset(id="p1", display_name="Camera only", camera_id="c1")],
+    )
+    manual = MetadataConfig(camera_id="c1", lens_id="l1", film_stock_id="f1")
+
+    applied = metadata_from_gear(manual, library, gear_preset_id="p1")
+
+    assert applied.camera_id == "c1"
+    assert applied.lens_id == ""
+    assert applied.film_stock_id == ""
+
+
 def test_metadata_from_gear_preset():
     library = GearLibrary(
         cameras=[Camera(id="c1", make="Canon", model="AE-1 Program")],

--- a/tests/metadata/test_gear_payload.py
+++ b/tests/metadata/test_gear_payload.py
@@ -11,7 +11,7 @@ import pytest
 
 from negpy.features.metadata.gear_models import Camera, FilmStock, GearLibrary, GearPreset, Lens
 
-from negpy.features.metadata.gear_logic import metadata_from_gear
+from negpy.features.metadata.gear_logic import metadata_from_gear, matches_gear_filter, gear_search_text
 
 from negpy.features.metadata.models import MetadataConfig
 
@@ -121,6 +121,166 @@ def test_load_and_save_library(gear_dir):
     assert loaded.cameras[0].make == "Canon"
 
     assert loaded.gear_presets[0].display_name == "Test"
+
+
+def test_matches_gear_filter_substring_case_insensitive():
+    camera = Camera(id="c1", make="Nikon", model="FM2")
+    lens = Lens(id="l1", lens_model="Nikkor 28mm f/2.8 AI-S", make="Nikkor", focal_length_mm=28)
+    film = FilmStock(id="f1", manufacturer="Kodak", stock_name="Portra 400", iso=400)
+    library = GearLibrary(
+        cameras=[camera],
+        lenses=[lens],
+        film_stocks=[film],
+        gear_presets=[GearPreset(id="p1", display_name="Street combo", camera_id="c1", lens_id="l1", film_stock_id="f1")],
+    )
+
+    assert matches_gear_filter(camera, "fm2")
+    assert matches_gear_filter(lens, "28")
+    assert matches_gear_filter(film, "portra")
+    assert matches_gear_filter(library.gear_presets[0], "street", library)
+    assert matches_gear_filter(library.gear_presets[0], "nikkor", library)
+    assert not matches_gear_filter(camera, "canon")
+    assert matches_gear_filter(camera, "")
+
+
+def test_gear_search_text_includes_preset_linked_labels():
+    library = GearLibrary(
+        cameras=[Camera(id="c1", make="Nikon", model="FM2")],
+        lenses=[Lens(id="l1", lens_model="Nikkor 50mm f/1.8 AI-S", make="Nikkor")],
+        film_stocks=[FilmStock(id="f1", manufacturer="Kodak", stock_name="Tri-X 400", iso=400)],
+        gear_presets=[GearPreset(id="p1", display_name="Daily carry", camera_id="c1", lens_id="l1", film_stock_id="f1")],
+    )
+    preset = library.gear_presets[0]
+
+    search_text = gear_search_text(preset, library)
+
+    assert "fm2" in search_text
+    assert "nikkor" in search_text
+    assert "tri-x" in search_text
+
+
+def test_searchable_gear_combo_empty_selection_shows_placeholder():
+    from negpy.desktop.view.widgets.searchable_gear_combo import SearchableGearCombo
+
+    combo = SearchableGearCombo(placeholder="Search cameras…")
+    library = GearLibrary(cameras=[Camera(id="c1", make="Nikon", model="FM2")])
+    combo.set_gear_items(library.cameras, "", lambda camera: camera.resolved_display_name)
+
+    assert combo.selected_id() == ""
+    assert combo.line_edit().text() == ""
+
+    combo.set_gear_items(library.cameras, "c1", lambda camera: camera.resolved_display_name)
+    assert combo.line_edit().text() == "Nikon FM2"
+    assert combo.selected_id() == "c1"
+
+    combo.set_selected_id("")
+    assert combo.line_edit().text() == ""
+    assert combo.selected_id() == ""
+
+
+def test_searchable_gear_combo_reverts_partial_search_on_blur():
+    from negpy.desktop.view.widgets.searchable_gear_combo import SearchableGearCombo
+
+    combo = SearchableGearCombo(placeholder="Search cameras…")
+    library = GearLibrary(cameras=[Camera(id="c1", make="Nikon", model="FM2")])
+    combo.set_gear_items(library.cameras, "c1", lambda camera: camera.resolved_display_name)
+
+    combo.line_edit().setText("nik")
+    combo._on_text_edited("nik")
+    combo._finalize()
+
+    assert combo.line_edit().text() == "Nikon FM2"
+    assert combo.selected_id() == "c1"
+
+
+def test_searchable_gear_combo_clearing_field_clears_selection():
+    from negpy.desktop.view.widgets.searchable_gear_combo import SearchableGearCombo
+
+    combo = SearchableGearCombo(placeholder="Search cameras…")
+    library = GearLibrary(cameras=[Camera(id="c1", make="Nikon", model="FM2")])
+    combo.set_gear_items(library.cameras, "c1", lambda camera: camera.resolved_display_name)
+
+    combo.line_edit().clear()
+    combo._on_text_edited("")
+    # Selection stays committed until the user finalizes (blur / Enter)…
+    assert combo.selected_id() == "c1"
+    assert combo.line_edit().text() == ""
+
+    combo._finalize()
+    assert combo.selected_id() == ""
+    assert combo.line_edit().text() == ""
+
+
+def test_searchable_gear_combo_replace_selection_after_search():
+    from negpy.desktop.view.widgets.searchable_gear_combo import SearchableGearCombo
+
+    events: list[str] = []
+    combo = SearchableGearCombo(placeholder="Search cameras…")
+    combo.selection_changed.connect(events.append)
+    library = GearLibrary(
+        cameras=[
+            Camera(id="leica", make="Leica", model="M6"),
+            Camera(id="nikon", make="Nikon", model="FM2"),
+        ]
+    )
+    combo.set_gear_items(library.cameras, "leica", lambda camera: camera.resolved_display_name)
+
+    # Typing to search does NOT mutate the committed selection or emit.
+    combo.line_edit().setText("Leica M")
+    combo._on_text_edited("Leica M")
+    combo.line_edit().setText("nik")
+    combo._on_text_edited("nik")
+    assert combo.selected_id() == "leica"
+    assert events == []
+
+    # Picking Nikon commits exactly once, and it sticks.
+    combo._commit_id("nikon")
+    assert combo.selected_id() == "nikon"
+    assert combo.line_edit().text() == "Nikon FM2"
+    assert events == ["nikon"]
+
+    combo._finalize()
+    assert combo.selected_id() == "nikon"
+    assert combo.line_edit().text() == "Nikon FM2"
+    assert events == ["nikon"]
+
+
+def test_gear_library_dialog_item_search_hides_non_matching_selection():
+    from negpy.desktop.view.widgets.gear_library_dialog import GearLibraryDialog
+
+    library = GearLibrary(
+        lenses=[
+            Lens(id="l-canon", lens_model="FD 50mm f/1.4", make="Canon"),
+            Lens(id="l-nikon", lens_model="Nikkor 50mm f/1.8 AI-S", make="Nikkor"),
+        ]
+    )
+    dlg = GearLibraryDialog(library)
+    dlg._select_category("lenses")
+    dlg.item_list.setCurrentRow(0)  # Canon selected
+
+    dlg.item_search.setText("nik")
+    dlg._rebuild_item_list()
+
+    labels = [dlg.item_list.item(i).text() for i in range(dlg.item_list.count())]
+    assert labels == ["Nikkor 50mm f/1.8 AI-S"]
+    assert dlg.item_list.currentRow() == -1
+    assert dlg.lens_model_edit.text() == "FD 50mm f/1.4"
+
+
+def test_metadata_from_gear_clearing_camera_id():
+    library = GearLibrary(
+        cameras=[Camera(id="c1", make="Leica", model="M6")],
+        lenses=[],
+        film_stocks=[],
+        gear_presets=[],
+    )
+    base = MetadataConfig(camera_id="c1", camera_make="Leica", camera_model="M6")
+
+    cleared = metadata_from_gear(base, library, camera_id="")
+
+    assert cleared.camera_id == ""
+    assert cleared.camera_make == ""
+    assert cleared.camera_model == ""
 
 
 def test_metadata_from_gear_preset():


### PR DESCRIPTION
## Summary

Adds type-to-search gear pickers across the Metadata tab and Gear Library dialog, replacing plain dropdowns that were painful with 50+ cameras/lenses.

**Searchable gear combos** (`SearchableGearCombo`) use a `QLineEdit` + `QCompleter` — not an editable `QComboBox`, which kept fighting us by re-syncing the field text to the current index. Typing filters live; an empty field means “not set” (placeholder only, no `— None —` row). Selection commits on pick, Enter, or blur.

**Metadata tab:** Preset, camera, lens, and film fields are searchable, with a short hint (“Type in any field to search the gear library.”).

**Manage dialog:** Item list has a search field; preset camera/lens/film link combos use the same searchable widget.

**Preset apply:** Selecting a preset now fully overwrites manual gear picks (empty preset slots clear the field). Fixed bundled `FM2 / Nikkor 50` preset pointing at the wrong lens ID.

## Test plan

- [x] Metadata tab: type to filter camera/lens/film/preset lists; pick from dropdown or Enter
- [x] Clear a field (backspace + blur) → placeholder shows, selection cleared
- [x] Select gear manually, then pick a preset → all three fields match the preset
- [x] Manage → Lenses: search filters the list; selected item doesn’t pin when it doesn’t match
- [x] `uv run pytest tests/metadata -q`