### PR TITLE
Tooltip readability fixes + clearer Batch Analysis crop warning

### DIFF
--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -976,27 +976,33 @@ class AppController(QObject):
                 cropped += 1
 
         if cropped == 0:
-            crop_note = (
-                "Crop status: none of the files have a crop set. Analysis samples the "
-                "full frame, so any border or letterboxing around the negative will skew "
-                "the average. For best results, crop each file to the negative area — or, "
-                "if that's not practical, raise the Analysis Buffer to exclude the margin."
+            crop_status = f"Crop status: 0 of {total} files are cropped."
+            crop_warning = (
+                "Strongly recommended: crop all images in this session before running "
+                "Batch Analysis. Without a crop, the Analysis Buffer's small centered "
+                "margin isn't enough to exclude sprocket holes and empty space outside "
+                "the actual frame — that unwanted region gets included in the luma and "
+                "color average, producing a less accurate result for every file."
             )
         elif cropped < total:
-            crop_note = (
-                f"Crop status: {cropped} of {total} files have a crop set. The uncropped "
-                "ones are analyzed on the full frame, so their borders may skew the "
-                "average. Crop them, or raise the Analysis Buffer to exclude the margin."
+            crop_status = f"Crop status: {cropped} of {total} files are cropped."
+            crop_warning = (
+                f"Strongly recommended: crop the remaining {total - cropped} file(s) "
+                "before running Batch Analysis. Uncropped files rely on the Analysis "
+                "Buffer's small centered margin, which isn't enough to exclude sprocket "
+                "holes and empty space outside the actual frame — that unwanted region "
+                "gets included in the luma and color average, producing a less accurate "
+                "result for every file."
             )
         else:
-            crop_note = (
-                "Crop status: all files are cropped — analysis runs on the negative area, "
-                "ignoring borders. The Analysis Buffer still trims a margin inside the crop."
-            )
+            crop_status = f"Crop status: all {total} files are cropped."
+            crop_warning = "Analysis will run on each file's cropped negative area."
 
         reply = QMessageBox.question(
             None,
             "Batch Analysis",
+            f"{crop_status}\n"
+            f"{crop_warning}\n\n"
             "Batch Analysis measures the exposure bounds of every file and applies "
             "their average to the whole roll, so all your frames share a consistent "
             "baseline.\n\n"
@@ -1007,7 +1013,6 @@ class AppController(QObject):
             "  • Luma Range Clip — how aggressively the highlight/shadow tails are "
             "clipped when setting each file's bounds.\n"
             "Set both on the current frame before running.\n\n"
-            f"{crop_note}\n\n"
             "Continue?",
             QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.Cancel,
             QMessageBox.StandardButton.Cancel,

--- a/negpy/desktop/view/shortcut_registry.py
+++ b/negpy/desktop/view/shortcut_registry.py
@@ -176,5 +176,8 @@ def tooltip_with_shortcut(text: str, action_ids: str | Iterable[str] | None = No
         f'<span style="color:#888;background:#1A1A1A;padding:1px 5px;border-radius:3px;font-size:10px;">{key}</span>'
         for key in keys
     ]
-    chips_html = ' <span style="color:#888;font-size:10px;">and</span> '.join(chips)
-    return f"{text}<br>{chips_html}"
+    # The " & " separator carries no colour of its own, so it inherits the
+    # tooltip's text colour (unlike the greyed chips). The shortcut row is
+    # right-aligned on its own line to balance the tooltip box.
+    chips_html = " &amp; ".join(chips)
+    return f'{text}<div align="right">{chips_html}</div>'

--- a/negpy/desktop/view/shortcut_registry.py
+++ b/negpy/desktop/view/shortcut_registry.py
@@ -172,8 +172,9 @@ def tooltip_with_shortcut(text: str, action_ids: str | Iterable[str] | None = No
     keys = [key_for(action_id, bindings) for action_id in ids if action_id in REGISTRY and key_for(action_id, bindings)]
     if not keys:
         return text
-    chips = " ".join(
-        f'<span style="color:#888;background:#1A1A1A;padding:1px 5px;border-radius:3px;margin-left:6px;font-size:10px;">{key}</span>'
+    chips = [
+        f'<span style="color:#888;background:#1A1A1A;padding:1px 5px;border-radius:3px;font-size:10px;">{key}</span>'
         for key in keys
-    )
-    return f"{text}{chips}"
+    ]
+    chips_html = ' <span style="color:#888;font-size:10px;">and</span> '.join(chips)
+    return f"{text}<br>{chips_html}"

--- a/negpy/desktop/view/sidebar/process.py
+++ b/negpy/desktop/view/sidebar/process.py
@@ -156,11 +156,16 @@ class ProcessSidebar(BaseSidebar):
         self.crosstalk_combo = QComboBox()
         self.crosstalk_combo.addItems(CrosstalkProfiles.list_profiles())
         self.crosstalk_combo.setCurrentText(conf.crosstalk_profile)
+        # Wrap the long tooltip in a fixed-width table so Qt word-wraps it to the
+        # panel width instead of rendering one line that runs off the screen (plain
+        # text tooltips are not auto-wrapped — only rich text is).
         self.crosstalk_combo.setToolTip(
+            "<table width='280'><tr><td>"
             "Spectral crosstalk (dye unmix): applies the film's crosstalk matrix to the raw NEGATIVE "
             "densities before analysis and inversion — the physically correct domain (the matrices are "
             "derived from negative dye-density curves). 'Default' is built-in; drop custom .toml matrices "
-            "in the NegPy/crosstalk folder (see docs/CROSSTALK.md). Re-run Batch Analysis after changing this"
+            "in the NegPy/crosstalk folder (see docs/CROSSTALK.md). Re-run Batch Analysis after changing this."
+            "</td></tr></table>"
         )
         matrix_row.addWidget(self.crosstalk_label)
         matrix_row.addWidget(self.crosstalk_combo, 1)

--- a/tests/test_shortcut_registry.py
+++ b/tests/test_shortcut_registry.py
@@ -56,3 +56,26 @@ def test_tooltip_with_multiple_shortcuts_renders_all_keys():
     assert "Density" in tooltip
     assert "Q" in tooltip
     assert "A" in tooltip
+
+
+def test_tooltip_places_shortcut_on_new_line():
+    tooltip = tooltip_with_shortcut("Density up", "density_up", {"density_up": "Q"})
+
+    # Shortcut sits on its own line below the tooltip text, inside the tooltip box.
+    text_part, _, shortcut_part = tooltip.partition("<br>")
+    assert text_part == "Density up"
+    assert "Q" in shortcut_part
+
+
+def test_tooltip_joins_two_shortcuts_with_and():
+    tooltip = tooltip_with_shortcut("Density", ["density_up", "density_down"], {"density_up": "Q", "density_down": "A"})
+
+    assert "<br>" in tooltip
+    assert ">and<" in tooltip.replace(" ", "")
+
+
+def test_tooltip_without_binding_returns_plain_text():
+    tooltip = tooltip_with_shortcut("Cyan up", "cyan_inc", {"cyan_inc": ""})
+
+    assert tooltip == "Cyan up"
+    assert "<br>" not in tooltip

--- a/tests/test_shortcut_registry.py
+++ b/tests/test_shortcut_registry.py
@@ -58,24 +58,25 @@ def test_tooltip_with_multiple_shortcuts_renders_all_keys():
     assert "A" in tooltip
 
 
-def test_tooltip_places_shortcut_on_new_line():
+def test_tooltip_places_shortcut_on_its_own_right_aligned_line():
     tooltip = tooltip_with_shortcut("Density up", "density_up", {"density_up": "Q"})
 
-    # Shortcut sits on its own line below the tooltip text, inside the tooltip box.
-    text_part, _, shortcut_part = tooltip.partition("<br>")
+    # Shortcut sits on its own right-aligned line below the tooltip text, inside the box.
+    text_part, sep, shortcut_part = tooltip.partition('<div align="right">')
     assert text_part == "Density up"
+    assert sep == '<div align="right">'
     assert "Q" in shortcut_part
 
 
-def test_tooltip_joins_two_shortcuts_with_and():
+def test_tooltip_joins_two_shortcuts_with_ampersand():
     tooltip = tooltip_with_shortcut("Density", ["density_up", "density_down"], {"density_up": "Q", "density_down": "A"})
 
-    assert "<br>" in tooltip
-    assert ">and<" in tooltip.replace(" ", "")
+    assert '<div align="right">' in tooltip
+    assert "&amp;" in tooltip
 
 
 def test_tooltip_without_binding_returns_plain_text():
     tooltip = tooltip_with_shortcut("Cyan up", "cyan_inc", {"cyan_inc": ""})
 
     assert tooltip == "Cyan up"
-    assert "<br>" not in tooltip
+    assert "<div" not in tooltip


### PR DESCRIPTION
Four small UX fixes across tooltips and the Batch Analysis dialog.

### Tooltip keyboard shortcuts
- Shortcut chips used to butt directly against the tooltip text. They now sit on their **own line** below the text, still inside the tooltip box.
- When an action has **two** bindings they're separated with **"&"** (previously they ran together).
- The "&" separator inherits the tooltip **text colour** so it's legible (the key chips stay greyed).
- The shortcut row is **right-aligned** to balance the box against the left-aligned label.

### Crosstalk "Matrix" tooltip wrapping
The Crosstalk **Matrix** tooltip was a long plain-text string. Qt only word-wraps tooltips it treats as rich text, so it rendered as a single line that ran across the whole screen. It's now wrapped in a fixed-width table so Qt word-wraps it to the controls-panel width.

### Batch Analysis warning
The Batch Analysis confirmation dialog now:
- **Leads with the crop-status count** (e.g. "0 of 12 files are cropped").
- **Strongly recommends cropping every image in the session first**, explaining that uncropped frames leave the Analysis Buffer to trim only a small centered margin — so sprocket holes and empty space outside the frame get pulled into the luma/colour average and skew the result for the whole roll.
- Retains the note that the **Analysis Buffer** and **Luma Range Clip** from the current frame are applied to every file before averaging.

### Tests
`tests/test_shortcut_registry.py` extended for the new tooltip layout (own line, "&" separator, right-alignment, plain-text passthrough). Lint clean.