### PR TITLE
feat(crosstalk): in-app density-matrix profile editor

### DIFF
--- a/crosstalk/portra_400.toml
+++ b/crosstalk/portra_400.toml
@@ -4,7 +4,7 @@ name = "Kodak Portra 400"
 # 3x3 row-major density unmixing matrix (out R/G/B × in R/G/B)
 # Derived analytically from Kodak E-4050 Spectral Dye-Density Curves
 matrix = [
-  [ 1.004, -0.030,  0.000],
-  [-0.129,  1.010, -0.040],
-  [-0.050, -0.158,  1.006]
+  [ 1.000, -0.030,  0.000],
+  [-0.129,  1.000, -0.040],
+  [-0.050, -0.158,  1.000]
 ]

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Change: **Better heals across the board** — clone sources are picked by how well they match the surroundings, heal edges feather with brush size, and the halo around auto-fixed spots is gone.
 - Change: **Dust detection is stable and WYSIWYG** — defects are detected once on the source scan: the detected set no longer shifts while you drag sliders, and preview and export heal exactly the same spots.
 - New: **Auto Dust works on slides** — E-6 positives get automatic dust removal for the first time.
+- New: **Crosstalk matrix editor** — a Manage button beside the Process → Crosstalk dropdown opens an editor: browse the bundled matrices (read-only), make an editable copy, adjust the channel-mixing terms with live preview, and save your own profiles as `.toml` files in the NegPy/crosstalk folder.
 - Fix: presets no longer embed the source frame's heal strokes, and Apply settings no longer overwrites other frames' heals.
 
 ## 0.36.0

--- a/docs/CROSSTALK.md
+++ b/docs/CROSSTALK.md
@@ -92,6 +92,23 @@ presets stay reproducible even if you later move or delete the file.
 3. Pick your profile and raise **Crosstalk** above 0 to apply it.
 4. Pick **Default** to revert to the built-in matrix.
 
+### Editing matrices in the app
+
+The **sliders icon** next to the dropdown opens the **matrix editor**, so you don't
+have to hand-edit TOML:
+
+- Browse every profile — bundled matrices (and **Default**) show a lock and are
+  **read-only**; your own profiles are editable.
+- Drag the off-diagonal grid sliders (`out R/G/B` × `in R/G/B`) and the preview updates
+  live. The diagonal is fixed — the matrix is row-normalized on apply, which makes the
+  diagonal redundant, so only the six mixing terms are editable. The **Preview strength**
+  slider only controls how strongly the matrix previews here — it's view-only; use the
+  sidebar **Separation** slider to actually apply it.
+- **Make Editable Copy** clones the selected (locked) matrix into an editable profile.
+- **Save** writes the profile as a `.toml` into `<Documents>/NegPy/crosstalk/` — the same
+  folder profiles are read from — so it shows up in the dropdown.
+- **Apply & Close** keeps what you were previewing; **Cancel** reverts.
+
 > Crosstalk is a color operation and is hidden in B&W mode. Because it changes what
 > the normalization meters read, re-run **Batch Analysis** (and re-save locked bounds)
 > after changing the profile or strength.

--- a/negpy/desktop/view/sidebar/process.py
+++ b/negpy/desktop/view/sidebar/process.py
@@ -4,6 +4,7 @@ import qtawesome as qta
 from PyQt6.QtWidgets import (
     QButtonGroup,
     QComboBox,
+    QDialog,
     QHBoxLayout,
     QPushButton,
 )
@@ -197,8 +198,12 @@ class ProcessSidebar(BaseSidebar):
             "in the NegPy/crosstalk folder (see docs/CROSSTALK.md). Re-run Batch Analysis after changing this."
             "</td></tr></table>"
         )
+        self.manage_crosstalk_btn = self._icon_action(
+            "fa5s.sliders-h", "Open the crosstalk matrix editor — view, copy and edit density-unmix profiles", width=32
+        )
         matrix_row.addWidget(self.crosstalk_label)
         matrix_row.addWidget(self.crosstalk_combo, 1)
+        matrix_row.addWidget(self.manage_crosstalk_btn)
         self.layout.addLayout(matrix_row)
 
         self.crosstalk_strength_slider = CompactSlider("Separation", 0.0, 1.0, conf.crosstalk_strength, has_neutral=True)
@@ -252,6 +257,7 @@ class ProcessSidebar(BaseSidebar):
         self.black_point_slider.valueCommitted.connect(lambda v: self._on_black_point_changed(v, persist=True))
 
         self.crosstalk_combo.currentTextChanged.connect(self._on_crosstalk_profile_changed)
+        self.manage_crosstalk_btn.clicked.connect(self._open_crosstalk_editor)
         self.crosstalk_strength_slider.valueChanged.connect(lambda v: self._on_crosstalk_strength_changed(v, persist=False))
         self.crosstalk_strength_slider.valueCommitted.connect(lambda v: self._on_crosstalk_strength_changed(v, persist=True))
         self.normalize_e6_btn.toggled.connect(self._on_normalize_e6_toggled)
@@ -316,6 +322,56 @@ class ProcessSidebar(BaseSidebar):
             crosstalk_strength=val,
             **invalidate_local_bounds(self.state.config.process),
         )
+
+    def _open_crosstalk_editor(self) -> None:
+        from negpy.desktop.view.widgets.crosstalk_editor_dialog import CrosstalkEditorDialog
+
+        conf = self.state.config.process
+        self._crosstalk_snapshot = (conf.crosstalk_profile, conf.crosstalk_matrix, conf.crosstalk_strength)
+        dlg = CrosstalkEditorDialog(conf.crosstalk_profile, conf.crosstalk_strength, parent=self)
+        dlg.matrix_previewed.connect(self._on_crosstalk_preview)
+        dlg.profiles_changed.connect(self.sync_ui)
+        dlg.finished.connect(lambda result: self._on_crosstalk_editor_finished(dlg, result))
+        self._crosstalk_dialog = dlg  # keep a reference so the modeless dialog isn't GC'd
+        dlg.show()
+
+    def _on_crosstalk_preview(self, matrix: object, strength: float) -> None:
+        self.update_config_section(
+            "process",
+            persist=False,
+            render=True,
+            crosstalk_matrix=tuple(matrix) if matrix is not None else None,
+            crosstalk_strength=strength,
+            **invalidate_local_bounds(self.state.config.process),
+        )
+
+    def _on_crosstalk_editor_finished(self, dlg, result: int) -> None:
+        if result == QDialog.DialogCode.Accepted:
+            name = dlg.selected_name() or CrosstalkProfiles.DEFAULT_NAME
+            snap_strength = self._crosstalk_snapshot[2]
+            self.update_config_section(
+                "process",
+                persist=True,
+                render=True,
+                crosstalk_profile=name,
+                # Default stores no matrix (falls back to the built-in) by convention.
+                crosstalk_matrix=None if name == CrosstalkProfiles.DEFAULT_NAME else tuple(dlg.working_matrix()),
+                # Preview strength is view-only; only adopt it if the edit had crosstalk off.
+                crosstalk_strength=dlg.preview_strength() if snap_strength == 0 else snap_strength,
+                **invalidate_local_bounds(self.state.config.process),
+            )
+        else:
+            profile, matrix, strength = self._crosstalk_snapshot
+            self.update_config_section(
+                "process",
+                persist=True,
+                render=True,
+                crosstalk_profile=profile,
+                crosstalk_matrix=matrix,
+                crosstalk_strength=strength,
+                **invalidate_local_bounds(self.state.config.process),
+            )
+        self.sync_ui()
 
     def _on_normalize_e6_toggled(self, checked: bool) -> None:
         self.update_config_section(
@@ -403,6 +459,7 @@ class ProcessSidebar(BaseSidebar):
             is_bw = conf.process_mode == ProcessMode.BW
             self.crosstalk_label.setVisible(not is_bw)
             self.crosstalk_combo.setVisible(not is_bw)
+            self.manage_crosstalk_btn.setVisible(not is_bw)
             self.crosstalk_strength_slider.setVisible(not is_bw)
             self.autodetect_btn.setChecked(self.state.autodetect_enabled)
 

--- a/negpy/desktop/view/widgets/crosstalk_editor_dialog.py
+++ b/negpy/desktop/view/widgets/crosstalk_editor_dialog.py
@@ -1,0 +1,410 @@
+from typing import List, Optional
+
+import qtawesome as qta
+from PyQt6.QtCore import Qt, pyqtSignal
+from PyQt6.QtGui import QColor, QPainter, QPen
+from PyQt6.QtWidgets import (
+    QDialog,
+    QGridLayout,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QListWidget,
+    QListWidgetItem,
+    QPushButton,
+    QSizePolicy,
+    QSplitter,
+    QVBoxLayout,
+    QWidget,
+)
+
+from negpy.desktop.view.sidebar.tone import _CH_COLORS
+from negpy.desktop.view.styles.templates import dialog_pane_qss, hint_label, pane_header_qss
+from negpy.desktop.view.styles.theme import THEME
+from negpy.desktop.view.widgets.sliders import CompactSlider
+from negpy.features.process.models import DEFAULT_CROSSTALK_MATRIX
+from negpy.services.assets.crosstalk import CrosstalkProfiles
+
+
+def flat_to_grid(flat: List[float]) -> List[List[float]]:
+    return [list(flat[i * 3 : i * 3 + 3]) for i in range(3)]
+
+
+def grid_to_flat(grid: List[List[float]]) -> List[float]:
+    return [float(v) for row in grid for v in row]
+
+
+def unique_copy_name(base: str, existing) -> str:
+    """"<base> Copy", then "<base> Copy 2", 3, ... skipping names already taken."""
+    taken = set(existing)
+    candidate = f"{base} Copy"
+    if candidate not in taken:
+        return candidate
+    i = 2
+    while f"{candidate} {i}" in taken:
+        i += 1
+    return f"{candidate} {i}"
+
+
+class _MatrixGridWidget(QWidget):
+    """Hosts the 3×3 slider grid and paints subtle separators between cells."""
+
+    def __init__(self, cells, parent=None):
+        super().__init__(parent)
+        self._cells = cells
+
+    def paintEvent(self, event) -> None:
+        super().paintEvent(event)
+        # Column/row centers from the slider cells (the diagonal cells are None).
+        ref = None
+        col_x: list = [None, None, None]
+        row_y: list = [None, None, None]
+        for r, row in enumerate(self._cells):
+            for c, cell in enumerate(row):
+                if cell is None:
+                    continue
+                g = cell.geometry()
+                ref = g
+                col_x[c] = (g.left() + g.right()) // 2
+                row_y[r] = (g.top() + g.bottom()) // 2
+        if ref is None or None in col_x or None in row_y:
+            return
+        p = QPainter(self)
+        p.setPen(QPen(QColor(255, 255, 255, 22), 1))
+        hw, hh = ref.width() // 2, ref.height() // 2
+        # Overhang a bit into the column/row header labels.
+        top, bottom = row_y[0] - hh - 18, row_y[2] + hh
+        left, right = col_x[0] - hw - 26, col_x[2] + hw
+        for j in (1, 2):
+            p.drawLine((col_x[j - 1] + col_x[j]) // 2, top, (col_x[j - 1] + col_x[j]) // 2, bottom)
+        for i in (1, 2):
+            p.drawLine(left, (row_y[i - 1] + row_y[i]) // 2, right, (row_y[i - 1] + row_y[i]) // 2)
+
+
+class CrosstalkEditorDialog(QDialog):
+    """Modeless editor for spectral-crosstalk density matrices.
+
+    Bundled matrices and Default are read-only (view + copy); user profiles live
+    as TOMLs in the docs folder. Emits live previews as sliders move; the sidebar
+    renders them and decides whether to apply or restore on close.
+    """
+
+    matrix_previewed = pyqtSignal(object, float)  # (flat 9-float matrix, preview strength)
+    profiles_changed = pyqtSignal()
+
+    def __init__(self, current_profile: str, current_strength: float, parent=None):
+        super().__init__(parent)
+        self._selected_name: Optional[str] = None
+        self._updating = False
+
+        self.setWindowTitle("Crosstalk Matrices")
+        self.resize(680, 620)
+        self.setMinimumSize(520, 560)
+        self._init_ui()
+
+        self._reload_list(select=current_profile if current_profile in CrosstalkProfiles.list_profiles() else CrosstalkProfiles.DEFAULT_NAME)
+        self.preview_strength_slider.setValue(current_strength if current_strength > 0 else 1.0)
+
+    # ------------------------------------------------------------------ UI
+
+    def _init_ui(self) -> None:
+        root = QHBoxLayout(self)
+        root.setContentsMargins(0, 0, 0, 0)
+        root.setSpacing(0)
+        splitter = QSplitter(Qt.Orientation.Horizontal)
+
+        # Left: profile list + new / copy / delete
+        left = QWidget()
+        left.setMinimumWidth(180)
+        left.setStyleSheet(dialog_pane_qss())
+        left_layout = QVBoxLayout(left)
+        left_layout.setContentsMargins(8, 8, 8, 8)
+        left_layout.setSpacing(6)
+
+        header = QLabel("PROFILES")
+        header.setStyleSheet(pane_header_qss())
+        left_layout.addWidget(header)
+
+        self.profile_list = QListWidget()
+        self.profile_list.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        self.profile_list.setTextElideMode(Qt.TextElideMode.ElideRight)
+        self.profile_list.currentRowChanged.connect(self._on_row_changed)
+        left_layout.addWidget(self.profile_list)
+
+        btns = QHBoxLayout()
+        self.new_btn = self._tool_btn("fa5s.plus", "New matrix (starts from identity)", self._on_new)
+        self.copy_btn = self._tool_btn("fa5s.copy", "Make an editable copy of the selected profile", self._on_copy)
+        self.delete_btn = self._tool_btn("fa5s.trash-alt", "Delete the selected profile", self._on_delete)
+        btns.addWidget(self.new_btn)
+        btns.addWidget(self.copy_btn)
+        btns.addWidget(self.delete_btn)
+        btns.addStretch()
+        left_layout.addLayout(btns)
+
+        splitter.addWidget(left)
+
+        # Right: name + matrix grid + preview strength
+        right = QWidget()
+        right.setStyleSheet(f"background: {THEME.bg_dark};")
+        rl = QVBoxLayout(right)
+        rl.setContentsMargins(16, 16, 16, 16)
+        rl.setSpacing(12)
+
+        name_row = QHBoxLayout()
+        name_row.addWidget(QLabel("Name"))
+        self.name_edit = QLineEdit()
+        self.name_edit.setPlaceholderText("Profile name")
+        self.name_edit.textChanged.connect(self._on_name_changed)
+        name_row.addWidget(self.name_edit, 1)
+        rl.addLayout(name_row)
+
+        info = QLabel(
+            "<b>Spectral crosstalk unmix</b><br>"
+            "Film dyes leak a little density into the channels they shouldn't, muddying colour.<br>"
+            "<br>"
+            "• <b>IN</b> columns are the source channel; each row is the output channel it feeds.<br>"
+            "• Each off-diagonal slider subtracts one channel's leak from another — e.g. column "
+            "green, row red removes green's contamination from red.<br>"
+            "• The diagonal is fixed (rows are re-normalized).<br>"
+            "• Raise <b>Separation</b> in the sidebar to dial the effect in."
+        )
+        info.setWordWrap(True)
+        info.setStyleSheet(
+            f"background: rgba(255, 255, 255, 0.04); border: 1px solid rgba(255, 255, 255, 0.08); "
+            f"border-radius: 6px; padding: 8px; color: {THEME.text_secondary};"
+        )
+        rl.addWidget(info)
+
+        self.readonly_hint = hint_label("Bundled matrix — read-only. Make an editable copy to change it.")
+        rl.addWidget(self.readonly_hint)
+
+        rl.addWidget(self._build_matrix_grid())
+
+        self.preview_strength_slider = CompactSlider("Preview strength", 0.0, 1.0, 1.0, has_neutral=False)
+        self.preview_strength_slider.setToolTip("How strongly the matrix previews here (view-only — set Separation in the sidebar to apply)")
+        self.preview_strength_slider.valueChanged.connect(lambda _v: self._emit_preview())
+        rl.addWidget(self.preview_strength_slider)
+
+        rl.addStretch()
+
+        save_row = QHBoxLayout()
+        save_row.addStretch()
+        self.save_btn = QPushButton(" Save to disk")
+        self.save_btn.setIcon(qta.icon("fa5s.save", color=THEME.text_primary))
+        self.save_btn.setToolTip("Write this profile as a .toml in the NegPy/crosstalk folder so it's reusable")
+        self.save_btn.clicked.connect(self._on_save)
+        save_row.addWidget(self.save_btn)
+        rl.addLayout(save_row)
+
+        close_row = QHBoxLayout()
+        cancel_btn = QPushButton("Cancel")
+        cancel_btn.clicked.connect(self.reject)
+        apply_btn = QPushButton("Apply and close")
+        apply_btn.setDefault(True)
+        apply_btn.clicked.connect(self.accept)
+        close_row.addStretch()
+        close_row.addWidget(cancel_btn)
+        close_row.addWidget(apply_btn)
+        rl.addLayout(close_row)
+
+        splitter.addWidget(right)
+        splitter.setStretchFactor(0, 0)
+        splitter.setStretchFactor(1, 1)
+        splitter.setSizes([210, 450])
+        root.addWidget(splitter)
+
+    def _build_matrix_grid(self) -> QWidget:
+        # Diagonal is pinned by row-normalization, so only off-diagonal terms are
+        # sliders; self._cells is 3×3 with None on the diagonal.
+        self._cells: List[List[Optional[CompactSlider]]] = []
+        self._diag = [1.0, 1.0, 1.0]
+        container = _MatrixGridWidget(self._cells)
+        grid = QGridLayout(container)
+        grid.setSpacing(10)
+        grid.setContentsMargins(2, 4, 2, 4)
+        # Axis-title (0) and colour-box (1) columns stay fixed; slider columns absorb resize.
+        grid.setColumnStretch(0, 0)
+        grid.setColumnStretch(1, 0)
+        for j in (2, 3, 4):
+            grid.setColumnStretch(j, 1)
+
+        in_title = QLabel("IN")
+        in_title.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        in_title.setStyleSheet(f"color: {THEME.text_secondary}; font-weight: bold; letter-spacing: 3px;")
+        in_title.setToolTip("Columns are the input channel a slider mixes in; each row is the output channel.")
+        grid.addWidget(in_title, 0, 2, 1, 3)
+
+        for c in range(3):
+            col = QLabel()
+            col.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+            col.setFixedHeight(22)
+            col.setStyleSheet(f"background: {_CH_COLORS[c]}; border-radius: 4px;")
+            grid.addWidget(col, 1, c + 2)
+
+        for r in range(3):
+            row_lbl = QLabel()
+            row_lbl.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Expanding)
+            row_lbl.setFixedWidth(22)
+            row_lbl.setStyleSheet(f"background: {_CH_COLORS[r]}; border-radius: 4px;")
+            grid.addWidget(row_lbl, r + 2, 1)
+            row_cells: List[Optional[CompactSlider]] = []
+            for c in range(3):
+                if r == c:
+                    dash = QLabel("—")
+                    dash.setAlignment(Qt.AlignmentFlag.AlignCenter)
+                    dash.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
+                    dash.setStyleSheet(f"color: {THEME.text_muted};")
+                    dash.setToolTip("Diagonal is fixed — this channel keeps itself (row normalization makes it redundant). Edit the off-diagonal mixing terms.")
+                    grid.addWidget(dash, r + 2, c + 2)
+                    row_cells.append(None)
+                    continue
+                sld = CompactSlider("", -0.25, 0.25, 0.0, step=0.001, precision=1000, has_neutral=True)
+                sld.spin.setDecimals(3)
+                sld.valueChanged.connect(lambda _v: self._emit_preview())
+                grid.addWidget(sld, r + 2, c + 2)
+                row_cells.append(sld)
+            self._cells.append(row_cells)
+        return container
+
+    def _tool_btn(self, icon: str, tooltip: str, slot) -> QPushButton:
+        btn = QPushButton()
+        btn.setIcon(qta.icon(icon, color=THEME.text_primary, color_disabled=THEME.text_muted))
+        btn.setToolTip(tooltip)
+        btn.setFixedWidth(34)
+        btn.clicked.connect(slot)
+        return btn
+
+    # ------------------------------------------------------------- helpers
+
+    def working_matrix(self) -> List[float]:
+        return [
+            self._diag[r] if r == c else self._cells[r][c].value()  # type: ignore[union-attr]
+            for r in range(3)
+            for c in range(3)
+        ]
+
+    def preview_strength(self) -> float:
+        return self.preview_strength_slider.value()
+
+    def selected_name(self) -> Optional[str]:
+        return self._selected_name
+
+    def _matrix_for(self, name: str) -> List[float]:
+        if name == CrosstalkProfiles.DEFAULT_NAME:
+            return list(DEFAULT_CROSSTALK_MATRIX)
+        return CrosstalkProfiles.get_matrix(name) or list(DEFAULT_CROSSTALK_MATRIX)
+
+    def _all_names(self) -> list:
+        return CrosstalkProfiles.list_profiles()
+
+    def _set_grid(self, flat: List[float]) -> None:
+        grid = flat_to_grid(flat)
+        for r in range(3):
+            self._diag[r] = grid[r][r]
+            for c in range(3):
+                if r != c:
+                    self._cells[r][c].setValue(grid[r][c])  # type: ignore[union-attr]
+
+    def _set_grid_enabled(self, enabled: bool) -> None:
+        for r, row in enumerate(self._cells):
+            for c, cell in enumerate(row):
+                if r != c:
+                    cell.setEnabled(enabled)  # type: ignore[union-attr]
+
+    def _emit_preview(self) -> None:
+        if self._updating:
+            return
+        self.matrix_previewed.emit(self.working_matrix(), self.preview_strength())
+
+    # ------------------------------------------------------------- list
+
+    def _reload_list(self, select: Optional[str] = None) -> None:
+        self._updating = True
+        self.profile_list.blockSignals(True)
+        self.profile_list.clear()
+        names = [*sorted(CrosstalkProfiles.scan_user()), CrosstalkProfiles.DEFAULT_NAME, *sorted(CrosstalkProfiles.scan_bundled())]
+        for name in names:
+            item = QListWidgetItem(name)
+            item.setData(Qt.ItemDataRole.UserRole, name)
+            if CrosstalkProfiles.is_bundled(name):
+                item.setForeground(QColor(THEME.text_muted))
+                item.setIcon(qta.icon("fa5s.lock", color=THEME.text_muted))
+            self.profile_list.addItem(item)
+        self.profile_list.blockSignals(False)
+        self._updating = False
+
+        target = select if select in names else (names[0] if names else None)
+        if target is not None:
+            self.profile_list.setCurrentRow(names.index(target))
+
+    def _on_row_changed(self, row: int) -> None:
+        item = self.profile_list.item(row)
+        if item is None:
+            return
+        name = item.data(Qt.ItemDataRole.UserRole)
+        self._selected_name = name
+        editable = not CrosstalkProfiles.is_bundled(name)
+
+        self._updating = True
+        self._set_grid(self._matrix_for(name))
+        self.name_edit.setText(name)
+        self._updating = False
+
+        self.name_edit.setEnabled(editable)
+        self._set_grid_enabled(editable)
+        self.save_btn.setEnabled(editable)
+        self.delete_btn.setEnabled(editable)
+        self.readonly_hint.setVisible(not editable)
+        self._emit_preview()
+
+    # ------------------------------------------------------------- actions
+
+    def _on_name_changed(self, _text: str) -> None:
+        if self._updating:
+            return
+        # A name colliding with a bundled/Default profile would be shadowed in the combo.
+        name = self.name_edit.text().strip()
+        self.save_btn.setEnabled(bool(name) and not CrosstalkProfiles.is_bundled(name))
+
+    def _on_new(self) -> None:
+        existing = set(self._all_names())
+        name, i = "New Matrix", 2
+        while name in existing:
+            name = f"New Matrix {i}"
+            i += 1
+        identity = [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0]
+        CrosstalkProfiles.save(name, identity)
+        self.profiles_changed.emit()
+        self._reload_list(select=name)
+
+    def _on_copy(self) -> None:
+        if self._selected_name is None:
+            return
+        new_name = unique_copy_name(self._selected_name, self._all_names())
+        CrosstalkProfiles.save(new_name, self.working_matrix())
+        self.profiles_changed.emit()
+        self._reload_list(select=new_name)
+
+    def _on_save(self) -> None:
+        name = self.name_edit.text().strip()
+        if not name or CrosstalkProfiles.is_bundled(name):
+            return
+        old = self._selected_name
+        if old and old != name and not CrosstalkProfiles.is_bundled(old):
+            CrosstalkProfiles.delete(old)
+        CrosstalkProfiles.save(name, self.working_matrix())
+        self.profiles_changed.emit()
+        self._reload_list(select=name)
+
+    def accept(self) -> None:
+        # Apply-and-close persists the edited profile too (bundled/Default are read-only).
+        if self._selected_name is not None and not CrosstalkProfiles.is_bundled(self._selected_name):
+            self._on_save()
+        super().accept()
+
+    def _on_delete(self) -> None:
+        if self._selected_name is None or CrosstalkProfiles.is_bundled(self._selected_name):
+            return
+        CrosstalkProfiles.delete(self._selected_name)
+        self.profiles_changed.emit()
+        self._reload_list(select=CrosstalkProfiles.DEFAULT_NAME)

--- a/negpy/services/assets/crosstalk.py
+++ b/negpy/services/assets/crosstalk.py
@@ -1,4 +1,5 @@
 import os
+import re
 import tomllib
 from typing import List, Optional
 
@@ -6,6 +7,18 @@ from negpy.kernel.system.config import APP_CONFIG
 from negpy.kernel.system.paths import get_resource_path
 
 DEFAULT_NAME = "Default"
+
+
+# ponytail: 2-line helpers duplicated from contact_sheet_templates; extract to a
+# shared module only if a third consumer appears.
+def _slugify(name: str) -> str:
+    slug = re.sub(r"[^\w\s-]", "", name.lower())
+    slug = re.sub(r"[-\s]+", "_", slug).strip("_")
+    return slug or "crosstalk"
+
+
+def _escape_toml_string(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
 
 
 class CrosstalkProfiles:
@@ -39,11 +52,19 @@ class CrosstalkProfiles:
         return result
 
     @staticmethod
+    def scan_bundled() -> dict:
+        """Read-only matrices shipped with the app, keyed by display name."""
+        return CrosstalkProfiles._scan_dir(get_resource_path("crosstalk"))
+
+    @staticmethod
+    def scan_user() -> dict:
+        """User-editable matrices in the docs folder, keyed by display name."""
+        return CrosstalkProfiles._scan_dir(APP_CONFIG.crosstalk_dir)
+
+    @staticmethod
     def _scan() -> dict:
         """Bundled ∪ user custom matrices, keyed by display name; bundled wins."""
-        bundled = CrosstalkProfiles._scan_dir(get_resource_path("crosstalk"))
-        user = CrosstalkProfiles._scan_dir(APP_CONFIG.crosstalk_dir)
-        return {**user, **bundled}
+        return {**CrosstalkProfiles.scan_user(), **CrosstalkProfiles.scan_bundled()}
 
     @staticmethod
     def _parse_file(path: str) -> Optional[tuple]:
@@ -82,6 +103,47 @@ class CrosstalkProfiles:
         if name == DEFAULT_NAME:
             return None
         return CrosstalkProfiles._scan().get(name)
+
+    @staticmethod
+    def is_bundled(name: str) -> bool:
+        """True for read-only profiles: the built-in Default or any bundled matrix."""
+        return name == DEFAULT_NAME or name in CrosstalkProfiles.scan_bundled()
+
+    @staticmethod
+    def path_for_name(name: str) -> str:
+        """Filesystem path a user profile with this display name would use."""
+        return os.path.join(APP_CONFIG.crosstalk_dir, f"{_slugify(name)}.toml")
+
+    @staticmethod
+    def save(name: str, matrix: List[float]) -> str:
+        """Write a user profile TOML (row-major 3×3) and return its path."""
+        os.makedirs(APP_CONFIG.crosstalk_dir, exist_ok=True)
+        rows = "\n".join(
+            "  [{:.6g}, {:.6g}, {:.6g}],".format(*matrix[i * 3 : i * 3 + 3]) for i in range(3)
+        )
+        content = f'name = "{_escape_toml_string(name)}"\nmatrix = [\n{rows}\n]\n'
+        path = CrosstalkProfiles.path_for_name(name)
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(content)
+        return path
+
+    @staticmethod
+    def delete(name: str) -> None:
+        """Remove the user profile file whose display name matches (no-op if absent)."""
+        directory = APP_CONFIG.crosstalk_dir
+        if not os.path.isdir(directory):
+            return
+        for fname in os.listdir(directory):
+            if not fname.endswith(".toml"):
+                continue
+            path = os.path.join(directory, fname)
+            parsed = CrosstalkProfiles._parse_file(path)
+            if parsed is None:
+                continue
+            parsed_name = parsed[0] or fname[:-5]
+            if parsed_name == name:
+                os.remove(path)
+                return
 
     @staticmethod
     def ensure_user_dir() -> None:

--- a/tests/test_crosstalk_profiles.py
+++ b/tests/test_crosstalk_profiles.py
@@ -84,6 +84,64 @@ def test_list_profiles_merges_bundled_and_user(tmp_path, monkeypatch):
     assert CrosstalkProfiles.get_matrix("My Film") == [0.9, 0.1, 0.0, 0.0, 0.9, 0.1, 0.0, 0.0, 0.9]
 
 
+def test_save_round_trips_through_get_matrix(tmp_path, monkeypatch):
+    monkeypatch.setattr(APP_CONFIG, "crosstalk_dir", str(tmp_path))
+    matrix = [1.004, -0.02, 0.001, -0.118, 1.01, -0.04, -0.042, -0.149, 1.006]
+
+    path = CrosstalkProfiles.save("My Film", matrix)
+
+    assert os.path.isfile(path)
+    assert path.startswith(str(tmp_path))
+    assert CrosstalkProfiles.get_matrix("My Film") == matrix
+    assert "My Film" in CrosstalkProfiles.list_profiles()
+
+
+def test_is_bundled_distinguishes_origin(tmp_path, monkeypatch):
+    user_dir = tmp_path / "user"
+    bundled_dir = tmp_path / "bundled"
+    user_dir.mkdir()
+    bundled_dir.mkdir()
+    _write(
+        os.path.join(bundled_dir, "portra.toml"),
+        'name = "Portra 400"\nmatrix = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]\n',
+    )
+    monkeypatch.setattr(APP_CONFIG, "crosstalk_dir", str(user_dir))
+    monkeypatch.setattr("negpy.services.assets.crosstalk.get_resource_path", lambda _: str(bundled_dir))
+    CrosstalkProfiles.save("My Film", [1, 0, 0, 0, 1, 0, 0, 0, 1])
+
+    assert CrosstalkProfiles.is_bundled("Default")
+    assert CrosstalkProfiles.is_bundled("Portra 400")
+    assert not CrosstalkProfiles.is_bundled("My Film")
+
+
+def test_delete_removes_only_matching_display_name(tmp_path, monkeypatch):
+    monkeypatch.setattr(APP_CONFIG, "crosstalk_dir", str(tmp_path))
+    CrosstalkProfiles.save("Alpha", [1, 0, 0, 0, 1, 0, 0, 0, 1])
+    CrosstalkProfiles.save("Beta", [1, 0, 0, 0, 1, 0, 0, 0, 1])
+
+    CrosstalkProfiles.delete("Alpha")
+
+    assert CrosstalkProfiles.get_matrix("Alpha") is None
+    assert CrosstalkProfiles.get_matrix("Beta") is not None
+    CrosstalkProfiles.delete("Nonexistent")  # no-op, no raise
+
+
+def test_dialog_pure_helpers():
+    from negpy.desktop.view.widgets.crosstalk_editor_dialog import (
+        flat_to_grid,
+        grid_to_flat,
+        unique_copy_name,
+    )
+
+    flat = [1.0, -0.05, -0.02, -0.04, 1.0, -0.08, -0.01, -0.1, 1.0]
+    assert grid_to_flat(flat_to_grid(flat)) == flat
+    assert flat_to_grid(flat)[1][2] == -0.08
+
+    assert unique_copy_name("Portra", []) == "Portra Copy"
+    assert unique_copy_name("Portra", ["Portra Copy"]) == "Portra Copy 2"
+    assert unique_copy_name("Portra", ["Portra Copy", "Portra Copy 2"]) == "Portra Copy 3"
+
+
 def test_bundled_wins_on_name_collision_dedup(tmp_path, monkeypatch):
     user_dir = tmp_path / "user"
     bundled_dir = tmp_path / "bundled"


### PR DESCRIPTION
## What

Adds an in-app editor for spectral-crosstalk density matrices, reachable from a **Manage** button next to the Process → Crosstalk dropdown.

- Browse bundled matrices + **Default** (read-only, locked) and user profiles.
- **New / Copy / Delete** manage user profiles; "Make Editable Copy" clones a locked matrix.
- 3×3 grid: six **off-diagonal** mixing terms are editable sliders with **live preview**; the diagonal is pinned (row-normalization makes it redundant) and shown as a dash.
- **Save to disk** writes profiles as `.toml` into `<Documents>/NegPy/crosstalk/` — the same folder they're read from.
- Info box explains the adjustment; **Apply and close** also persists.

## Implementation

- New `negpy/desktop/view/widgets/crosstalk_editor_dialog.py` (modeless `QDialog`, styled after the Export Presets dialog).
- `CrosstalkProfiles` extended with origin-aware scans (`scan_bundled`/`scan_user`), `is_bundled`, `path_for_name`, `save`, `delete` — `list_profiles`/`get_matrix` unchanged so the sidebar combo is untouched.
- Sidebar wiring in `process.py`: live preview while open (persist off, local bounds invalidated like the Separation slider), commit-on-apply / restore-on-cancel.
- Normalized the bundled Portra 400 diagonal to 1.0.
- Docs: `docs/CROSSTALK.md` editor section, `docs/CHANGELOG.md` 0.37.0 entry.

## Test plan

- `make lint`, `make type` green.
- `make test`: **1580 passed, 4 skipped**. New service/helper tests in `tests/test_crosstalk_profiles.py` (save round-trip, is_bundled origin, delete-by-display-name, copy-name dedup, grid packing).
- Headless render checks of the dialog across window sizes.