### PR TITLE
Fix black surfaces in shortcut dialogs

### DIFF
--- a/negpy/desktop/view/styles/modern_dark.qss
+++ b/negpy/desktop/view/styles/modern_dark.qss
@@ -386,6 +386,18 @@ QFrame#toolbar_separator {
     background-color: #333333;
 }
 
+/* Shortcut overview/Customize dialog rows. Transparent by default so the row
+   frame doesn't paint the global #0D0D0D over the #121212 collapsible card;
+   the highlighted variant is the jump-to-row flash. */
+QFrame#shortcut_editor_row {
+    background: transparent;
+}
+
+QFrame#shortcut_editor_row[highlighted="true"] {
+    background-color: rgba(183, 28, 28, 0.12);
+    border-left: 2px solid @accent_primary;
+}
+
 QLabel#update_label {
     font-size: 12px;
     color: #558B2F;
@@ -496,8 +508,10 @@ QToolButton#gear_combo_arrow:hover {
     color: #D4D4D4;
 }
 
-/* QCompleter view — the QMenu/combo rules above don't reach it; mirror them. */
-QAbstractItemView#gear_combo_popup {
+/* QCompleter views — the QMenu/combo rules above don't reach them; mirror them.
+   Covers the gear combo and the shortcut-dialog search fields. */
+QAbstractItemView#gear_combo_popup,
+QAbstractItemView#shortcut_editor_search_popup {
     background: #161616;
     color: #D4D4D4;
     border: 1px solid #333333;
@@ -506,7 +520,8 @@ QAbstractItemView#gear_combo_popup {
     outline: 0;
 }
 
-QAbstractItemView#gear_combo_popup::item {
+QAbstractItemView#gear_combo_popup::item,
+QAbstractItemView#shortcut_editor_search_popup::item {
     background: transparent;
     border: none;
     border-radius: 3px;
@@ -514,7 +529,9 @@ QAbstractItemView#gear_combo_popup::item {
 }
 
 QAbstractItemView#gear_combo_popup::item:selected,
-QAbstractItemView#gear_combo_popup::item:hover {
+QAbstractItemView#gear_combo_popup::item:hover,
+QAbstractItemView#shortcut_editor_search_popup::item:selected,
+QAbstractItemView#shortcut_editor_search_popup::item:hover {
     background: #2E2E2E;
     color: #FFFFFF;
     border: none;

--- a/negpy/desktop/view/widgets/shortcut_editor.py
+++ b/negpy/desktop/view/widgets/shortcut_editor.py
@@ -79,16 +79,6 @@ class ShortcutEditorDialog(QDialog):
         root.setContentsMargins(18, 18, 18, 18)
         root.setSpacing(12)
 
-        self.setStyleSheet(f"""
-            QDialog {{ background-color: {THEME.bg_panel}; }}
-            QLabel {{ color: {THEME.text_primary}; font-size: 12px; }}
-            QPushButton {{ padding: 6px 14px; }}
-            QFrame#shortcut_editor_row[highlighted="true"] {{
-                background-color: rgba(183, 28, 28, 0.12);
-                border-left: 2px solid {THEME.accent_primary};
-            }}
-        """)
-
         intro = QLabel(
             "Set shortcuts and keyboard step sizes for slider actions. "
             "Search by name or press a shortcut to filter results, then choose or press Enter. "

--- a/negpy/desktop/view/widgets/shortcuts_overlay.py
+++ b/negpy/desktop/view/widgets/shortcuts_overlay.py
@@ -82,16 +82,6 @@ class ShortcutsOverlay(QDialog):
         root.setContentsMargins(18, 18, 18, 18)
         root.setSpacing(12)
 
-        self.setStyleSheet(f"""
-            QDialog {{ background-color: {THEME.bg_panel}; }}
-            QLabel {{ color: {THEME.text_primary}; font-size: 12px; }}
-            QPushButton {{ padding: 6px 14px; }}
-            QFrame#shortcut_editor_row[highlighted="true"] {{
-                background-color: rgba(183, 28, 28, 0.12);
-                border-left: 2px solid {THEME.accent_primary};
-            }}
-        """)
-
         intro = QLabel(
             "Current keyboard shortcuts and slider step sizes. "
             "Search by name or press a shortcut to filter results, then choose or press Enter. "


### PR DESCRIPTION
## What

The keyboard-shortcut **overview** (`?`) and **Customize** dialogs rendered two surfaces on near-black backgrounds, inconsistent with the app's menus and sidebar sections:

- the search-field autocomplete dropdown (unstyled `QListView` fallback → `#0D0D0D` with bordered item boxes)
- each shortcut **row**, which as a plain `QFrame` got painted the global `#0D0D0D` over the `#121212` collapsible card — a darker strip behind the content

## Changes

- Style the search completer popup by folding `#shortcut_editor_search_popup` into the existing global `gear_combo_popup` rule (flat `#161616` menu surface, flat items).
- Default `QFrame#shortcut_editor_row` to `background: transparent` so rows show the collapsible card — the same fix `collapsible_content_body` already uses for this global-`QWidget` paint gotcha.
- Move the jump-to-row highlight rule into the global stylesheet and drop both dialogs' now-redundant inline `setStyleSheet` blocks.

Net: both dialogs render fully on global styles, matching the sidebars.

## Verification

- `make lint` + `make type` green; shortcut dialog tests pass (9/9).
- Drove the Customize dialog headlessly under Xvfb and confirmed the darker row strip is gone (rows sit on the uniform `#121212` card).