### PR TITLE
Fix shortcut editor dropping numpad modifier so for example Num+9 and 9 can bind separately.

### DIFF
--- a/docs/KEYBOARD.md
+++ b/docs/KEYBOARD.md
@@ -4,6 +4,8 @@ Summary of available keyboard shortcuts in NegPy.
 
 All shortcuts, including slider adjustments, can be changed in-app from the `?` shortcut overlay via `Customize`.
 
+Numpad keys can be bound separately from the number row (e.g. `Num+9` vs `9`). Num Lock must be on for numpad digits to register.
+
 ## Navigation
 | Key | Action |
 |-----|--------|

--- a/negpy/desktop/view/widgets/key_sequence_edit.py
+++ b/negpy/desktop/view/widgets/key_sequence_edit.py
@@ -1,0 +1,47 @@
+"""Key sequence capture widget.
+
+Qt's QKeySequenceEdit drops KeyboardModifier.KeypadModifier, so numpad digits
+are stored as the same binding as the number row (``9`` instead of ``Num+9``).
+We preserve the keypad modifier so both keys can be bound independently.
+"""
+
+from PyQt6.QtCore import QEvent, QKeyCombination, Qt
+from PyQt6.QtGui import QKeyEvent, QKeySequence
+from PyQt6.QtWidgets import QKeySequenceEdit
+
+_KEYPAD_MODIFIERS = (
+    Qt.KeyboardModifier.ShiftModifier,
+    Qt.KeyboardModifier.ControlModifier,
+    Qt.KeyboardModifier.AltModifier,
+    Qt.KeyboardModifier.MetaModifier,
+    Qt.KeyboardModifier.KeypadModifier,
+)
+
+
+def key_event_to_sequence(event: QKeyEvent) -> QKeySequence | None:
+    """Build a portable QKeySequence from a key event, preserving numpad keys."""
+    if event.key() in (Qt.Key.Key_unknown,):
+        return None
+    if not event.modifiers() & Qt.KeyboardModifier.KeypadModifier:
+        return None
+
+    mods = Qt.KeyboardModifier.NoModifier
+    for modifier in _KEYPAD_MODIFIERS:
+        if event.modifiers() & modifier:
+            mods |= modifier
+    return QKeySequence(QKeyCombination(mods, Qt.Key(event.key())))
+
+
+class KeypadAwareKeySequenceEdit(QKeySequenceEdit):
+    def keyPressEvent(self, event: QKeyEvent) -> None:
+        if event.key() == Qt.Key.Key_Backspace:
+            super().keyPressEvent(event)
+            return
+
+        sequence = key_event_to_sequence(event)
+        if sequence is not None:
+            self.setKeySequence(sequence)
+            event.accept()
+            return
+
+        super().keyPressEvent(event)

--- a/negpy/desktop/view/widgets/key_sequence_edit.py
+++ b/negpy/desktop/view/widgets/key_sequence_edit.py
@@ -5,7 +5,7 @@ are stored as the same binding as the number row (``9`` instead of ``Num+9``).
 We preserve the keypad modifier so both keys can be bound independently.
 """
 
-from PyQt6.QtCore import QEvent, QKeyCombination, Qt
+from PyQt6.QtCore import QKeyCombination, Qt
 from PyQt6.QtGui import QKeyEvent, QKeySequence
 from PyQt6.QtWidgets import QKeySequenceEdit
 

--- a/negpy/desktop/view/widgets/shortcut_editor.py
+++ b/negpy/desktop/view/widgets/shortcut_editor.py
@@ -11,10 +11,10 @@ from PyQt6.QtWidgets import (
     QScrollArea,
     QVBoxLayout,
     QWidget,
-    QKeySequenceEdit,
 )
 
 from negpy.desktop.view.shortcut_registry import REGISTRY, default_bindings
+from negpy.desktop.view.widgets.key_sequence_edit import KeypadAwareKeySequenceEdit
 from negpy.desktop.view.styles.theme import THEME
 
 
@@ -23,7 +23,7 @@ class ShortcutEditorDialog(QDialog):
         super().__init__(parent)
         self._initial_bindings = dict(bindings)
         self._session = session
-        self._edits: dict[str, QKeySequenceEdit] = {}
+        self._edits: dict[str, KeypadAwareKeySequenceEdit] = {}
         self.setWindowTitle("Customize Shortcuts")
         self.resize(760, 720)
         self._init_ui()
@@ -81,7 +81,7 @@ class ShortcutEditorDialog(QDialog):
             desc = QLabel(entry.description)
             default_lbl = QLabel(entry.default_key)
             default_lbl.setStyleSheet(f"color: {THEME.text_secondary}; font-family: Consolas, monospace;")
-            edit = QKeySequenceEdit(QKeySequence(self._initial_bindings.get(action_id, entry.default_key)))
+            edit = KeypadAwareKeySequenceEdit(QKeySequence(self._initial_bindings.get(action_id, entry.default_key)))
             edit.setClearButtonEnabled(True)
             self._edits[action_id] = edit
 
@@ -110,7 +110,7 @@ class ShortcutEditorDialog(QDialog):
         for action_id, key in default_bindings().items():
             self._edits[action_id].setKeySequence(QKeySequence(key))
 
-    def _portable(self, edit: QKeySequenceEdit) -> str:
+    def _portable(self, edit: KeypadAwareKeySequenceEdit) -> str:
         return edit.keySequence().toString(QKeySequence.SequenceFormat.PortableText)
 
     def bindings(self) -> dict[str, str]:

--- a/tests/test_key_sequence_edit.py
+++ b/tests/test_key_sequence_edit.py
@@ -1,0 +1,53 @@
+import pytest
+from PyQt6.QtCore import QEvent, Qt
+from PyQt6.QtGui import QKeyEvent, QKeySequence
+from PyQt6.QtWidgets import QApplication, QKeySequenceEdit
+
+from negpy.desktop.view.widgets.key_sequence_edit import KeypadAwareKeySequenceEdit, key_event_to_sequence
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+
+def _key_press(key: Qt.Key, modifiers: Qt.KeyboardModifier = Qt.KeyboardModifier.NoModifier) -> QKeyEvent:
+    return QKeyEvent(QEvent.Type.KeyPress, key, modifiers)
+
+
+def test_key_event_to_sequence_preserves_numpad_modifier():
+    seq = key_event_to_sequence(_key_press(Qt.Key.Key_9, Qt.KeyboardModifier.KeypadModifier))
+    assert seq is not None
+    assert seq.toString(QKeySequence.SequenceFormat.PortableText) == "Num+9"
+
+
+def test_key_event_to_sequence_ignores_number_row():
+    assert key_event_to_sequence(_key_press(Qt.Key.Key_9)) is None
+
+
+def test_keypad_aware_edit_differs_from_stock_qkeysequenceedit(qapp):
+    stock = QKeySequenceEdit()
+    aware = KeypadAwareKeySequenceEdit()
+    event = _key_press(Qt.Key.Key_9, Qt.KeyboardModifier.KeypadModifier)
+
+    stock.keyPressEvent(event)
+    aware.keyPressEvent(event)
+
+    assert stock.keySequence().toString(QKeySequence.SequenceFormat.PortableText) == "9"
+    assert aware.keySequence().toString(QKeySequence.SequenceFormat.PortableText) == "Num+9"
+
+
+def test_keypad_aware_edit_keeps_number_row_binding(qapp):
+    edit = KeypadAwareKeySequenceEdit()
+    edit.keyPressEvent(_key_press(Qt.Key.Key_9))
+    assert edit.keySequence().toString(QKeySequence.SequenceFormat.PortableText) == "9"
+
+
+def test_numpad_and_number_row_bindings_do_not_conflict():
+    row = QKeySequence("9")
+    pad = QKeySequence("Num+9")
+    assert row.toString(QKeySequence.SequenceFormat.PortableText) != pad.toString(QKeySequence.SequenceFormat.PortableText)
+    assert row.matches(pad) == QKeySequence.SequenceMatch.NoMatch


### PR DESCRIPTION
## Summary

Fixes numpad keys being captured as the same binding as the number row in Customize Shortcuts. Qt’s `QKeySequenceEdit` drops `KeypadModifier`, so for example numpad `9` was stored as `9` and conflicted with top-row `9`. A keypad-aware capture widget now preserves numpad keys as `Num+9`, allowing independent bindings.

## Changes

- Add `KeypadAwareKeySequenceEdit` for shortcut capture
- Use it in the shortcut editor dialog
- Add tests for numpad vs number-row capture
- Document numpad binding in `KEYBOARD.md`

## Test plan

- [x] Open `?` → Customize
- [x] Bind one action to top-row `9` → shows `9`
- [x] Bind another to numpad `9` (Num Lock on) → shows `Num+9`
- [x] Save without duplicate-binding error
- [x] Confirm both shortcuts fire the correct actions in the app

Fixes #456 