### PR TITLE
Add jump-to-row search to the shortcut overview dialog, sharing search helpers with Customize.

### DIFF
--- a/negpy/desktop/view/shortcut_editor_search.py
+++ b/negpy/desktop/view/shortcut_editor_search.py
@@ -1,9 +1,13 @@
-"""Search index for the Customize Shortcuts dialog."""
+"""Search index for shortcut dialogs (Customize and overview)."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Literal
+
+from PyQt6.QtCore import QModelIndex, QPoint, Qt, QSortFilterProxyModel
+from PyQt6.QtGui import QStandardItemModel
+from PyQt6.QtWidgets import QCompleter, QScrollArea, QWidget
 
 from negpy.desktop.view.shortcut_registry import (
     REGISTRY,
@@ -12,8 +16,76 @@ from negpy.desktop.view.shortcut_registry import (
     category_editor_rows,
 )
 
+TARGET_ROLE = Qt.ItemDataRole.UserRole
+SEARCH_ROLE = Qt.ItemDataRole.UserRole + 1
+HIGHLIGHT_MS = 1800
 
 RowKind = Literal["single", "slider"]
+
+
+class ShortcutSearchProxy(QSortFilterProxyModel):
+    def __init__(self, parent=None) -> None:
+        super().__init__(parent)
+        self._query = ""
+
+    def set_query(self, query: str) -> None:
+        needle = (query or "").strip().casefold()
+        if needle == self._query:
+            return
+        self._query = needle
+        self.invalidateFilter()
+
+    def filterAcceptsRow(self, source_row: int, source_parent: QModelIndex) -> bool:  # noqa: N802
+        if not self._query:
+            return False
+        model = self.sourceModel()
+        if model is None:
+            return False
+        index = model.index(source_row, 0, source_parent)
+        search_text = model.data(index, SEARCH_ROLE) or ""
+        return self._query in search_text
+
+
+def target_id_from_completer_index(
+    completer: QCompleter,
+    search_model: QStandardItemModel,
+    search_proxy: ShortcutSearchProxy,
+    index: QModelIndex,
+) -> str:
+    if not index.isValid():
+        return ""
+    completion_model = completer.completionModel()
+    proxy_index = completion_model.mapToSource(index)
+    source_index = search_proxy.mapToSource(proxy_index)
+    if not source_index.isValid():
+        return ""
+    target_id = search_model.data(source_index, TARGET_ROLE)
+    return str(target_id) if target_id else ""
+
+
+def first_matching_target_id(
+    completer: QCompleter,
+    search_model: QStandardItemModel,
+    search_proxy: ShortcutSearchProxy,
+) -> str:
+    completion_model = completer.completionModel()
+    for row in range(completion_model.rowCount()):
+        target_id = target_id_from_completer_index(completer, search_model, search_proxy, completion_model.index(row, 0))
+        if target_id:
+            return target_id
+    return ""
+
+
+def scroll_row_to_center(scroll: QScrollArea, row: QWidget) -> None:
+    content = scroll.widget()
+    if content is None:
+        return
+    center = row.mapTo(content, QPoint(0, row.height() // 2))
+    bar = scroll.verticalScrollBar()
+    viewport_h = scroll.viewport().height()
+    value = center.y() - viewport_h // 2
+    value = max(bar.minimum(), min(bar.maximum(), value))
+    bar.setValue(value)
 
 
 @dataclass(frozen=True)

--- a/negpy/desktop/view/shortcut_editor_search.py
+++ b/negpy/desktop/view/shortcut_editor_search.py
@@ -18,6 +18,8 @@ from negpy.desktop.view.shortcut_registry import (
 
 TARGET_ROLE = Qt.ItemDataRole.UserRole
 SEARCH_ROLE = Qt.ItemDataRole.UserRole + 1
+BINDING_KEYS_ROLE = Qt.ItemDataRole.UserRole + 2
+TEXT_SEARCH_ROLE = Qt.ItemDataRole.UserRole + 3
 HIGHLIGHT_MS = 1800
 
 RowKind = Literal["single", "slider"]
@@ -34,6 +36,8 @@ class ShortcutSearchProxy(QSortFilterProxyModel):
             return
         self._query = needle
         self.invalidateFilter()
+        if self._query:
+            self.sort(0, Qt.SortOrder.AscendingOrder)
 
     def filterAcceptsRow(self, source_row: int, source_parent: QModelIndex) -> bool:  # noqa: N802
         if not self._query:
@@ -42,8 +46,33 @@ class ShortcutSearchProxy(QSortFilterProxyModel):
         if model is None:
             return False
         index = model.index(source_row, 0, source_parent)
-        search_text = model.data(index, SEARCH_ROLE) or ""
-        return self._query in search_text
+        binding_keys = model.data(index, BINDING_KEYS_ROLE) or ""
+        if self._query in binding_keys.split():
+            return True
+        if len(self._query) < 2:
+            return False
+        text = model.data(index, TEXT_SEARCH_ROLE) or ""
+        return self._query in text
+
+    def lessThan(self, source_left: QModelIndex, source_right: QModelIndex) -> bool:  # noqa: N802
+        if not self._query:
+            return super().lessThan(source_left, source_right)
+        left_rank = self._binding_match_rank(source_left)
+        right_rank = self._binding_match_rank(source_right)
+        if left_rank != right_rank:
+            return left_rank < right_rank
+        left_label = self.sourceModel().data(source_left, Qt.ItemDataRole.DisplayRole) or ""
+        right_label = self.sourceModel().data(source_right, Qt.ItemDataRole.DisplayRole) or ""
+        return left_label.casefold() < right_label.casefold()
+
+    def _binding_match_rank(self, source_index: QModelIndex) -> int:
+        model = self.sourceModel()
+        if model is None or not source_index.isValid():
+            return 1
+        keys = model.data(source_index, BINDING_KEYS_ROLE) or ""
+        if self._query in keys.split():
+            return 0
+        return 1
 
 
 def target_id_from_completer_index(
@@ -94,20 +123,68 @@ class ShortcutEditorTarget:
     label: str
     category: str
     search_text: str
+    text_search: str
     row_kind: RowKind
+    binding_keys: frozenset[str]
+
+
+def binding_keys_display(keys: frozenset[str]) -> str:
+    return " ".join(sorted(keys))
+
+
+def normalize_binding(key: str) -> str:
+    return key.strip().casefold()
+
+
+def _binding_keys(bindings: dict[str, str], *action_ids: str) -> frozenset[str]:
+    keys: set[str] = set()
+    for action_id in action_ids:
+        key = bindings.get(action_id) or REGISTRY[action_id].default_key
+        if key:
+            keys.add(normalize_binding(key))
+    return frozenset(keys)
+
+
+def action_id_for_binding(bindings: dict[str, str], portable: str) -> str | None:
+    needle = normalize_binding(portable)
+    for action_id, key in bindings.items():
+        if key and normalize_binding(key) == needle:
+            return action_id
+    return None
+
+
+def target_ids_for_binding(targets: list[ShortcutEditorTarget], portable: str) -> list[str]:
+    needle = normalize_binding(portable)
+    return [target.target_id for target in targets if needle in target.binding_keys]
+
+
+def _text_tokens(*parts: str) -> str:
+    return _tokens(*parts)
+
+
+def _combined_search_text(text_search: str, binding_keys: frozenset[str]) -> str:
+    keys = binding_keys_display(binding_keys)
+    if text_search and keys:
+        return f"{text_search} {keys}"
+    return text_search or keys
+
+
+def configure_search_completer(completer: QCompleter) -> None:
+    """Keep popup rows aligned with proxy filtering (not display-label prefix matching)."""
+    completer.setCompletionMode(QCompleter.CompletionMode.UnfilteredPopupCompletion)
+    completer.setCaseSensitivity(Qt.CaseSensitivity.CaseInsensitive)
+    completer.setCompletionColumn(0)
+    completer.setCompletionRole(SEARCH_ROLE)
+    completer.setFilterMode(Qt.MatchFlag.MatchContains)
 
 
 def _tokens(*parts: str) -> str:
     return " ".join(p.strip() for p in parts if p and str(p).strip()).casefold()
 
 
-def _binding_tokens(bindings: dict[str, str], *action_ids: str) -> str:
-    return " ".join(bindings.get(action_id, "") for action_id in action_ids if bindings.get(action_id, ""))
-
-
 def build_shortcut_editor_targets(bindings: dict[str, str] | None = None) -> list[ShortcutEditorTarget]:
     """Build navigable editor rows with precomputed search text (includes current bindings)."""
-    resolved = bindings or {}
+    resolved = bindings if bindings is not None else {}
     targets: list[ShortcutEditorTarget] = []
     seen_categories: dict[str, list[tuple[str, ShortcutEntry]]] = {}
     for action_id, entry in REGISTRY.items():
@@ -119,41 +196,34 @@ def build_shortcut_editor_targets(bindings: dict[str, str] | None = None) -> lis
                 group = editor_row.group
                 inc = REGISTRY[group.inc_action]
                 dec = REGISTRY[group.dec_action]
+                binding_keys = _binding_keys(resolved, group.inc_action, group.dec_action)
+                text_search = _text_tokens(group.label, category, inc.description, dec.description)
                 targets.append(
                     ShortcutEditorTarget(
                         target_id=group.id,
                         label=group.label,
                         category=category,
                         row_kind="slider",
-                        search_text=_tokens(
-                            group.label,
-                            group.id,
-                            category,
-                            inc.description,
-                            dec.description,
-                            inc.default_key,
-                            dec.default_key,
-                            _binding_tokens(resolved, group.inc_action, group.dec_action),
-                        ),
+                        binding_keys=binding_keys,
+                        search_text=_combined_search_text(text_search, binding_keys),
+                        text_search=text_search,
                     )
                 )
                 continue
 
             action_id = editor_row.action_id
             entry = editor_row.entry
+            binding_keys = _binding_keys(resolved, action_id)
+            text_search = _text_tokens(entry.description, category)
             targets.append(
                 ShortcutEditorTarget(
                     target_id=action_id,
                     label=entry.description,
                     category=category,
                     row_kind="single",
-                    search_text=_tokens(
-                        entry.description,
-                        action_id,
-                        category,
-                        entry.default_key,
-                        _binding_tokens(resolved, action_id),
-                    ),
+                    binding_keys=binding_keys,
+                    search_text=_combined_search_text(text_search, binding_keys),
+                    text_search=text_search,
                 )
             )
 
@@ -164,4 +234,10 @@ def filter_targets(targets: list[ShortcutEditorTarget], query: str) -> list[Shor
     needle = query.strip().casefold()
     if not needle:
         return list(targets)
-    return [target for target in targets if needle in target.search_text]
+    return [
+        target
+        for target in targets
+        if needle in target.binding_keys or (len(needle) >= 2 and needle in target.text_search)
+    ]
+
+

--- a/negpy/desktop/view/widgets/key_sequence_edit.py
+++ b/negpy/desktop/view/widgets/key_sequence_edit.py
@@ -5,6 +5,10 @@ are stored as the same binding as the number row (``9`` instead of ``Num+9``).
 We preserve the keypad modifier so both keys can be bound independently.
 """
 
+from __future__ import annotations
+
+from collections.abc import Callable
+
 from PyQt6.QtCore import QKeyCombination, Qt
 from PyQt6.QtGui import QKeyEvent, QKeySequence
 from PyQt6.QtWidgets import QKeySequenceEdit
@@ -17,19 +21,84 @@ _KEYPAD_MODIFIERS = (
     Qt.KeyboardModifier.KeypadModifier,
 )
 
+_MODIFIER_KEYS = frozenset(
+    {
+        Qt.Key.Key_Shift,
+        Qt.Key.Key_Control,
+        Qt.Key.Key_Alt,
+        Qt.Key.Key_AltGr,
+        Qt.Key.Key_Meta,
+    }
+)
 
-def key_event_to_sequence(event: QKeyEvent) -> QKeySequence | None:
-    """Build a portable QKeySequence from a key event, preserving numpad keys."""
-    if event.key() in (Qt.Key.Key_unknown,):
-        return None
-    if not event.modifiers() & Qt.KeyboardModifier.KeypadModifier:
+_CHORD_MODIFIER_MASK = (
+    Qt.KeyboardModifier.ControlModifier
+    | Qt.KeyboardModifier.AltModifier
+    | Qt.KeyboardModifier.MetaModifier
+    | Qt.KeyboardModifier.KeypadModifier
+)
+
+
+def _sequence_from_event(event: QKeyEvent) -> QKeySequence | None:
+    key = event.key()
+    if key in (Qt.Key.Key_unknown,) or key in _MODIFIER_KEYS:
         return None
 
     mods = Qt.KeyboardModifier.NoModifier
     for modifier in _KEYPAD_MODIFIERS:
         if event.modifiers() & modifier:
             mods |= modifier
-    return QKeySequence(QKeyCombination(mods, Qt.Key(event.key())))
+    return QKeySequence(QKeyCombination(mods, Qt.Key(key)))
+
+
+def key_event_to_sequence(event: QKeyEvent) -> QKeySequence | None:
+    """Build a portable QKeySequence from a numpad key event."""
+    if not event.modifiers() & Qt.KeyboardModifier.KeypadModifier:
+        return None
+    return _sequence_from_event(event)
+
+
+def key_event_to_portable(event: QKeyEvent) -> str | None:
+    """Return the portable binding string for a key event, or None if incomplete."""
+    sequence = _sequence_from_event(event)
+    if sequence is None or sequence.isEmpty():
+        return None
+    return sequence.toString(QKeySequence.SequenceFormat.PortableText)
+
+
+def normalize_binding(key: str) -> str:
+    return key.strip().casefold()
+
+
+def format_binding_display(portable: str) -> str:
+    return normalize_binding(portable)
+
+
+def should_capture_binding(
+    event: QKeyEvent,
+    known_bindings: frozenset[str],
+    *,
+    portable: str | None = None,
+    allow_single_key: bool = True,
+) -> bool:
+    """Decide whether a search-field key press should be treated as shortcut lookup."""
+    resolved = portable if portable is not None else key_event_to_portable(event)
+    if not resolved:
+        return False
+
+    normalized = normalize_binding(resolved)
+    normalized_known = {normalize_binding(binding) for binding in known_bindings if binding}
+
+    if event.modifiers() & _CHORD_MODIFIER_MASK:
+        return True
+
+    if allow_single_key and normalized in normalized_known:
+        return True
+
+    return False
+
+
+KnownBindingsProvider = Callable[[], frozenset[str]]
 
 
 class KeypadAwareKeySequenceEdit(QKeySequenceEdit):

--- a/negpy/desktop/view/widgets/shortcut_editor.py
+++ b/negpy/desktop/view/widgets/shortcut_editor.py
@@ -1,4 +1,4 @@
-from PyQt6.QtCore import QEvent, QModelIndex, QPoint, QSortFilterProxyModel, Qt, QTimer
+from PyQt6.QtCore import QEvent, QModelIndex, Qt, QTimer
 from PyQt6.QtGui import QKeySequence, QStandardItem, QStandardItemModel
 from PyQt6.QtWidgets import (
     QCheckBox,
@@ -18,8 +18,15 @@ from PyQt6.QtWidgets import (
 )
 
 from negpy.desktop.view.shortcut_editor_search import (
+    HIGHLIGHT_MS,
+    SEARCH_ROLE,
+    TARGET_ROLE,
     ShortcutEditorTarget,
+    ShortcutSearchProxy,
     build_shortcut_editor_targets,
+    first_matching_target_id,
+    scroll_row_to_center,
+    target_id_from_completer_index,
 )
 from negpy.desktop.view.shortcut_registry import (
     REGISTRY,
@@ -34,33 +41,6 @@ from negpy.desktop.view.shortcut_registry import (
 from negpy.desktop.view.widgets.collapsible import CollapsibleSection
 from negpy.desktop.view.widgets.key_sequence_edit import KeypadAwareKeySequenceEdit
 from negpy.desktop.view.styles.theme import THEME
-
-_TARGET_ROLE = Qt.ItemDataRole.UserRole
-_SEARCH_ROLE = Qt.ItemDataRole.UserRole + 1
-_HIGHLIGHT_MS = 1800
-
-
-class _ShortcutSearchProxy(QSortFilterProxyModel):
-    def __init__(self, parent=None) -> None:
-        super().__init__(parent)
-        self._query = ""
-
-    def set_query(self, query: str) -> None:
-        needle = (query or "").strip().casefold()
-        if needle == self._query:
-            return
-        self._query = needle
-        self.invalidateFilter()
-
-    def filterAcceptsRow(self, source_row: int, source_parent: QModelIndex) -> bool:  # noqa: N802
-        if not self._query:
-            return False
-        model = self.sourceModel()
-        if model is None:
-            return False
-        index = model.index(source_row, 0, source_parent)
-        search_text = model.data(index, _SEARCH_ROLE) or ""
-        return self._query in search_text
 
 
 def _format_default_pair(inc_key: str, dec_key: str) -> str:
@@ -171,7 +151,7 @@ class ShortcutEditorDialog(QDialog):
 
     def _init_search_completer(self) -> None:
         self._search_model = QStandardItemModel(self)
-        self._search_proxy = _ShortcutSearchProxy(self)
+        self._search_proxy = ShortcutSearchProxy(self)
         self._search_proxy.setSourceModel(self._search_model)
         self._reload_search_model()
 
@@ -188,29 +168,16 @@ class ShortcutEditorDialog(QDialog):
         self._targets = build_shortcut_editor_targets(bindings)
         for target in self._targets:
             item = QStandardItem(f"{target.label}  ·  {target.category}")
-            item.setData(target.target_id, _TARGET_ROLE)
-            item.setData(target.search_text, _SEARCH_ROLE)
+            item.setData(target.target_id, TARGET_ROLE)
+            item.setData(target.search_text, SEARCH_ROLE)
             item.setEditable(False)
             self._search_model.appendRow(item)
 
     def _target_id_from_completer_index(self, index: QModelIndex) -> str:
-        if not index.isValid():
-            return ""
-        completion_model = self._search_completer.completionModel()
-        proxy_index = completion_model.mapToSource(index)
-        source_index = self._search_proxy.mapToSource(proxy_index)
-        if not source_index.isValid():
-            return ""
-        target_id = self._search_model.data(source_index, _TARGET_ROLE)
-        return str(target_id) if target_id else ""
+        return target_id_from_completer_index(self._search_completer, self._search_model, self._search_proxy, index)
 
     def _first_matching_target_id(self) -> str:
-        completion_model = self._search_completer.completionModel()
-        for row in range(completion_model.rowCount()):
-            target_id = self._target_id_from_completer_index(completion_model.index(row, 0))
-            if target_id:
-                return target_id
-        return ""
+        return first_matching_target_id(self._search_completer, self._search_model, self._search_proxy)
 
     def _on_search_edited(self, text: str) -> None:
         self._search_proxy.set_query(text)
@@ -258,23 +225,12 @@ class ShortcutEditorDialog(QDialog):
                 section.expand()
 
         def _reveal() -> None:
-            self._scroll_row_to_center(row)
+            scroll_row_to_center(self._scroll, row)
             self._set_highlight(row)
             if focus_edit is not None:
                 focus_edit.setFocus()
 
         QTimer.singleShot(50, _reveal)
-
-    def _scroll_row_to_center(self, row: QWidget) -> None:
-        content = self._scroll.widget()
-        if content is None:
-            return
-        center = row.mapTo(content, QPoint(0, row.height() // 2))
-        bar = self._scroll.verticalScrollBar()
-        viewport_h = self._scroll.viewport().height()
-        value = center.y() - viewport_h // 2
-        value = max(bar.minimum(), min(bar.maximum(), value))
-        bar.setValue(value)
 
     def _set_highlight(self, row: QFrame) -> None:
         self._clear_highlight()
@@ -282,7 +238,7 @@ class ShortcutEditorDialog(QDialog):
         row.style().unpolish(row)
         row.style().polish(row)
         self._highlighted_row = row
-        self._highlight_timer.start(_HIGHLIGHT_MS)
+        self._highlight_timer.start(HIGHLIGHT_MS)
 
     def _clear_highlight(self) -> None:
         if self._highlighted_row is None:

--- a/negpy/desktop/view/widgets/shortcut_editor.py
+++ b/negpy/desktop/view/widgets/shortcut_editor.py
@@ -9,7 +9,6 @@ from PyQt6.QtWidgets import (
     QGridLayout,
     QHBoxLayout,
     QLabel,
-    QLineEdit,
     QMessageBox,
     QPushButton,
     QScrollArea,
@@ -18,12 +17,17 @@ from PyQt6.QtWidgets import (
 )
 
 from negpy.desktop.view.shortcut_editor_search import (
+    BINDING_KEYS_ROLE,
     HIGHLIGHT_MS,
     SEARCH_ROLE,
     TARGET_ROLE,
+    TEXT_SEARCH_ROLE,
     ShortcutEditorTarget,
     ShortcutSearchProxy,
+    action_id_for_binding,
+    binding_keys_display,
     build_shortcut_editor_targets,
+    configure_search_completer,
     first_matching_target_id,
     scroll_row_to_center,
     target_id_from_completer_index,
@@ -40,6 +44,7 @@ from negpy.desktop.view.shortcut_registry import (
 )
 from negpy.desktop.view.widgets.collapsible import CollapsibleSection
 from negpy.desktop.view.widgets.key_sequence_edit import KeypadAwareKeySequenceEdit
+from negpy.desktop.view.widgets.shortcut_search_line_edit import ShortcutSearchLineEdit
 from negpy.desktop.view.styles.theme import THEME
 
 
@@ -86,13 +91,14 @@ class ShortcutEditorDialog(QDialog):
 
         intro = QLabel(
             "Set shortcuts and keyboard step sizes for slider actions. "
-            "Search to jump to an action. Duplicate bindings are rejected. Reset All restores defaults."
+            "Search by name or press a shortcut to filter results, then choose or press Enter. "
+            "Duplicate bindings are rejected. Reset All restores defaults."
         )
         intro.setWordWrap(True)
         root.addWidget(intro)
 
-        self._search_edit = QLineEdit()
-        self._search_edit.setPlaceholderText("Search actions or key bindings…")
+        self._search_edit = ShortcutSearchLineEdit(self._known_bindings)
+        self._search_edit.setPlaceholderText("Search actions, press a shortcut, then choose or Enter…")
         self._search_edit.setClearButtonEnabled(True)
         self._search_edit.textEdited.connect(self._on_search_edited)
         self._search_edit.installEventFilter(self)
@@ -156,20 +162,29 @@ class ShortcutEditorDialog(QDialog):
         self._reload_search_model()
 
         self._search_completer = QCompleter(self._search_proxy, self)
-        self._search_completer.setCompletionMode(QCompleter.CompletionMode.UnfilteredPopupCompletion)
-        self._search_completer.setCaseSensitivity(Qt.CaseSensitivity.CaseInsensitive)
+        configure_search_completer(self._search_completer)
         self._search_completer.setWidget(self._search_edit)
         self._search_completer.activated[QModelIndex].connect(self._on_search_activated)
         self._search_completer.popup().setObjectName("shortcut_editor_search_popup")
 
+    def _current_bindings(self) -> dict[str, str]:
+        if self._edits:
+            return {action_id: self._portable(edit) for action_id, edit in self._edits.items()}
+        return dict(self._initial_bindings)
+
+    def _known_bindings(self) -> frozenset[str]:
+        return frozenset(key for key in self._current_bindings().values() if key)
+
     def _reload_search_model(self) -> None:
         self._search_model.clear()
-        bindings = {action_id: self._portable(edit) for action_id, edit in self._edits.items()} if self._edits else self._initial_bindings
+        bindings = self._current_bindings()
         self._targets = build_shortcut_editor_targets(bindings)
         for target in self._targets:
             item = QStandardItem(f"{target.label}  ·  {target.category}")
             item.setData(target.target_id, TARGET_ROLE)
             item.setData(target.search_text, SEARCH_ROLE)
+            item.setData(target.text_search, TEXT_SEARCH_ROLE)
+            item.setData(binding_keys_display(target.binding_keys), BINDING_KEYS_ROLE)
             item.setEditable(False)
             self._search_model.appendRow(item)
 
@@ -188,10 +203,12 @@ class ShortcutEditorDialog(QDialog):
         target_id = self._target_id_from_completer_index(index)
         if not target_id:
             return
+        query = self._search_edit.text()
+        focus_action_id = action_id_for_binding(self._current_bindings(), query) if query else None
         self._search_edit.clear()
         self._search_proxy.set_query("")
         self._search_completer.popup().hide()
-        self._navigate_to_target(target_id)
+        self._navigate_to_target(target_id, focus_action_id=focus_action_id)
 
     def eventFilter(self, watched, event) -> bool:  # noqa: N802
         if watched is self._search_edit and event.type() == QEvent.Type.KeyPress:
@@ -206,15 +223,19 @@ class ShortcutEditorDialog(QDialog):
                         return True
                 target_id = self._first_matching_target_id()
                 if target_id:
+                    query = self._search_edit.text()
+                    focus_action_id = action_id_for_binding(self._current_bindings(), query) if query else None
                     self._search_edit.clear()
                     self._search_proxy.set_query("")
-                    self._navigate_to_target(target_id)
+                    self._navigate_to_target(target_id, focus_action_id=focus_action_id)
                     return True
         return super().eventFilter(watched, event)
 
-    def _navigate_to_target(self, target_id: str) -> None:
+    def _navigate_to_target(self, target_id: str, focus_action_id: str | None = None) -> None:
         row = self._row_widgets.get(target_id)
         focus_edit = self._row_focus_edits.get(target_id)
+        if focus_action_id and focus_action_id in self._edits:
+            focus_edit = self._edits[focus_action_id]
         if row is None:
             return
 

--- a/negpy/desktop/view/widgets/shortcut_search_line_edit.py
+++ b/negpy/desktop/view/widgets/shortcut_search_line_edit.py
@@ -1,0 +1,44 @@
+"""Search field that accepts text queries and live shortcut presses."""
+
+from __future__ import annotations
+
+from PyQt6.QtCore import Qt, pyqtSignal
+from PyQt6.QtGui import QKeyEvent
+from PyQt6.QtWidgets import QLineEdit
+
+from negpy.desktop.view.widgets.key_sequence_edit import (
+    KnownBindingsProvider,
+    format_binding_display,
+    key_event_to_portable,
+    should_capture_binding,
+)
+
+
+class ShortcutSearchLineEdit(QLineEdit):
+    """Line edit that can be searched by name or by pressing a bound shortcut."""
+
+    bindingCaptured = pyqtSignal(str)
+
+    def __init__(self, known_bindings: KnownBindingsProvider, parent=None) -> None:
+        super().__init__(parent)
+        self._known_bindings = known_bindings
+
+    def keyPressEvent(self, event: QKeyEvent) -> None:
+        if event.key() in (Qt.Key.Key_Return, Qt.Key.Key_Enter, Qt.Key.Key_Escape, Qt.Key.Key_Backspace):
+            super().keyPressEvent(event)
+            return
+
+        known = self._known_bindings()
+        portable = key_event_to_portable(event)
+        allow_single_key = not self.text()
+        if portable and should_capture_binding(
+            event, known, portable=portable, allow_single_key=allow_single_key
+        ):
+            text = format_binding_display(portable)
+            self.setText(text)
+            self.textEdited.emit(text)
+            self.bindingCaptured.emit(portable)
+            event.accept()
+            return
+
+        super().keyPressEvent(event)

--- a/negpy/desktop/view/widgets/shortcuts_overlay.py
+++ b/negpy/desktop/view/widgets/shortcuts_overlay.py
@@ -7,7 +7,6 @@ from PyQt6.QtWidgets import (
     QGridLayout,
     QHBoxLayout,
     QLabel,
-    QLineEdit,
     QPushButton,
     QScrollArea,
     QVBoxLayout,
@@ -15,12 +14,16 @@ from PyQt6.QtWidgets import (
 )
 
 from negpy.desktop.view.shortcut_editor_search import (
+    BINDING_KEYS_ROLE,
     HIGHLIGHT_MS,
     SEARCH_ROLE,
     TARGET_ROLE,
+    TEXT_SEARCH_ROLE,
     ShortcutEditorTarget,
     ShortcutSearchProxy,
+    binding_keys_display,
     build_shortcut_editor_targets,
+    configure_search_completer,
     first_matching_target_id,
     scroll_row_to_center,
     target_id_from_completer_index,
@@ -35,6 +38,7 @@ from negpy.desktop.view.shortcut_registry import (
 )
 from negpy.desktop.view.styles.theme import THEME
 from negpy.desktop.view.widgets.collapsible import CollapsibleSection
+from negpy.desktop.view.widgets.shortcut_search_line_edit import ShortcutSearchLineEdit
 
 
 def _format_key_pair(inc_key: str, dec_key: str) -> str:
@@ -90,13 +94,14 @@ class ShortcutsOverlay(QDialog):
 
         intro = QLabel(
             "Current keyboard shortcuts and slider step sizes. "
-            "Search to jump to an action, or open Customize to change bindings."
+            "Search by name or press a shortcut to filter results, then choose or press Enter. "
+            "Open Customize to change bindings."
         )
         intro.setWordWrap(True)
         root.addWidget(intro)
 
-        self._search_edit = QLineEdit()
-        self._search_edit.setPlaceholderText("Search actions or key bindings…")
+        self._search_edit = ShortcutSearchLineEdit(self._known_bindings)
+        self._search_edit.setPlaceholderText("Search actions, press a shortcut, then choose or Enter…")
         self._search_edit.setClearButtonEnabled(True)
         self._search_edit.textEdited.connect(self._on_search_edited)
         self._search_edit.installEventFilter(self)
@@ -146,11 +151,13 @@ class ShortcutsOverlay(QDialog):
         self._reload_search_model()
 
         self._search_completer = QCompleter(self._search_proxy, self)
-        self._search_completer.setCompletionMode(QCompleter.CompletionMode.UnfilteredPopupCompletion)
-        self._search_completer.setCaseSensitivity(Qt.CaseSensitivity.CaseInsensitive)
+        configure_search_completer(self._search_completer)
         self._search_completer.setWidget(self._search_edit)
         self._search_completer.activated[QModelIndex].connect(self._on_search_activated)
         self._search_completer.popup().setObjectName("shortcut_editor_search_popup")
+
+    def _known_bindings(self) -> frozenset[str]:
+        return frozenset(key for key in self._bindings.values() if key)
 
     def _reload_search_model(self) -> None:
         self._search_model.clear()
@@ -159,6 +166,8 @@ class ShortcutsOverlay(QDialog):
             item = QStandardItem(f"{target.label}  ·  {target.category}")
             item.setData(target.target_id, TARGET_ROLE)
             item.setData(target.search_text, SEARCH_ROLE)
+            item.setData(target.text_search, TEXT_SEARCH_ROLE)
+            item.setData(binding_keys_display(target.binding_keys), BINDING_KEYS_ROLE)
             item.setEditable(False)
             self._search_model.appendRow(item)
 

--- a/negpy/desktop/view/widgets/shortcuts_overlay.py
+++ b/negpy/desktop/view/widgets/shortcuts_overlay.py
@@ -1,16 +1,30 @@
-from PyQt6.QtCore import Qt
+from PyQt6.QtCore import QEvent, QModelIndex, Qt, QTimer
+from PyQt6.QtGui import QStandardItem, QStandardItemModel
 from PyQt6.QtWidgets import (
+    QCompleter,
     QDialog,
     QFrame,
     QGridLayout,
     QHBoxLayout,
     QLabel,
+    QLineEdit,
     QPushButton,
     QScrollArea,
     QVBoxLayout,
     QWidget,
 )
 
+from negpy.desktop.view.shortcut_editor_search import (
+    HIGHLIGHT_MS,
+    SEARCH_ROLE,
+    TARGET_ROLE,
+    ShortcutEditorTarget,
+    ShortcutSearchProxy,
+    build_shortcut_editor_targets,
+    first_matching_target_id,
+    scroll_row_to_center,
+    target_id_from_completer_index,
+)
 from negpy.desktop.view.shortcut_registry import (
     REGISTRY,
     EditorRowSingle,
@@ -44,6 +58,15 @@ class ShortcutsOverlay(QDialog):
     def __init__(self, shortcut_manager, parent=None):
         super().__init__(parent)
         self._shortcut_manager = shortcut_manager
+        self._bindings = dict(shortcut_manager.bindings)
+        self._slider_steps = dict(shortcut_manager.slider_steps)
+        self._sections: dict[str, CollapsibleSection] = {}
+        self._row_widgets: dict[str, QFrame] = {}
+        self._targets: list[ShortcutEditorTarget] = build_shortcut_editor_targets(self._bindings)
+        self._highlighted_row: QFrame | None = None
+        self._highlight_timer = QTimer(self)
+        self._highlight_timer.setSingleShot(True)
+        self._highlight_timer.timeout.connect(self._clear_highlight)
         self.setWindowTitle("Keyboard Shortcuts")
         self.setWindowFlags(Qt.WindowType.Dialog | Qt.WindowType.WindowCloseButtonHint)
         self.setModal(True)
@@ -59,26 +82,35 @@ class ShortcutsOverlay(QDialog):
             QDialog {{ background-color: {THEME.bg_panel}; }}
             QLabel {{ color: {THEME.text_primary}; font-size: 12px; }}
             QPushButton {{ padding: 6px 14px; }}
+            QFrame#shortcut_editor_row[highlighted="true"] {{
+                background-color: rgba(183, 28, 28, 0.12);
+                border-left: 2px solid {THEME.accent_primary};
+            }}
         """)
 
         intro = QLabel(
             "Current keyboard shortcuts and slider step sizes. "
-            "Expand a section to browse bindings, or open Customize to change them."
+            "Search to jump to an action, or open Customize to change bindings."
         )
         intro.setWordWrap(True)
         root.addWidget(intro)
+
+        self._search_edit = QLineEdit()
+        self._search_edit.setPlaceholderText("Search actions or key bindings…")
+        self._search_edit.setClearButtonEnabled(True)
+        self._search_edit.textEdited.connect(self._on_search_edited)
+        self._search_edit.installEventFilter(self)
+        self._init_search_completer()
+        root.addWidget(self._search_edit)
 
         divider = QFrame()
         divider.setFrameShape(QFrame.Shape.HLine)
         divider.setStyleSheet(f"color: {THEME.border_color};")
         root.addWidget(divider)
 
-        bindings = self._shortcut_manager.bindings
-        slider_steps = self._shortcut_manager.slider_steps
-
-        scroll = QScrollArea()
-        scroll.setWidgetResizable(True)
-        scroll.setFrameShape(QScrollArea.Shape.NoFrame)
+        self._scroll = QScrollArea()
+        self._scroll.setWidgetResizable(True)
+        self._scroll.setFrameShape(QScrollArea.Shape.NoFrame)
 
         container = QWidget()
         sections_layout = QVBoxLayout(container)
@@ -87,12 +119,13 @@ class ShortcutsOverlay(QDialog):
 
         for category, items in categories_in_order():
             section = CollapsibleSection(category, expanded=False)
-            section.set_content(self._build_category_grid(items, bindings, slider_steps))
+            section.set_content(self._build_category_grid(items))
+            self._sections[category] = section
             sections_layout.addWidget(section)
 
         sections_layout.addStretch()
-        scroll.setWidget(container)
-        root.addWidget(scroll, stretch=1)
+        self._scroll.setWidget(container)
+        root.addWidget(self._scroll, stretch=1)
 
         actions = QHBoxLayout()
         customize_btn = QPushButton("Customize")
@@ -106,16 +139,109 @@ class ShortcutsOverlay(QDialog):
         actions.addWidget(close_btn)
         root.addLayout(actions)
 
+    def _init_search_completer(self) -> None:
+        self._search_model = QStandardItemModel(self)
+        self._search_proxy = ShortcutSearchProxy(self)
+        self._search_proxy.setSourceModel(self._search_model)
+        self._reload_search_model()
+
+        self._search_completer = QCompleter(self._search_proxy, self)
+        self._search_completer.setCompletionMode(QCompleter.CompletionMode.UnfilteredPopupCompletion)
+        self._search_completer.setCaseSensitivity(Qt.CaseSensitivity.CaseInsensitive)
+        self._search_completer.setWidget(self._search_edit)
+        self._search_completer.activated[QModelIndex].connect(self._on_search_activated)
+        self._search_completer.popup().setObjectName("shortcut_editor_search_popup")
+
+    def _reload_search_model(self) -> None:
+        self._search_model.clear()
+        self._targets = build_shortcut_editor_targets(self._bindings)
+        for target in self._targets:
+            item = QStandardItem(f"{target.label}  ·  {target.category}")
+            item.setData(target.target_id, TARGET_ROLE)
+            item.setData(target.search_text, SEARCH_ROLE)
+            item.setEditable(False)
+            self._search_model.appendRow(item)
+
+    def _on_search_edited(self, text: str) -> None:
+        self._search_proxy.set_query(text)
+        if text.strip():
+            self._search_completer.complete()
+
+    def _on_search_activated(self, index: QModelIndex) -> None:
+        target_id = target_id_from_completer_index(self._search_completer, self._search_model, self._search_proxy, index)
+        if not target_id:
+            return
+        self._search_edit.clear()
+        self._search_proxy.set_query("")
+        self._search_completer.popup().hide()
+        self._navigate_to_target(target_id)
+
+    def eventFilter(self, watched, event) -> bool:  # noqa: N802
+        if watched is self._search_edit and event.type() == QEvent.Type.KeyPress:
+            if event.key() in (Qt.Key.Key_Return, Qt.Key.Key_Enter):
+                popup = self._search_completer.popup()
+                if popup.isVisible():
+                    idx = popup.currentIndex()
+                    if not idx.isValid() and popup.model().rowCount() > 0:
+                        idx = popup.model().index(0, 0)
+                    if idx.isValid():
+                        self._on_search_activated(idx)
+                        return True
+                target_id = first_matching_target_id(self._search_completer, self._search_model, self._search_proxy)
+                if target_id:
+                    self._search_edit.clear()
+                    self._search_proxy.set_query("")
+                    self._navigate_to_target(target_id)
+                    return True
+        return super().eventFilter(watched, event)
+
+    def _navigate_to_target(self, target_id: str) -> None:
+        row = self._row_widgets.get(target_id)
+        if row is None:
+            return
+
+        target = next((t for t in self._targets if t.target_id == target_id), None)
+        if target is not None:
+            section = self._sections.get(target.category)
+            if section is not None:
+                section.expand()
+
+        def _reveal() -> None:
+            scroll_row_to_center(self._scroll, row)
+            self._set_highlight(row)
+            row.setFocus()
+
+        QTimer.singleShot(50, _reveal)
+
+    def _set_highlight(self, row: QFrame) -> None:
+        self._clear_highlight()
+        row.setProperty("highlighted", True)
+        row.style().unpolish(row)
+        row.style().polish(row)
+        self._highlighted_row = row
+        self._highlight_timer.start(HIGHLIGHT_MS)
+
+    def _clear_highlight(self) -> None:
+        if self._highlighted_row is None:
+            return
+        row = self._highlighted_row
+        row.setProperty("highlighted", False)
+        row.style().unpolish(row)
+        row.style().polish(row)
+        self._highlighted_row = None
+
     def _customize(self) -> None:
         if self._shortcut_manager.open_editor(self):
             self.accept()
 
-    def _build_category_grid(
-        self,
-        items: list,
-        bindings: dict[str, str],
-        slider_steps: dict[str, float],
-    ) -> QWidget:
+    def _make_row_frame(self, target_id: str) -> QFrame:
+        row = QFrame()
+        row.setObjectName("shortcut_editor_row")
+        row.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
+        self._row_widgets[target_id] = row
+        return row
+
+    def _build_category_grid(self, items: list) -> QWidget:
         body = QWidget()
         grid = QGridLayout(body)
         grid.setContentsMargins(0, 0, 0, 0)
@@ -134,9 +260,9 @@ class ShortcutsOverlay(QDialog):
         mono = f"color: {THEME.text_secondary}; font-family: Consolas, monospace;"
         for row, editor_row in enumerate(category_editor_rows(items), start=1):
             if isinstance(editor_row, EditorRowSlider):
-                self._add_slider_row(grid, row, editor_row, bindings, slider_steps, mono)
+                self._add_slider_row(grid, row, editor_row, mono)
             else:
-                self._add_single_row(grid, row, editor_row, bindings, mono)
+                self._add_single_row(grid, row, editor_row, mono)
 
         return body
 
@@ -164,46 +290,57 @@ class ShortcutsOverlay(QDialog):
         grid: QGridLayout,
         row: int,
         editor_row: EditorRowSingle,
-        bindings: dict[str, str],
         mono: str,
     ) -> None:
         entry = editor_row.entry
-        grid.addWidget(QLabel(entry.description), row, 0)
-        grid.addWidget(self._mono_label(entry.default_key, mono), row, 1)
-        grid.addWidget(self._keycap(bindings.get(editor_row.action_id, "")), row, 2)
-        grid.addWidget(QLabel("—"), row, 3)
+        row_frame = self._make_row_frame(editor_row.action_id)
+        inner = QGridLayout(row_frame)
+        inner.setContentsMargins(4, 4, 4, 4)
+        inner.setHorizontalSpacing(12)
+        inner.setVerticalSpacing(0)
+
+        inner.addWidget(QLabel(entry.description), 0, 0)
+        inner.addWidget(self._mono_label(entry.default_key, mono), 0, 1)
+        inner.addWidget(self._keycap(self._bindings.get(editor_row.action_id, "")), 0, 2)
+        inner.addWidget(QLabel("—"), 0, 3)
+        grid.addWidget(row_frame, row, 0, 1, 4)
 
     def _add_slider_row(
         self,
         grid: QGridLayout,
         row: int,
         editor_row: EditorRowSlider,
-        bindings: dict[str, str],
-        slider_steps: dict[str, float],
         mono: str,
     ) -> None:
         group = editor_row.group
         inc_entry = REGISTRY[group.inc_action]
         dec_entry = REGISTRY[group.dec_action]
 
-        grid.addWidget(QLabel(group.label), row, 0)
-        grid.addWidget(
+        row_frame = self._make_row_frame(group.id)
+        inner = QGridLayout(row_frame)
+        inner.setContentsMargins(4, 4, 4, 4)
+        inner.setHorizontalSpacing(12)
+        inner.setVerticalSpacing(0)
+
+        inner.addWidget(QLabel(group.label), 0, 0)
+        inner.addWidget(
             self._mono_label(_format_key_pair(inc_entry.default_key, dec_entry.default_key), mono),
-            row,
+            0,
             1,
         )
 
         shortcuts = QHBoxLayout()
         shortcuts.setContentsMargins(0, 0, 0, 0)
         shortcuts.setSpacing(6)
-        shortcuts.addWidget(self._keycap(bindings.get(group.inc_action, "")), 1)
+        shortcuts.addWidget(self._keycap(self._bindings.get(group.inc_action, "")), 1)
         sep = QLabel("/")
         sep.setStyleSheet(f"color: {THEME.text_muted};")
         shortcuts.addWidget(sep)
-        shortcuts.addWidget(self._keycap(bindings.get(group.dec_action, "")), 1)
+        shortcuts.addWidget(self._keycap(self._bindings.get(group.dec_action, "")), 1)
         shortcuts_host = QWidget()
         shortcuts_host.setLayout(shortcuts)
-        grid.addWidget(shortcuts_host, row, 2)
+        inner.addWidget(shortcuts_host, 0, 2)
 
-        step_value = slider_step_for(group.id, slider_steps)
-        grid.addWidget(QLabel(_format_step_value(group, step_value)), row, 3)
+        step_value = slider_step_for(group.id, self._slider_steps)
+        inner.addWidget(QLabel(_format_step_value(group, step_value)), 0, 3)
+        grid.addWidget(row_frame, row, 0, 1, 4)

--- a/tests/test_key_sequence_edit.py
+++ b/tests/test_key_sequence_edit.py
@@ -3,7 +3,12 @@ from PyQt6.QtCore import QEvent, Qt
 from PyQt6.QtGui import QKeyEvent, QKeySequence
 from PyQt6.QtWidgets import QApplication, QKeySequenceEdit
 
-from negpy.desktop.view.widgets.key_sequence_edit import KeypadAwareKeySequenceEdit, key_event_to_sequence
+from negpy.desktop.view.widgets.key_sequence_edit import (
+    KeypadAwareKeySequenceEdit,
+    key_event_to_portable,
+    key_event_to_sequence,
+    should_capture_binding,
+)
 
 
 @pytest.fixture(scope="module")
@@ -26,6 +31,39 @@ def test_key_event_to_sequence_preserves_numpad_modifier():
 
 def test_key_event_to_sequence_ignores_number_row():
     assert key_event_to_sequence(_key_press(Qt.Key.Key_9)) is None
+
+
+def test_key_event_to_portable_modifier_chord():
+    assert key_event_to_portable(_key_press(Qt.Key.Key_T, Qt.KeyboardModifier.AltModifier)) == "Alt+T"
+
+
+def test_key_event_to_portable_numpad():
+    assert key_event_to_portable(_key_press(Qt.Key.Key_9, Qt.KeyboardModifier.KeypadModifier)) == "Num+9"
+
+
+def test_key_event_to_portable_single_key():
+    assert key_event_to_portable(_key_press(Qt.Key.Key_Q)) == "Q"
+
+
+def test_should_capture_modifier_chord_even_when_unbound():
+    event = _key_press(Qt.Key.Key_T, Qt.KeyboardModifier.AltModifier)
+    assert should_capture_binding(event, frozenset(), portable="Alt+T") is True
+
+
+def test_should_capture_single_key_only_when_bound():
+    event = _key_press(Qt.Key.Key_Q)
+    assert should_capture_binding(event, frozenset({"Q"}), portable="Q") is True
+    assert should_capture_binding(event, frozenset(), portable="Q") is False
+
+
+def test_should_not_capture_single_key_while_typing():
+    event = _key_press(Qt.Key.Key_G)
+    assert should_capture_binding(event, frozenset({"G"}), portable="G", allow_single_key=False) is False
+
+
+def test_should_still_capture_chord_while_typing():
+    event = _key_press(Qt.Key.Key_T, Qt.KeyboardModifier.AltModifier)
+    assert should_capture_binding(event, frozenset(), portable="Alt+T", allow_single_key=False) is True
 
 
 def test_keypad_aware_edit_differs_from_stock_qkeysequenceedit(qapp):

--- a/tests/test_shortcut_editor_search.py
+++ b/tests/test_shortcut_editor_search.py
@@ -1,7 +1,10 @@
 from negpy.desktop.view.shortcut_editor_search import (
+    action_id_for_binding,
     build_shortcut_editor_targets,
     filter_targets,
+    target_ids_for_binding,
 )
+from negpy.desktop.view.shortcut_registry import default_bindings
 
 
 def test_build_targets_includes_action_description():
@@ -25,6 +28,18 @@ def test_search_matches_current_key_binding():
     assert any(t.target_id == "density" for t in matches)
 
 
+def test_search_g_matches_binding_without_action_id_noise():
+    targets = build_shortcut_editor_targets(default_bindings())
+    matches = filter_targets(targets, "g")
+    assert [t.target_id for t in matches] == ["temperature"]
+
+
+def test_search_alt_t_matches_toe_binding():
+    targets = build_shortcut_editor_targets(default_bindings())
+    matches = filter_targets(targets, "alt+t")
+    assert [t.target_id for t in matches] == ["toe"]
+
+
 def test_search_matches_category_name():
     targets = build_shortcut_editor_targets()
     matches = filter_targets(targets, "finishing")
@@ -35,3 +50,13 @@ def test_search_matches_ctrl_binding():
     targets = build_shortcut_editor_targets({"export": "Ctrl+E"})
     matches = filter_targets(targets, "ctrl+e")
     assert any(t.target_id == "export" for t in matches)
+
+
+def test_target_ids_for_binding_matches_slider_row():
+    targets = build_shortcut_editor_targets({"toe_inc": "Alt+T", "toe_dec": "Alt+Shift+T"})
+    assert target_ids_for_binding(targets, "Alt+T") == ["toe"]
+
+
+def test_action_id_for_binding_resolves_inc_action():
+    bindings = {"toe_inc": "Alt+T", "toe_dec": "Alt+Shift+T"}
+    assert action_id_for_binding(bindings, "Alt+T") == "toe_inc"


### PR DESCRIPTION
## Summary

Extends shortcut dialog search so **Customize** and the **`?` overview** share the same jump-to-row UX, plus **press-to-search** shortcut lookup in both.

- **Shared search** — Collapsible sections, smart search bar, expand/scroll/highlight on select; helpers live in `shortcut_editor_search.py` (`ShortcutSearchProxy`, completer mapping, scroll-to-center)
- **Press a shortcut to search** — In the search field, press a bound key (`G`, `Alt+T`, `Num+9`, …) to fill the bar and filter the result list; navigate with **Enter** or a click
- **Smarter matching** — Exact binding match for single-key presses; name/description search from 2+ characters; binding matches ranked above text matches; case-insensitive throughout
- **`ShortcutSearchLineEdit`** — Captures chord/numpad/single-key bindings without breaking text entry mid-word (`Mag` → `g` stays text)

## Test plan

- [x] Press `?`, search for an action (e.g. `density`) — section expands and row is highlighted
- [x] Type `grade` — matches Grade by name, not unrelated `g` bindings
- [x] Press `G` on empty search — shows Temperature in list; press Enter to jump
- [x] Press `Alt+T` — shows `alt+t` in bar and Toe in the list
- [x] Type `gr` then backspace to `g` — Temperature appears (same as pressing `G`)
- [x] Type `mag` — matches Magenta without jumping on `g`
- [x] Confirm Customize search behaves the same as overview
- [x] `uv run ruff check` and `uv run pytest tests/test_shortcut_editor_search.py tests/test_key_sequence_edit.py` pass