### PR TITLE
UI/customize shortcut UI improvements

### DIFF
--- a/docs/KEYBOARD.md
+++ b/docs/KEYBOARD.md
@@ -2,7 +2,7 @@
 
 Summary of available keyboard shortcuts in NegPy.
 
-All shortcuts, including slider adjustments, can be changed in-app from the `?` shortcut overlay via `Customize`.
+All shortcuts, including slider adjustments, can be changed in-app from the `?` shortcut overlay via `Customize`. Slider shortcuts are shown as merged rows (e.g. **Density ↑/↓**) with a customizable **Step** column — defaults match the built-in keyboard increments below.
 
 Numpad keys can be bound separately from the number row (e.g. `Num+9` vs `9`). Num Lock must be on for numpad digits to register.
 
@@ -15,11 +15,11 @@ Numpad keys can be bound separately from the number row (e.g. `Num+9` vs `9`). N
 ## Image Adjustments (High Speed)
 | Key | Action |
 |-----|--------|
-| `Q` / `A` | Increase / Decrease **Density** (0.01) |
-| `W` / `S` | Increase / Decrease **Grade** (0.01) |
-| `E` / `D` | Increase / Decrease **Magenta** (0.01) |
-| `R` / `F` | Increase / Decrease **Yellow** (0.01) |
-| `X` / `Z` | Increase / Decrease **Crop Offset** (1.0) |
+| `Q` / `A` | Increase / Decrease **Density** (default step 0.01) |
+| `W` / `S` | Increase / Decrease **Grade** (default step 10 ISO-R) |
+| `E` / `D` | Increase / Decrease **Magenta** (default step 0.01) |
+| `R` / `F` | Increase / Decrease **Yellow** (default step 0.01) |
+| `X` / `Z` | Increase / Decrease **Crop Offset** (default step 1 px) |
 
 ## Tools
 | Key | Action |

--- a/negpy/desktop/view/keyboard_shortcuts.py
+++ b/negpy/desktop/view/keyboard_shortcuts.py
@@ -3,7 +3,16 @@ from collections.abc import Callable
 from PyQt6.QtGui import QKeySequence, QShortcut
 
 from negpy.desktop.session import ToolMode
-from negpy.desktop.view.shortcut_registry import REGISTRY, load_bindings, save_bindings, set_current_bindings
+from negpy.desktop.view.shortcut_registry import (
+    REGISTRY,
+    load_bindings,
+    load_slider_steps,
+    save_bindings,
+    save_slider_steps,
+    set_current_bindings,
+    slider_step_for,
+)
+from negpy.desktop.view.slider_shortcut_groups import SLIDER_GROUP_BY_ACTION, sign_for_action
 
 
 def _context_undo(controller) -> None:
@@ -26,15 +35,17 @@ class ShortcutManager:
     def __init__(self, window):
         self.window = window
         self.bindings = load_bindings(window.controller.session.repo)
+        self.slider_steps = load_slider_steps(window.controller.session.repo)
         self._shortcuts: list[QShortcut] = []
         self._actions = self._build_actions()
         self.apply_bindings(self.bindings)
 
-    def _slider_adjuster(self, getter: Callable[[], object], direction: float) -> Callable[[], None]:
+    def _slider_adjuster(self, getter: Callable[[], object], action_id: str) -> Callable[[], None]:
+        group = SLIDER_GROUP_BY_ACTION[action_id]
+
         def _adjust() -> None:
-            slider = getter()
-            step = slider.spin.singleStep()
-            slider.adjust_by(step * direction)
+            step = slider_step_for(group.id, self.slider_steps)
+            getter().adjust_by(step * sign_for_action(action_id))
 
         return _adjust
 
@@ -84,96 +95,94 @@ class ShortcutManager:
             "show_shortcuts": lambda: _show_shortcuts(self.window),
         }
 
-        slider_targets: dict[str, tuple[Callable[[], object], float]] = {
-            "cyan_inc": (lambda: controls.colour_sidebar.cyan_slider, 1.0),
-            "cyan_dec": (lambda: controls.colour_sidebar.cyan_slider, -1.0),
-            "magenta_up": (lambda: controls.colour_sidebar.magenta_slider, 1.0),
-            "magenta_down": (lambda: controls.colour_sidebar.magenta_slider, -1.0),
-            "yellow_up": (lambda: controls.colour_sidebar.yellow_slider, 1.0),
-            "yellow_down": (lambda: controls.colour_sidebar.yellow_slider, -1.0),
-            # Warmer = lower Kelvin.
-            "temp_warm": (lambda: controls.colour_sidebar.temp_slider, -1.0),
-            "temp_cool": (lambda: controls.colour_sidebar.temp_slider, 1.0),
-            "density_up": (lambda: controls.tone_sidebar.density_slider, 1.0),
-            "density_down": (lambda: controls.tone_sidebar.density_slider, -1.0),
-            # ISO R scale is inverted: harder grade = lower R.
-            "grade_up": (lambda: controls.tone_sidebar.grade_slider, -10.0),
-            "grade_down": (lambda: controls.tone_sidebar.grade_slider, 10.0),
-            "toe_inc": (lambda: controls.tone_sidebar.toe_slider, 1.0),
-            "toe_dec": (lambda: controls.tone_sidebar.toe_slider, -1.0),
-            "toe_width_inc": (lambda: controls.tone_sidebar.toe_w_slider, 1.0),
-            "toe_width_dec": (lambda: controls.tone_sidebar.toe_w_slider, -1.0),
-            "shoulder_inc": (lambda: controls.tone_sidebar.sh_slider, 1.0),
-            "shoulder_dec": (lambda: controls.tone_sidebar.sh_slider, -1.0),
-            "shoulder_width_inc": (lambda: controls.tone_sidebar.sh_w_slider, 1.0),
-            "shoulder_width_dec": (lambda: controls.tone_sidebar.sh_w_slider, -1.0),
-            "snap_inc": (lambda: controls.tone_sidebar.midtone_gamma_slider, 1.0),
-            "snap_dec": (lambda: controls.tone_sidebar.midtone_gamma_slider, -1.0),
-            "shadow_density_inc": (lambda: controls.tone_sidebar.shadow_density_slider, 1.0),
-            "shadow_density_dec": (lambda: controls.tone_sidebar.shadow_density_slider, -1.0),
-            "highlight_density_inc": (lambda: controls.tone_sidebar.highlight_density_slider, 1.0),
-            "highlight_density_dec": (lambda: controls.tone_sidebar.highlight_density_slider, -1.0),
-            "shadow_grade_inc": (lambda: controls.tone_sidebar.shadow_grade_slider, 1.0),
-            "shadow_grade_dec": (lambda: controls.tone_sidebar.shadow_grade_slider, -1.0),
-            "highlight_grade_inc": (lambda: controls.tone_sidebar.highlight_grade_slider, 1.0),
-            "highlight_grade_dec": (lambda: controls.tone_sidebar.highlight_grade_slider, -1.0),
-            "offset_inc": (lambda: controls.geometry_sidebar.offset_slider, 1.0),
-            "offset_dec": (lambda: controls.geometry_sidebar.offset_slider, -1.0),
-            "fine_rot_inc": (lambda: controls.geometry_sidebar.fine_rot_slider, 1.0),
-            "fine_rot_dec": (lambda: controls.geometry_sidebar.fine_rot_slider, -1.0),
-            "analysis_buffer_inc": (lambda: controls.process_sidebar.analysis_buffer_slider, 1.0),
-            "analysis_buffer_dec": (lambda: controls.process_sidebar.analysis_buffer_slider, -1.0),
-            "luma_range_clip_inc": (lambda: controls.process_sidebar.luma_range_clip_slider, 1.0),
-            "luma_range_clip_dec": (lambda: controls.process_sidebar.luma_range_clip_slider, -1.0),
-            "color_range_clip_inc": (lambda: controls.process_sidebar.color_range_clip_slider, 1.0),
-            "color_range_clip_dec": (lambda: controls.process_sidebar.color_range_clip_slider, -1.0),
-            "white_point_inc": (lambda: controls.process_sidebar.white_point_slider, 1.0),
-            "white_point_dec": (lambda: controls.process_sidebar.white_point_slider, -1.0),
-            "black_point_inc": (lambda: controls.process_sidebar.black_point_slider, 1.0),
-            "black_point_dec": (lambda: controls.process_sidebar.black_point_slider, -1.0),
-            "separation_inc": (lambda: controls.process_sidebar.crosstalk_strength_slider, 1.0),
-            "separation_dec": (lambda: controls.process_sidebar.crosstalk_strength_slider, -1.0),
-            "chroma_denoise_inc": (lambda: controls.lab_sidebar.chroma_denoise_slider, 1.0),
-            "chroma_denoise_dec": (lambda: controls.lab_sidebar.chroma_denoise_slider, -1.0),
-            "saturation_inc": (lambda: controls.lab_sidebar.saturation_slider, 1.0),
-            "saturation_dec": (lambda: controls.lab_sidebar.saturation_slider, -1.0),
-            "vibrance_inc": (lambda: controls.lab_sidebar.vibrance_slider, 1.0),
-            "vibrance_dec": (lambda: controls.lab_sidebar.vibrance_slider, -1.0),
-            "clahe_inc": (lambda: controls.lab_sidebar.clahe_slider, 1.0),
-            "clahe_dec": (lambda: controls.lab_sidebar.clahe_slider, -1.0),
-            "sharpen_inc": (lambda: controls.lab_sidebar.sharpen_slider, 1.0),
-            "sharpen_dec": (lambda: controls.lab_sidebar.sharpen_slider, -1.0),
-            "glow_inc": (lambda: controls.lab_sidebar.glow_slider, 1.0),
-            "glow_dec": (lambda: controls.lab_sidebar.glow_slider, -1.0),
-            "halation_inc": (lambda: controls.lab_sidebar.halation_slider, 1.0),
-            "halation_dec": (lambda: controls.lab_sidebar.halation_slider, -1.0),
-            "threshold_inc": (lambda: controls.retouch_sidebar.threshold_slider, 1.0),
-            "threshold_dec": (lambda: controls.retouch_sidebar.threshold_slider, -1.0),
-            "auto_size_inc": (lambda: controls.retouch_sidebar.auto_size_slider, 1.0),
-            "auto_size_dec": (lambda: controls.retouch_sidebar.auto_size_slider, -1.0),
-            "manual_size_inc": (lambda: controls.retouch_sidebar.manual_size_slider, 1.0),
-            "manual_size_dec": (lambda: controls.retouch_sidebar.manual_size_slider, -1.0),
-            "selenium_inc": (lambda: controls.toning_sidebar.selenium_slider, 1.0),
-            "selenium_dec": (lambda: controls.toning_sidebar.selenium_slider, -1.0),
-            "sepia_inc": (lambda: controls.toning_sidebar.sepia_slider, 1.0),
-            "sepia_dec": (lambda: controls.toning_sidebar.sepia_slider, -1.0),
-            "shadow_hue_inc": (lambda: controls.toning_sidebar.shadow_hue_slider, 1.0),
-            "shadow_hue_dec": (lambda: controls.toning_sidebar.shadow_hue_slider, -1.0),
-            "shadow_strength_inc": (lambda: controls.toning_sidebar.shadow_str_slider, 1.0),
-            "shadow_strength_dec": (lambda: controls.toning_sidebar.shadow_str_slider, -1.0),
-            "highlight_hue_inc": (lambda: controls.toning_sidebar.highlight_hue_slider, 1.0),
-            "highlight_hue_dec": (lambda: controls.toning_sidebar.highlight_hue_slider, -1.0),
-            "highlight_strength_inc": (lambda: controls.toning_sidebar.highlight_str_slider, 1.0),
-            "highlight_strength_dec": (lambda: controls.toning_sidebar.highlight_str_slider, -1.0),
-            "vignette_str_inc": (lambda: controls.finish_sidebar.vignette_strength_slider, 1.0),
-            "vignette_str_dec": (lambda: controls.finish_sidebar.vignette_strength_slider, -1.0),
-            "vignette_size_inc": (lambda: controls.finish_sidebar.vignette_size_slider, 1.0),
-            "vignette_size_dec": (lambda: controls.finish_sidebar.vignette_size_slider, -1.0),
-            "border_size_inc": (lambda: controls.finish_sidebar.border_slider, 1.0),
-            "border_size_dec": (lambda: controls.finish_sidebar.border_slider, -1.0),
+        slider_targets: dict[str, Callable[[], object]] = {
+            "cyan_inc": lambda: controls.colour_sidebar.cyan_slider,
+            "cyan_dec": lambda: controls.colour_sidebar.cyan_slider,
+            "magenta_up": lambda: controls.colour_sidebar.magenta_slider,
+            "magenta_down": lambda: controls.colour_sidebar.magenta_slider,
+            "yellow_up": lambda: controls.colour_sidebar.yellow_slider,
+            "yellow_down": lambda: controls.colour_sidebar.yellow_slider,
+            "temp_warm": lambda: controls.colour_sidebar.temp_slider,
+            "temp_cool": lambda: controls.colour_sidebar.temp_slider,
+            "density_up": lambda: controls.tone_sidebar.density_slider,
+            "density_down": lambda: controls.tone_sidebar.density_slider,
+            "grade_up": lambda: controls.tone_sidebar.grade_slider,
+            "grade_down": lambda: controls.tone_sidebar.grade_slider,
+            "toe_inc": lambda: controls.tone_sidebar.toe_slider,
+            "toe_dec": lambda: controls.tone_sidebar.toe_slider,
+            "toe_width_inc": lambda: controls.tone_sidebar.toe_w_slider,
+            "toe_width_dec": lambda: controls.tone_sidebar.toe_w_slider,
+            "shoulder_inc": lambda: controls.tone_sidebar.sh_slider,
+            "shoulder_dec": lambda: controls.tone_sidebar.sh_slider,
+            "shoulder_width_inc": lambda: controls.tone_sidebar.sh_w_slider,
+            "shoulder_width_dec": lambda: controls.tone_sidebar.sh_w_slider,
+            "snap_inc": lambda: controls.tone_sidebar.midtone_gamma_slider,
+            "snap_dec": lambda: controls.tone_sidebar.midtone_gamma_slider,
+            "shadow_density_inc": lambda: controls.tone_sidebar.shadow_density_slider,
+            "shadow_density_dec": lambda: controls.tone_sidebar.shadow_density_slider,
+            "highlight_density_inc": lambda: controls.tone_sidebar.highlight_density_slider,
+            "highlight_density_dec": lambda: controls.tone_sidebar.highlight_density_slider,
+            "shadow_grade_inc": lambda: controls.tone_sidebar.shadow_grade_slider,
+            "shadow_grade_dec": lambda: controls.tone_sidebar.shadow_grade_slider,
+            "highlight_grade_inc": lambda: controls.tone_sidebar.highlight_grade_slider,
+            "highlight_grade_dec": lambda: controls.tone_sidebar.highlight_grade_slider,
+            "offset_inc": lambda: controls.geometry_sidebar.offset_slider,
+            "offset_dec": lambda: controls.geometry_sidebar.offset_slider,
+            "fine_rot_inc": lambda: controls.geometry_sidebar.fine_rot_slider,
+            "fine_rot_dec": lambda: controls.geometry_sidebar.fine_rot_slider,
+            "analysis_buffer_inc": lambda: controls.process_sidebar.analysis_buffer_slider,
+            "analysis_buffer_dec": lambda: controls.process_sidebar.analysis_buffer_slider,
+            "luma_range_clip_inc": lambda: controls.process_sidebar.luma_range_clip_slider,
+            "luma_range_clip_dec": lambda: controls.process_sidebar.luma_range_clip_slider,
+            "color_range_clip_inc": lambda: controls.process_sidebar.color_range_clip_slider,
+            "color_range_clip_dec": lambda: controls.process_sidebar.color_range_clip_slider,
+            "white_point_inc": lambda: controls.process_sidebar.white_point_slider,
+            "white_point_dec": lambda: controls.process_sidebar.white_point_slider,
+            "black_point_inc": lambda: controls.process_sidebar.black_point_slider,
+            "black_point_dec": lambda: controls.process_sidebar.black_point_slider,
+            "separation_inc": lambda: controls.process_sidebar.crosstalk_strength_slider,
+            "separation_dec": lambda: controls.process_sidebar.crosstalk_strength_slider,
+            "chroma_denoise_inc": lambda: controls.lab_sidebar.chroma_denoise_slider,
+            "chroma_denoise_dec": lambda: controls.lab_sidebar.chroma_denoise_slider,
+            "saturation_inc": lambda: controls.lab_sidebar.saturation_slider,
+            "saturation_dec": lambda: controls.lab_sidebar.saturation_slider,
+            "vibrance_inc": lambda: controls.lab_sidebar.vibrance_slider,
+            "vibrance_dec": lambda: controls.lab_sidebar.vibrance_slider,
+            "clahe_inc": lambda: controls.lab_sidebar.clahe_slider,
+            "clahe_dec": lambda: controls.lab_sidebar.clahe_slider,
+            "sharpen_inc": lambda: controls.lab_sidebar.sharpen_slider,
+            "sharpen_dec": lambda: controls.lab_sidebar.sharpen_slider,
+            "glow_inc": lambda: controls.lab_sidebar.glow_slider,
+            "glow_dec": lambda: controls.lab_sidebar.glow_slider,
+            "halation_inc": lambda: controls.lab_sidebar.halation_slider,
+            "halation_dec": lambda: controls.lab_sidebar.halation_slider,
+            "threshold_inc": lambda: controls.retouch_sidebar.threshold_slider,
+            "threshold_dec": lambda: controls.retouch_sidebar.threshold_slider,
+            "auto_size_inc": lambda: controls.retouch_sidebar.auto_size_slider,
+            "auto_size_dec": lambda: controls.retouch_sidebar.auto_size_slider,
+            "manual_size_inc": lambda: controls.retouch_sidebar.manual_size_slider,
+            "manual_size_dec": lambda: controls.retouch_sidebar.manual_size_slider,
+            "selenium_inc": lambda: controls.toning_sidebar.selenium_slider,
+            "selenium_dec": lambda: controls.toning_sidebar.selenium_slider,
+            "sepia_inc": lambda: controls.toning_sidebar.sepia_slider,
+            "sepia_dec": lambda: controls.toning_sidebar.sepia_slider,
+            "shadow_hue_inc": lambda: controls.toning_sidebar.shadow_hue_slider,
+            "shadow_hue_dec": lambda: controls.toning_sidebar.shadow_hue_slider,
+            "shadow_strength_inc": lambda: controls.toning_sidebar.shadow_str_slider,
+            "shadow_strength_dec": lambda: controls.toning_sidebar.shadow_str_slider,
+            "highlight_hue_inc": lambda: controls.toning_sidebar.highlight_hue_slider,
+            "highlight_hue_dec": lambda: controls.toning_sidebar.highlight_hue_slider,
+            "highlight_strength_inc": lambda: controls.toning_sidebar.highlight_str_slider,
+            "highlight_strength_dec": lambda: controls.toning_sidebar.highlight_str_slider,
+            "vignette_str_inc": lambda: controls.finish_sidebar.vignette_strength_slider,
+            "vignette_str_dec": lambda: controls.finish_sidebar.vignette_strength_slider,
+            "vignette_size_inc": lambda: controls.finish_sidebar.vignette_size_slider,
+            "vignette_size_dec": lambda: controls.finish_sidebar.vignette_size_slider,
+            "border_size_inc": lambda: controls.finish_sidebar.border_slider,
+            "border_size_dec": lambda: controls.finish_sidebar.border_slider,
         }
-        for action_id, (getter, direction) in slider_targets.items():
-            actions[action_id] = self._slider_adjuster(getter, direction)
+        for action_id, getter in slider_targets.items():
+            actions[action_id] = self._slider_adjuster(getter, action_id)
         return actions
 
     def apply_bindings(self, bindings: dict[str, str]) -> None:
@@ -198,12 +207,22 @@ class ShortcutManager:
         save_bindings(self.window.controller.session.repo, bindings)
         self.apply_bindings(bindings)
 
+    def update_slider_steps(self, steps: dict[str, float]) -> None:
+        save_slider_steps(self.window.controller.session.repo, steps)
+        self.slider_steps = dict(steps)
+
     def open_editor(self, parent=None) -> bool:
         from negpy.desktop.view.widgets.shortcut_editor import ShortcutEditorDialog
 
-        dlg = ShortcutEditorDialog(self.bindings, parent or self.window, session=self.window.controller.session)
+        dlg = ShortcutEditorDialog(
+            self.bindings,
+            self.slider_steps,
+            parent or self.window,
+            session=self.window.controller.session,
+        )
         if dlg.exec():
             self.update_bindings(dlg.bindings())
+            self.update_slider_steps(dlg.slider_steps())
             return True
         return False
 

--- a/negpy/desktop/view/shortcut_editor_search.py
+++ b/negpy/desktop/view/shortcut_editor_search.py
@@ -1,0 +1,95 @@
+"""Search index for the Customize Shortcuts dialog."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from negpy.desktop.view.shortcut_registry import (
+    REGISTRY,
+    EditorRowSlider,
+    ShortcutEntry,
+    category_editor_rows,
+)
+
+
+RowKind = Literal["single", "slider"]
+
+
+@dataclass(frozen=True)
+class ShortcutEditorTarget:
+    target_id: str
+    label: str
+    category: str
+    search_text: str
+    row_kind: RowKind
+
+
+def _tokens(*parts: str) -> str:
+    return " ".join(p.strip() for p in parts if p and str(p).strip()).casefold()
+
+
+def _binding_tokens(bindings: dict[str, str], *action_ids: str) -> str:
+    return " ".join(bindings.get(action_id, "") for action_id in action_ids if bindings.get(action_id, ""))
+
+
+def build_shortcut_editor_targets(bindings: dict[str, str] | None = None) -> list[ShortcutEditorTarget]:
+    """Build navigable editor rows with precomputed search text (includes current bindings)."""
+    resolved = bindings or {}
+    targets: list[ShortcutEditorTarget] = []
+    seen_categories: dict[str, list[tuple[str, ShortcutEntry]]] = {}
+    for action_id, entry in REGISTRY.items():
+        seen_categories.setdefault(entry.category, []).append((action_id, entry))
+
+    for category, items in seen_categories.items():
+        for editor_row in category_editor_rows(items):
+            if isinstance(editor_row, EditorRowSlider):
+                group = editor_row.group
+                inc = REGISTRY[group.inc_action]
+                dec = REGISTRY[group.dec_action]
+                targets.append(
+                    ShortcutEditorTarget(
+                        target_id=group.id,
+                        label=group.label,
+                        category=category,
+                        row_kind="slider",
+                        search_text=_tokens(
+                            group.label,
+                            group.id,
+                            category,
+                            inc.description,
+                            dec.description,
+                            inc.default_key,
+                            dec.default_key,
+                            _binding_tokens(resolved, group.inc_action, group.dec_action),
+                        ),
+                    )
+                )
+                continue
+
+            action_id = editor_row.action_id
+            entry = editor_row.entry
+            targets.append(
+                ShortcutEditorTarget(
+                    target_id=action_id,
+                    label=entry.description,
+                    category=category,
+                    row_kind="single",
+                    search_text=_tokens(
+                        entry.description,
+                        action_id,
+                        category,
+                        entry.default_key,
+                        _binding_tokens(resolved, action_id),
+                    ),
+                )
+            )
+
+    return targets
+
+
+def filter_targets(targets: list[ShortcutEditorTarget], query: str) -> list[ShortcutEditorTarget]:
+    needle = query.strip().casefold()
+    if not needle:
+        return list(targets)
+    return [target for target in targets if needle in target.search_text]

--- a/negpy/desktop/view/shortcut_registry.py
+++ b/negpy/desktop/view/shortcut_registry.py
@@ -202,6 +202,17 @@ class EditorRowSlider:
 EditorRow = EditorRowSingle | EditorRowSlider
 
 
+def categories_in_order() -> list[tuple[str, list[tuple[str, ShortcutEntry]]]]:
+    ordered: list[tuple[str, list[tuple[str, ShortcutEntry]]]] = []
+    index: dict[str, int] = {}
+    for action_id, entry in REGISTRY.items():
+        if entry.category not in index:
+            index[entry.category] = len(ordered)
+            ordered.append((entry.category, []))
+        ordered[index[entry.category]][1].append((action_id, entry))
+    return ordered
+
+
 def category_editor_rows(items: list[tuple[str, ShortcutEntry]]) -> list[EditorRow]:
     """Merge paired slider shortcuts into one editor row, preserving registry order."""
     rows: list[EditorRow] = []

--- a/negpy/desktop/view/shortcut_registry.py
+++ b/negpy/desktop/view/shortcut_registry.py
@@ -1,6 +1,13 @@
 from dataclasses import dataclass
 from typing import Iterable
 
+from negpy.desktop.view.slider_shortcut_groups import (
+    SLIDER_GROUPS,
+    SLIDER_GROUP_BY_ACTION,
+    SLIDER_GROUP_BY_ID,
+    SliderShortcutGroup,
+)
+
 
 @dataclass(frozen=True)
 class ShortcutEntry:
@@ -134,6 +141,81 @@ REGISTRY: dict[str, ShortcutEntry] = {
 }
 
 _CURRENT_BINDINGS: dict[str, str] = {}
+_CURRENT_SLIDER_STEPS: dict[str, float] = {}
+
+
+def default_slider_steps() -> dict[str, float]:
+    return {group.id: group.default_step for group in SLIDER_GROUPS}
+
+
+def merge_slider_steps(overrides: dict[str, float] | None = None) -> dict[str, float]:
+    steps = default_slider_steps()
+    if overrides:
+        for group_id, value in overrides.items():
+            if group_id in SLIDER_GROUP_BY_ID:
+                steps[group_id] = float(value)
+    return steps
+
+
+def load_slider_steps(repo) -> dict[str, float]:
+    saved = repo.get_global_setting("shortcut_slider_steps", {}) or {}
+    return merge_slider_steps(saved if isinstance(saved, dict) else {})
+
+
+def save_slider_steps(repo, steps: dict[str, float]) -> None:
+    defaults = default_slider_steps()
+    overrides = {
+        group_id: value
+        for group_id, value in steps.items()
+        if group_id in defaults and float(value) != defaults[group_id]
+    }
+    repo.save_global_setting("shortcut_slider_steps", overrides)
+
+
+def set_current_slider_steps(steps: dict[str, float]) -> None:
+    global _CURRENT_SLIDER_STEPS
+    _CURRENT_SLIDER_STEPS = merge_slider_steps(steps)
+
+
+def current_slider_steps() -> dict[str, float]:
+    if not _CURRENT_SLIDER_STEPS:
+        set_current_slider_steps(default_slider_steps())
+    return dict(_CURRENT_SLIDER_STEPS)
+
+
+def slider_step_for(group_id: str, steps: dict[str, float] | None = None) -> float:
+    resolved = steps or current_slider_steps()
+    return resolved.get(group_id, default_slider_steps()[group_id])
+
+
+@dataclass(frozen=True)
+class EditorRowSingle:
+    action_id: str
+    entry: ShortcutEntry
+
+
+@dataclass(frozen=True)
+class EditorRowSlider:
+    group: SliderShortcutGroup
+
+
+EditorRow = EditorRowSingle | EditorRowSlider
+
+
+def category_editor_rows(items: list[tuple[str, ShortcutEntry]]) -> list[EditorRow]:
+    """Merge paired slider shortcuts into one editor row, preserving registry order."""
+    rows: list[EditorRow] = []
+    seen_groups: set[str] = set()
+    for action_id, entry in items:
+        group = SLIDER_GROUP_BY_ACTION.get(action_id)
+        if group is not None:
+            if group.id in seen_groups:
+                continue
+            seen_groups.add(group.id)
+            rows.append(EditorRowSlider(group))
+            continue
+        rows.append(EditorRowSingle(action_id, entry))
+    return rows
 
 
 def default_bindings() -> dict[str, str]:

--- a/negpy/desktop/view/slider_shortcut_groups.py
+++ b/negpy/desktop/view/slider_shortcut_groups.py
@@ -1,0 +1,128 @@
+"""Slider shortcut groups: paired inc/dec actions with keyboard step defaults."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SliderShortcutGroup:
+    id: str
+    label: str
+    inc_action: str
+    dec_action: str
+    default_step: float
+    category: str
+    step_decimals: int = 2
+    step_suffix: str = ""
+    inc_sign: float = 1.0
+    dec_sign: float = -1.0
+
+
+def _g(
+    id: str,
+    label: str,
+    inc_action: str,
+    dec_action: str,
+    default_step: float,
+    category: str,
+    *,
+    step_decimals: int = 2,
+    step_suffix: str = "",
+    inc_sign: float = 1.0,
+    dec_sign: float = -1.0,
+) -> SliderShortcutGroup:
+    return SliderShortcutGroup(
+        id=id,
+        label=label,
+        inc_action=inc_action,
+        dec_action=dec_action,
+        default_step=default_step,
+        category=category,
+        step_decimals=step_decimals,
+        step_suffix=step_suffix,
+        inc_sign=inc_sign,
+        dec_sign=dec_sign,
+    )
+
+
+SLIDER_GROUPS: tuple[SliderShortcutGroup, ...] = (
+    _g("cyan", "Cyan ↑/↓", "cyan_inc", "cyan_dec", 0.01, "Exposure"),
+    _g("magenta", "Magenta ↑/↓", "magenta_up", "magenta_down", 0.01, "Exposure"),
+    _g("yellow", "Yellow ↑/↓", "yellow_up", "yellow_down", 0.01, "Exposure"),
+    _g(
+        "temperature",
+        "Temperature ↑/↓",
+        "temp_warm",
+        "temp_cool",
+        50.0,
+        "Exposure",
+        step_decimals=0,
+        step_suffix=" K",
+        inc_sign=-1.0,
+        dec_sign=1.0,
+    ),
+    _g("density", "Density ↑/↓", "density_up", "density_down", 0.01, "Exposure"),
+    _g(
+        "grade",
+        "Grade ↑/↓",
+        "grade_up",
+        "grade_down",
+        10.0,
+        "Exposure",
+        step_decimals=0,
+        step_suffix=" ISO-R",
+        inc_sign=-1.0,
+        dec_sign=1.0,
+    ),
+    _g("toe", "Toe ↑/↓", "toe_inc", "toe_dec", 0.01, "Exposure"),
+    _g("toe_width", "Toe width ↑/↓", "toe_width_inc", "toe_width_dec", 0.01, "Exposure"),
+    _g("shoulder", "Shoulder ↑/↓", "shoulder_inc", "shoulder_dec", 0.01, "Exposure"),
+    _g("shoulder_width", "Shoulder width ↑/↓", "shoulder_width_inc", "shoulder_width_dec", 0.01, "Exposure"),
+    _g("snap", "Snap ↑/↓", "snap_inc", "snap_dec", 0.01, "Exposure"),
+    _g("shadow_density", "Shadows density ↑/↓", "shadow_density_inc", "shadow_density_dec", 0.01, "Exposure"),
+    _g("highlight_density", "Highlights density ↑/↓", "highlight_density_inc", "highlight_density_dec", 0.01, "Exposure"),
+    _g("shadow_grade", "Shadows grade ↑/↓", "shadow_grade_inc", "shadow_grade_dec", 1.0, "Exposure", step_decimals=0),
+    _g("highlight_grade", "Highlights grade ↑/↓", "highlight_grade_inc", "highlight_grade_dec", 1.0, "Exposure", step_decimals=0),
+    _g("offset", "Crop offset ↑/↓", "offset_inc", "offset_dec", 1.0, "Geometry", step_decimals=0, step_suffix=" px"),
+    _g("fine_rot", "Fine rotation ↑/↓", "fine_rot_inc", "fine_rot_dec", 0.01, "Geometry", step_suffix="°"),
+    _g("analysis_buffer", "Analysis buffer ↑/↓", "analysis_buffer_inc", "analysis_buffer_dec", 0.01, "Process"),
+    _g("luma_range_clip", "Luma range clip ↑/↓", "luma_range_clip_inc", "luma_range_clip_dec", 1.0, "Process", step_decimals=0),
+    _g("color_range_clip", "Colour range clip ↑/↓", "color_range_clip_inc", "color_range_clip_dec", 1.0, "Process", step_decimals=0),
+    _g("white_point", "White point ↑/↓", "white_point_inc", "white_point_dec", 0.01, "Process"),
+    _g("black_point", "Black point ↑/↓", "black_point_inc", "black_point_dec", 0.01, "Process"),
+    _g("separation", "Crosstalk ↑/↓", "separation_inc", "separation_dec", 0.01, "Process"),
+    _g("chroma_denoise", "Denoise ↑/↓", "chroma_denoise_inc", "chroma_denoise_dec", 0.01, "Lab"),
+    _g("saturation", "Saturation ↑/↓", "saturation_inc", "saturation_dec", 0.01, "Lab"),
+    _g("vibrance", "Vibrance ↑/↓", "vibrance_inc", "vibrance_dec", 0.01, "Lab"),
+    _g("clahe", "CLAHE ↑/↓", "clahe_inc", "clahe_dec", 0.01, "Lab"),
+    _g("sharpen", "Sharpening ↑/↓", "sharpen_inc", "sharpen_dec", 0.01, "Lab"),
+    _g("glow", "Glow ↑/↓", "glow_inc", "glow_dec", 0.01, "Lab"),
+    _g("halation", "Halation ↑/↓", "halation_inc", "halation_dec", 0.01, "Lab"),
+    _g("threshold", "Threshold ↑/↓", "threshold_inc", "threshold_dec", 0.01, "Retouch"),
+    _g("auto_size", "Auto size ↑/↓", "auto_size_inc", "auto_size_dec", 1.0, "Retouch", step_decimals=0, step_suffix=" px"),
+    _g("manual_size", "Brush size ↑/↓", "manual_size_inc", "manual_size_dec", 1.0, "Retouch", step_decimals=0, step_suffix=" px"),
+    _g("selenium", "Selenium ↑/↓", "selenium_inc", "selenium_dec", 0.01, "Toning"),
+    _g("sepia", "Sepia ↑/↓", "sepia_inc", "sepia_dec", 0.01, "Toning"),
+    _g("shadow_hue", "Shadow hue ↑/↓", "shadow_hue_inc", "shadow_hue_dec", 0.01, "Toning"),
+    _g("shadow_strength", "Shadow strength ↑/↓", "shadow_strength_inc", "shadow_strength_dec", 0.01, "Toning"),
+    _g("highlight_hue", "Highlight hue ↑/↓", "highlight_hue_inc", "highlight_hue_dec", 0.01, "Toning"),
+    _g("highlight_strength", "Highlight strength ↑/↓", "highlight_strength_inc", "highlight_strength_dec", 0.01, "Toning"),
+    _g("vignette_str", "Vignette strength ↑/↓", "vignette_str_inc", "vignette_str_dec", 0.01, "Finishing"),
+    _g("vignette_size", "Vignette size ↑/↓", "vignette_size_inc", "vignette_size_dec", 0.01, "Finishing"),
+    _g("border_size", "Border width ↑/↓", "border_size_inc", "border_size_dec", 0.01, "Finishing"),
+)
+
+SLIDER_GROUP_BY_ID: dict[str, SliderShortcutGroup] = {group.id: group for group in SLIDER_GROUPS}
+
+SLIDER_GROUP_BY_ACTION: dict[str, SliderShortcutGroup] = {}
+for _group in SLIDER_GROUPS:
+    SLIDER_GROUP_BY_ACTION[_group.inc_action] = _group
+    SLIDER_GROUP_BY_ACTION[_group.dec_action] = _group
+
+
+def sign_for_action(action_id: str) -> float:
+    group = SLIDER_GROUP_BY_ACTION[action_id]
+    if action_id == group.inc_action:
+        return group.inc_sign
+    return group.dec_sign

--- a/negpy/desktop/view/widgets/collapsible.py
+++ b/negpy/desktop/view/widgets/collapsible.py
@@ -135,3 +135,7 @@ class CollapsibleSection(QWidget):
         self.content_area.setVisible(checked)
         self._update_chevron(checked)
         self.expanded_changed.emit(checked)
+
+    def expand(self) -> None:
+        if not self.toggle_button.isChecked():
+            self.toggle_button.setChecked(True)

--- a/negpy/desktop/view/widgets/shortcut_editor.py
+++ b/negpy/desktop/view/widgets/shortcut_editor.py
@@ -1,12 +1,15 @@
-from PyQt6.QtGui import QKeySequence
+from PyQt6.QtCore import QEvent, QModelIndex, QPoint, QSortFilterProxyModel, Qt, QTimer
+from PyQt6.QtGui import QKeySequence, QStandardItem, QStandardItemModel
 from PyQt6.QtWidgets import (
     QCheckBox,
+    QCompleter,
     QDialog,
     QDoubleSpinBox,
     QFrame,
     QGridLayout,
     QHBoxLayout,
     QLabel,
+    QLineEdit,
     QMessageBox,
     QPushButton,
     QScrollArea,
@@ -14,6 +17,10 @@ from PyQt6.QtWidgets import (
     QWidget,
 )
 
+from negpy.desktop.view.shortcut_editor_search import (
+    ShortcutEditorTarget,
+    build_shortcut_editor_targets,
+)
 from negpy.desktop.view.shortcut_registry import (
     REGISTRY,
     EditorRowSingle,
@@ -26,6 +33,33 @@ from negpy.desktop.view.shortcut_registry import (
 from negpy.desktop.view.widgets.collapsible import CollapsibleSection
 from negpy.desktop.view.widgets.key_sequence_edit import KeypadAwareKeySequenceEdit
 from negpy.desktop.view.styles.theme import THEME
+
+_TARGET_ROLE = Qt.ItemDataRole.UserRole
+_SEARCH_ROLE = Qt.ItemDataRole.UserRole + 1
+_HIGHLIGHT_MS = 1800
+
+
+class _ShortcutSearchProxy(QSortFilterProxyModel):
+    def __init__(self, parent=None) -> None:
+        super().__init__(parent)
+        self._query = ""
+
+    def set_query(self, query: str) -> None:
+        needle = (query or "").strip().casefold()
+        if needle == self._query:
+            return
+        self._query = needle
+        self.invalidateFilter()
+
+    def filterAcceptsRow(self, source_row: int, source_parent: QModelIndex) -> bool:  # noqa: N802
+        if not self._query:
+            return False
+        model = self.sourceModel()
+        if model is None:
+            return False
+        index = model.index(source_row, 0, source_parent)
+        search_text = model.data(index, _SEARCH_ROLE) or ""
+        return self._query in search_text
 
 
 def _categories_in_order() -> list[tuple[str, list[tuple[str, ShortcutEntry]]]]:
@@ -53,6 +87,14 @@ class ShortcutEditorDialog(QDialog):
         self._session = session
         self._edits: dict[str, KeypadAwareKeySequenceEdit] = {}
         self._step_edits: dict[str, QDoubleSpinBox] = {}
+        self._sections: dict[str, CollapsibleSection] = {}
+        self._row_widgets: dict[str, QFrame] = {}
+        self._row_focus_edits: dict[str, KeypadAwareKeySequenceEdit] = {}
+        self._targets: list[ShortcutEditorTarget] = build_shortcut_editor_targets(self._initial_bindings)
+        self._highlighted_row: QFrame | None = None
+        self._highlight_timer = QTimer(self)
+        self._highlight_timer.setSingleShot(True)
+        self._highlight_timer.timeout.connect(self._clear_highlight)
         self.setWindowTitle("Customize Shortcuts")
         self.resize(820, 720)
         self._init_ui()
@@ -66,14 +108,26 @@ class ShortcutEditorDialog(QDialog):
             QDialog {{ background-color: {THEME.bg_panel}; }}
             QLabel {{ color: {THEME.text_primary}; font-size: 12px; }}
             QPushButton {{ padding: 6px 14px; }}
+            QFrame#shortcut_editor_row[highlighted="true"] {{
+                background-color: rgba(183, 28, 28, 0.12);
+                border-left: 2px solid {THEME.accent_primary};
+            }}
         """)
 
         intro = QLabel(
             "Set shortcuts and keyboard step sizes for slider actions. "
-            "Duplicate bindings are rejected. Reset All restores defaults."
+            "Search to jump to an action. Duplicate bindings are rejected. Reset All restores defaults."
         )
         intro.setWordWrap(True)
         root.addWidget(intro)
+
+        self._search_edit = QLineEdit()
+        self._search_edit.setPlaceholderText("Search actions or key bindings…")
+        self._search_edit.setClearButtonEnabled(True)
+        self._search_edit.textEdited.connect(self._on_search_edited)
+        self._search_edit.installEventFilter(self)
+        self._init_search_completer()
+        root.addWidget(self._search_edit)
 
         self._invert_zoom_chk = QCheckBox("Reverse scroll-to-zoom direction (scroll up zooms out)")
         self._invert_zoom_chk.setToolTip(
@@ -90,9 +144,9 @@ class ShortcutEditorDialog(QDialog):
         divider.setStyleSheet(f"color: {THEME.border_color};")
         root.addWidget(divider)
 
-        scroll = QScrollArea()
-        scroll.setWidgetResizable(True)
-        scroll.setFrameShape(QScrollArea.Shape.NoFrame)
+        self._scroll = QScrollArea()
+        self._scroll.setWidgetResizable(True)
+        self._scroll.setFrameShape(QScrollArea.Shape.NoFrame)
         container = QWidget()
         sections_layout = QVBoxLayout(container)
         sections_layout.setContentsMargins(0, 0, 0, 0)
@@ -100,12 +154,13 @@ class ShortcutEditorDialog(QDialog):
 
         for category, items in _categories_in_order():
             section = CollapsibleSection(category, expanded=False)
-            section.set_content(self._build_category_grid(items))
+            section.set_content(self._build_category_grid(category, items))
+            self._sections[category] = section
             sections_layout.addWidget(section)
 
         sections_layout.addStretch()
-        scroll.setWidget(container)
-        root.addWidget(scroll, stretch=1)
+        self._scroll.setWidget(container)
+        root.addWidget(self._scroll, stretch=1)
 
         buttons = QHBoxLayout()
         reset_btn = QPushButton("Reset All")
@@ -120,7 +175,135 @@ class ShortcutEditorDialog(QDialog):
         buttons.addWidget(save_btn)
         root.addLayout(buttons)
 
-    def _build_category_grid(self, items: list[tuple[str, ShortcutEntry]]) -> QWidget:
+        self._reload_search_model()
+        for edit in self._edits.values():
+            edit.keySequenceChanged.connect(self._reload_search_model)
+
+    def _init_search_completer(self) -> None:
+        self._search_model = QStandardItemModel(self)
+        self._search_proxy = _ShortcutSearchProxy(self)
+        self._search_proxy.setSourceModel(self._search_model)
+        self._reload_search_model()
+
+        self._search_completer = QCompleter(self._search_proxy, self)
+        self._search_completer.setCompletionMode(QCompleter.CompletionMode.UnfilteredPopupCompletion)
+        self._search_completer.setCaseSensitivity(Qt.CaseSensitivity.CaseInsensitive)
+        self._search_completer.setWidget(self._search_edit)
+        self._search_completer.activated[QModelIndex].connect(self._on_search_activated)
+        self._search_completer.popup().setObjectName("shortcut_editor_search_popup")
+
+    def _reload_search_model(self) -> None:
+        self._search_model.clear()
+        bindings = {action_id: self._portable(edit) for action_id, edit in self._edits.items()} if self._edits else self._initial_bindings
+        self._targets = build_shortcut_editor_targets(bindings)
+        for target in self._targets:
+            item = QStandardItem(f"{target.label}  ·  {target.category}")
+            item.setData(target.target_id, _TARGET_ROLE)
+            item.setData(target.search_text, _SEARCH_ROLE)
+            item.setEditable(False)
+            self._search_model.appendRow(item)
+
+    def _target_id_from_completer_index(self, index: QModelIndex) -> str:
+        if not index.isValid():
+            return ""
+        completion_model = self._search_completer.completionModel()
+        proxy_index = completion_model.mapToSource(index)
+        source_index = self._search_proxy.mapToSource(proxy_index)
+        if not source_index.isValid():
+            return ""
+        target_id = self._search_model.data(source_index, _TARGET_ROLE)
+        return str(target_id) if target_id else ""
+
+    def _first_matching_target_id(self) -> str:
+        completion_model = self._search_completer.completionModel()
+        for row in range(completion_model.rowCount()):
+            target_id = self._target_id_from_completer_index(completion_model.index(row, 0))
+            if target_id:
+                return target_id
+        return ""
+
+    def _on_search_edited(self, text: str) -> None:
+        self._search_proxy.set_query(text)
+        if text.strip():
+            self._search_completer.complete()
+
+    def _on_search_activated(self, index: QModelIndex) -> None:
+        target_id = self._target_id_from_completer_index(index)
+        if not target_id:
+            return
+        self._search_edit.clear()
+        self._search_proxy.set_query("")
+        self._search_completer.popup().hide()
+        self._navigate_to_target(target_id)
+
+    def eventFilter(self, watched, event) -> bool:  # noqa: N802
+        if watched is self._search_edit and event.type() == QEvent.Type.KeyPress:
+            if event.key() in (Qt.Key.Key_Return, Qt.Key.Key_Enter):
+                popup = self._search_completer.popup()
+                if popup.isVisible():
+                    idx = popup.currentIndex()
+                    if not idx.isValid() and popup.model().rowCount() > 0:
+                        idx = popup.model().index(0, 0)
+                    if idx.isValid():
+                        self._on_search_activated(idx)
+                        return True
+                target_id = self._first_matching_target_id()
+                if target_id:
+                    self._search_edit.clear()
+                    self._search_proxy.set_query("")
+                    self._navigate_to_target(target_id)
+                    return True
+        return super().eventFilter(watched, event)
+
+    def _navigate_to_target(self, target_id: str) -> None:
+        row = self._row_widgets.get(target_id)
+        focus_edit = self._row_focus_edits.get(target_id)
+        if row is None:
+            return
+
+        target = next((t for t in self._targets if t.target_id == target_id), None)
+        if target is not None:
+            section = self._sections.get(target.category)
+            if section is not None:
+                section.expand()
+
+        def _reveal() -> None:
+            self._scroll_row_to_center(row)
+            self._set_highlight(row)
+            if focus_edit is not None:
+                focus_edit.setFocus()
+
+        QTimer.singleShot(50, _reveal)
+
+    def _scroll_row_to_center(self, row: QWidget) -> None:
+        content = self._scroll.widget()
+        if content is None:
+            return
+        center = row.mapTo(content, QPoint(0, row.height() // 2))
+        bar = self._scroll.verticalScrollBar()
+        viewport_h = self._scroll.viewport().height()
+        value = center.y() - viewport_h // 2
+        value = max(bar.minimum(), min(bar.maximum(), value))
+        bar.setValue(value)
+
+    def _set_highlight(self, row: QFrame) -> None:
+        self._clear_highlight()
+        row.setProperty("highlighted", True)
+        row.style().unpolish(row)
+        row.style().polish(row)
+        self._highlighted_row = row
+        self._highlight_timer.start(_HIGHLIGHT_MS)
+
+    def _clear_highlight(self) -> None:
+        if self._highlighted_row is None:
+            return
+        row = self._highlighted_row
+        row.setProperty("highlighted", False)
+        row.style().unpolish(row)
+        row.style().polish(row)
+        self._highlighted_row = None
+
+    def _build_category_grid(self, _category: str, items: list[tuple[str, ShortcutEntry]]) -> QWidget:
         body = QWidget()
         grid = QGridLayout(body)
         grid.setContentsMargins(0, 0, 0, 0)
@@ -145,32 +328,52 @@ class ShortcutEditorDialog(QDialog):
 
         return body
 
+    def _make_row_frame(self, target_id: str, focus_edit: KeypadAwareKeySequenceEdit) -> QFrame:
+        row = QFrame()
+        row.setObjectName("shortcut_editor_row")
+        self._row_widgets[target_id] = row
+        self._row_focus_edits[target_id] = focus_edit
+        return row
+
     def _add_single_row(self, grid: QGridLayout, row: int, editor_row: EditorRowSingle, mono: str) -> None:
         action_id = editor_row.action_id
         entry = editor_row.entry
-        grid.addWidget(QLabel(entry.description), row, 0)
+        edit = self._make_key_edit(action_id, entry.default_key)
+        row_frame = self._make_row_frame(action_id, edit)
+        inner = QGridLayout(row_frame)
+        inner.setContentsMargins(4, 4, 4, 4)
+        inner.setHorizontalSpacing(12)
+        inner.setVerticalSpacing(0)
+
+        inner.addWidget(QLabel(entry.description), 0, 0)
         default_lbl = QLabel(entry.default_key or "—")
         default_lbl.setStyleSheet(mono)
-        grid.addWidget(default_lbl, row, 1)
-        edit = self._make_key_edit(action_id, entry.default_key)
-        grid.addWidget(edit, row, 2)
-        grid.addWidget(QLabel("—"), row, 3)
+        inner.addWidget(default_lbl, 0, 1)
+        inner.addWidget(edit, 0, 2)
+        inner.addWidget(QLabel("—"), 0, 3)
+        grid.addWidget(row_frame, row, 0, 1, 4)
 
     def _add_slider_row(self, grid: QGridLayout, row: int, editor_row: EditorRowSlider, mono: str) -> None:
         group = editor_row.group
         inc_entry = REGISTRY[group.inc_action]
         dec_entry = REGISTRY[group.dec_action]
 
-        grid.addWidget(QLabel(group.label), row, 0)
+        inc_edit = self._make_key_edit(group.inc_action, inc_entry.default_key)
+        dec_edit = self._make_key_edit(group.dec_action, dec_entry.default_key)
+        row_frame = self._make_row_frame(group.id, inc_edit)
+        inner = QGridLayout(row_frame)
+        inner.setContentsMargins(4, 4, 4, 4)
+        inner.setHorizontalSpacing(12)
+        inner.setVerticalSpacing(0)
+
+        inner.addWidget(QLabel(group.label), 0, 0)
         default_lbl = QLabel(_format_default_pair(inc_entry.default_key, dec_entry.default_key))
         default_lbl.setStyleSheet(mono)
-        grid.addWidget(default_lbl, row, 1)
+        inner.addWidget(default_lbl, 0, 1)
 
         shortcuts = QHBoxLayout()
         shortcuts.setContentsMargins(0, 0, 0, 0)
         shortcuts.setSpacing(6)
-        inc_edit = self._make_key_edit(group.inc_action, inc_entry.default_key)
-        dec_edit = self._make_key_edit(group.dec_action, dec_entry.default_key)
         sep = QLabel("/")
         sep.setStyleSheet(f"color: {THEME.text_muted};")
         shortcuts.addWidget(inc_edit, 1)
@@ -178,8 +381,9 @@ class ShortcutEditorDialog(QDialog):
         shortcuts.addWidget(dec_edit, 1)
         shortcuts_host = QWidget()
         shortcuts_host.setLayout(shortcuts)
-        grid.addWidget(shortcuts_host, row, 2)
-        grid.addWidget(self._make_step_edit(group), row, 3)
+        inner.addWidget(shortcuts_host, 0, 2)
+        inner.addWidget(self._make_step_edit(group), 0, 3)
+        grid.addWidget(row_frame, row, 0, 1, 4)
 
     def _make_key_edit(self, action_id: str, default_key: str) -> KeypadAwareKeySequenceEdit:
         edit = KeypadAwareKeySequenceEdit(QKeySequence(self._initial_bindings.get(action_id, default_key)))
@@ -207,6 +411,7 @@ class ShortcutEditorDialog(QDialog):
         for group_id, value in default_slider_steps().items():
             if group_id in self._step_edits:
                 self._step_edits[group_id].setValue(value)
+        self._reload_search_model()
 
     def _portable(self, edit: KeypadAwareKeySequenceEdit) -> str:
         return edit.keySequence().toString(QKeySequence.SequenceFormat.PortableText)

--- a/negpy/desktop/view/widgets/shortcut_editor.py
+++ b/negpy/desktop/view/widgets/shortcut_editor.py
@@ -2,6 +2,7 @@ from PyQt6.QtGui import QKeySequence
 from PyQt6.QtWidgets import (
     QCheckBox,
     QDialog,
+    QDoubleSpinBox,
     QFrame,
     QGridLayout,
     QHBoxLayout,
@@ -13,7 +14,15 @@ from PyQt6.QtWidgets import (
     QWidget,
 )
 
-from negpy.desktop.view.shortcut_registry import REGISTRY, ShortcutEntry, default_bindings
+from negpy.desktop.view.shortcut_registry import (
+    REGISTRY,
+    EditorRowSingle,
+    EditorRowSlider,
+    ShortcutEntry,
+    category_editor_rows,
+    default_bindings,
+    default_slider_steps,
+)
 from negpy.desktop.view.widgets.collapsible import CollapsibleSection
 from negpy.desktop.view.widgets.key_sequence_edit import KeypadAwareKeySequenceEdit
 from negpy.desktop.view.styles.theme import THEME
@@ -30,14 +39,22 @@ def _categories_in_order() -> list[tuple[str, list[tuple[str, ShortcutEntry]]]]:
     return ordered
 
 
+def _format_default_pair(inc_key: str, dec_key: str) -> str:
+    inc = inc_key or "—"
+    dec = dec_key or "—"
+    return f"{inc} / {dec}"
+
+
 class ShortcutEditorDialog(QDialog):
-    def __init__(self, bindings: dict[str, str], parent=None, session=None):
+    def __init__(self, bindings: dict[str, str], slider_steps: dict[str, float] | None = None, parent=None, session=None):
         super().__init__(parent)
         self._initial_bindings = dict(bindings)
+        self._initial_slider_steps = dict(slider_steps or default_slider_steps())
         self._session = session
         self._edits: dict[str, KeypadAwareKeySequenceEdit] = {}
+        self._step_edits: dict[str, QDoubleSpinBox] = {}
         self.setWindowTitle("Customize Shortcuts")
-        self.resize(760, 720)
+        self.resize(820, 720)
         self._init_ui()
 
     def _init_ui(self) -> None:
@@ -51,11 +68,13 @@ class ShortcutEditorDialog(QDialog):
             QPushButton {{ padding: 6px 14px; }}
         """)
 
-        intro = QLabel("Set a shortcut for any action. Duplicate bindings are rejected. Reset All restores the defaults.")
+        intro = QLabel(
+            "Set shortcuts and keyboard step sizes for slider actions. "
+            "Duplicate bindings are rejected. Reset All restores defaults."
+        )
         intro.setWordWrap(True)
         root.addWidget(intro)
 
-        # Mouse / general viewer preferences, kept up top for easy access.
         self._invert_zoom_chk = QCheckBox("Reverse scroll-to-zoom direction (scroll up zooms out)")
         self._invert_zoom_chk.setToolTip(
             "Flip the mouse-wheel zoom direction on the image viewer: scroll up to zoom out, scroll down to zoom in."
@@ -112,35 +131,91 @@ class ShortcutEditorDialog(QDialog):
             f"color: {THEME.text_muted}; font-size: {THEME.font_size_xs}px; "
             f"font-weight: {THEME.weight_semibold};"
         )
-        for col, label in enumerate(("Action", "Default", "Shortcut")):
+        for col, label in enumerate(("Action", "Default", "Shortcut", "Step")):
             hdr = QLabel(label)
             hdr.setStyleSheet(header_style)
             grid.addWidget(hdr, 0, col)
 
         mono = f"color: {THEME.text_secondary}; font-family: Consolas, monospace;"
-        for row, (action_id, entry) in enumerate(items, start=1):
-            desc = QLabel(entry.description)
-            default_lbl = QLabel(entry.default_key or "—")
-            default_lbl.setStyleSheet(mono)
-            edit = KeypadAwareKeySequenceEdit(QKeySequence(self._initial_bindings.get(action_id, entry.default_key)))
-            edit.setClearButtonEnabled(True)
-            self._edits[action_id] = edit
-
-            grid.addWidget(desc, row, 0)
-            grid.addWidget(default_lbl, row, 1)
-            grid.addWidget(edit, row, 2)
+        for row, editor_row in enumerate(category_editor_rows(items), start=1):
+            if isinstance(editor_row, EditorRowSlider):
+                self._add_slider_row(grid, row, editor_row, mono)
+            else:
+                self._add_single_row(grid, row, editor_row, mono)
 
         return body
 
+    def _add_single_row(self, grid: QGridLayout, row: int, editor_row: EditorRowSingle, mono: str) -> None:
+        action_id = editor_row.action_id
+        entry = editor_row.entry
+        grid.addWidget(QLabel(entry.description), row, 0)
+        default_lbl = QLabel(entry.default_key or "—")
+        default_lbl.setStyleSheet(mono)
+        grid.addWidget(default_lbl, row, 1)
+        edit = self._make_key_edit(action_id, entry.default_key)
+        grid.addWidget(edit, row, 2)
+        grid.addWidget(QLabel("—"), row, 3)
+
+    def _add_slider_row(self, grid: QGridLayout, row: int, editor_row: EditorRowSlider, mono: str) -> None:
+        group = editor_row.group
+        inc_entry = REGISTRY[group.inc_action]
+        dec_entry = REGISTRY[group.dec_action]
+
+        grid.addWidget(QLabel(group.label), row, 0)
+        default_lbl = QLabel(_format_default_pair(inc_entry.default_key, dec_entry.default_key))
+        default_lbl.setStyleSheet(mono)
+        grid.addWidget(default_lbl, row, 1)
+
+        shortcuts = QHBoxLayout()
+        shortcuts.setContentsMargins(0, 0, 0, 0)
+        shortcuts.setSpacing(6)
+        inc_edit = self._make_key_edit(group.inc_action, inc_entry.default_key)
+        dec_edit = self._make_key_edit(group.dec_action, dec_entry.default_key)
+        sep = QLabel("/")
+        sep.setStyleSheet(f"color: {THEME.text_muted};")
+        shortcuts.addWidget(inc_edit, 1)
+        shortcuts.addWidget(sep)
+        shortcuts.addWidget(dec_edit, 1)
+        shortcuts_host = QWidget()
+        shortcuts_host.setLayout(shortcuts)
+        grid.addWidget(shortcuts_host, row, 2)
+        grid.addWidget(self._make_step_edit(group), row, 3)
+
+    def _make_key_edit(self, action_id: str, default_key: str) -> KeypadAwareKeySequenceEdit:
+        edit = KeypadAwareKeySequenceEdit(QKeySequence(self._initial_bindings.get(action_id, default_key)))
+        edit.setClearButtonEnabled(True)
+        self._edits[action_id] = edit
+        return edit
+
+    def _make_step_edit(self, group) -> QDoubleSpinBox:
+        spin = QDoubleSpinBox()
+        spin.setDecimals(group.step_decimals)
+        spin.setMinimum(10 ** -group.step_decimals)
+        spin.setMaximum(10_000.0)
+        spin.setSingleStep(group.default_step)
+        if group.step_suffix:
+            spin.setSuffix(group.step_suffix)
+        spin.setValue(self._initial_slider_steps.get(group.id, group.default_step))
+        spin.setToolTip("Amount applied per shortcut press")
+        self._step_edits[group.id] = spin
+        return spin
+
     def _reset_all(self) -> None:
         for action_id, key in default_bindings().items():
-            self._edits[action_id].setKeySequence(QKeySequence(key))
+            if action_id in self._edits:
+                self._edits[action_id].setKeySequence(QKeySequence(key))
+        for group_id, value in default_slider_steps().items():
+            if group_id in self._step_edits:
+                self._step_edits[group_id].setValue(value)
 
     def _portable(self, edit: KeypadAwareKeySequenceEdit) -> str:
         return edit.keySequence().toString(QKeySequence.SequenceFormat.PortableText)
 
     def bindings(self) -> dict[str, str]:
         return {action_id: self._portable(edit) for action_id, edit in self._edits.items()}
+
+    def slider_steps(self) -> dict[str, float]:
+        return {group_id: float(spin.value()) for group_id, spin in self._step_edits.items()}
 
     def _save(self) -> None:
         seen: dict[str, str] = {}
@@ -158,8 +233,11 @@ class ShortcutEditorDialog(QDialog):
                 return
             seen[key] = action_id
 
-        # Persist the viewer preferences alongside the shortcut bindings. The state is
-        # shared with the canvas, so the change takes effect immediately (no restart).
+        for group_id, spin in self._step_edits.items():
+            if spin.value() <= 0:
+                QMessageBox.warning(self, "Invalid Step", f"Step size for {group_id} must be greater than zero.")
+                return
+
         if self._session is not None:
             invert = self._invert_zoom_chk.isChecked()
             self._session.state.invert_zoom_scroll = invert

--- a/negpy/desktop/view/widgets/shortcut_editor.py
+++ b/negpy/desktop/view/widgets/shortcut_editor.py
@@ -26,6 +26,7 @@ from negpy.desktop.view.shortcut_registry import (
     EditorRowSingle,
     EditorRowSlider,
     ShortcutEntry,
+    categories_in_order,
     category_editor_rows,
     default_bindings,
     default_slider_steps,
@@ -60,17 +61,6 @@ class _ShortcutSearchProxy(QSortFilterProxyModel):
         index = model.index(source_row, 0, source_parent)
         search_text = model.data(index, _SEARCH_ROLE) or ""
         return self._query in search_text
-
-
-def _categories_in_order() -> list[tuple[str, list[tuple[str, ShortcutEntry]]]]:
-    ordered: list[tuple[str, list[tuple[str, ShortcutEntry]]]] = []
-    index: dict[str, int] = {}
-    for action_id, entry in REGISTRY.items():
-        if entry.category not in index:
-            index[entry.category] = len(ordered)
-            ordered.append((entry.category, []))
-        ordered[index[entry.category]][1].append((action_id, entry))
-    return ordered
 
 
 def _format_default_pair(inc_key: str, dec_key: str) -> str:
@@ -152,7 +142,7 @@ class ShortcutEditorDialog(QDialog):
         sections_layout.setContentsMargins(0, 0, 0, 0)
         sections_layout.setSpacing(THEME.space_sm)
 
-        for category, items in _categories_in_order():
+        for category, items in categories_in_order():
             section = CollapsibleSection(category, expanded=False)
             section.set_content(self._build_category_grid(category, items))
             self._sections[category] = section

--- a/negpy/desktop/view/widgets/shortcut_editor.py
+++ b/negpy/desktop/view/widgets/shortcut_editor.py
@@ -13,9 +13,21 @@ from PyQt6.QtWidgets import (
     QWidget,
 )
 
-from negpy.desktop.view.shortcut_registry import REGISTRY, default_bindings
+from negpy.desktop.view.shortcut_registry import REGISTRY, ShortcutEntry, default_bindings
+from negpy.desktop.view.widgets.collapsible import CollapsibleSection
 from negpy.desktop.view.widgets.key_sequence_edit import KeypadAwareKeySequenceEdit
 from negpy.desktop.view.styles.theme import THEME
+
+
+def _categories_in_order() -> list[tuple[str, list[tuple[str, ShortcutEntry]]]]:
+    ordered: list[tuple[str, list[tuple[str, ShortcutEntry]]]] = []
+    index: dict[str, int] = {}
+    for action_id, entry in REGISTRY.items():
+        if entry.category not in index:
+            index[entry.category] = len(ordered)
+            ordered.append((entry.category, []))
+        ordered[index[entry.category]][1].append((action_id, entry))
+    return ordered
 
 
 class ShortcutEditorDialog(QDialog):
@@ -63,33 +75,16 @@ class ShortcutEditorDialog(QDialog):
         scroll.setWidgetResizable(True)
         scroll.setFrameShape(QScrollArea.Shape.NoFrame)
         container = QWidget()
-        grid = QGridLayout(container)
-        grid.setContentsMargins(0, 0, 0, 0)
-        grid.setHorizontalSpacing(12)
-        grid.setVerticalSpacing(8)
+        sections_layout = QVBoxLayout(container)
+        sections_layout.setContentsMargins(0, 0, 0, 0)
+        sections_layout.setSpacing(THEME.space_sm)
 
-        row = 0
-        last_category = None
-        for action_id, entry in REGISTRY.items():
-            if entry.category != last_category:
-                category = QLabel(entry.category)
-                category.setStyleSheet(f"color: {THEME.text_secondary}; font-weight: bold; padding-top: 8px;")
-                grid.addWidget(category, row, 0, 1, 3)
-                row += 1
-                last_category = entry.category
+        for category, items in _categories_in_order():
+            section = CollapsibleSection(category, expanded=False)
+            section.set_content(self._build_category_grid(items))
+            sections_layout.addWidget(section)
 
-            desc = QLabel(entry.description)
-            default_lbl = QLabel(entry.default_key)
-            default_lbl.setStyleSheet(f"color: {THEME.text_secondary}; font-family: Consolas, monospace;")
-            edit = KeypadAwareKeySequenceEdit(QKeySequence(self._initial_bindings.get(action_id, entry.default_key)))
-            edit.setClearButtonEnabled(True)
-            self._edits[action_id] = edit
-
-            grid.addWidget(desc, row, 0)
-            grid.addWidget(default_lbl, row, 1)
-            grid.addWidget(edit, row, 2)
-            row += 1
-
+        sections_layout.addStretch()
         scroll.setWidget(container)
         root.addWidget(scroll, stretch=1)
 
@@ -105,6 +100,37 @@ class ShortcutEditorDialog(QDialog):
         buttons.addWidget(cancel_btn)
         buttons.addWidget(save_btn)
         root.addLayout(buttons)
+
+    def _build_category_grid(self, items: list[tuple[str, ShortcutEntry]]) -> QWidget:
+        body = QWidget()
+        grid = QGridLayout(body)
+        grid.setContentsMargins(0, 0, 0, 0)
+        grid.setHorizontalSpacing(12)
+        grid.setVerticalSpacing(8)
+
+        header_style = (
+            f"color: {THEME.text_muted}; font-size: {THEME.font_size_xs}px; "
+            f"font-weight: {THEME.weight_semibold};"
+        )
+        for col, label in enumerate(("Action", "Default", "Shortcut")):
+            hdr = QLabel(label)
+            hdr.setStyleSheet(header_style)
+            grid.addWidget(hdr, 0, col)
+
+        mono = f"color: {THEME.text_secondary}; font-family: Consolas, monospace;"
+        for row, (action_id, entry) in enumerate(items, start=1):
+            desc = QLabel(entry.description)
+            default_lbl = QLabel(entry.default_key or "—")
+            default_lbl.setStyleSheet(mono)
+            edit = KeypadAwareKeySequenceEdit(QKeySequence(self._initial_bindings.get(action_id, entry.default_key)))
+            edit.setClearButtonEnabled(True)
+            self._edits[action_id] = edit
+
+            grid.addWidget(desc, row, 0)
+            grid.addWidget(default_lbl, row, 1)
+            grid.addWidget(edit, row, 2)
+
+        return body
 
     def _reset_all(self) -> None:
         for action_id, key in default_bindings().items():

--- a/negpy/desktop/view/widgets/shortcuts_overlay.py
+++ b/negpy/desktop/view/widgets/shortcuts_overlay.py
@@ -1,11 +1,45 @@
-from PyQt6.QtWidgets import QDialog, QVBoxLayout, QGridLayout, QLabel, QPushButton, QFrame, QHBoxLayout, QScrollArea, QWidget
 from PyQt6.QtCore import Qt
+from PyQt6.QtWidgets import (
+    QDialog,
+    QFrame,
+    QGridLayout,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QScrollArea,
+    QVBoxLayout,
+    QWidget,
+)
+
+from negpy.desktop.view.shortcut_registry import (
+    REGISTRY,
+    EditorRowSingle,
+    EditorRowSlider,
+    categories_in_order,
+    category_editor_rows,
+    slider_step_for,
+)
 from negpy.desktop.view.styles.theme import THEME
-from negpy.desktop.view.shortcut_registry import REGISTRY
+from negpy.desktop.view.widgets.collapsible import CollapsibleSection
+
+
+def _format_key_pair(inc_key: str, dec_key: str) -> str:
+    inc = inc_key or "—"
+    dec = dec_key or "—"
+    return f"{inc} / {dec}"
+
+
+def _format_step_value(group, value: float) -> str:
+    if group.step_decimals == 0:
+        text = str(int(value)) if value == int(value) else str(value)
+    else:
+        text = f"{value:.{group.step_decimals}f}".rstrip("0").rstrip(".")
+    suffix = group.step_suffix or ""
+    return f"{text}{suffix}" if text else "—"
 
 
 class ShortcutsOverlay(QDialog):
-    """Modal keyboard shortcut reference, opened with '?'. Reads from REGISTRY."""
+    """Modal keyboard shortcut reference, opened with '?'."""
 
     def __init__(self, shortcut_manager, parent=None):
         super().__init__(parent)
@@ -13,62 +47,60 @@ class ShortcutsOverlay(QDialog):
         self.setWindowTitle("Keyboard Shortcuts")
         self.setWindowFlags(Qt.WindowType.Dialog | Qt.WindowType.WindowCloseButtonHint)
         self.setModal(True)
-        self.resize(920, 700)
+        self.resize(820, 720)
         self._init_ui()
 
     def _init_ui(self) -> None:
         root = QVBoxLayout(self)
-        root.setContentsMargins(24, 20, 24, 20)
-        root.setSpacing(0)
+        root.setContentsMargins(18, 18, 18, 18)
+        root.setSpacing(12)
 
         self.setStyleSheet(f"""
-            QDialog {{
-                background-color: {THEME.bg_panel};
-                border: 1px solid {THEME.border_primary};
-            }}
-            QLabel {{
-                color: {THEME.text_primary};
-                font-size: 12px;
-            }}
+            QDialog {{ background-color: {THEME.bg_panel}; }}
+            QLabel {{ color: {THEME.text_primary}; font-size: 12px; }}
+            QPushButton {{ padding: 6px 14px; }}
         """)
 
-        bindings = self._shortcut_manager.bindings
-        categories: dict[str, list] = {}
-        for action_id, entry in REGISTRY.items():
-            categories.setdefault(entry.category, []).append((action_id, entry))
+        intro = QLabel(
+            "Current keyboard shortcuts and slider step sizes. "
+            "Expand a section to browse bindings, or open Customize to change them."
+        )
+        intro.setWordWrap(True)
+        root.addWidget(intro)
 
-        grouped_categories = list(categories.items())
-        left_column, right_column = self._split_categories(grouped_categories)
+        divider = QFrame()
+        divider.setFrameShape(QFrame.Shape.HLine)
+        divider.setStyleSheet(f"color: {THEME.border_color};")
+        root.addWidget(divider)
+
+        bindings = self._shortcut_manager.bindings
+        slider_steps = self._shortcut_manager.slider_steps
 
         scroll = QScrollArea()
         scroll.setWidgetResizable(True)
-        scroll.setFrameShape(QFrame.Shape.NoFrame)
+        scroll.setFrameShape(QScrollArea.Shape.NoFrame)
 
         container = QWidget()
-        columns = QHBoxLayout(container)
-        columns.setContentsMargins(0, 0, 0, 0)
-        columns.setSpacing(20)
+        sections_layout = QVBoxLayout(container)
+        sections_layout.setContentsMargins(0, 0, 0, 0)
+        sections_layout.setSpacing(THEME.space_sm)
 
-        self._add_category_column(columns, left_column, bindings)
-        self._add_category_column(columns, right_column, bindings)
+        for category, items in categories_in_order():
+            section = CollapsibleSection(category, expanded=False)
+            section.set_content(self._build_category_grid(items, bindings, slider_steps))
+            sections_layout.addWidget(section)
 
+        sections_layout.addStretch()
         scroll.setWidget(container)
         root.addWidget(scroll, stretch=1)
-        root.addSpacing(16)
 
         actions = QHBoxLayout()
         customize_btn = QPushButton("Customize")
-        # Padding-only override: a widget-level `background:` would beat the app
-        # stylesheet in every state and kill the global hover/pressed feedback.
-        customize_btn.setStyleSheet("font-size: 12px; padding: 6px 20px;")
         customize_btn.clicked.connect(self._customize)
         actions.addWidget(customize_btn)
         actions.addStretch()
 
         close_btn = QPushButton("Close")
-        close_btn.setStyleSheet("font-size: 12px; padding: 6px 20px;")
-        # Primary action styling from the app stylesheet (accent fill with its own
-        # hover/pressed shades), same as the Export panel's call-to-action.
         close_btn.setProperty("primary", True)
         close_btn.clicked.connect(self.accept)
         actions.addWidget(close_btn)
@@ -78,69 +110,100 @@ class ShortcutsOverlay(QDialog):
         if self._shortcut_manager.open_editor(self):
             self.accept()
 
-    def _split_categories(self, grouped_categories: list[tuple[str, list]]) -> tuple[list[tuple[str, list]], list[tuple[str, list]]]:
-        left_column: list[tuple[str, list]] = []
-        right_column: list[tuple[str, list]] = []
-        left_weight = 0
-        right_weight = 0
+    def _build_category_grid(
+        self,
+        items: list,
+        bindings: dict[str, str],
+        slider_steps: dict[str, float],
+    ) -> QWidget:
+        body = QWidget()
+        grid = QGridLayout(body)
+        grid.setContentsMargins(0, 0, 0, 0)
+        grid.setHorizontalSpacing(12)
+        grid.setVerticalSpacing(8)
 
-        for category in grouped_categories:
-            weight = len(category[1]) + 1
-            if left_weight <= right_weight:
-                left_column.append(category)
-                left_weight += weight
+        header_style = (
+            f"color: {THEME.text_muted}; font-size: {THEME.font_size_xs}px; "
+            f"font-weight: {THEME.weight_semibold};"
+        )
+        for col, label in enumerate(("Action", "Default", "Shortcut", "Step")):
+            hdr = QLabel(label)
+            hdr.setStyleSheet(header_style)
+            grid.addWidget(hdr, 0, col)
+
+        mono = f"color: {THEME.text_secondary}; font-family: Consolas, monospace;"
+        for row, editor_row in enumerate(category_editor_rows(items), start=1):
+            if isinstance(editor_row, EditorRowSlider):
+                self._add_slider_row(grid, row, editor_row, bindings, slider_steps, mono)
             else:
-                right_column.append(category)
-                right_weight += weight
+                self._add_single_row(grid, row, editor_row, bindings, mono)
 
-        return left_column, right_column
+        return body
 
-    def _add_category_column(
-        self, parent_layout: QHBoxLayout, grouped_categories: list[tuple[str, list]], bindings: dict[str, str]
+    def _keycap(self, text: str) -> QLabel:
+        lbl = QLabel(text or "—")
+        lbl.setStyleSheet(f"""
+            color: {THEME.text_primary};
+            background-color: {THEME.bg_header};
+            border: 1px solid {THEME.border_primary};
+            border-radius: 3px;
+            font-family: Consolas, monospace;
+            font-size: 11px;
+            padding: 2px 6px;
+        """)
+        lbl.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        return lbl
+
+    def _mono_label(self, text: str, mono: str) -> QLabel:
+        lbl = QLabel(text or "—")
+        lbl.setStyleSheet(mono)
+        return lbl
+
+    def _add_single_row(
+        self,
+        grid: QGridLayout,
+        row: int,
+        editor_row: EditorRowSingle,
+        bindings: dict[str, str],
+        mono: str,
     ) -> None:
-        column_widget = QWidget()
-        column_layout = QVBoxLayout(column_widget)
-        column_layout.setContentsMargins(0, 0, 0, 0)
-        column_layout.setSpacing(10)
+        entry = editor_row.entry
+        grid.addWidget(QLabel(entry.description), row, 0)
+        grid.addWidget(self._mono_label(entry.default_key, mono), row, 1)
+        grid.addWidget(self._keycap(bindings.get(editor_row.action_id, "")), row, 2)
+        grid.addWidget(QLabel("—"), row, 3)
 
-        for index, (category, entries) in enumerate(grouped_categories):
-            if index > 0:
-                sep = QFrame()
-                sep.setFrameShape(QFrame.Shape.HLine)
-                sep.setStyleSheet(f"background-color: {THEME.border_primary}; border: none; margin: 4px 0;")
-                sep.setFixedHeight(1)
-                column_layout.addWidget(sep)
+    def _add_slider_row(
+        self,
+        grid: QGridLayout,
+        row: int,
+        editor_row: EditorRowSlider,
+        bindings: dict[str, str],
+        slider_steps: dict[str, float],
+        mono: str,
+    ) -> None:
+        group = editor_row.group
+        inc_entry = REGISTRY[group.inc_action]
+        dec_entry = REGISTRY[group.dec_action]
 
-            cat_lbl = QLabel(category)
-            cat_lbl.setStyleSheet(f"color: {THEME.text_secondary}; font-size: 10px; font-weight: bold; padding: 6px 0 2px 0;")
-            column_layout.addWidget(cat_lbl)
+        grid.addWidget(QLabel(group.label), row, 0)
+        grid.addWidget(
+            self._mono_label(_format_key_pair(inc_entry.default_key, dec_entry.default_key), mono),
+            row,
+            1,
+        )
 
-            grid = QGridLayout()
-            grid.setContentsMargins(0, 0, 0, 0)
-            grid.setHorizontalSpacing(8)
-            grid.setVerticalSpacing(6)
-            grid.setColumnMinimumWidth(0, 90)
-            grid.setColumnMinimumWidth(1, 240)
+        shortcuts = QHBoxLayout()
+        shortcuts.setContentsMargins(0, 0, 0, 0)
+        shortcuts.setSpacing(6)
+        shortcuts.addWidget(self._keycap(bindings.get(group.inc_action, "")), 1)
+        sep = QLabel("/")
+        sep.setStyleSheet(f"color: {THEME.text_muted};")
+        shortcuts.addWidget(sep)
+        shortcuts.addWidget(self._keycap(bindings.get(group.dec_action, "")), 1)
+        shortcuts_host = QWidget()
+        shortcuts_host.setLayout(shortcuts)
+        grid.addWidget(shortcuts_host, row, 2)
 
-            for row, (action_id, entry) in enumerate(entries):
-                key_lbl = QLabel(bindings.get(action_id, ""))
-                key_lbl.setStyleSheet(f"""
-                    color: {THEME.text_primary};
-                    background-color: {THEME.bg_header};
-                    border: 1px solid {THEME.border_primary};
-                    border-radius: 3px;
-                    font-family: monospace;
-                    font-size: 11px;
-                    padding: 1px 5px;
-                """)
-                key_lbl.setAlignment(Qt.AlignmentFlag.AlignCenter)
-                desc_lbl = QLabel(entry.description)
-                desc_lbl.setWordWrap(True)
-                desc_lbl.setStyleSheet(f"color: {THEME.text_secondary}; font-size: 12px; padding-left: 4px;")
-                grid.addWidget(key_lbl, row, 0, alignment=Qt.AlignmentFlag.AlignTop)
-                grid.addWidget(desc_lbl, row, 1)
-
-            column_layout.addLayout(grid)
-
-        column_layout.addStretch()
-        parent_layout.addWidget(column_widget, stretch=1)
+        step_value = slider_step_for(group.id, slider_steps)
+        grid.addWidget(QLabel(_format_step_value(group, step_value)), row, 3)

--- a/tests/test_shortcut_editor_search.py
+++ b/tests/test_shortcut_editor_search.py
@@ -1,0 +1,37 @@
+from negpy.desktop.view.shortcut_editor_search import (
+    build_shortcut_editor_targets,
+    filter_targets,
+)
+
+
+def test_build_targets_includes_action_description():
+    targets = build_shortcut_editor_targets()
+    export = next(t for t in targets if t.target_id == "export")
+    assert export.label == "Export"
+    assert "export" in export.search_text
+
+
+def test_build_targets_includes_slider_group_label():
+    targets = build_shortcut_editor_targets()
+    density = next(t for t in targets if t.target_id == "density")
+    assert density.label == "Density ↑/↓"
+    assert density.row_kind == "slider"
+    assert "density" in density.search_text
+
+
+def test_search_matches_current_key_binding():
+    targets = build_shortcut_editor_targets({"density_up": "Q", "density_down": "A"})
+    matches = filter_targets(targets, "q")
+    assert any(t.target_id == "density" for t in matches)
+
+
+def test_search_matches_category_name():
+    targets = build_shortcut_editor_targets()
+    matches = filter_targets(targets, "finishing")
+    assert any(t.target_id == "border_size" for t in matches)
+
+
+def test_search_matches_ctrl_binding():
+    targets = build_shortcut_editor_targets({"export": "Ctrl+E"})
+    matches = filter_targets(targets, "ctrl+e")
+    assert any(t.target_id == "export" for t in matches)

--- a/tests/test_shortcut_registry.py
+++ b/tests/test_shortcut_registry.py
@@ -7,7 +7,6 @@ from negpy.desktop.view.shortcut_registry import (
     load_bindings,
     load_slider_steps,
     merge_bindings,
-    merge_slider_steps,
     save_bindings,
     save_slider_steps,
     tooltip_with_shortcut,

--- a/tests/test_shortcut_registry.py
+++ b/tests/test_shortcut_registry.py
@@ -1,4 +1,18 @@
-from negpy.desktop.view.shortcut_registry import default_bindings, load_bindings, merge_bindings, save_bindings, tooltip_with_shortcut
+from negpy.desktop.view.shortcut_registry import (
+    REGISTRY,
+    EditorRowSlider,
+    category_editor_rows,
+    default_bindings,
+    default_slider_steps,
+    load_bindings,
+    load_slider_steps,
+    merge_bindings,
+    merge_slider_steps,
+    save_bindings,
+    save_slider_steps,
+    tooltip_with_shortcut,
+)
+from negpy.desktop.view.slider_shortcut_groups import SLIDER_GROUP_BY_ACTION, SLIDER_GROUPS
 
 
 class _Repo:
@@ -83,3 +97,50 @@ def test_tooltip_without_binding_returns_plain_text():
 
     assert tooltip == "Cyan up"
     assert "<div" not in tooltip
+
+
+def test_default_slider_steps_match_current_keyboard_behavior():
+    steps = default_slider_steps()
+    assert steps["density"] == 0.01
+    assert steps["grade"] == 10.0
+    assert steps["offset"] == 1.0
+    assert steps["temperature"] == 50.0
+    assert len(steps) == len(SLIDER_GROUPS)
+
+
+def test_save_slider_steps_only_persists_overrides():
+    repo = _Repo()
+    steps = default_slider_steps()
+    steps["density"] = 0.05
+
+    save_slider_steps(repo, steps)
+
+    assert repo.data["shortcut_slider_steps"] == {"density": 0.05}
+
+
+def test_load_slider_steps_merges_saved_overrides():
+    repo = _Repo()
+    repo.data["shortcut_slider_steps"] = {"grade": 5.0}
+
+    steps = load_slider_steps(repo)
+
+    assert steps["grade"] == 5.0
+    assert steps["density"] == 0.01
+
+
+def test_category_editor_rows_merge_slider_pairs():
+    exposure_items = [(action_id, entry) for action_id, entry in REGISTRY.items() if entry.category == "Exposure"]
+    rows = category_editor_rows(exposure_items)
+    labels = [row.group.label if isinstance(row, EditorRowSlider) else row.entry.description for row in rows]
+
+    assert "Density ↑/↓" in labels
+    assert "Density up" not in labels
+    assert "Density down" not in labels
+    assert "Magenta ↑/↓" in labels
+
+
+def test_every_slider_action_has_a_group():
+    slider_actions = {group.inc_action for group in SLIDER_GROUPS} | {group.dec_action for group in SLIDER_GROUPS}
+    for action_id in slider_actions:
+        assert action_id in REGISTRY
+        assert action_id in SLIDER_GROUP_BY_ACTION


### PR DESCRIPTION
## Summary

Redesigns NegPy’s keyboard shortcut UI so **Customize** and the **`?` overview** share the same structure: collapsible categories, merged slider rows, and per-control step sizes.

- **Customize Shortcuts** — Categories are collapsible sections (collapsed by default). Slider adjustments are one row each (e.g. **Density ↑/↓**) with separate inc/dec bindings and a **Step** column. Step sizes are persisted per slider group (`shortcut_slider_steps`) and used at runtime for keyboard nudges.
- **Smart search** — Search bar in Customize matches action names, categories, and **current** key bindings. Selecting a result expands the section, scrolls the row into view, highlights it briefly, and focuses the first shortcut field.
- **Shortcut overview (`?`)** — Rebuilt to mirror Customize: same columns (**Action | Default | Shortcut | Step**), merged slider rows, read-only keycaps for current bindings, and displayed step sizes.
- **Docs** — `docs/KEYBOARD.md` updated for merged rows, customizable steps.

## Details

| Area | Change |
|------|--------|
| `slider_shortcut_groups.py` | Central definition of 42 paired slider shortcut groups (labels, defaults, step format) |
| `shortcut_registry.py` | `category_editor_rows()`, `categories_in_order()`, slider step load/save/merge |
| `shortcut_editor.py` | Full UI rewrite: grid layout, collapsible sections, step spinboxes |
| `shortcut_editor_search.py` | Search index + target resolution for jump-to-row |
| `shortcuts_overlay.py` | Overview dialog aligned with Customize layout |
| `keyboard_shortcuts.py` | Applies custom step sizes when handling slider shortcuts |

## Test plan

- [x] Press `?` — overview opens with collapsible sections; expand a category and confirm merged slider rows show default, current binding, and step
- [x] Open **Customize** from overview — same section/row layout as overview
- [x] Change a slider step size, save, reopen both dialogs — step value persists and keyboard nudge uses new increment
- [x] Search in Customize for an action name (e.g. `density`) — result expands section, scrolls, highlights, focuses shortcut field
- [x] Search by current binding (e.g. `Q`) — jumps to the correct row
- [x] Bind conflicting shortcuts — duplicate rejection still works
- [x] **Reset All** — restores default bindings and step sizes
- [x] `uv run pytest tests/test_shortcut_registry.py tests/test_shortcut_editor_search.py` — all pass