### PR TITLE
Added a Protect original metadata feature in the metadata tab

### DIFF
--- a/negpy/desktop/session.py
+++ b/negpy/desktop/session.py
@@ -482,6 +482,13 @@ class DesktopSessionManager(QObject):
             filtered = {k: v for k, v in sticky_export.items() if k in valid_keys}
             config = replace(config, export=ExportConfig(**filtered))
 
+        sticky_protect = self.repo.get_global_setting("last_protect_original_metadata")
+        if sticky_protect is not None:
+            config = replace(
+                config,
+                metadata=replace(config.metadata, protect_original_metadata=bool(sticky_protect)),
+            )
+
         # Flat-field reference and distortion k1 are rig-global: the active profile's
         # values always override the per-file ones. New files default to enabled when a
         # profile is active; saved files keep their toggle.
@@ -637,6 +644,7 @@ class DesktopSessionManager(QObject):
                 "last_toning_config": asdict(config.toning),
                 "last_retouch_config": asdict(config.retouch),
                 "last_dust_remove": config.retouch.dust_remove,
+                "last_protect_original_metadata": config.metadata.protect_original_metadata,
             }
         )
 

--- a/negpy/desktop/view/sidebar/metadata.py
+++ b/negpy/desktop/view/sidebar/metadata.py
@@ -50,96 +50,114 @@ class MetadataSidebar(BaseSidebar):
         self._dirty = False
         self._exif_locked = {"exposure": True}
 
+        self.protect_check = QCheckBox("Protect original metadata")
+        self.protect_check.setChecked(conf.protect_original_metadata)
+        self.protect_check.setToolTip(
+            "When enabled, NegPy copies EXIF and XMP from the source file onto exports "
+            "without adding or changing metadata. Gear and process fields are ignored."
+        )
+        self.layout.addWidget(self.protect_check)
+
+        self._metadata_controls = QWidget()
+        controls = QVBoxLayout(self._metadata_controls)
+        controls.setContentsMargins(0, 0, 0, 0)
+        controls.setSpacing(10)
+        self._controls_layout = controls
+
         # ── ORIGINAL ANALOG GEAR ─────────────────────────────────────────
-        self.layout.addWidget(section_subheader("ORIGINAL ANALOG GEAR"))
+        controls.addWidget(section_subheader("ORIGINAL ANALOG GEAR"))
 
         gear_hint = QLabel("Type in any field to search the gear library.")
         gear_hint.setStyleSheet(f"font-size: {THEME.font_size_xs}px; color: {THEME.text_muted};")
-        self.layout.addWidget(gear_hint)
+        controls.addWidget(gear_hint)
 
         preset_row = QHBoxLayout()
         preset_row.setSpacing(4)
-        self.layout.addWidget(field_label("Preset"))
+        controls.addWidget(field_label("Preset"))
         self.preset_combo = SearchableGearCombo(placeholder="Search presets…")
         self.preset_combo.setToolTip("Reusable camera + lens + film combination. Click and type to search.")
         preset_row.addWidget(self.preset_combo, 1)
         self.preset_clear_btn = QPushButton("Clear")
         self.preset_clear_btn.setToolTip("Clear gear preset selection")
         preset_row.addWidget(self.preset_clear_btn)
-        self.layout.addLayout(preset_row)
+        controls.addLayout(preset_row)
 
-        self.layout.addWidget(field_label("Camera"))
+        controls.addWidget(field_label("Camera"))
         self.camera_combo = SearchableGearCombo(placeholder="Search cameras…")
         self.camera_combo.setToolTip("Original film camera body. Click and type to search.")
-        self.layout.addWidget(self.camera_combo)
+        controls.addWidget(self.camera_combo)
 
-        self.layout.addWidget(field_label("Lens"))
+        controls.addWidget(field_label("Lens"))
         self.lens_combo = SearchableGearCombo(placeholder="Search lenses…")
         self.lens_combo.setToolTip("Original lens used on the film camera. Click and type to search.")
-        self.layout.addWidget(self.lens_combo)
+        controls.addWidget(self.lens_combo)
 
-        self.layout.addWidget(field_label("Film stock"))
+        controls.addWidget(field_label("Film stock"))
         self.film_stock_combo = SearchableGearCombo(placeholder="Search film stocks…")
         self.film_stock_combo.setToolTip("Film stock used for the original capture. Click and type to search.")
-        self.layout.addWidget(self.film_stock_combo)
+        controls.addWidget(self.film_stock_combo)
 
         self.manage_btn = QPushButton(" Manage…")
         self.manage_btn.setIcon(qta.icon("fa5s.cog", color=THEME.text_primary))
         self.manage_btn.setToolTip("Edit cameras, lenses, film stocks, and gear presets")
-        self.layout.addWidget(self.manage_btn)
+        controls.addWidget(self.manage_btn)
 
         # ── PROCESS ──────────────────────────────────────────────────────
-        self.layout.addWidget(section_subheader("PROCESS"))
+        controls.addWidget(section_subheader("PROCESS"))
 
-        self.layout.addWidget(field_label("Format"))
+        controls.addWidget(field_label("Format"))
         self.format_combo = QComboBox()
         self.format_combo.addItems(FORMAT_OPTIONS)
         if conf.format in FORMAT_OPTIONS:
             self.format_combo.setCurrentText(conf.format)
-        self.layout.addWidget(self.format_combo)
+        controls.addWidget(self.format_combo)
 
         self.format_other_edit = QLineEdit()
         self.format_other_edit.setPlaceholderText("e.g. 6×7")
         self.format_other_edit.setText(conf.format_other)
         self.format_other_edit.setVisible(conf.format == "Other")
-        self.layout.addWidget(self.format_other_edit)
+        controls.addWidget(self.format_other_edit)
 
-        self.layout.addWidget(field_label("Developer"))
+        controls.addWidget(field_label("Developer"))
         self.developer_edit = QLineEdit()
         self.developer_edit.setPlaceholderText("e.g. D-76 1+1")
         self.developer_edit.setText(conf.developer)
-        self.layout.addWidget(self.developer_edit)
+        controls.addWidget(self.developer_edit)
 
-        self.layout.addWidget(field_label("Push / Pull"))
+        controls.addWidget(field_label("Push / Pull"))
         self.push_pull_combo = QComboBox()
         self.push_pull_combo.addItems(PUSH_PULL_OPTIONS)
         idx = PUSH_PULL_VALUES.index(conf.push_pull) if conf.push_pull in PUSH_PULL_VALUES else 3
         self.push_pull_combo.setCurrentIndex(idx)
-        self.layout.addWidget(self.push_pull_combo)
+        controls.addWidget(self.push_pull_combo)
 
         # ── SCANNING ─────────────────────────────────────────────────────
-        self.layout.addWidget(section_subheader("SCANNING"))
+        controls.addWidget(section_subheader("SCANNING"))
 
-        self.layout.addWidget(field_label("Scanning"))
+        controls.addWidget(field_label("Scanning"))
         self.scanning_edit = QLineEdit()
         self.scanning_edit.setPlaceholderText("e.g. DSLR copy-stand scan")
         self.scanning_edit.setText(conf.scanning)
-        self.layout.addWidget(self.scanning_edit)
+        controls.addWidget(self.scanning_edit)
 
         self.sync_check = QCheckBox("Sync custom metadata to all files in batch export")
         self.sync_check.setChecked(conf.sync_to_batch)
-        self.layout.addWidget(self.sync_check)
+        controls.addWidget(self.sync_check)
 
         # ── EXPOSURE ─────────────────────────────────────────────────────
-        self.layout.addWidget(section_subheader("EXPOSURE"))
+        controls.addWidget(section_subheader("EXPOSURE"))
 
         hint = QLabel("Optional original capture exposure — click 🔓 to edit")
         hint.setStyleSheet(f"font-size: {THEME.font_size_xs}px; color: {THEME.text_muted};")
-        self.layout.addWidget(hint)
+        controls.addWidget(hint)
 
         self.exposure_label = field_label("Exposure")
-        self.layout.addWidget(self.exposure_label)
+        controls.addWidget(self.exposure_label)
         self.exposure_edit = self._make_exif_field("exposure")
+
+        self._refresh_gear_combos()
+        controls.addStretch()
+        self.layout.addWidget(self._metadata_controls, 1)
 
         # ── METADATA PREVIEW ─────────────────────────────────────────────
         self.preview_content = QWidget()
@@ -165,8 +183,7 @@ class MetadataSidebar(BaseSidebar):
         self.preview_section.set_content(self.preview_content)
         self.layout.addWidget(self.preview_section)
 
-        self._refresh_gear_combos()
-        self.layout.addStretch()
+        self._set_metadata_controls_enabled(not conf.protect_original_metadata)
 
     def _make_exif_field(self, key: str) -> QLineEdit:
         row = QHBoxLayout()
@@ -185,9 +202,12 @@ class MetadataSidebar(BaseSidebar):
 
         row.addWidget(edit)
         row.addWidget(lock_btn)
-        self.layout.addLayout(row)
+        self._controls_layout.addLayout(row)
         setattr(self, f"_{key}_lock_btn", lock_btn)
         return edit
+
+    def _set_metadata_controls_enabled(self, enabled: bool) -> None:
+        self._metadata_controls.setEnabled(enabled)
 
     def _apply_lock_style(self, edit: QLineEdit, locked: bool) -> None:
         if locked:
@@ -214,6 +234,7 @@ class MetadataSidebar(BaseSidebar):
         self._mark_dirty()
 
     def _connect_signals(self) -> None:
+        self.protect_check.toggled.connect(self._on_protect_toggled)
         self.preset_combo.selection_changed.connect(self._on_preset_changed)
         self.preset_clear_btn.clicked.connect(self._on_preset_clear)
         self.camera_combo.selection_changed.connect(self._on_gear_changed)
@@ -230,6 +251,17 @@ class MetadataSidebar(BaseSidebar):
         self.exposure_edit.textChanged.connect(self._mark_dirty)
 
         self.controller.session.file_selected.connect(self._on_file_selected)
+
+    def _on_protect_toggled(self, checked: bool) -> None:
+        self._set_metadata_controls_enabled(not checked)
+        self.update_config_section(
+            "metadata",
+            persist=True,
+            render=False,
+            readback_metrics=False,
+            protect_original_metadata=checked,
+        )
+        self._schedule_preview()
 
     def _refresh_gear_combos(self, *, force: bool = False) -> None:
         conf = self.state.config.metadata
@@ -401,6 +433,8 @@ class MetadataSidebar(BaseSidebar):
 
         self.block_signals(True)
         try:
+            self.protect_check.setChecked(conf.protect_original_metadata)
+            self._set_metadata_controls_enabled(not conf.protect_original_metadata)
             self._refresh_gear_combos()
 
             if conf.format in FORMAT_OPTIONS:
@@ -463,6 +497,12 @@ class MetadataSidebar(BaseSidebar):
                 item.widget().deleteLater()
 
         conf = self.state.config.metadata
+        if conf.protect_original_metadata:
+            self.preview_empty.setText("Original metadata will be copied from the source file on export.")
+            self.preview_empty.setVisible(True)
+            self.preview_section.setEnabled(True)
+            return
+
         source_exif = None
         current_hash = self.state.current_file_hash
         if current_hash and current_hash in self.state.source_exif:
@@ -471,6 +511,7 @@ class MetadataSidebar(BaseSidebar):
         payload = build_metadata_payload(conf, self._gear_library, source_exif)
         sections = payload.to_preview_sections()
 
+        self.preview_empty.setText("Select gear or enter process metadata to see a preview.")
         self.preview_empty.setVisible(not sections)
         mono = f"font-family: Consolas, monospace; font-size: {THEME.font_size_xs}px;"
 

--- a/negpy/desktop/workers/export.py
+++ b/negpy/desktop/workers/export.py
@@ -6,7 +6,7 @@ import tempfile
 import threading
 from PyQt6.QtCore import QObject, pyqtSignal, pyqtSlot
 from negpy.domain.models import WorkspaceConfig, ExportConfig, ExportFormat, ExportPreset, ExportPresetOutputMode
-from negpy.features.metadata.writer import embed_metadata
+from negpy.features.metadata.writer import embed_metadata, preserve_source_metadata
 from negpy.features.metadata.models import MetadataConfig
 from negpy.infrastructure.display.color_spaces import WORKING_COLOR_SPACE
 from negpy.services.rendering.image_processor import ImageProcessor
@@ -141,7 +141,14 @@ class ExportWorker(QObject):
                         ExportFormat.JXL,
                         ExportFormat.WEBP,
                     ):
-                        bits = embed_metadata(bits, task.metadata_config, task.source_exif)
+                        if task.metadata_config.protect_original_metadata:
+                            bits = preserve_source_metadata(
+                                bits,
+                                task.file_info["path"],
+                                task.source_exif,
+                            )
+                        else:
+                            bits = embed_metadata(bits, task.metadata_config, task.source_exif)
 
                     out_dir, filename, ext = resolve_export_naming(task)
                     os.makedirs(out_dir, exist_ok=True)

--- a/negpy/features/metadata/models.py
+++ b/negpy/features/metadata/models.py
@@ -45,4 +45,7 @@ class MetadataConfig:
     scanning: str = ""
     sync_to_batch: bool = False
 
+    # When True, export copies source EXIF/XMP unchanged — NegPy writes no metadata.
+    protect_original_metadata: bool = False
+
     exposure_override: str = ""  # free-text e.g. "1/125s f/2.8 ISO 400"; empty = use source EXIF

--- a/negpy/features/metadata/writer.py
+++ b/negpy/features/metadata/writer.py
@@ -191,6 +191,9 @@ def _prepare_jpeg_exif(exif_dict: dict) -> dict:
     return prepared
 
 
+_APP1_EXIF_LIMIT = 65533
+
+
 def _resolve_payload(
     config: MetadataConfig,
     gear: Optional[GearLibrary],
@@ -199,6 +202,123 @@ def _resolve_payload(
     if gear is None:
         gear = GearProfiles.load_library()
     return build_metadata_payload(config, gear, source_exif)
+
+
+def _read_xmp_from_source(source_path: str) -> Optional[bytes]:
+    """Read embedded XMP from a source JPEG or TIFF/DNG file."""
+    try:
+        with open(source_path, "rb") as fh:
+            head = fh.read(12)
+        if head[:2] == b"\xff\xd8":
+            with open(source_path, "rb") as fh:
+                data = fh.read()
+            return _extract_jpeg_xmp(data)
+        with tifffile.TiffFile(source_path) as tf:
+            tag = tf.pages[0].tags.get(_TIFF_XMP_TAG)
+            if tag is None:
+                return None
+            value = tag.value
+            if isinstance(value, bytes):
+                return value
+            if isinstance(value, str):
+                return value.encode("utf-8")
+    except Exception:
+        pass
+    return None
+
+
+def _extract_jpeg_xmp(data: bytes) -> Optional[bytes]:
+    i = 2
+    n = len(data)
+    while i < n:
+        if data[i] != 0xFF:
+            break
+        marker = data[i + 1]
+        if marker == 0xD9:
+            break
+        if marker in range(0xD0, 0xD8):
+            i += 2
+            continue
+        if i + 4 > n:
+            break
+        seg_len = struct.unpack(">H", data[i + 2 : i + 4])[0]
+        seg_end = i + 2 + seg_len
+        if marker == 0xE1 and seg_end <= n:
+            payload_start = i + 4
+            if data[payload_start : payload_start + len(_XMP_APP1_HEADER)] == _XMP_APP1_HEADER:
+                return data[payload_start + len(_XMP_APP1_HEADER) : seg_end]
+        i = seg_end
+    return None
+
+
+def _load_source_exif(source_path: str, source_exif: Optional[dict]) -> Optional[dict]:
+    if source_exif is not None:
+        return copy.deepcopy(source_exif)
+    from negpy.infrastructure.loaders.helpers import read_exif_from_file
+
+    return read_exif_from_file(source_path)
+
+
+def _dump_exif_preserve(exif_dict: dict) -> Optional[bytes]:
+    """Serialize source EXIF for embed without NegPy field injection."""
+    candidate = _prepare_jpeg_exif(exif_dict)
+
+    def _fits(strip_maker_note: bool = False) -> Optional[bytes]:
+        work = copy.deepcopy(candidate)
+        if strip_maker_note and isinstance(work.get("Exif"), dict):
+            work["Exif"].pop(piexif.ExifIFD.MakerNote, None)
+        try:
+            b = piexif.dump(work)
+        except Exception:
+            return None
+        return b if len(b) <= _APP1_EXIF_LIMIT else None
+
+    exif_bytes = _fits()
+    if exif_bytes is not None:
+        return exif_bytes
+    exif_bytes = _fits(strip_maker_note=True)
+    if exif_bytes is not None:
+        _log.warning("source EXIF too large for JPEG APP1; dropped MakerNote for passthrough")
+        return exif_bytes
+    _log.warning("source EXIF too large for JPEG APP1; metadata passthrough skipped")
+    return None
+
+
+def preserve_source_metadata(
+    image_bytes: bytes,
+    source_path: str,
+    source_exif: Optional[dict] = None,
+) -> bytes:
+    """
+    Copy EXIF/XMP from the source file onto exported image bytes without
+    adding or altering NegPy metadata fields.
+    """
+    exif_dict = _load_source_exif(source_path, source_exif)
+    if not exif_dict:
+        return image_bytes
+
+    xmp_bytes = _read_xmp_from_source(source_path)
+
+    try:
+        output = io.BytesIO()
+        if image_bytes[:2] == b"\xff\xd8":
+            exif_bytes = _dump_exif_preserve(exif_dict)
+            if exif_bytes is None:
+                return image_bytes
+            jpeg_buf = io.BytesIO()
+            piexif.insert(exif_bytes, image_bytes, jpeg_buf)
+            result = _inject_jpeg_xmp(jpeg_buf.getvalue(), xmp_bytes) if xmp_bytes else jpeg_buf.getvalue()
+            output.write(result)
+        elif image_bytes[:8] == b"\x89PNG\r\n\x1a\n":
+            exif_bytes = piexif.dump(_sanitize_exif(exif_dict))
+            _rewrite_png_with_metadata(image_bytes, exif_bytes, output, xmp_bytes)
+        else:
+            exif_bytes = piexif.dump(_sanitize_exif(exif_dict))
+            _rewrite_tiff_preserve(image_bytes, exif_bytes, output, xmp_bytes, fold_user_comment=False)
+        return output.getvalue()
+    except Exception:
+        _log.warning("metadata passthrough failed", exc_info=True)
+        return image_bytes
 
 
 def embed_metadata(
@@ -253,9 +373,6 @@ def embed_metadata(
     except Exception:
         _log.warning("metadata embed failed", exc_info=True)
         return image_bytes
-
-
-_APP1_EXIF_LIMIT = 65533
 
 
 def _strip_jpeg_xmp_segments(data: bytes) -> bytes:
@@ -417,6 +534,67 @@ def _build_extratag(tag: int, ttype: int, value: object) -> tuple | None:
     return None
 
 
+def _tiff_metadata_from_exif_bytes(exif_bytes: bytes) -> tuple[dict | None, str | None]:
+    """Map reserved TIFF tags (managed by tifffile, not extratags) from source EXIF."""
+    exif_dict = piexif.load(exif_bytes)
+    zeroth = exif_dict.get("0th", {}) or {}
+    metadata: dict[str, str] = {}
+    software: str | None = None
+    for tag, key in (
+        (piexif.ImageIFD.Artist, "Artist"),
+        (piexif.ImageIFD.Copyright, "Copyright"),
+    ):
+        text = _decode_ascii(zeroth.get(tag))
+        if text:
+            metadata[key] = text
+    software = _decode_ascii(zeroth.get(piexif.ImageIFD.Software))
+    return (metadata or None), software
+
+
+def _rewrite_tiff_preserve(
+    image_bytes: bytes,
+    exif_bytes: bytes,
+    output: io.BytesIO,
+    xmp_bytes: Optional[bytes] = None,
+    *,
+    fold_user_comment: bool = True,
+) -> None:
+    if image_bytes[:8] == b"\x89PNG\r\n\x1a\n":
+        _rewrite_png_with_metadata(image_bytes, exif_bytes, output, xmp_bytes)
+        return
+
+    with tifffile.TiffFile(io.BytesIO(image_bytes)) as tf:
+        page = tf.pages[0]
+        arr = page.asarray()
+        photometric = page.photometric.name.lower()
+        compression = page.compression.name.lower() if int(page.compression) != 1 else None
+        icc = page.iccprofile
+
+    description, extratags = _exif_bytes_to_extratags(exif_bytes)
+    if fold_user_comment:
+        description = _fold_user_comment_into_description(description, extratags)
+
+    if xmp_bytes:
+        extratags.append((_TIFF_XMP_TAG, 7, len(xmp_bytes), xmp_bytes, True))
+
+    metadata = None
+    software = None
+    if not fold_user_comment:
+        metadata, software = _tiff_metadata_from_exif_bytes(exif_bytes)
+
+    tifffile.imwrite(
+        output,
+        arr,
+        photometric=photometric,
+        compression=compression,
+        iccprofile=icc,
+        description=description or "",
+        metadata=metadata,
+        software=software,
+        extratags=extratags,
+    )
+
+
 def _rewrite_png_with_metadata(
     image_bytes: bytes,
     exif_bytes: bytes,
@@ -441,29 +619,7 @@ def _rewrite_tiff_with_metadata(
     output: io.BytesIO,
     xmp_bytes: Optional[bytes] = None,
 ) -> None:
-    with tifffile.TiffFile(io.BytesIO(image_bytes)) as tf:
-        page = tf.pages[0]
-        arr = page.asarray()
-        photometric = page.photometric.name.lower()
-        compression = page.compression.name.lower() if int(page.compression) != 1 else None
-        icc = page.iccprofile
-
-    description, extratags = _exif_bytes_to_extratags(exif_bytes)
-    description = _fold_user_comment_into_description(description, extratags)
-
-    if xmp_bytes:
-        extratags.append((_TIFF_XMP_TAG, 7, len(xmp_bytes), xmp_bytes, True))
-
-    tifffile.imwrite(
-        output,
-        arr,
-        photometric=photometric,
-        compression=compression,
-        iccprofile=icc,
-        description=description or "",
-        metadata=None,
-        extratags=extratags,
-    )
+    _rewrite_tiff_preserve(image_bytes, exif_bytes, output, xmp_bytes, fold_user_comment=True)
 
 
 def _fold_user_comment_into_description(description: str | None, extratags: list[tuple]) -> str | None:

--- a/tests/metadata/test_writer.py
+++ b/tests/metadata/test_writer.py
@@ -7,7 +7,7 @@ import piexif
 import tifffile
 
 from negpy.features.metadata.models import MetadataConfig
-from negpy.features.metadata.writer import _sanitize_exif, embed_metadata
+from negpy.features.metadata.writer import _sanitize_exif, embed_metadata, preserve_source_metadata
 
 
 def _make_tiff_bytes() -> bytes:
@@ -185,3 +185,53 @@ class TestEmbedMetadata:
             desc = tf.pages[0].tags.get(piexif.ImageIFD.ImageDescription).value
         for fragment in ("Portra 400", "35mm", "HC-110", "Push +1"):
             assert fragment in desc, f"missing {fragment!r} in {desc!r}"
+
+
+class TestPreserveSourceMetadata:
+    def test_copies_source_exif_without_negpy_software(self) -> None:
+        image_bytes = _make_tiff_bytes()
+        source_exif = {
+            "0th": {
+                piexif.ImageIFD.Make: b"Nikon",
+                piexif.ImageIFD.Model: b"F6",
+                piexif.ImageIFD.Software: b"MV-1 Recorder",
+            },
+            "Exif": {piexif.ExifIFD.LensModel: b"Nikkor 50mm f/1.8"},
+            "GPS": {},
+            "Interop": {},
+            "1st": {},
+        }
+        config = MetadataConfig(film="Portra 400", developer="C-41")
+
+        embedded = embed_metadata(image_bytes, config, source_exif)
+        preserved = preserve_source_metadata(image_bytes, "/unused/source.dng", source_exif)
+
+        with tifffile.TiffFile(io.BytesIO(embedded)) as tf:
+            tags = tf.pages[0].tags
+            desc = tags.get(piexif.ImageIFD.ImageDescription).value
+            assert "Portra 400" in desc and "C-41" in desc
+
+        with tifffile.TiffFile(io.BytesIO(preserved)) as tf:
+            tags = tf.pages[0].tags
+            assert tags.get(piexif.ImageIFD.Make).value == "Nikon"
+            assert tags.get(piexif.ImageIFD.Model).value == "F6"
+            assert tags.get(piexif.ImageIFD.Software).value == "MV-1 Recorder"
+            assert tags.get(piexif.ExifIFD.LensModel).value == "Nikkor 50mm f/1.8"
+
+    def test_does_not_normalize_orientation(self) -> None:
+        from PIL import Image
+
+        jpeg = io.BytesIO()
+        Image.new("RGB", (16, 16), (128, 0, 0)).save(jpeg, "JPEG")
+        source_exif = {
+            "0th": {piexif.ImageIFD.Orientation: 6, piexif.ImageIFD.Make: b"Nikon"},
+            "Exif": {},
+            "GPS": {},
+            "Interop": {},
+            "1st": {},
+        }
+
+        out = preserve_source_metadata(jpeg.getvalue(), "/unused/source.dng", source_exif)
+        loaded = piexif.load(out)
+        assert loaded["0th"].get(piexif.ImageIFD.Orientation) == 6
+        assert loaded["0th"].get(piexif.ImageIFD.Make) == b"Nikon"

--- a/tests/test_desktop_session.py
+++ b/tests/test_desktop_session.py
@@ -4,7 +4,6 @@ from dataclasses import replace
 
 from negpy.desktop.session import AppState, AssetListModel, DesktopSessionManager
 from negpy.domain.models import WorkspaceConfig, GeometryConfig, RetouchConfig, ProcessConfig
-from negpy.features.metadata.models import MetadataConfig
 from negpy.infrastructure.storage.repository import StorageRepository
 from negpy.kernel.system.config import APP_CONFIG
 

--- a/tests/test_desktop_session.py
+++ b/tests/test_desktop_session.py
@@ -4,6 +4,7 @@ from dataclasses import replace
 
 from negpy.desktop.session import AppState, AssetListModel, DesktopSessionManager
 from negpy.domain.models import WorkspaceConfig, GeometryConfig, RetouchConfig, ProcessConfig
+from negpy.features.metadata.models import MetadataConfig
 from negpy.infrastructure.storage.repository import StorageRepository
 from negpy.kernel.system.config import APP_CONFIG
 
@@ -62,6 +63,26 @@ class TestDesktopSessionSync(unittest.TestCase):
         self.assertIn("last_process_mode", saved)
         self.assertIn("last_export_config", saved)
         self.assertIn("last_dust_remove", saved)
+        self.assertIn("last_protect_original_metadata", saved)
+
+    def test_protect_original_metadata_carries_globally(self):
+        sticky = {
+            "last_export_config": {},
+            "last_protect_original_metadata": True,
+        }
+        self.mock_repo.get_global_setting.side_effect = lambda key, default=None: sticky.get(key, default)
+        config = self.session._apply_sticky_settings(WorkspaceConfig(), only_global=False)
+        self.assertTrue(config.metadata.protect_original_metadata)
+
+    def test_protect_original_metadata_applied_to_saved_files(self):
+        sticky = {
+            "last_export_config": {},
+            "last_protect_original_metadata": True,
+        }
+        self.mock_repo.get_global_setting.side_effect = lambda key, default=None: sticky.get(key, default)
+        base = WorkspaceConfig(metadata=replace(WorkspaceConfig().metadata, protect_original_metadata=False))
+        config = self.session._apply_sticky_settings(base, only_global=True)
+        self.assertTrue(config.metadata.protect_original_metadata)
 
     def test_processing_toggles_carry_to_new_files(self):
         # Globally remembered toggles must be applied to a fresh (sidecar-less) file.


### PR DESCRIPTION
## Summary

Adds a **Protect original metadata** checkbox at the top of the Metadata tab. When enabled, all other metadata controls are disabled and exports copy EXIF/XMP from the source file without NegPy adding or altering tags (no gear/process fields, no `Software=NegPy`, no scan-tag stripping).

Export routing calls `preserve_source_metadata()` instead of `embed_metadata()` for TIFF, JPEG, and PNG. DNG, JXL, and WebP are unchanged (metadata rewrite was already skipped).

Addresses workflows where external tools (e.g. MV-1 / EXIFTool) pre-tag scanner DNGs and NegPy's metadata embed was truncating or overwriting those tags on export.

## Test plan

- [x] Enable **Protect original metadata**, confirm gear/process/scanning/exposure controls are greyed out
- [x] Export a pre-tagged scanner DNG as TIFF — verify source tags (Make/Model/Software/custom EXIF) survive unchanged
- [x] Disable the checkbox, set gear/process metadata, export — verify NegPy metadata is written as before
- [x] `uv run pytest tests/metadata/test_writer.py tests/test_metadata_writer.py` — 14 passed

Fixes #410 