### PR TITLE
fix: consistent sidebar card inset & row spacing

### DIFF
--- a/negpy/desktop/view/sidebar/base.py
+++ b/negpy/desktop/view/sidebar/base.py
@@ -15,6 +15,9 @@ class BaseSidebar(QWidget):
     Handles common setup and configuration updates.
     """
 
+    # 0 = the card owns horizontal inset; standalone panels override.
+    SIDE_MARGIN = 0
+
     def __init__(self, controller: AppController):
         super().__init__()
         self.controller = controller
@@ -40,8 +43,8 @@ class BaseSidebar(QWidget):
     def _init_layout(self) -> None:
         """Sets up the default QVBoxLayout."""
         self.layout = QVBoxLayout(self)
-        self.layout.setContentsMargins(5, 0, 5, 5)
-        self.layout.setSpacing(THEME.space_md)
+        self.layout.setContentsMargins(self.SIDE_MARGIN, 0, self.SIDE_MARGIN, 5)
+        self.layout.setSpacing(THEME.space_lg)
 
     def _init_ui(self) -> None:
         """Override to add widgets to self.layout."""

--- a/negpy/desktop/view/sidebar/colour.py
+++ b/negpy/desktop/view/sidebar/colour.py
@@ -13,7 +13,6 @@ class ColourSidebar(BaseSidebar):
     """White balance (region CMY + Pick WB) and Cast Removal."""
 
     def _init_ui(self) -> None:
-        self.layout.setSpacing(12)
         conf = self.state.config.exposure
 
         # Region selector, same idiom as the tone page's channel selector.

--- a/negpy/desktop/view/sidebar/export.py
+++ b/negpy/desktop/view/sidebar/export.py
@@ -42,8 +42,9 @@ class ExportSidebar(BaseSidebar):
     Panel for export settings, presets and batch processing.
     """
 
+    SIDE_MARGIN = THEME.space_xl
+
     def _init_ui(self) -> None:
-        self.layout.setSpacing(10)
 
         self.update_timer = QTimer()
         self.update_timer.setSingleShot(True)

--- a/negpy/desktop/view/sidebar/finish.py
+++ b/negpy/desktop/view/sidebar/finish.py
@@ -12,7 +12,6 @@ class FinishSidebar(BaseSidebar):
     """
 
     def _init_ui(self) -> None:
-        self.layout.setSpacing(12)
         conf = self.state.config.finish
 
         self.layout.addWidget(section_subheader("VIGNETTE"))

--- a/negpy/desktop/view/sidebar/history.py
+++ b/negpy/desktop/view/sidebar/history.py
@@ -4,12 +4,15 @@ from PyQt6.QtWidgets import QListWidget, QListWidgetItem, QMenu
 
 from negpy.desktop.view.sidebar.base import BaseSidebar
 from negpy.desktop.view.styles.templates import section_subheader
+from negpy.desktop.view.styles.theme import THEME
 
 _INDEX_ROLE = Qt.ItemDataRole.UserRole
 
 
 class HistoryPanel(BaseSidebar):
     """Scrollable list of edit-history steps; click to jump, right-click to export."""
+
+    SIDE_MARGIN = THEME.space_xl
 
     def _init_ui(self) -> None:
         self.layout.addWidget(section_subheader("EDIT HISTORY"))

--- a/negpy/desktop/view/sidebar/lab.py
+++ b/negpy/desktop/view/sidebar/lab.py
@@ -12,7 +12,6 @@ class LabSidebar(BaseSidebar):
     """
 
     def _init_ui(self) -> None:
-        self.layout.setSpacing(12)
         conf = self.state.config.lab
 
         self.color_header = section_subheader("COLOR")

--- a/negpy/desktop/view/sidebar/local.py
+++ b/negpy/desktop/view/sidebar/local.py
@@ -14,8 +14,6 @@ class LocalSidebar(BaseSidebar):
     """
 
     def _init_ui(self) -> None:
-        self.layout.setSpacing(10)
-
         self.draw_btn = self._tool_toggle(
             "fa5s.draw-polygon",
             "Draw Mask",

--- a/negpy/desktop/view/sidebar/metadata.py
+++ b/negpy/desktop/view/sidebar/metadata.py
@@ -32,8 +32,9 @@ PUSH_PULL_VALUES = [3, 2, 1, 0, -1, -2, -3]
 class MetadataSidebar(BaseSidebar):
     """Panel for analog gear metadata written to exported files."""
 
+    SIDE_MARGIN = THEME.space_xl
+
     def _init_ui(self) -> None:
-        self.layout.setSpacing(10)
         conf = self.state.config.metadata
         self._gear_library: GearLibrary = GearProfiles.load_library()
 

--- a/negpy/desktop/view/sidebar/process.py
+++ b/negpy/desktop/view/sidebar/process.py
@@ -66,7 +66,6 @@ class ProcessSidebar(BaseSidebar):
     """
 
     def _init_ui(self) -> None:
-        self.layout.setSpacing(12)
         conf = self.state.config.process
 
         mode_row = QHBoxLayout()

--- a/negpy/desktop/view/sidebar/retouch.py
+++ b/negpy/desktop/view/sidebar/retouch.py
@@ -14,7 +14,6 @@ class RetouchSidebar(BaseSidebar):
     """
 
     def _init_ui(self) -> None:
-        self.layout.setSpacing(10)
         conf = self.state.config.retouch
 
         auto_row = QHBoxLayout()

--- a/negpy/desktop/view/sidebar/roll.py
+++ b/negpy/desktop/view/sidebar/roll.py
@@ -18,7 +18,6 @@ class RollAnalysisSidebar(BaseSidebar):
     """
 
     def _init_ui(self) -> None:
-        self.layout.setSpacing(12)
         conf = self.state.config.process
 
         self.layout.addWidget(section_subheader("BATCH"))

--- a/negpy/desktop/view/sidebar/scan.py
+++ b/negpy/desktop/view/sidebar/scan.py
@@ -62,8 +62,8 @@ class ScanSidebar(QWidget):
 
     def _init_ui(self) -> None:
         layout = QVBoxLayout(self)
-        layout.setContentsMargins(5, 0, 5, 5)
-        layout.setSpacing(10)
+        layout.setContentsMargins(THEME.space_xl, 0, THEME.space_xl, 5)
+        layout.setSpacing(THEME.space_lg)
 
         # ── DEVICE ───────────────────────────────────────────
         layout.addWidget(section_subheader("DEVICE"))

--- a/negpy/desktop/view/sidebar/tone.py
+++ b/negpy/desktop/view/sidebar/tone.py
@@ -17,7 +17,6 @@ class ToneSidebar(BaseSidebar):
     selector scoping Grade/Toe/Shoulder to per-layer trims (crossover correction)."""
 
     def _init_ui(self) -> None:
-        self.layout.setSpacing(12)
         conf = self.state.config.exposure
 
         self.density_slider = CompactSlider("Print Density", 0.0, 2.0, conf.density)

--- a/negpy/desktop/view/sidebar/toning.py
+++ b/negpy/desktop/view/sidebar/toning.py
@@ -12,7 +12,6 @@ class ToningSidebar(BaseSidebar):
     """
 
     def _init_ui(self) -> None:
-        self.layout.setSpacing(12)
         conf = self.state.config.toning
 
         self.chemical_header = section_subheader("CHEMICAL TONING")

--- a/negpy/desktop/view/widgets/collapsible.py
+++ b/negpy/desktop/view/widgets/collapsible.py
@@ -49,7 +49,7 @@ class CollapsibleSection(QWidget):
         self.toggle_button.setProperty("overlay", "true" if background_widget else "false")
 
         btn_layout = QHBoxLayout(self.toggle_button)
-        btn_layout.setContentsMargins(12, 8, 12, 8)
+        btn_layout.setContentsMargins(THEME.space_xl, 8, THEME.space_xl, 8)
         btn_layout.setSpacing(10)
 
         if icon:
@@ -97,7 +97,7 @@ class CollapsibleSection(QWidget):
         self.content_area = QFrame()
         self.content_area.setObjectName("collapsible_content")
         self.content_layout = QVBoxLayout(self.content_area)
-        self.content_layout.setContentsMargins(0, 4, 0, 8)
+        self.content_layout.setContentsMargins(THEME.space_xl, 4, THEME.space_xl, 8)  # same inset as header
         self.content_layout.setSpacing(4)
         self.content_area.setVisible(expanded)
 


### PR DESCRIPTION
Card owns the horizontal inset (THEME.space_xl) so section headers and the fields below them share one left edge on every sidebar tab. BaseSidebar no longer adds its own horizontal margin; standalone panels (export/metadata/ history) inset their loose content via a SIDE_MARGIN class attr. Row spacing unified to THEME.space_lg across all tabs.

Fixes export/metadata field text sitting flush against the card border.