### PR TITLE
fix(capture): release the camera PTP session when the scan/preset windows close

### DIFF
--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -173,6 +173,7 @@ class AppController(QObject):
     capture_status = pyqtSignal(str)
     live_view_requested = pyqtSignal(LiveViewRequest)
     live_view_stop_requested = pyqtSignal()
+    camera_session_close_requested = pyqtSignal()
     live_view_focus_magnifier_requested = pyqtSignal(bool)
     live_view_focus_magnifier_pos_requested = pyqtSignal(int, int)
     live_view_camera_setting_requested = pyqtSignal(str, int)
@@ -416,6 +417,7 @@ class AppController(QObject):
         self.capture_worker.status.connect(self.capture_status.emit)
         self.live_view_requested.connect(self.capture_worker.start_live_view)
         self.live_view_stop_requested.connect(self.capture_worker.stop_live_view)
+        self.camera_session_close_requested.connect(self.capture_worker.close_camera_session)
         self.live_view_focus_magnifier_requested.connect(self.capture_worker.set_focus_magnifier)
         self.live_view_focus_magnifier_pos_requested.connect(self.capture_worker.set_focus_magnifier_pos)
         self.live_view_camera_setting_requested.connect(self.capture_worker.set_camera_setting)
@@ -1564,6 +1566,14 @@ class AppController(QObject):
 
     def stop_live_view(self) -> None:
         self.live_view_stop_requested.emit()
+
+    def close_camera_session(self) -> None:
+        """Release the held PTP session. Call once neither the scan window nor the
+        preset-calibration pop-up is open — some bodies (Fuji) get stuck in a
+        tethered-capture state until the session is cleanly exited, and leaving it
+        open past the last consuming window makes the next connection attempt hang."""
+        if self._capture_thread_started:
+            self.camera_session_close_requested.emit()
 
     def set_focus_magnifier(self, on: bool) -> None:
         self.live_view_focus_magnifier_requested.emit(on)

--- a/negpy/desktop/view/sidebar/scanlight.py
+++ b/negpy/desktop/view/sidebar/scanlight.py
@@ -76,6 +76,7 @@ class ScanlightSidebar(QWidget):
         self._magnifier_on = False  # camera focus magnifier state (driven by clicks on the live image)
         self._settings_loaded = False  # have the live camera-setting dropdowns been populated yet?
         self._slider_readouts: dict = {}  # slider → its value label (updated on preset apply, where signals are blocked)
+        self._suppress_camera_release = False  # true only mid hand-off between lv_window/calib_window
         self._no_wheel = _NoWheel(self)
 
         self.lv_window = LiveViewWindow(self)
@@ -567,12 +568,43 @@ class ScanlightSidebar(QWidget):
                 self._calibrating_preset = ""
             self._apply_gating()
             self._push_light()
+        self._maybe_release_camera_session(closing=self.calib_window)
+
+    def _maybe_release_camera_session(self, *, closing=None) -> None:
+        """Once neither camera pop-up is open and nothing is mid-capture, release the held
+        PTP session rather than leaving it open indefinitely. Some bodies (Fuji in
+        particular) get stuck in a tethered-capture state on the camera side until the
+        session is cleanly exited — holding it open past the last window that uses it
+        makes the next connection attempt hang instead of reconnecting.
+
+        `closing`, when given, names the window whose closeEvent just fired: `closed` is
+        emitted from inside closeEvent, before Qt actually hides the widget, so
+        `closing.isVisible()` would still (wrongly) read True here — treat it as already
+        gone instead. Omit it when called after the fact (e.g. once a cancelled
+        calibration actually stops), when both windows' visibility is already accurate.
+        """
+        if self._suppress_camera_release:
+            return  # a hand-off between the two pop-ups, not a real exit
+        lv_open = self.lv_window.isVisible() and closing is not self.lv_window
+        calib_open = self.calib_window.isVisible() and closing is not self.calib_window
+        if lv_open or calib_open:
+            return
+        if self._scanning or self._calibrating_preset:
+            return
+        self.controller.close_camera_session()
 
     # ── live view ─────────────────────────────────────────────────────
 
     def _on_live_view_toggled(self, on: bool) -> None:
         if on and self.calib_window.isVisible() and not self._calibrating_preset:
-            self.calib_window.close()  # only one live-view window at a time
+            # Hand-off, not an exit: closing calib_window here would otherwise look like
+            # the last camera window going away and release the session, only to have
+            # _start_live_view_worker() below immediately reopen it (~2-4 s reconnect).
+            self._suppress_camera_release = True
+            try:
+                self.calib_window.close()  # only one live-view window at a time
+            finally:
+                self._suppress_camera_release = False
         if on:
             self._settings_loaded = False  # repopulate the camera-setting dropdowns
             self._update_settings_from_ui()
@@ -618,6 +650,7 @@ class ScanlightSidebar(QWidget):
     def _on_live_view_window_closed(self) -> None:
         if self.lv_btn.isChecked():
             self.lv_btn.setChecked(False)  # stops live view via _on_live_view_toggled(False)
+        self._maybe_release_camera_session(closing=self.lv_window)
 
     def _refresh_live_view(self) -> None:
         if not self._lv_jpeg_path:
@@ -899,6 +932,7 @@ class ScanlightSidebar(QWidget):
         self._lv_target = self.lv_image
         self._stop_calibration_live_view()
         self._apply_gating()
+        self._maybe_release_camera_session()  # covers a calibration that was still running when its window closed
 
     @pyqtSlot(str)
     def _on_error(self, msg: str) -> None:

--- a/negpy/desktop/workers/capture_worker.py
+++ b/negpy/desktop/workers/capture_worker.py
@@ -307,6 +307,15 @@ class CaptureWorker(QObject):
             except Exception:
                 logger.exception("error stopping live view")
 
+    @pyqtSlot()
+    def close_camera_session(self) -> None:
+        """Release the held PTP session (called once neither the scan window nor the
+        preset-calibration pop-up is open). Some bodies (Fuji in particular) get stuck
+        in a tethered-capture state on the camera side until the session is cleanly
+        exited — leaving it open past the last window that uses it makes the *next*
+        connection attempt hang rather than reconnect."""
+        self._close_camera()
+
     def _camera_control_failed(self, action: str, exc: Exception) -> None:
         """Turn a failed Qt camera-control callback into a recoverable disconnect."""
         logger.exception("%s failed", action)


### PR DESCRIPTION
## Summary
- The tethered gphoto2 camera session was only ever closed on a capture error or full app shutdown, so exiting the Live View window or the new-preset calibration pop-up left it held open indefinitely.
- Some bodies (Fuji in particular) get stuck in a tethered-capture state on the camera side until the session is cleanly exited — leaving it open past the last window that uses it makes the *next* connection attempt hang instead of reconnecting.
- The session is now released once neither camera window is open and nothing is mid-capture/calibration, with a suppression guard so switching directly between Live View and the calibration pop-up doesn't trigger a spurious close+reconnect.

## Test plan
- [x] `uv run pytest tests/test_capture_gphoto.py tests/test_capture_worker.py tests/test_capture_controller.py tests/test_scanlight_sidebar.py` — 100 passed
- [x] `uv run ruff check` on the touched files — clean
- [x] `uv run ty check` on the touched files — no new diagnostics (7 pre-existing, unrelated to this change, confirmed identical on `main`)
- [x] Verified against a real Fuji X-T5 over USB: repeated open → close → reopen cycles are fast (~0.6s) and reliable, with no hangs
- [ ] Could not force-reproduce the original multi-second hang on the test rig to empirically prove the exact failure mode; this fix closes the identified gap (session never released on dialog close) that is the most likely root cause

🤖 Generated with [Claude Code](https://claude.com/claude-code)