### PR TITLE
Fix UnicodeEncodeError from non-ASCII EXIF metadata on export (#452)

### DIFF
--- a/negpy/features/metadata/writer.py
+++ b/negpy/features/metadata/writer.py
@@ -477,9 +477,9 @@ _TIFFFILE_RESERVED_TAGS: set[int] = set(tifffile.TIFF.TAG_FILTERED) | {270, 282,
 
 def _decode_ascii(value: object) -> str | None:
     if isinstance(value, bytes):
-        return value.rstrip(b"\x00").decode("ascii", "replace")
+        value = value.rstrip(b"\x00").decode("ascii", "replace")
     if isinstance(value, str):
-        return value
+        return value.encode("ascii", "replace").decode("ascii")
     return None
 
 

--- a/tests/metadata/test_writer.py
+++ b/tests/metadata/test_writer.py
@@ -7,7 +7,7 @@ import piexif
 import tifffile
 
 from negpy.features.metadata.models import MetadataConfig
-from negpy.features.metadata.writer import _sanitize_exif, embed_metadata, preserve_source_metadata
+from negpy.features.metadata.writer import _decode_ascii, _sanitize_exif, embed_metadata, preserve_source_metadata
 
 
 def _make_tiff_bytes() -> bytes:
@@ -235,3 +235,46 @@ class TestPreserveSourceMetadata:
         loaded = piexif.load(out)
         assert loaded["0th"].get(piexif.ImageIFD.Orientation) == 6
         assert loaded["0th"].get(piexif.ImageIFD.Make) == b"Nikon"
+
+
+class TestDecodeAscii:
+    """_decode_ascii must always return pure-ASCII str (#452)."""
+
+    def test_bytes_with_non_ascii(self) -> None:
+        assert _decode_ascii(b"4\xd75 negative") == "4?5 negative"
+
+    def test_str_with_non_ascii(self) -> None:
+        assert _decode_ascii("4\u00d75 negative") == "4?5 negative"
+
+    def test_pure_ascii_bytes_unchanged(self) -> None:
+        assert _decode_ascii(b"Portra 400") == "Portra 400"
+
+    def test_pure_ascii_str_unchanged(self) -> None:
+        assert _decode_ascii("Portra 400") == "Portra 400"
+
+    def test_null_terminated_bytes_stripped(self) -> None:
+        assert _decode_ascii(b"Hello\x00World\x00") == "Hello\x00World"
+
+    def test_none_returns_none(self) -> None:
+        assert _decode_ascii(None) is None
+        assert _decode_ascii(42) is None
+
+    def test_non_ascii_exif_does_not_crash_tiff_metadata_embed(self) -> None:
+        """Regression: non-ASCII EXIF description must not crash tifffile (#452)."""
+        image_bytes = _make_tiff_bytes()
+        source_exif = {
+            "0th": {
+                piexif.ImageIFD.Make: b"Nikon",
+                piexif.ImageIFD.ImageDescription: "4\u00d75 - Portra 400",
+            },
+            "Exif": {},
+            "GPS": {},
+            "Interop": {},
+            "1st": {},
+        }
+        out = embed_metadata(image_bytes, MetadataConfig(), source_exif)
+        assert out != image_bytes
+        with tifffile.TiffFile(io.BytesIO(out)) as tf:
+            desc = tf.pages[0].tags.get("ImageDescription")
+            # ASCII-safe -- tifffile would reject non-ASCII
+            desc.value.encode("ascii")


### PR DESCRIPTION
Fixes #452 -- export crashes with UnicodeEncodeError when source EXIF metadata contains non-ASCII characters like the multiplication sign.

## Root cause

`_decode_ascii` in `negpy/features/metadata/writer.py` is the single chokepoint for all EXIF string values flowing into `tifffile.imwrite`. Its str branch returned non-ASCII characters unchanged, and its bytes branch produced U+FFFD (also non-ASCII). When either reached `tifffile.imwrite(description=...)`, tifffile's bare `.encode('ascii')` raised `UnicodeEncodeError`.

The error appeared as "Failed to load file" because the export worker's error signal connects to `_on_render_error`, which prefixes all messages with that string.

## Fix

Make both branches round-trip through `encode("ascii", "replace")` then `decode("ascii")`, replacing non-ASCII characters with `?`. Consistent with the existing `_exif_ascii` helper used for NegPy-authored metadata.

**Files changed:**
- `negpy/features/metadata/writer.py` -- the fix
- `tests/metadata/test_writer.py` -- 7 new tests

## Verification

- All tests in tests/metadata/test_writer.py pass (9 existing + 7 new)
- New tests cover both branches, NULL bytes, None, and the exact crash scenario (non-ASCII in EXIF ImageDescription through `embed_metadata`)
- Lint and format checks clean