### PR TITLE
Silence the 'surround' unknown-config-key warning for pre-#432 edits

### DIFF
--- a/negpy/domain/models.py
+++ b/negpy/domain/models.py
@@ -388,7 +388,13 @@ class WorkspaceConfig:
         for cc in config_classes:
             valid_keys.update(cc.__dataclass_fields__.keys())
 
-        unknown = set(data) - valid_keys
+        # Fields deliberately removed from the config over time. Every edit saved
+        # before the removal still carries them, so they'd otherwise warn on every
+        # file load; drop silently and keep the warning for truly unknown keys.
+        #   surround: dim-surround print gamma, removed in #432 (replaced by Snap).
+        legacy_keys = {"surround"}
+
+        unknown = set(data) - valid_keys - legacy_keys
         if unknown:
             logger.warning("Dropping unknown config keys: %s", sorted(unknown))
 


### PR DESCRIPTION
## Problem

After #432 removed `ExposureConfig.surround` (dim-surround gamma, superseded by Snap), every edit saved before that merge still carries the key in `edits.db` / sidecars. `WorkspaceConfig.from_flat_dict` now logs on **every file load** for upgrading users:

```
WARNING negpy.domain.models: Dropping unknown config keys: ['surround']
```

The key is correctly discarded — the warning is just noise, and it recurs until each edit happens to be re-saved.

## Fix

Track deliberately-removed fields in a small `legacy_keys` set that is dropped silently (with a comment noting what removed each key and when). Genuinely unknown keys keep the warning, so it still flags real corruption or version skew.

## Testing

Round-trip check: a config dict with `surround` loads with no warning; an actually-unknown key still warns. `tests/test_config_deserialization.py` (18 tests) passes; ruff clean.