### PR TITLE
Fix startup crash when OneDrive-backed Documents folder is missing on disk (#441)

### DIFF
--- a/negpy/kernel/system/paths.py
+++ b/negpy/kernel/system/paths.py
@@ -21,6 +21,25 @@ def get_resource_path(relative_path: str) -> str:
     return os.path.join(base_path, relative_path)
 
 
+def _usable_user_dir(base: Path) -> Optional[str]:
+    """
+    The NegPy dir under `base` if `base` is usable, else None.
+
+    When `base` already exists this touches nothing (the app creates its
+    subdirectories at startup). When it's missing, creatability has to be proven
+    by actually creating — a registered-but-absent folder is indistinguishable
+    from a creatable one until CreateDirectory runs.
+    """
+    target = base / "NegPy"
+    try:
+        if os.path.isdir(base):
+            return str(target.absolute())
+        os.makedirs(target, exist_ok=True)
+        return str(target.absolute())
+    except OSError:
+        return None
+
+
 def get_default_user_dir() -> str:
     """Resolve the user directory, defaulting to Documents/NegPy with platform-native detection."""
     env_path = os.getenv("NEGPY_USER_DIR")
@@ -36,8 +55,8 @@ def get_default_user_dir() -> str:
 
             buf = ctypes.create_unicode_buffer(wintypes.MAX_PATH)
             # CSIDL_PERSONAL = 5
-            ctypes.windll.shell32.SHGetFolderPathW(None, 5, None, 0, buf)
-            if buf.value:
+            res = ctypes.windll.shell32.SHGetFolderPathW(None, 5, None, 0, buf)
+            if res == 0 and buf.value:
                 docs_dir = Path(buf.value)
         except Exception:
             pass
@@ -78,11 +97,20 @@ def get_default_user_dir() -> str:
     elif sys.platform == "darwin":
         docs_dir = Path.home() / "Documents"
 
-    # fallback
+    home = Path(os.path.expanduser("~"))
     if not docs_dir:
-        try:
-            docs_dir = Path.home() / "Documents"
-        except RuntimeError:
-            docs_dir = Path(os.path.expanduser("~")) / "Documents"
+        docs_dir = home / "Documents"
 
-    return str((docs_dir / "NegPy").absolute())
+    # The registered Documents folder can point at a location that does not exist
+    # on disk — most commonly a OneDrive-backed Documents (...\OneDrive\Documents)
+    # after OneDrive is unlinked, signed out, or not yet synced. Trusting it blindly
+    # made the startup os.makedirs die with WinError 2 (#441). Validate the
+    # candidate and fall back to plain local locations that always exist.
+    candidates = list(dict.fromkeys([docs_dir, home / "Documents", home]))
+    for base in candidates:
+        usable = _usable_user_dir(base)
+        if usable is not None:
+            return usable
+
+    # Last resort: home always exists in practice; let startup surface any error.
+    return str((home / "NegPy").absolute())

--- a/tests/test_user_dir_resolution.py
+++ b/tests/test_user_dir_resolution.py
@@ -1,0 +1,76 @@
+"""
+User-dir resolution must survive a registered Documents folder that does not
+exist on disk — e.g. a OneDrive-backed Documents after OneDrive is unlinked or
+signed out (issue #441: startup makedirs died with WinError 2).
+"""
+
+import os
+from pathlib import Path
+
+from negpy.kernel.system.paths import _usable_user_dir, get_default_user_dir
+
+
+def test_usable_dir_existing_base_returns_without_creating(tmp_path):
+    result = _usable_user_dir(tmp_path)
+
+    assert result == str((tmp_path / "NegPy").absolute())
+    # Base exists, so resolution must not touch the filesystem.
+    assert not (tmp_path / "NegPy").exists()
+
+
+def test_usable_dir_missing_but_creatable_base_creates(tmp_path):
+    base = tmp_path / "Documents"
+
+    result = _usable_user_dir(base)
+
+    assert result == str((base / "NegPy").absolute())
+    assert (base / "NegPy").is_dir()
+
+
+def test_usable_dir_uncreatable_base_returns_none(tmp_path):
+    blocker = tmp_path / "blocker"
+    blocker.write_text("a file, not a directory")
+
+    # A path under a regular file can never be created — mirrors the broken
+    # OneDrive case where CreateDirectory fails on the registered path.
+    assert _usable_user_dir(blocker / "Documents") is None
+
+
+def test_env_override_wins(monkeypatch, tmp_path):
+    monkeypatch.setenv("NEGPY_USER_DIR", str(tmp_path / "custom"))
+
+    assert get_default_user_dir() == os.path.abspath(str(tmp_path / "custom"))
+
+
+def test_broken_documents_falls_back_to_home(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    home.mkdir()
+    blocker = tmp_path / "blocker"
+    blocker.write_text("")
+
+    monkeypatch.delenv("NEGPY_USER_DIR", raising=False)
+    # Deterministic docs detection on every platform: the linux branch reads
+    # XDG_DOCUMENTS_DIR directly, so point it at an uncreatable path.
+    monkeypatch.setattr("sys.platform", "linux")
+    monkeypatch.setenv("XDG_DOCUMENTS_DIR", str(blocker / "OneDrive" / "Documents"))
+    monkeypatch.setattr(os.path, "expanduser", lambda p: str(home) if p == "~" else p)
+
+    result = get_default_user_dir()
+
+    # Falls past the broken Documents to home/Documents, created on the spot.
+    assert result == str((home / "Documents" / "NegPy").absolute())
+    assert Path(result).is_dir()
+
+
+def test_existing_documents_used_without_side_effects(monkeypatch, tmp_path):
+    docs = tmp_path / "Docs"
+    docs.mkdir()
+
+    monkeypatch.delenv("NEGPY_USER_DIR", raising=False)
+    monkeypatch.setattr("sys.platform", "linux")
+    monkeypatch.setenv("XDG_DOCUMENTS_DIR", str(docs))
+
+    result = get_default_user_dir()
+
+    assert result == str((docs / "NegPy").absolute())
+    assert not (docs / "NegPy").exists()


### PR DESCRIPTION
Fixes #441.

## Problem

On Windows with a OneDrive-backed Documents folder, startup can crash before the window appears:

```
File "negpy\desktop\main.py", line 60, in _bootstrap_environment
File "<frozen os>", line 228, in makedirs
FileNotFoundError: [WinError 2] The system cannot find the file specified:
'C:\Users\xxxxx\OneDrive\Documents\NegPy'
```

`SHGetFolderPathW(CSIDL_PERSONAL)` returns the **registered** Documents path — under OneDrive folder backup that is `...\OneDrive\Documents` — even when that folder does not actually exist on disk (OneDrive unlinked, signed out, or not yet synced on a fresh machine). `get_default_user_dir()` trusted the registered path blindly, so `_bootstrap_environment`'s `os.makedirs` died on it.

## Fix

Validate the Documents candidate before committing to it:

- If the registered Documents folder **exists**, use it — unchanged behavior, and resolution stays side-effect free.
- If it's **missing but creatable** (e.g. a healthy OneDrive that simply hasn't made the folder yet), create it and keep user data in Documents as intended.
- If it's **unusable**, fall back to `~/Documents`, then to the home directory — locations that exist locally regardless of OneDrive state.

Also check the `SHGetFolderPathW` HRESULT instead of ignoring it, so a failed shell call goes through the same fallback instead of yielding an empty path. The `NEGPY_USER_DIR` env override keeps its explicit, unvalidated semantics.

## Testing

New `tests/test_user_dir_resolution.py` covers: existing base used without side effects, missing-but-creatable base created, uncreatable base rejected, env override, fallback from a broken Documents to home, and the no-side-effect happy path. Adjacent config suites (`test_override_config`, `test_config_deserialization`, `test_config_hash_caching`) pass; ruff + ty clean.
