### PR TITLE
Batch export always uses session export path/mode (#292)

### DIFF
--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -1971,6 +1971,16 @@ class AppController(QObject):
 
             if override_settings:
                 params = replace(params, export=current_export)
+            else:
+                # Always use current session export path/mode even for per-file
+                # exports. Per-file configs from the DB bypass _apply_sticky_settings
+                # and may have stale ABSOLUTE/export_path values.
+                params = replace(params, export=replace(
+                    params.export,
+                    output_mode=current_export.output_mode,
+                    export_path=current_export.export_path,
+                    output_subfolder=current_export.output_subfolder,
+                ))
 
             final_export = replace(
                 params.export,

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -525,6 +525,31 @@ class TestBatchExportFiltering(unittest.TestCase):
         for t in tasks:
             self.assertEqual(t.params.export.export_path, "/tmp/out")
 
+    def test_export_all_saved_overrides_path_with_session_values(self):
+        """all_saved scope uses session path/mode even when per-file configs are stale."""
+        self.visible_indices = [0, 1]
+        session_export = self.controller.state.config.export
+        stale_export = replace(
+            session_export,
+            output_mode=ExportPresetOutputMode.ABSOLUTE,
+            export_path="/stale/default",
+            output_subfolder="old_sub",
+        )
+        stale_config = replace(self.controller.state.config, export=stale_export)
+        # Per-file config has stale ABSOLUTE; session has SAME_AS_SOURCE
+        self.mock_session_manager.repo.load_file_settings.return_value = stale_config
+        self.controller.request_batch_export(override_settings=False)
+        tasks = self._captured_tasks()
+        self.assertEqual(len(tasks), 2)
+        for t in tasks:
+            # output_mode and output_subfolder come from session config
+            self.assertEqual(t.params.export.output_mode, session_export.output_mode)
+            self.assertEqual(t.params.export.output_subfolder, session_export.output_subfolder)
+            # export_path is validated by _ensure_valid_export_path (mocked to /tmp/out)
+            self.assertEqual(t.params.export.export_path, "/tmp/out")
+            # Format/quality from per-file config is preserved
+            self.assertEqual(t.params.export.export_fmt, stale_export.export_fmt)
+
 
 class TestPresetBatchExport(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Fixes #292 -- batch export writes files to the default ~/NegPy/export directory instead of "same as source" when using the all_saved or selected export scopes, because per-file configs loaded from the DB bypass the session's sticky export settings.

## Root cause

`_batch_params_for()` loads raw per-file configs from the DB via `load_file_settings()` without applying `_apply_sticky_settings()`. `select_file()` does apply the sticky overlay, so the UI correctly shows SAME_AS_SOURCE, but the per-file configs retain whatever export settings were saved to DB when the file was last individually edited -- typically the default `output_mode=ABSOLUTE` with `export_path=~/NegPy/export`.

When `all_saved` or `selected` scope is used (`override_settings=False`), `request_batch_export` uses each file's raw DB config as-is, sending files to the stale default path instead of beside the source. The `all_current` scope (`override_settings=True`) already works correctly -- it replaces the entire export config with the session values.

## Fix

In `request_batch_export`, always apply the current session's three destination fields (`output_mode`, `export_path`, `output_subfolder`) to each task's export config, even when `override_settings=False`. This makes per-file export destination a session-level decision while preserving per-file format, quality, resolution, and color settings.

The change is a small `else` branch in the per-task loop, using the same `replace()` idiom already present for the `override_settings=True` path.

**Files changed:**

- `negpy/desktop/controller.py` -- else branch in request_batch_export overrides per-file destination fields with session values
- `tests/test_controller.py` -- new test for all_saved scope with stale per-file config

## Verification

- 1700 tests pass (new test covers stale ABSOLUTE → session SAME_AS_SOURCE path)
- All four export scopes verified unchanged or correctly fixed (all_current, all_saved, selected, current)
- Single-file export, preset batch export, and contact sheet export paths unaffected
- Lint and type checks clean