### PR TITLE
Fix macOS segfault from GPU display-texture use-after-free (#434)

### DIFF
--- a/negpy/services/rendering/gpu_engine.py
+++ b/negpy/services/rendering/gpu_engine.py
@@ -18,12 +18,12 @@ from negpy.features.exposure.normalization import (
     measure_clip_fractions,
     measure_neutral_axis_from_log,
     measure_shadow_refs_from_log,
-    resolve_crosstalk_matrix,
-    unmix_log_image,
     measure_textural_range_from_log,
     prefilter_log_grid,
     resolve_analysis_region,
     resolve_bounds_detailed,
+    resolve_crosstalk_matrix,
+    unmix_log_image,
 )
 from negpy.features.geometry.logic import (
     AUTOCROP_DETECT_RES,
@@ -192,6 +192,11 @@ class GPUEngine:
         self._sampler: Optional[Any] = None
         self._tex_cache: Dict[Tuple[int, int, int, str], GPUTexture] = {}
 
+        # Display output textures live outside _tex_cache so cleanup()/next-render reuse can't
+        # free or overwrite the frame the main-thread canvas is presenting.
+        self._display_ring: list[Optional[GPUTexture]] = [None, None, None]
+        self._display_idx: int = 0
+
         self._uniform_names = [
             "geometry",
             "normalization",
@@ -291,6 +296,24 @@ class GPUEngine:
         if key not in self._tex_cache:
             self._tex_cache[key] = GPUTexture(w, h, usage=usage)
         return self._tex_cache[key]
+
+    def _get_display_texture(self, w: int, h: int, usage: int) -> GPUTexture:
+        """Rotating display-output texture, deliberately kept out of _tex_cache.
+
+        The returned texture is handed to the main-thread canvas, which keeps
+        sampling it until the next frame arrives. Pooling it would let the next
+        render overwrite it, or cleanup() destroy it, while the canvas is still
+        reading — a cross-thread use-after-free (issue #434). Rotating through a
+        small ring gives the canvas a stable frame while the worker renders into a
+        different slot; the engine holds strong refs so GC can't free a live slot.
+        """
+        idx = self._display_idx
+        slot = self._display_ring[idx]
+        if slot is None or slot.width != w or slot.height != h:
+            slot = GPUTexture(w, h, usage=usage)
+            self._display_ring[idx] = slot
+        self._display_idx = (idx + 1) % len(self._display_ring)
+        return slot
 
     def _init_resources(self) -> None:
         """Initializes hardware pipelines and persistent buffers."""
@@ -888,11 +911,10 @@ class GPUEngine:
 
         # Output transform: scene-linear -> display-encoded, so every consumer
         # (readback, display LUT) reads encoded data.
-        tex_output = self._get_intermediate_texture(
+        tex_output = self._get_display_texture(
             tex_final.width,
             tex_final.height,
             wgpu.TextureUsage.STORAGE_BINDING | wgpu.TextureUsage.TEXTURE_BINDING | wgpu.TextureUsage.COPY_SRC,
-            "output_encoded",
         )
         self._dispatch_pass(enc, "output_encode", [(0, tex_final.view), (1, tex_output.view)], tex_final.width, tex_final.height)
         tex_final = tex_output
@@ -1776,6 +1798,11 @@ class GPUEngine:
     def destroy_all(self) -> None:
         """Full resource teardown."""
         self.cleanup()
+        for i, tex in enumerate(self._display_ring):
+            if tex is not None:
+                tex.destroy()
+            self._display_ring[i] = None
+        self._display_idx = 0
         if self._metrics_staging is not None:
             self._metrics_staging.destroy()
             self._metrics_staging = None

--- a/tests/test_display_ring.py
+++ b/tests/test_display_ring.py
@@ -1,0 +1,62 @@
+"""Display-texture ring mechanics (issue #434 use-after-free guard).
+
+The engine hands the main-thread canvas a GPU texture it keeps sampling until the
+next frame. If that texture were pooled in `_tex_cache`, the next render would
+overwrite it — or `cleanup()` on file load would destroy it — while the canvas
+still reads it (a cross-thread use-after-free). The ring keeps display output
+textures out of the pool so a rendered frame stays valid until it's replaced.
+
+Tests exercise the pure ring logic with a fake texture so no GPU is required.
+"""
+
+import negpy.services.rendering.gpu_engine as ge
+
+
+class _FakeTex:
+    def __init__(self, width, height, usage=0):
+        self.width, self.height, self.usage = width, height, usage
+        self.destroyed = False
+
+    def destroy(self):
+        self.destroyed = True
+
+
+def _bare_engine(monkeypatch):
+    monkeypatch.setattr(ge, "GPUTexture", _FakeTex)
+    eng = ge.GPUEngine.__new__(ge.GPUEngine)
+    eng._tex_cache = {}
+    eng._display_ring = [None, None, None]
+    eng._display_idx = 0
+    return eng
+
+
+def test_consecutive_renders_hand_out_distinct_textures(monkeypatch):
+    eng = _bare_engine(monkeypatch)
+    frames = [ge.GPUEngine._get_display_texture(eng, 100, 50, 7) for _ in range(3)]
+    # A new render must not target the slot(s) the canvas is still presenting.
+    assert len({id(f) for f in frames}) == 3
+    # Wraps around and reuses the oldest slot (same size) — by now off-screen.
+    assert ge.GPUEngine._get_display_texture(eng, 100, 50, 7) is frames[0]
+
+
+def test_resolution_change_reallocates_slot(monkeypatch):
+    eng = _bare_engine(monkeypatch)
+    a = ge.GPUEngine._get_display_texture(eng, 100, 50, 7)
+    # Fill the ring, then wrap back to a's slot at a new size.
+    ge.GPUEngine._get_display_texture(eng, 100, 50, 7)
+    ge.GPUEngine._get_display_texture(eng, 100, 50, 7)
+    b = ge.GPUEngine._get_display_texture(eng, 200, 100, 7)
+    assert b is not a
+    assert (b.width, b.height) == (200, 100)
+
+
+def test_display_texture_survives_pool_cleanup(monkeypatch):
+    eng = _bare_engine(monkeypatch)
+    tex = ge.GPUEngine._get_display_texture(eng, 64, 64, 7)
+    # It must never enter the shared pool that cleanup() destroys.
+    assert tex not in eng._tex_cache.values()
+    # Simulate GPUEngine.cleanup() nuking the pool (the load_file path).
+    for t in eng._tex_cache.values():
+        t.destroy()
+    eng._tex_cache.clear()
+    assert not tex.destroyed


### PR DESCRIPTION
Fixes #434 — hard segfault on macOS when dragging an image (e.g. a TIFF) into the sidebar.

## Root cause

Not the multi-core Numba work from #426 (parallel kernels are **off by default on macOS**). The crash is a GPU display-texture **use-after-free**:

- `GPUEngine.process_to_texture` returned the canvas a texture from its shared intermediate **pool** (`_get_intermediate_texture(..., "output_encoded")`, stored in `_tex_cache`) as `base_positive`.
- The main-thread canvas keeps sampling that texture's `.view` every `_draw_frame`.
- The next same-resolution render pulled the **same pooled object** and overwrote it while the canvas was reading it; worse, `load_file` fires `_render_cleanup_requested` → `RenderWorker.cleanup()` → `GPUEngine.cleanup()`, which `destroy()`s the entire pool **on the worker thread** — including the texture the canvas still holds. `load_file` never clears the canvas view.
- The next `_draw_frame` samples the freed view → GPU use-after-free → heap corruption → segfault at an unrelated later allocation (the `QPixmap` build in `_on_thumbnails_finished`), exactly matching the reported trace.

#426 didn't create this (it never touched `gpu_engine`, the cleanup path, or the canvas); its resolution-keyed `source_hash` and new redraw triggers plausibly raised the hit-rate of a latent UAF.

## Fix

Decouple the display texture's lifetime from the pool. `process_to_texture`'s final `output_encode` now targets a dedicated 3-slot ring (`_get_display_texture`) kept **out of `_tex_cache`** and **out of `cleanup()`**, so a frame the canvas is presenting is never reused or destroyed until it's replaced. The engine holds strong refs so GC can't free a live slot. GPU stays on for all platforms — no macOS CPU fallback.

## Verification

- New `tests/test_display_ring.py` (ring mechanics); full suite **1234 passed**; `ruff` + `ty` clean.
- On real GPU (Vulkan): consecutive renders return **distinct** textures, the display texture is **not** in `_tex_cache`, and it **survives `cleanup()`** (readback identical before/after) — the exact `load_file` destroy path that previously killed it.
- End-to-end headless run (load TIFF → rotate → load 2nd TIFF → toggle HQ) completes without crash and renders valid frames.

macOS can't be reproduced from CI (same reason #426 asked for macOS testers); please confirm on a macOS build. Immediate workaround for affected users meanwhile: the canvas toolbar **GPU toggle** ("force the CPU pipeline") routes display through the Qt overlay, so no live GPU texture crosses threads.