### PR TITLE
feat(dodge-burn): editable masks + always-smooth polylines (#461)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Change: **One healing engine for everything** — Auto Dust and IR removal now use the same texture-preserving clone as the manual Heal tool instead of the old smoothed fill. Hairs and scratches are traced along their length.
 - Change: **Better heals across the board** — clone sources are picked by how well they match the surroundings, heal edges feather with brush size, and the halo around auto-fixed spots is gone.
 - Change: **Dust detection is stable and WYSIWYG** — defects are detected once on the source scan: the detected set no longer shifts while you drag sliders, and preview and export heal exactly the same spots.
+- New: **Editable Dodge & Burn masks** — the panel lists every mask you've drawn; pick one to select it, then reshape it right on the canvas (drag a point to move it, click an edge to add a point, right-click a point to remove it) and tune its sliders — no need to redraw from scratch.
+- Change: **Smoother masks and scratch heals** — Dodge & Burn mask outlines and Scratch heal strokes now follow smooth curves through their points instead of straight segments, and the line previews curved as you draw it.
 - New: **Auto Dust works on slides** — E-6 positives get automatic dust removal for the first time.
 - New: **Crosstalk matrix editor** — a Manage button beside the Process → Crosstalk dropdown opens an editor: browse the bundled matrices (read-only), make an editable copy, adjust the channel-mixing terms with live preview, and save your own profiles as `.toml` files in the NegPy/crosstalk folder.
 - Fix: presets no longer embed the source frame's heal strokes, and Apply settings no longer overwrites other frames' heals.

--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -1050,7 +1050,7 @@ class AppController(QObject):
 
         from negpy.features.local.models import PolygonMask
 
-        mask = PolygonMask(vertices=raw_vertices, strength=0.3, feather=0.02)
+        mask = PolygonMask(vertices=raw_vertices, strength=0.3)
         local = self.state.config.local
         new_masks = local.masks + (mask,)
         new_local = replace(local, masks=new_masks)
@@ -1095,22 +1095,33 @@ class AppController(QObject):
         self.state.local_selected_mask = index
         self.config_updated.emit()
 
-    def delete_selected_local_mask(self) -> None:
-        local = self.state.config.local
-        idx = self.state.local_selected_mask
-        if not (0 <= idx < len(local.masks)):
+    def set_local_mask_visible(self, index: int, visible: bool) -> None:
+        """Show/hide one mask's outline on the canvas (view-only; no re-render)."""
+        if not (0 <= index < len(self.state.config.local.masks)):
             return
-        new_masks = local.masks[:idx] + local.masks[idx + 1 :]
+        if visible:
+            self.state.local_hidden_masks.discard(index)
+        else:
+            self.state.local_hidden_masks.add(index)
+        if self.canvas:
+            self.canvas.overlay.update()
+
+    def delete_local_mask(self, index: int) -> None:
+        local = self.state.config.local
+        if not (0 <= index < len(local.masks)):
+            return
+        from negpy.desktop.view.confirm import confirm_delete_mask
+
+        if not confirm_delete_mask(None):
+            return
+        new_masks = local.masks[:index] + local.masks[index + 1 :]
         new_local = replace(local, masks=new_masks)
         self.session.update_config(replace(self.state.config, local=new_local), persist=True)
-        self.state.local_selected_mask = -1
-        self.config_updated.emit()
-        self.request_render()
 
-    def clear_local(self) -> None:
-        new_local = replace(self.state.config.local, masks=())
-        self.session.update_config(replace(self.state.config, local=new_local), persist=True)
-        self.state.local_selected_mask = -1
+        sel = self.state.local_selected_mask
+        self.state.local_selected_mask = -1 if sel == index else (sel - 1 if sel > index else sel)
+        self.state.local_hidden_masks = {j - 1 if j > index else j for j in self.state.local_hidden_masks if j != index}
+
         self.config_updated.emit()
         self.request_render()
 
@@ -1744,12 +1755,6 @@ class AppController(QObject):
             self.request_render(readback_metrics=False, config_override=flat_master_config(self.state.config))
         else:
             self.request_render()
-
-    def set_local_overlay_visible(self, visible: bool) -> None:
-        """Show/hide the dodge/burn mask overlay (view-only; no re-render)."""
-        self.state.show_local_overlay = visible
-        if self.canvas:
-            self.canvas.overlay.update()
 
     def _enabled_presets(self) -> List[ExportPreset]:
         return [p for p in self.state.export_presets if p.enabled]

--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -1060,6 +1060,37 @@ class AppController(QObject):
         self.config_updated.emit()
         self.request_render()
 
+    def handle_local_mask_edited(self, index: int, viewport_vertices: list) -> None:
+        """Replace a mask's vertices after an on-canvas drag/add edit (persist on release)."""
+        with self.state.metrics_lock:
+            uv_grid = self.state.last_metrics.get("uv_grid")
+        local = self.state.config.local
+        if uv_grid is None or not (0 <= index < len(local.masks)) or len(viewport_vertices) < 3:
+            return
+        raw_vertices = tuple(CoordinateMapping.map_click_to_raw(nx, ny, uv_grid) for nx, ny in viewport_vertices)
+        masks = list(local.masks)
+        masks[index] = replace(masks[index], vertices=raw_vertices)
+        new_local = replace(local, masks=tuple(masks))
+        self.session.update_config(replace(self.state.config, local=new_local), persist=True)
+        self.config_updated.emit()
+        self.request_render()
+
+    def delete_local_vertex(self, index: int, vertex_index: int) -> None:
+        """Remove one vertex from a mask (keeps a minimum of 3)."""
+        local = self.state.config.local
+        if not (0 <= index < len(local.masks)):
+            return
+        mask = local.masks[index]
+        if len(mask.vertices) <= 3 or not (0 <= vertex_index < len(mask.vertices)):
+            return
+        verts = mask.vertices[:vertex_index] + mask.vertices[vertex_index + 1 :]
+        masks = list(local.masks)
+        masks[index] = replace(mask, vertices=verts)
+        new_local = replace(local, masks=tuple(masks))
+        self.session.update_config(replace(self.state.config, local=new_local), persist=True)
+        self.config_updated.emit()
+        self.request_render()
+
     def select_local_mask(self, index: int) -> None:
         self.state.local_selected_mask = index
         self.config_updated.emit()

--- a/negpy/desktop/session.py
+++ b/negpy/desktop/session.py
@@ -92,7 +92,8 @@ class AppState:
 
     # Local adjustments UI state (not persisted in workspace config)
     local_selected_mask: int = -1
-    show_local_overlay: bool = True
+    # Indices of masks whose outline is hidden on the canvas; empty = all shown.
+    local_hidden_masks: set = field(default_factory=set)
 
     # History tracking
     undo_index: int = 0
@@ -734,6 +735,9 @@ class DesktopSessionManager(QObject):
                 self.state.config = replace(
                     self.state.config, rgbscan=RgbScanConfig(enabled=True, green_path=green, blue_path=blue, align=align)
                 )
+
+            # Mask hide-state is keyed by index into this file's masks; the swap invalidates it.
+            self.state.local_hidden_masks = set()
 
             self.file_selected.emit(file_info["path"])
             self.state_changed.emit()

--- a/negpy/desktop/view/canvas/overlay.py
+++ b/negpy/desktop/view/canvas/overlay.py
@@ -416,13 +416,7 @@ class CanvasOverlay(QWidget):
                 painter.drawLine(QPointF(visible_rect.x(), self._mouse_pos.y()), QPointF(visible_rect.right(), self._mouse_pos.y()))
                 painter.drawLine(QPointF(self._mouse_pos.x(), visible_rect.top()), QPointF(self._mouse_pos.x(), visible_rect.bottom()))
 
-        selected_present = getattr(self.state, "local_selected_mask", -1) >= 0
-        show_masks = (
-            getattr(self.state, "show_local_overlay", False)
-            or self._tool_mode == ToolMode.LOCAL_DRAW
-            or (self._tool_mode == ToolMode.NONE and selected_present)
-        )
-        if show_masks:
+        if self.state.config.local.masks:
             self._draw_local_masks(painter)
         if self._tool_mode == ToolMode.LOCAL_DRAW:
             self._draw_lasso_in_progress(painter)
@@ -947,6 +941,8 @@ class CanvasOverlay(QWidget):
             self._local_mask_screen_polys.append(ctrl)
 
             is_selected = i == selected
+            if i in getattr(self.state, "local_hidden_masks", ()):
+                continue
             working = self._local_edit_verts if is_selected else None
             drag_this = working is not None
             draw_ctrl = working if working is not None else ctrl

--- a/negpy/desktop/view/canvas/overlay.py
+++ b/negpy/desktop/view/canvas/overlay.py
@@ -12,7 +12,7 @@ from negpy.desktop.converters import ImageConverter
 from negpy.desktop.session import AppState, ToolMode
 from negpy.desktop.view.canvas.crop_guides import CropGuide, guide_shapes
 from negpy.desktop.view.styles.theme import THEME
-from negpy.features.geometry.logic import rotation_drag_angle, straighten_delta_degrees, translate_manual_crop_rect
+from negpy.features.geometry.logic import rotation_drag_angle, smooth_polyline, straighten_delta_degrees, translate_manual_crop_rect
 from negpy.features.local.logic import _rasterise_mask
 from negpy.features.retouch.models import HEAL_SIZE_REF
 
@@ -82,6 +82,8 @@ class CanvasOverlay(QWidget):
     lasso_completed = pyqtSignal(list)
     scratch_completed = pyqtSignal(list)
     local_mask_selected = pyqtSignal(int)
+    local_mask_edited = pyqtSignal(int, list)  # (mask index, viewport-normalized vertices)
+    local_vertex_deleted = pyqtSignal(int, int)  # (mask index, vertex index)
     straighten_completed = pyqtSignal(float)  # fine-rotation delta, stored convention (CCW+)
 
     def __init__(self, state: AppState, parent=None):
@@ -128,6 +130,10 @@ class CanvasOverlay(QWidget):
         self._scratch_pts: List[QPointF] = []
         self._local_mask_screen_polys: List[List[QPointF]] = []
         self._mask_img_cache: Dict[tuple, QImage] = {}
+
+        # Working screen points while a selected-mask vertex is dragged/added.
+        self._local_edit_verts: Optional[List[QPointF]] = None
+        self._local_drag_vertex: Optional[int] = None
 
         # Straighten tool: reference-line drag (press -> drag -> release applies).
         self._straighten_p1: Optional[QPointF] = None
@@ -218,12 +224,17 @@ class CanvasOverlay(QWidget):
         if mode != ToolMode.LOCAL_DRAW:
             self._lasso_pts = []
             self._lasso_drawing = False
+            self._end_local_edit()
         if mode != ToolMode.SCRATCH_PICK:
             self._scratch_pts = []
         if mode != ToolMode.STRAIGHTEN:
             self._straighten_p1 = None
             self._straighten_p2 = None
         self.update()
+
+    def _end_local_edit(self) -> None:
+        self._local_edit_verts = None
+        self._local_drag_vertex = None
 
     def _end_crop_drag(self) -> None:
         self._crop_drag_mode = None
@@ -286,6 +297,7 @@ class CanvasOverlay(QWidget):
         self.update()
 
     def _recalc_view_rect(self) -> None:
+        old_rect = self._view_rect
         size = None
         if self._qimage:
             size = self._qimage.size()
@@ -310,6 +322,30 @@ class CanvasOverlay(QWidget):
         center_y = (h / 2) + (self.pan_y * h)
 
         self._view_rect = QRectF(center_x - (final_w / 2), center_y - (final_h / 2), final_w, final_h)
+        self._remap_inflight_points(old_rect)
+
+    def _remap_inflight_points(self, old: QRectF) -> None:
+        """Repin in-progress screen points to the image when the view rect changes
+        (zoom/pan/resize mid-draw), so the preview tracks the image, not the screen."""
+        new = self._view_rect
+        if old.isEmpty() or new.isEmpty() or old == new:
+            return
+
+        def remap(p: QPointF) -> QPointF:
+            nx = (p.x() - old.x()) / old.width()
+            ny = (p.y() - old.y()) / old.height()
+            return QPointF(new.x() + nx * new.width(), new.y() + ny * new.height())
+
+        if self._lasso_pts:
+            self._lasso_pts = [remap(p) for p in self._lasso_pts]
+        if self._scratch_pts:
+            self._scratch_pts = [remap(p) for p in self._scratch_pts]
+        if self._local_edit_verts is not None:
+            self._local_edit_verts = [remap(p) for p in self._local_edit_verts]
+        if self._straighten_p1 is not None:
+            self._straighten_p1 = remap(self._straighten_p1)
+        if self._straighten_p2 is not None:
+            self._straighten_p2 = remap(self._straighten_p2)
 
     def paintEvent(self, event) -> None:
         painter = QPainter(self)
@@ -380,7 +416,12 @@ class CanvasOverlay(QWidget):
                 painter.drawLine(QPointF(visible_rect.x(), self._mouse_pos.y()), QPointF(visible_rect.right(), self._mouse_pos.y()))
                 painter.drawLine(QPointF(self._mouse_pos.x(), visible_rect.top()), QPointF(self._mouse_pos.x(), visible_rect.bottom()))
 
-        show_masks = getattr(self.state, "show_local_overlay", False) or self._tool_mode == ToolMode.LOCAL_DRAW
+        selected_present = getattr(self.state, "local_selected_mask", -1) >= 0
+        show_masks = (
+            getattr(self.state, "show_local_overlay", False)
+            or self._tool_mode == ToolMode.LOCAL_DRAW
+            or (self._tool_mode == ToolMode.NONE and selected_present)
+        )
         if show_masks:
             self._draw_local_masks(painter)
         if self._tool_mode == ToolMode.LOCAL_DRAW:
@@ -454,6 +495,18 @@ class CanvasOverlay(QWidget):
         max_screen_dim = max(self._view_rect.width(), self._view_rect.height())
         return (size / (2.0 * HEAL_SIZE_REF)) * max_screen_dim
 
+    def _preview_curve_path(self, pts: List[QPointF]) -> QPainterPath:
+        """Smoothed path through the placed points plus the live cursor."""
+        scr = [(p.x(), p.y()) for p in pts]
+        if self._view_rect.contains(self._mouse_pos):
+            scr.append((self._mouse_pos.x(), self._mouse_pos.y()))
+        if len(scr) >= 3:
+            scr = smooth_polyline(scr, closed=False)
+        path = QPainterPath(QPointF(*scr[0]))
+        for x, y in scr[1:]:
+            path.lineTo(QPointF(x, y))
+        return path
+
     def _draw_scratch_in_progress(self, painter: QPainter) -> None:
         if not self._scratch_pts:
             return
@@ -464,11 +517,7 @@ class CanvasOverlay(QWidget):
         pen = QPen(band, width, Qt.PenStyle.SolidLine, Qt.PenCapStyle.RoundCap, Qt.PenJoinStyle.RoundJoin)
         painter.setPen(pen)
         painter.setBrush(Qt.BrushStyle.NoBrush)
-        path = QPainterPath(self._scratch_pts[0])
-        for pt in self._scratch_pts[1:]:
-            path.lineTo(pt)
-        if self._view_rect.contains(self._mouse_pos):
-            path.lineTo(self._mouse_pos)
+        path = self._preview_curve_path(self._scratch_pts)
         painter.drawPath(path)
 
         centerline = QPen(Qt.GlobalColor.white, 1.0, Qt.PenStyle.SolidLine)
@@ -523,13 +572,16 @@ class CanvasOverlay(QWidget):
         pen.setCosmetic(True)
         painter.setBrush(Qt.BrushStyle.NoBrush)
 
-        for points, size, _dx, _dy in conf.manual_heal_strokes:
+        for stroke in conf.manual_heal_strokes:
+            points, size = stroke[0], stroke[1]
             screen_pts = [self._raw_to_screen(px, py, uv_grid) for px, py in points]
             radius = max(2.0, self._brush_screen_radius(size))
             if len(screen_pts) == 1:
                 painter.setPen(pen)
                 painter.drawEllipse(screen_pts[0], radius, radius)
             else:
+                if len(screen_pts) >= 3:
+                    screen_pts = [QPointF(x, y) for x, y in smooth_polyline([(p.x(), p.y()) for p in screen_pts], closed=False)]
                 band = QPen(
                     QColor(THEME.accent_primary), 2.0 * radius, Qt.PenStyle.SolidLine, Qt.PenCapStyle.RoundCap, Qt.PenJoinStyle.RoundJoin
                 )
@@ -891,42 +943,82 @@ class CanvasOverlay(QWidget):
             if len(mask.vertices) < 3:
                 self._local_mask_screen_polys.append([])
                 continue
-            screen_pts = [self._raw_to_screen(rx, ry, uv_grid) for rx, ry in mask.vertices]
-            self._local_mask_screen_polys.append(screen_pts)
+            ctrl = [self._raw_to_screen(rx, ry, uv_grid) for rx, ry in mask.vertices]
+            self._local_mask_screen_polys.append(ctrl)
 
             is_selected = i == selected
+            working = self._local_edit_verts if is_selected else None
+            drag_this = working is not None
+            draw_ctrl = working if working is not None else ctrl
+            curve = smooth_polyline([(p.x(), p.y()) for p in draw_ctrl], closed=True)
             outline = QColor(232, 200, 74) if mask.strength >= 0 else QColor(74, 143, 232)
             max_alpha = 70 if is_selected else 32
 
-            sigma_screen = mask.feather * min(self._view_rect.width(), self._view_rect.height())
-            pad = 3.0 * sigma_screen + 2.0
-            xs = [p.x() for p in screen_pts]
-            ys = [p.y() for p in screen_pts]
-            x0, y0 = min(xs) - pad, min(ys) - pad
-            bw, bh = max(xs) + pad - x0, max(ys) + pad - y0
-            scale = min(1.0, _MASK_RASTER_MAX / max(bw, bh, 1.0))
-            rw, rh = max(int(bw * scale), 2), max(int(bh * scale), 2)
-            # Bbox-relative points are pan-invariant, so panning reuses the cache.
-            local = tuple((round((p.x() - x0) * scale, 1), round((p.y() - y0) * scale, 1)) for p in screen_pts)
+            # Skip the feathered fill mid-drag; it re-rasters every frame.
+            if not drag_this:
+                sigma_screen = mask.feather * min(self._view_rect.width(), self._view_rect.height())
+                pad = 3.0 * sigma_screen + 2.0
+                xs = [x for x, _ in curve]
+                ys = [y for _, y in curve]
+                x0, y0 = min(xs) - pad, min(ys) - pad
+                bw, bh = max(xs) + pad - x0, max(ys) + pad - y0
+                scale = min(1.0, _MASK_RASTER_MAX / max(bw, bh, 1.0))
+                rw, rh = max(int(bw * scale), 2), max(int(bh * scale), 2)
+                # Bbox-relative points are pan-invariant, so panning reuses the cache.
+                local = tuple((round((x - x0) * scale, 1), round((y - y0) * scale, 1)) for x, y in curve)
 
-            key = (local, rw, rh, round(sigma_screen * scale, 2), outline.rgb(), max_alpha)
-            img = self._mask_img_cache.get(key)
-            if img is None:
-                img = feathered_mask_image(local, rw, rh, sigma_screen * scale, outline, max_alpha)
-            fresh_cache[key] = img
-            painter.drawImage(QRectF(x0, y0, bw, bh), img)
+                key = (local, rw, rh, round(sigma_screen * scale, 2), outline.rgb(), max_alpha)
+                img = self._mask_img_cache.get(key)
+                if img is None:
+                    img = feathered_mask_image(local, rw, rh, sigma_screen * scale, outline, max_alpha)
+                fresh_cache[key] = img
+                painter.drawImage(QRectF(x0, y0, bw, bh), img)
 
             if is_selected:
                 outline_color = QColor(outline)
-                outline_color.setAlpha(160)
-                pen = QPen(outline_color, 2.0, Qt.PenStyle.SolidLine)
+                outline_color.setAlpha(200)
+                pen = QPen(outline_color, 2.6, Qt.PenStyle.SolidLine)
             else:
-                pen = QPen(QColor(255, 255, 255, 100), 1.0, Qt.PenStyle.SolidLine)
+                pen = QPen(QColor(255, 255, 255, 110), 1.4, Qt.PenStyle.SolidLine)
             pen.setCosmetic(True)
             painter.setPen(pen)
             painter.setBrush(Qt.BrushStyle.NoBrush)
-            painter.drawPolygon(QPolygonF(screen_pts))
+            painter.drawPolygon(QPolygonF([QPointF(x, y) for x, y in curve]))
+
+            if is_selected and self._tool_mode in (ToolMode.NONE, ToolMode.LOCAL_DRAW) and not self._lasso_drawing:
+                self._draw_local_handles(painter, draw_ctrl, outline)
         self._mask_img_cache = fresh_cache
+
+    def _draw_local_handles(self, painter: QPainter, ctrl_pts: List[QPointF], color: QColor) -> None:
+        """Draggable vertices + '+' discs on edge midpoints for the selected mask."""
+        n = len(ctrl_pts)
+        if n < 2:
+            return
+
+        # Edge-midpoint "add point" handles: white disc with a plus glyph.
+        plus_pen = QPen(QColor(35, 35, 35, 235), 1.5)
+        plus_pen.setCosmetic(True)
+        for i in range(n):
+            a, b = ctrl_pts[i], ctrl_pts[(i + 1) % n]
+            m = QPointF((a.x() + b.x()) / 2.0, (a.y() + b.y()) / 2.0)
+            painter.setPen(Qt.PenStyle.NoPen)
+            painter.setBrush(QColor(0, 0, 0, 130))
+            painter.drawEllipse(m, 6.0, 6.0)
+            painter.setBrush(QColor(255, 255, 255, 220))
+            painter.drawEllipse(m, 5.0, 5.0)
+            painter.setPen(plus_pen)
+            painter.drawLine(QPointF(m.x() - 2.6, m.y()), QPointF(m.x() + 2.6, m.y()))
+            painter.drawLine(QPointF(m.x(), m.y() - 2.6), QPointF(m.x(), m.y() + 2.6))
+
+        # White halo behind a solid coloured core so vertices read on any image.
+        core = QColor(color)
+        core.setAlpha(255)
+        for p in ctrl_pts:
+            painter.setPen(Qt.PenStyle.NoPen)
+            painter.setBrush(QColor(255, 255, 255, 240))
+            painter.drawEllipse(p, 7.0, 7.0)
+            painter.setBrush(core)
+            painter.drawEllipse(p, 5.0, 5.0)
 
     def _draw_lasso_in_progress(self, painter: QPainter) -> None:
         if not self._lasso_drawing or not self._lasso_pts:
@@ -937,12 +1029,7 @@ class CanvasOverlay(QWidget):
         painter.setPen(pen)
         painter.setBrush(Qt.BrushStyle.NoBrush)
 
-        path = QPainterPath(self._lasso_pts[0])
-        for pt in self._lasso_pts[1:]:
-            path.lineTo(pt)
-        if self._view_rect.contains(self._mouse_pos):
-            path.lineTo(self._mouse_pos)
-        painter.drawPath(path)
+        painter.drawPath(self._preview_curve_path(self._lasso_pts))
 
         first = self._lasso_pts[0]
         near_close = len(self._lasso_pts) >= 3 and (self._mouse_pos - first).manhattanLength() < _LASSO_SNAP_PX * 2
@@ -962,6 +1049,15 @@ class CanvasOverlay(QWidget):
         return float(np.clip(nb_x, 0, 1)), float(np.clip(nb_y, 0, 1))
 
     def mousePressEvent(self, event: QMouseEvent) -> None:
+        # A selected mask is editable even without the Draw Mask tool (grab a handle).
+        if (
+            event.button() == Qt.MouseButton.LeftButton
+            and self._tool_mode == ToolMode.NONE
+            and self._try_start_vertex_edit(event.position())
+        ):
+            event.accept()
+            return
+
         if event.button() == Qt.MouseButton.MiddleButton or (
             event.button() == Qt.MouseButton.LeftButton and self.zoom_level > 1.0 and self._tool_mode == ToolMode.NONE
         ):
@@ -1085,6 +1181,14 @@ class CanvasOverlay(QWidget):
             event.accept()
             return
 
+        if self._local_drag_vertex is not None and self._local_edit_verts is not None and not self._view_rect.isEmpty():
+            px = float(np.clip(event.position().x(), self._view_rect.left(), self._view_rect.right()))
+            py = float(np.clip(event.position().y(), self._view_rect.top(), self._view_rect.bottom()))
+            self._local_edit_verts[self._local_drag_vertex] = QPointF(px, py)
+            self.update()
+            event.accept()
+            return
+
         # Hovering the crop tool (no drag in progress): reflect the action under the
         # cursor — rotate handle, corner resize, interior move, or draw — right away.
         if self._tool_mode == ToolMode.CROP_MANUAL and self._crop_drag_mode is None:
@@ -1184,11 +1288,71 @@ class CanvasOverlay(QWidget):
 
         self.update()
 
+    def _selected_mask_screen_pts(self) -> Optional[List[QPointF]]:
+        idx = getattr(self.state, "local_selected_mask", -1)
+        if 0 <= idx < len(self._local_mask_screen_polys):
+            pts = self._local_mask_screen_polys[idx]
+            return pts if len(pts) >= 3 else None
+        return None
+
+    def _hit_local_vertex(self, pos: QPointF, pts: List[QPointF]) -> Optional[int]:
+        for i, p in enumerate(pts):
+            dx, dy = pos.x() - p.x(), pos.y() - p.y()
+            if dx * dx + dy * dy <= _CROP_HANDLE_PX * _CROP_HANDLE_PX:
+                return i
+        return None
+
+    def _hit_local_edge_midpoint(self, pos: QPointF, pts: List[QPointF]) -> Optional[int]:
+        """Index i of the edge (i, i+1) whose midpoint handle is under `pos`."""
+        n = len(pts)
+        for i in range(n):
+            a, b = pts[i], pts[(i + 1) % n]
+            mx, my = (a.x() + b.x()) / 2.0, (a.y() + b.y()) / 2.0
+            dx, dy = pos.x() - mx, pos.y() - my
+            if dx * dx + dy * dy <= _CROP_HANDLE_PX * _CROP_HANDLE_PX:
+                return i
+        return None
+
+    def try_delete_local_vertex(self, pos: QPointF) -> bool:
+        """Right-click on a selected-mask vertex removes it. Returns True if handled."""
+        pts = self._selected_mask_screen_pts()
+        if pts is None:
+            return False
+        vi = self._hit_local_vertex(pos, pts)
+        if vi is None:
+            return False
+        self.local_vertex_deleted.emit(getattr(self.state, "local_selected_mask", -1), vi)
+        return True
+
+    def _try_start_vertex_edit(self, pos: QPointF) -> bool:
+        """Grab a selected-mask vertex, or insert one at an edge midpoint; True if started."""
+        pts = self._selected_mask_screen_pts()
+        if pts is None:
+            return False
+        vi = self._hit_local_vertex(pos, pts)
+        if vi is not None:
+            self._local_edit_verts = list(pts)
+            self._local_drag_vertex = vi
+            self.update()
+            return True
+        ei = self._hit_local_edge_midpoint(pos, pts)
+        if ei is not None:
+            work = list(pts)
+            a, b = work[ei], work[(ei + 1) % len(work)]
+            work.insert(ei + 1, QPointF((a.x() + b.x()) / 2.0, (a.y() + b.y()) / 2.0))
+            self._local_edit_verts = work
+            self._local_drag_vertex = ei + 1
+            self.update()
+            return True
+        return False
+
     def _handle_lasso_press(self, pos: QPointF) -> None:
         if not self._view_rect.contains(pos):
             return
 
         if not self._lasso_drawing:
+            if self._try_start_vertex_edit(pos):
+                return
             for i, poly_pts in enumerate(self._local_mask_screen_polys):
                 if len(poly_pts) < 3:
                     continue
@@ -1330,6 +1494,24 @@ class CanvasOverlay(QWidget):
         if self.parent()._is_panning:
             self.parent()._is_panning = False
             self.parent().reset_tool_cursor()
+            event.accept()
+            return
+
+        if self._local_drag_vertex is not None:
+            verts = self._local_edit_verts or []
+            selected = getattr(self.state, "local_selected_mask", -1)
+            self._end_local_edit()
+            if verts and selected >= 0 and not self._view_rect.isEmpty():
+                w, h = self._view_rect.width(), self._view_rect.height()
+                vp = [
+                    (
+                        float(np.clip((p.x() - self._view_rect.x()) / w, 0.0, 1.0)),
+                        float(np.clip((p.y() - self._view_rect.y()) / h, 0.0, 1.0)),
+                    )
+                    for p in verts
+                ]
+                self.local_mask_edited.emit(selected, vp)
+            self.update()
             event.accept()
             return
 

--- a/negpy/desktop/view/canvas/widget.py
+++ b/negpy/desktop/view/canvas/widget.py
@@ -109,6 +109,8 @@ class ImageCanvas(QWidget):
     scratch_completed = pyqtSignal(list)
     straighten_completed = pyqtSignal(float)
     local_mask_selected = pyqtSignal(int)
+    local_mask_edited = pyqtSignal(int, list)
+    local_vertex_deleted = pyqtSignal(int, int)
 
     def __init__(self, state: AppState, parent=None):
         super().__init__(parent)
@@ -160,6 +162,8 @@ class ImageCanvas(QWidget):
         self.overlay.scratch_completed.connect(self.scratch_completed.emit)
         self.overlay.straighten_completed.connect(self.straighten_completed.emit)
         self.overlay.local_mask_selected.connect(self.local_mask_selected.emit)
+        self.overlay.local_mask_edited.connect(self.local_mask_edited.emit)
+        self.overlay.local_vertex_deleted.connect(self.local_vertex_deleted.emit)
 
         self.hud = CanvasHud(self)
         self._floating_toolbar: Optional[QWidget] = None
@@ -525,6 +529,11 @@ class ImageCanvas(QWidget):
         # settings menu would be noise mid-retouch.
         if self.state.active_tool in (ToolMode.DUST_PICK, ToolMode.SCRATCH_PICK):
             self._exec_retouch_menu(event)
+            return
+
+        # Right-click on a selected mask's vertex deletes that point (no menu).
+        if self.state.active_tool in (ToolMode.NONE, ToolMode.LOCAL_DRAW) and self.overlay.try_delete_local_vertex(QPointF(event.pos())):
+            event.accept()
             return
 
         menu = QMenu(self)

--- a/negpy/desktop/view/confirm.py
+++ b/negpy/desktop/view/confirm.py
@@ -29,6 +29,17 @@ def confirm_unload(parent, *, clear_all: bool = False, count: int = 1) -> bool:
     return box.exec() == QMessageBox.StandardButton.Yes
 
 
+def confirm_delete_mask(parent) -> bool:
+    """Ask before deleting a single dodge/burn mask. Enter confirms; Esc cancels."""
+    box = QMessageBox(parent)
+    box.setIcon(QMessageBox.Icon.Question)
+    box.setWindowTitle("Delete Mask")
+    box.setText("Delete this dodge/burn mask?")
+    box.setStandardButtons(QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.Cancel)
+    box.setDefaultButton(QMessageBox.StandardButton.Yes)
+    return box.exec() == QMessageBox.StandardButton.Yes
+
+
 def confirm_clear_heals(parent, count: int) -> bool:
     """Ask before wiping every manual heal/scratch on the frame.
 

--- a/negpy/desktop/view/main_window.py
+++ b/negpy/desktop/view/main_window.py
@@ -328,6 +328,8 @@ class MainWindow(QMainWindow):
         self.canvas.scratch_completed.connect(self.controller.handle_heal_stroke_completed)
         self.canvas.straighten_completed.connect(self.controller.handle_straighten_completed)
         self.canvas.local_mask_selected.connect(self.controller.select_local_mask)
+        self.canvas.local_mask_edited.connect(self.controller.handle_local_mask_edited)
+        self.canvas.local_vertex_deleted.connect(self.controller.delete_local_vertex)
 
         self.controller.export_progress.connect(self._on_export_progress)
         self.controller.export_finished.connect(self._on_export_finished)

--- a/negpy/desktop/view/sidebar/local.py
+++ b/negpy/desktop/view/sidebar/local.py
@@ -1,4 +1,6 @@
-from PyQt6.QtWidgets import QPushButton, QHBoxLayout, QLabel
+from PyQt6.QtCore import Qt
+from PyQt6.QtGui import QColor
+from PyQt6.QtWidgets import QPushButton, QHBoxLayout, QLabel, QListWidget, QListWidgetItem
 import qtawesome as qta
 from negpy.desktop.view.widgets.sliders import CompactSlider
 from negpy.desktop.view.sidebar.base import BaseSidebar
@@ -17,8 +19,10 @@ class LocalSidebar(BaseSidebar):
         self.draw_btn = self._tool_toggle(
             "fa5s.draw-polygon",
             "Draw Mask",
-            "Click to place vertices; double-click, Enter, or a click near the start closes. "
-            "Click inside an existing mask to select it. Esc cancels the current shape.",
+            "Draw a new mask: click to place vertices; double-click, Enter, or a click near "
+            "the start closes; Esc cancels. Select a mask from the list to edit it (no need to "
+            "re-enter this tool): drag a vertex to move it, click an edge '+' dot to add a point, "
+            "right-click a vertex to delete it.",
         )
         self.show_btn = self._small_toggle("fa5s.eye", "Show Masks", False, "Show or hide the mask outlines on the canvas")
 
@@ -26,6 +30,12 @@ class LocalSidebar(BaseSidebar):
         button_row.addWidget(self.draw_btn)
         button_row.addWidget(self.show_btn)
         self.layout.addLayout(button_row)
+
+        self.mask_list = QListWidget()
+        self.mask_list.setToolTip("Click a mask to select it — then edit its points on the canvas and tune the sliders below.")
+        self.mask_list.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        self.mask_list.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        self.layout.addWidget(self.mask_list)
 
         self.strength_slider = CompactSlider("Strength", -1.0, 1.0, 0.3, step=0.05, precision=100, has_neutral=True, unit=" EV")
         self.strength_slider.setToolTip("EV adjustment for the selected mask — positive brightens (dodge), negative darkens (burn)")
@@ -59,6 +69,7 @@ class LocalSidebar(BaseSidebar):
     def _connect_signals(self) -> None:
         self.draw_btn.toggled.connect(self._on_draw_toggled)
         self.show_btn.toggled.connect(self.controller.set_local_overlay_visible)
+        self.mask_list.itemClicked.connect(lambda item: self.controller.select_local_mask(self.mask_list.row(item)))
         self.strength_slider.valueChanged.connect(lambda v: self.controller.update_selected_local_mask(strength=float(v)))
         self.feather_slider.valueChanged.connect(lambda v: self.controller.update_selected_local_mask(feather=float(v)))
         self.delete_btn.clicked.connect(self.controller.delete_selected_local_mask)
@@ -80,6 +91,22 @@ class LocalSidebar(BaseSidebar):
 
             idx = self.state.local_selected_mask
             has_selection = 0 <= idx < n
+
+            self.mask_list.blockSignals(True)
+            self.mask_list.clear()
+            for i, mask in enumerate(conf.masks):
+                kind = "Dodge" if mask.strength >= 0 else "Burn"
+                item = QListWidgetItem(f"{i + 1}.  {kind}   {mask.strength:+.2f} EV")
+                item.setForeground(QColor(232, 200, 74) if mask.strength >= 0 else QColor(74, 143, 232))
+                self.mask_list.addItem(item)
+            if has_selection:
+                self.mask_list.setCurrentRow(idx)
+            else:
+                self.mask_list.clearSelection()
+            self.mask_list.setVisible(n > 0)
+            if n:
+                self.mask_list.setFixedHeight(self.mask_list.sizeHintForRow(0) * n + 2 * self.mask_list.frameWidth())
+            self.mask_list.blockSignals(False)
             self.delete_btn.setEnabled(has_selection)
             self.strength_slider.setEnabled(has_selection)
             self.feather_slider.setEnabled(has_selection)

--- a/negpy/desktop/view/sidebar/local.py
+++ b/negpy/desktop/view/sidebar/local.py
@@ -1,12 +1,24 @@
-from PyQt6.QtCore import Qt
-from PyQt6.QtGui import QColor
-from PyQt6.QtWidgets import QPushButton, QHBoxLayout, QLabel, QListWidget, QListWidgetItem
+from PyQt6.QtCore import Qt, QSize, pyqtSignal
+from PyQt6.QtWidgets import QPushButton, QHBoxLayout, QLabel, QListWidget, QListWidgetItem, QWidget
 import qtawesome as qta
 from negpy.desktop.view.widgets.sliders import CompactSlider
 from negpy.desktop.view.sidebar.base import BaseSidebar
 from negpy.desktop.session import ToolMode
 from negpy.desktop.view.styles.templates import field_label_qss
 from negpy.desktop.view.styles.theme import THEME
+
+
+_MASK_ROW_H = 30
+
+
+class _MaskRow(QWidget):
+    """One mask list row; clicking its background (not the buttons) selects the mask."""
+
+    clicked = pyqtSignal()
+
+    def mousePressEvent(self, event) -> None:
+        self.clicked.emit()
+        super().mousePressEvent(event)
 
 
 class LocalSidebar(BaseSidebar):
@@ -24,23 +36,26 @@ class LocalSidebar(BaseSidebar):
             "re-enter this tool): drag a vertex to move it, click an edge '+' dot to add a point, "
             "right-click a vertex to delete it.",
         )
-        self.show_btn = self._small_toggle("fa5s.eye", "Show Masks", False, "Show or hide the mask outlines on the canvas")
-
-        button_row = QHBoxLayout()
-        button_row.addWidget(self.draw_btn)
-        button_row.addWidget(self.show_btn)
-        self.layout.addLayout(button_row)
+        self.layout.addWidget(self.draw_btn)
 
         self.mask_list = QListWidget()
-        self.mask_list.setToolTip("Click a mask to select it — then edit its points on the canvas and tune the sliders below.")
+        self.mask_list.setToolTip(
+            "Click a mask to select it. Use the eye to show/hide its outline and the trash icon to delete it."
+        )
         self.mask_list.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
         self.mask_list.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        # The row is a custom widget, so drop the app-wide item padding/margin/border
+        # that would otherwise squeeze and clip it.
+        self.mask_list.setStyleSheet(
+            "QListView::item { border: none; margin: 0px; padding: 0px; }"
+            "QListView::item:selected { background-color: #2A2A2A; }"
+        )
         self.layout.addWidget(self.mask_list)
 
         self.strength_slider = CompactSlider("Strength", -1.0, 1.0, 0.3, step=0.05, precision=100, has_neutral=True, unit=" EV")
         self.strength_slider.setToolTip("EV adjustment for the selected mask — positive brightens (dodge), negative darkens (burn)")
 
-        self.feather_slider = CompactSlider("Feather", 0.0, 0.15, 0.02, step=0.005, precision=1000)
+        self.feather_slider = CompactSlider("Feather", 0.0, 0.15, 0.04, step=0.005, precision=1000)
         self.feather_slider.setToolTip("Edge softness for the selected mask")
 
         slider_row = QHBoxLayout()
@@ -48,46 +63,69 @@ class LocalSidebar(BaseSidebar):
         slider_row.addWidget(self.feather_slider)
         self.layout.addLayout(slider_row)
 
-        status_row = QHBoxLayout()
         self.mask_count_label = QLabel("0 masks")
         self.mask_count_label.setStyleSheet(field_label_qss())
-        self.delete_btn = QPushButton(" Delete")
-        self.delete_btn.setIcon(qta.icon("fa5s.times", color=THEME.text_primary))
-        self.delete_btn.setToolTip("Delete the selected mask")
-        self.delete_btn.setEnabled(False)
-        self.clear_btn = QPushButton(" Clear All")
-        self.clear_btn.setIcon(qta.icon("fa5s.trash-alt", color=THEME.text_primary))
-        self.clear_btn.setToolTip("Remove all dodge/burn masks")
-        status_row.addWidget(self.mask_count_label)
-        status_row.addStretch()
-        status_row.addWidget(self.delete_btn)
-        status_row.addWidget(self.clear_btn)
-        self.layout.addLayout(status_row)
+        self.layout.addWidget(self.mask_count_label)
 
         self.layout.addStretch()
 
     def _connect_signals(self) -> None:
         self.draw_btn.toggled.connect(self._on_draw_toggled)
-        self.show_btn.toggled.connect(self.controller.set_local_overlay_visible)
-        self.mask_list.itemClicked.connect(lambda item: self.controller.select_local_mask(self.mask_list.row(item)))
         self.strength_slider.valueChanged.connect(lambda v: self.controller.update_selected_local_mask(strength=float(v)))
         self.feather_slider.valueChanged.connect(lambda v: self.controller.update_selected_local_mask(feather=float(v)))
-        self.delete_btn.clicked.connect(self.controller.delete_selected_local_mask)
-        self.clear_btn.clicked.connect(self.controller.clear_local)
 
     def _on_draw_toggled(self, checked: bool) -> None:
         self.controller.set_active_tool(ToolMode.LOCAL_DRAW if checked else ToolMode.NONE)
+
+    def _row_icon_btn(self, icon_name: str, checkable: bool) -> QPushButton:
+        btn = QPushButton()
+        btn.setCheckable(checkable)
+        btn.setFlat(True)
+        btn.setIcon(qta.icon(icon_name, color=THEME.text_primary))
+        btn.setFixedSize(26, 22)
+        btn.setStyleSheet("QPushButton {border: none; padding: 0px;}")
+        return btn
+
+    def _build_mask_row(self, i: int, mask) -> _MaskRow:
+        kind = "Dodge" if mask.strength >= 0 else "Burn"
+        row = _MaskRow()
+        lay = QHBoxLayout(row)
+        lay.setContentsMargins(6, 2, 4, 2)
+        lay.setSpacing(4)
+
+        label = QLabel(f"{i + 1}.  {kind}   {mask.strength:+.2f} EV")
+        label.setStyleSheet(f"color: {'#E8C84A' if mask.strength >= 0 else '#4A8FE8'};")
+        label.setAttribute(Qt.WidgetAttribute.WA_TransparentForMouseEvents, True)
+
+        visible = i not in self.state.local_hidden_masks
+        eye = self._row_icon_btn("fa5s.eye" if visible else "fa5s.eye-slash", checkable=True)
+        eye.setChecked(visible)
+        eye.setToolTip("Show or hide this mask's outline on the canvas")
+        delete = self._row_icon_btn("fa5s.trash-alt", checkable=False)
+        delete.setToolTip("Delete this mask")
+
+        lay.addWidget(label)
+        lay.addStretch()
+        lay.addWidget(eye)
+        lay.addWidget(delete)
+
+        row.clicked.connect(lambda i=i: self.controller.select_local_mask(i))
+        eye.toggled.connect(lambda checked, i=i, b=eye: self._on_eye_toggled(i, checked, b))
+        delete.clicked.connect(lambda _=False, i=i: self.controller.delete_local_mask(i))
+        return row
+
+    def _on_eye_toggled(self, i: int, checked: bool, btn: QPushButton) -> None:
+        btn.setIcon(qta.icon("fa5s.eye" if checked else "fa5s.eye-slash", color=THEME.text_primary))
+        self.controller.set_local_mask_visible(i, checked)
 
     def sync_ui(self) -> None:
         conf = self.state.config.local
         self.block_signals(True)
         try:
             self.draw_btn.setChecked(self.state.active_tool == ToolMode.LOCAL_DRAW)
-            self.show_btn.setChecked(self.state.show_local_overlay)
 
             n = len(conf.masks)
             self.mask_count_label.setText(f"{n} mask{'s' if n != 1 else ''}")
-            self.clear_btn.setEnabled(n > 0)
 
             idx = self.state.local_selected_mask
             has_selection = 0 <= idx < n
@@ -95,19 +133,19 @@ class LocalSidebar(BaseSidebar):
             self.mask_list.blockSignals(True)
             self.mask_list.clear()
             for i, mask in enumerate(conf.masks):
-                kind = "Dodge" if mask.strength >= 0 else "Burn"
-                item = QListWidgetItem(f"{i + 1}.  {kind}   {mask.strength:+.2f} EV")
-                item.setForeground(QColor(232, 200, 74) if mask.strength >= 0 else QColor(74, 143, 232))
+                item = QListWidgetItem()
+                row = self._build_mask_row(i, mask)
+                item.setSizeHint(QSize(0, _MASK_ROW_H))
                 self.mask_list.addItem(item)
+                self.mask_list.setItemWidget(item, row)
             if has_selection:
                 self.mask_list.setCurrentRow(idx)
             else:
                 self.mask_list.clearSelection()
             self.mask_list.setVisible(n > 0)
             if n:
-                self.mask_list.setFixedHeight(self.mask_list.sizeHintForRow(0) * n + 2 * self.mask_list.frameWidth())
+                self.mask_list.setFixedHeight(_MASK_ROW_H * n + 2 * self.mask_list.frameWidth())
             self.mask_list.blockSignals(False)
-            self.delete_btn.setEnabled(has_selection)
             self.strength_slider.setEnabled(has_selection)
             self.feather_slider.setEnabled(has_selection)
             if has_selection:
@@ -118,5 +156,5 @@ class LocalSidebar(BaseSidebar):
             self.block_signals(False)
 
     def block_signals(self, blocked: bool) -> None:
-        for w in [self.draw_btn, self.show_btn, self.strength_slider, self.feather_slider]:
+        for w in [self.draw_btn, self.strength_slider, self.feather_slider]:
             w.blockSignals(blocked)

--- a/negpy/domain/models.py
+++ b/negpy/domain/models.py
@@ -410,7 +410,7 @@ class WorkspaceConfig:
                     PolygonMask(
                         vertices=verts,
                         strength=float(m.get("strength", 0.3)),
-                        feather=float(m.get("feather", 0.02)),
+                        feather=float(m.get("feather", 0.04)),
                     )
                 )
             return LocalAdjustmentsConfig(masks=tuple(masks))

--- a/negpy/features/geometry/logic.py
+++ b/negpy/features/geometry/logic.py
@@ -1,6 +1,6 @@
 import math
 from dataclasses import replace
-from typing import NamedTuple, Optional, Tuple
+from typing import List, NamedTuple, Optional, Tuple
 
 import cv2
 import numpy as np
@@ -1082,6 +1082,38 @@ def map_coords_to_geometry(
     ny_new = np.clip(py / max(h, 1), 0.0, 1.0)
 
     return float(nx_new), float(ny_new)
+
+
+def smooth_polyline(
+    pts: List[Tuple[float, float]],
+    closed: bool = True,
+    samples_per_seg: int = 16,
+) -> List[Tuple[float, float]]:
+    """Densify a polyline into a uniform Catmull-Rom curve through its points.
+
+    The curve interpolates every control point (a control point is the t=0 sample
+    of its segment). Fewer than 3 points are returned unchanged. `closed` wraps the
+    tangents so the loop joins smoothly; open keeps the endpoints fixed.
+    """
+    n = len(pts)
+    if n < 3:
+        return [(float(x), float(y)) for x, y in pts]
+
+    p = np.asarray(pts, dtype=np.float64)
+    t = np.linspace(0.0, 1.0, samples_per_seg, endpoint=False)[:, None]
+    t2, t3 = t * t, t * t * t
+    out: List[Tuple[float, float]] = []
+    n_seg = n if closed else n - 1
+    for i in range(n_seg):
+        p0 = p[(i - 1) % n] if closed else p[max(i - 1, 0)]
+        p1 = p[i]
+        p2 = p[(i + 1) % n] if closed else p[i + 1]
+        p3 = p[(i + 2) % n] if closed else p[min(i + 2, n - 1)]
+        seg = 0.5 * (2 * p1 + (p2 - p0) * t + (2 * p0 - 5 * p1 + 4 * p2 - p3) * t2 + (-p0 + 3 * p1 - 3 * p2 + p3) * t3)
+        out.extend((float(x), float(y)) for x, y in seg)
+    if not closed:
+        out.append((float(p[-1][0]), float(p[-1][1])))
+    return out
 
 
 def translate_manual_crop_rect(

--- a/negpy/features/local/logic.py
+++ b/negpy/features/local/logic.py
@@ -4,7 +4,7 @@ import cv2
 import numpy as np
 
 from negpy.features.local.models import LocalAdjustmentsConfig
-from negpy.features.geometry.logic import map_coords_to_geometry
+from negpy.features.geometry.logic import map_coords_to_geometry, smooth_polyline
 
 
 def _rasterise_mask(
@@ -67,7 +67,7 @@ def compute_local_ev_map(
         ]
 
         sigma_px = mask.feather * short_side
-        alpha = _rasterise_mask(transformed, h, w, sigma_px)
+        alpha = _rasterise_mask(smooth_polyline(transformed, closed=True), h, w, sigma_px)
         ev += mask.strength * alpha
 
     return ev

--- a/negpy/features/local/models.py
+++ b/negpy/features/local/models.py
@@ -7,7 +7,7 @@ class PolygonMask:
     # Vertices in raw-image normalised coords [0,1]×[0,1].
     vertices: Tuple[Tuple[float, float], ...] = field(default_factory=tuple)
     strength: float = 0.3  # EV stops; positive = dodge, negative = burn
-    feather: float = 0.02  # Gaussian sigma as fraction of shorter image dimension
+    feather: float = 0.04  # Gaussian sigma as fraction of shorter image dimension
 
 
 @dataclass(frozen=True)

--- a/negpy/features/retouch/logic.py
+++ b/negpy/features/retouch/logic.py
@@ -6,7 +6,7 @@ import numpy as np
 from numba import njit  # type: ignore
 
 from negpy.domain.types import LUMA_B, LUMA_G, LUMA_R, ImageBuffer
-from negpy.features.geometry.logic import map_coords_to_geometry
+from negpy.features.geometry.logic import map_coords_to_geometry, smooth_polyline
 from negpy.features.retouch.models import HEAL_SIZE_REF
 from negpy.kernel.image.logic import get_luminance, working_oetf_decode, working_oetf_encode
 from negpy.kernel.image.validation import ensure_image
@@ -661,6 +661,9 @@ def build_heal_regions(
 
     for points, size, sdx, sdy, gate in entries[:max_regions]:
         chain = np.array([_map(p[0], p[1]) for p in points], dtype=np.float32)
+        # Curve the heal band through its waypoints (spots/2-point strokes unaffected).
+        if len(chain) >= 3:
+            chain = np.array(smooth_polyline([(float(x), float(y)) for x, y in chain], closed=False), dtype=np.float32)
         # Brush size is a DIAMETER at HEAL_SIZE_REF scale: the footprint must match
         # the cursor (overlay._brush_screen_radius draws size/(2·HEAL_SIZE_REF)).
         radius = max(1.0, float(size) * (max(fw, fh) / HEAL_SIZE_REF) * 0.5)

--- a/tests/test_canvas_mask_edit.py
+++ b/tests/test_canvas_mask_edit.py
@@ -1,0 +1,64 @@
+from PyQt6.QtCore import QEvent, QPointF, QRectF, Qt
+from PyQt6.QtGui import QMouseEvent
+
+from negpy.desktop.session import AppState, ToolMode
+from negpy.desktop.view.canvas.overlay import CanvasOverlay
+
+_TRIANGLE = [QPointF(20, 20), QPointF(80, 20), QPointF(50, 80)]
+
+
+def _overlay_with_mask(tool: ToolMode = ToolMode.LOCAL_DRAW) -> CanvasOverlay:
+    overlay = CanvasOverlay(AppState())
+    overlay._view_rect = QRectF(0, 0, 100, 100)
+    overlay.set_tool_mode(tool)
+    overlay.state.local_selected_mask = 0
+    overlay._local_mask_screen_polys = [list(_TRIANGLE)]  # normally set during paint
+    return overlay
+
+
+def test_selected_mask_editable_without_draw_tool() -> None:
+    # No Draw Mask tool active: pressing a vertex of the selected mask still edits it.
+    overlay = _overlay_with_mask(ToolMode.NONE)
+    ev = QMouseEvent(
+        QEvent.Type.MouseButtonPress,
+        QPointF(20, 20),
+        Qt.MouseButton.LeftButton,
+        Qt.MouseButton.LeftButton,
+        Qt.KeyboardModifier.NoModifier,
+    )
+    overlay.mousePressEvent(ev)
+    assert overlay._local_drag_vertex == 0
+    assert ev.isAccepted()
+
+
+def test_press_grabs_mask_vertex() -> None:
+    overlay = _overlay_with_mask()
+    overlay._handle_lasso_press(QPointF(20, 20))  # on vertex 0
+    assert overlay._local_drag_vertex == 0
+    assert overlay._local_edit_verts is not None and len(overlay._local_edit_verts) == 3
+    assert overlay._lasso_drawing is False  # did not start a fresh shape
+
+
+def test_press_on_edge_midpoint_inserts_point() -> None:
+    overlay = _overlay_with_mask()
+    overlay._handle_lasso_press(QPointF(50, 20))  # midpoint of edge 0->1
+    assert overlay._local_edit_verts is not None and len(overlay._local_edit_verts) == 4
+    assert overlay._local_drag_vertex == 1  # inserted right after vertex 0
+
+
+def test_right_click_deletes_vertex() -> None:
+    overlay = _overlay_with_mask()
+    emitted: list = []
+    overlay.local_vertex_deleted.connect(lambda i, v: emitted.append((i, v)))
+    assert overlay.try_delete_local_vertex(QPointF(80, 20)) is True  # vertex 1
+    assert emitted == [(0, 1)]
+    assert overlay.try_delete_local_vertex(QPointF(5, 5)) is False  # empty space
+
+
+def test_press_selects_mask_when_off_handles() -> None:
+    overlay = _overlay_with_mask()
+    selected: list = []
+    overlay.local_mask_selected.connect(selected.append)
+    overlay._handle_lasso_press(QPointF(50, 45))  # inside, clear of vertices/midpoints
+    assert selected == [0]
+    assert overlay._local_drag_vertex is None

--- a/tests/test_canvas_polyline_finish.py
+++ b/tests/test_canvas_polyline_finish.py
@@ -55,6 +55,20 @@ def test_enter_ignores_incomplete_lasso() -> None:
     assert len(overlay._lasso_pts) == 2
 
 
+def test_inflight_points_track_view_rect_change() -> None:
+    # Zoom/pan while drawing must keep placed points pinned to the image, not the screen.
+    overlay = _overlay_with_view()  # old rect (0,0,100,100)
+    overlay._lasso_pts = [QPointF(25, 25), QPointF(75, 50)]
+    overlay._scratch_pts = [QPointF(50, 50)]
+    old = QRectF(0, 0, 100, 100)
+    overlay._view_rect = QRectF(50, 50, 200, 200)  # new zoomed/panned rect
+    overlay._remap_inflight_points(old)
+    # (25,25) sits at viewport-norm (0.25,0.25) -> 50 + 0.25*200 = 100
+    assert overlay._lasso_pts[0] == QPointF(100, 100)
+    assert overlay._lasso_pts[1] == QPointF(200, 150)
+    assert overlay._scratch_pts[0] == QPointF(150, 150)
+
+
 def test_enter_noop_without_active_draw() -> None:
     overlay = _overlay_with_view()
     overlay.set_tool_mode(ToolMode.DUST_PICK)

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -383,15 +383,47 @@ class TestAppController(unittest.TestCase):
 
         self.assertEqual(self.controller.state.active_tool, ToolMode.NONE)
 
-    def test_local_overlay_visible_default_on(self):
-        self.assertTrue(AppState().show_local_overlay)
+    def _seed_two_masks(self):
+        from negpy.features.local.models import LocalAdjustmentsConfig, PolygonMask
 
-    def test_set_local_overlay_visible_toggles_flag(self):
+        verts = ((0.1, 0.1), (0.9, 0.1), (0.5, 0.9))
+        masks = (
+            PolygonMask(vertices=verts, strength=0.3, feather=0.02),
+            PolygonMask(vertices=verts, strength=-0.3, feather=0.02),
+        )
+        self.controller.state.config = replace(self.controller.state.config, local=LocalAdjustmentsConfig(masks=masks))
+
+    def test_set_local_mask_visible_toggles_hidden_set(self):
+        self._seed_two_masks()
         self.controller.canvas = None  # tolerate no registered canvas
-        self.controller.set_local_overlay_visible(False)
-        self.assertFalse(self.controller.state.show_local_overlay)
-        self.controller.set_local_overlay_visible(True)
-        self.assertTrue(self.controller.state.show_local_overlay)
+        self.controller.set_local_mask_visible(1, False)
+        self.assertEqual(self.controller.state.local_hidden_masks, {1})
+        self.controller.set_local_mask_visible(1, True)
+        self.assertEqual(self.controller.state.local_hidden_masks, set())
+
+    def test_delete_local_mask_confirmed_remaps_view_indices(self):
+        self._seed_two_masks()
+        self.controller.request_render = MagicMock()
+        self.controller.state.local_selected_mask = 1
+        self.controller.state.local_hidden_masks = {1}
+
+        with patch("negpy.desktop.view.confirm.confirm_delete_mask", return_value=True):
+            self.controller.delete_local_mask(0)
+
+        saved_config = self.mock_session_manager.update_config.call_args.args[0]
+        self.assertEqual(len(saved_config.local.masks), 1)
+        self.assertEqual(self.controller.state.local_selected_mask, 0)
+        self.assertEqual(self.controller.state.local_hidden_masks, {0})
+
+    def test_delete_local_mask_cancelled_is_noop(self):
+        self._seed_two_masks()
+        self.controller.request_render = MagicMock()
+        self.mock_session_manager.update_config.reset_mock()
+
+        with patch("negpy.desktop.view.confirm.confirm_delete_mask", return_value=False):
+            self.controller.delete_local_mask(0)
+
+        self.mock_session_manager.update_config.assert_not_called()
 
     def test_lasso_completion_adds_mask_and_exits_draw_mode(self):
         import numpy as np

--- a/tests/test_local_logic.py
+++ b/tests/test_local_logic.py
@@ -3,6 +3,7 @@ import unittest
 import numpy as np
 
 from negpy.domain.models import WorkspaceConfig
+from negpy.features.geometry.logic import smooth_polyline
 from negpy.features.local.logic import compute_local_ev_map
 from negpy.features.local.models import LocalAdjustmentsConfig, PolygonMask
 
@@ -52,6 +53,36 @@ class TestComputeEvMap(unittest.TestCase):
         self.assertGreaterEqual(float(ev.min()), 0.0)
         self.assertLessEqual(float(ev.max()), 1.0 + 1e-5)
         self.assertGreater(float(ev[50, 50]), 0.9)
+
+
+class TestSmoothPolyline(unittest.TestCase):
+    """Mask outlines and heal paths are always drawn as a Catmull-Rom curve."""
+
+    def test_short_input_returned_unchanged(self) -> None:
+        self.assertEqual(smooth_polyline([(0.0, 0.0), (1.0, 1.0)]), [(0.0, 0.0), (1.0, 1.0)])
+
+    def test_closed_interpolates_control_points(self) -> None:
+        sq = [(0.25, 0.25), (0.75, 0.25), (0.75, 0.75), (0.25, 0.75)]
+        out = smooth_polyline(sq, closed=True, samples_per_seg=8)
+        self.assertEqual(len(out), 4 * 8)  # denser than the 4 control points
+        for i, p in enumerate(sq):  # each control point is the t=0 sample of its segment
+            self.assertAlmostEqual(out[i * 8][0], p[0])
+            self.assertAlmostEqual(out[i * 8][1], p[1])
+
+    def test_open_keeps_endpoints(self) -> None:
+        line = [(0.1, 0.1), (0.5, 0.2), (0.9, 0.1)]
+        out = smooth_polyline(line, closed=False, samples_per_seg=8)
+        self.assertEqual(out[0], (0.1, 0.1))
+        self.assertEqual(out[-1], (0.9, 0.1))
+        self.assertGreater(len(out), len(line))
+
+    def test_smoothed_square_mask_still_fills_interior(self) -> None:
+        # Smoothing is unconditional in compute_local_ev_map; the interior/exterior
+        # invariants the pipeline relies on must survive it.
+        cfg = LocalAdjustmentsConfig(masks=(_center_square_mask(1.0),))
+        ev = compute_local_ev_map(cfg, 100, 100, (100, 100))
+        self.assertAlmostEqual(float(ev[50, 50]), 1.0, places=5)
+        self.assertAlmostEqual(float(ev[5, 5]), 0.0, places=5)
 
 
 class TestLocalSerialization(unittest.TestCase):

--- a/tests/test_retouch_logic.py
+++ b/tests/test_retouch_logic.py
@@ -27,6 +27,27 @@ def _regions_for_spot(nx, ny, size_px, shape):
     return build_heal_regions([([[nx, ny]], size, 0.15, 0.0)], [], (h, w), 0, 0.0, False, False, 0.0, (w, h))
 
 
+def test_polyline_stroke_is_smoothed():
+    """A >=3-waypoint scratch heals along a densified Catmull-Rom chain."""
+    h, w = 120, 160
+    pts = [[0.2, 0.2], [0.5, 0.35], [0.8, 0.2], [0.6, 0.6]]
+    reg_i, _reg_f, _pts = build_heal_regions(
+        [(pts, _size_at_ref(10.0, (h, w)), 0.1, 0.0)], [], (h, w), 0, 0.0, False, False, 0.0, (w, h)
+    )
+    chain_len = int(reg_i[0][1])
+    assert chain_len > len(pts), "polyline heal chain was not smoothed/densified"
+
+
+def test_two_point_stroke_not_densified():
+    """A straight 2-point stroke stays exactly 2 chain points (nothing to smooth)."""
+    h, w = 120, 160
+    pts = [[0.3, 0.3], [0.7, 0.6]]
+    reg_i, _reg_f, _pts = build_heal_regions(
+        [(pts, _size_at_ref(10.0, (h, w)), 0.1, 0.0)], [], (h, w), 0, 0.0, False, False, 0.0, (w, h)
+    )
+    assert int(reg_i[0][1]) == 2
+
+
 def test_manual_dust_removal_effect():
     # Use grey background and white dust (inverted film scan scenario)
     img = np.full((100, 100, 3), 0.5, dtype=np.float32)


### PR DESCRIPTION
closes #461

- Smooth D&B mask outlines and Scratch heal paths as Catmull-Rom curves via a shared smooth_polyline helper (EV map, heal regions, overlay, draw preview).
- Edit any selected mask on canvas: drag a vertex, click an edge to add one, right-click to delete — in the draw tool or idle. Select from a new mask list in the Dodge & Burn panel.
- Fix in-progress polyline points drifting off the image on zoom/pan/resize.