### PR TITLE
Fix process abort when switching files while densitometer readout is active

### DIFF
--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -658,6 +658,9 @@ class AppController(QObject):
         self._thumb_config = None
 
         self._render_cleanup_requested.emit()
+        # The cleanup destroys the GPU textures last_metrics still points at; drop the
+        # densitometer's probe source so hover readouts go quiet until the next render.
+        self.state.last_metrics.pop("normalized_log", None)
 
         self.state.preview_raw = None
         self.state.preview_ir = None
@@ -1985,12 +1988,15 @@ class AppController(QObject):
                 # Always use current session export path/mode even for per-file
                 # exports. Per-file configs from the DB bypass _apply_sticky_settings
                 # and may have stale ABSOLUTE/export_path values.
-                params = replace(params, export=replace(
-                    params.export,
-                    output_mode=current_export.output_mode,
-                    export_path=current_export.export_path,
-                    output_subfolder=current_export.output_subfolder,
-                ))
+                params = replace(
+                    params,
+                    export=replace(
+                        params.export,
+                        output_mode=current_export.output_mode,
+                        export_path=current_export.export_path,
+                        output_subfolder=current_export.output_subfolder,
+                    ),
+                )
 
             final_export = replace(
                 params.export,

--- a/negpy/infrastructure/gpu/resources.py
+++ b/negpy/infrastructure/gpu/resources.py
@@ -1,3 +1,5 @@
+import threading
+
 import numpy as np
 import wgpu  # type: ignore
 from negpy.infrastructure.gpu.device import GPUDevice
@@ -33,6 +35,10 @@ class GPUTexture:
         self._readback_staging = None  # full-texture readback
         self._region_staging = None  # sub-region readback
         self._region_staging_size: int = 0  # allocated size of _region_staging
+        # Serializes readback vs. destroy: the UI thread probes textures (densitometer,
+        # pixel readout) while the render worker may destroy them (engine cleanup on file
+        # switch). Destroying a mapped staging buffer panics in wgpu-native — uncatchable.
+        self._lock = threading.Lock()
 
     def upload(self, data: np.ndarray) -> None:
         """Transfers ndarray to VRAM."""
@@ -57,109 +63,112 @@ class GPUTexture:
     def readback_region(self, x: int, y: int, rw: int, rh: int) -> np.ndarray:
         """Downloads a sub-region from VRAM. Significantly faster than a full readback."""
         gpu = GPUDevice.get()
-        if not gpu.device or not self.texture:
-            return np.zeros((rh, rw, 4), dtype=np.float32)
+        with self._lock:
+            if not gpu.device or not self.texture:
+                return np.zeros((rh, rw, 4), dtype=np.float32)
 
-        rw = min(rw, max(1, self.width - x))
-        rh = min(rh, max(1, self.height - y))
+            rw = min(rw, max(1, self.width - x))
+            rh = min(rh, max(1, self.height - y))
 
-        bytes_per_row = (rw * 16 + 255) & ~255
-        required_size = bytes_per_row * rh
+            bytes_per_row = (rw * 16 + 255) & ~255
+            required_size = bytes_per_row * rh
 
-        if self._region_staging is None or self._region_staging_size < required_size:
-            if self._region_staging is not None:
+            if self._region_staging is None or self._region_staging_size < required_size:
+                if self._region_staging is not None:
+                    try:
+                        self._region_staging.destroy()
+                    except Exception as e:
+                        logger.warning("Failed to destroy region staging buffer", exc_info=e)
+                    try:
+                        gpu.poll()
+                    except Exception as e:
+                        logger.warning("Failed to poll GPU device", exc_info=e)
+                self._region_staging = None
+                self._region_staging_size = 0
                 try:
-                    self._region_staging.destroy()
+                    self._region_staging = gpu.device.create_buffer(
+                        size=required_size, usage=wgpu.BufferUsage.COPY_DST | wgpu.BufferUsage.MAP_READ
+                    )
+                    self._region_staging_size = required_size
                 except Exception as e:
-                    logger.warning("Failed to destroy region staging buffer", exc_info=e)
-                try:
-                    gpu.poll()
-                except Exception as e:
-                    logger.warning("Failed to poll GPU device", exc_info=e)
-            self._region_staging = None
-            self._region_staging_size = 0
+                    logger.warning("Failed to create region staging buffer", exc_info=e)
+                    self._region_staging = None
+                    self._region_staging_size = 0
+                    raise
+            staging = self._region_staging
+
+            enc = gpu.device.create_command_encoder()
+            enc.copy_texture_to_buffer(
+                {"texture": self.texture, "origin": (x, y, 0)},
+                {"buffer": staging, "bytes_per_row": bytes_per_row},
+                (rw, rh, 1),
+            )
+            gpu.device.queue.submit([enc.finish()])
+
             try:
-                self._region_staging = gpu.device.create_buffer(
-                    size=required_size, usage=wgpu.BufferUsage.COPY_DST | wgpu.BufferUsage.MAP_READ
-                )
-                self._region_staging_size = required_size
-            except Exception as e:
-                logger.warning("Failed to create region staging buffer", exc_info=e)
+                staging.map_sync(mode=wgpu.MapMode.READ)
+                view = staging.read_mapped()
+                arr = np.frombuffer(view, dtype=np.float32).reshape((rh, bytes_per_row // 4))
+                result = arr[:, : rw * 4].reshape((rh, rw, 4)).copy()
+                staging.unmap()
+                return result
+            except Exception:
                 self._region_staging = None
                 self._region_staging_size = 0
                 raise
-        staging = self._region_staging
-
-        enc = gpu.device.create_command_encoder()
-        enc.copy_texture_to_buffer(
-            {"texture": self.texture, "origin": (x, y, 0)},
-            {"buffer": staging, "bytes_per_row": bytes_per_row},
-            (rw, rh, 1),
-        )
-        gpu.device.queue.submit([enc.finish()])
-
-        try:
-            staging.map_sync(mode=wgpu.MapMode.READ)
-            view = staging.read_mapped()
-            arr = np.frombuffer(view, dtype=np.float32).reshape((rh, bytes_per_row // 4))
-            result = arr[:, : rw * 4].reshape((rh, rw, 4)).copy()
-            staging.unmap()
-            return result
-        except Exception:
-            self._region_staging = None
-            self._region_staging_size = 0
-            raise
 
     def readback(self) -> np.ndarray:
         """Downloads pixels from VRAM to CPU ndarray (float32)."""
         gpu = GPUDevice.get()
-        if not gpu.device or not self.texture:
-            return np.zeros((self.height, self.width, 4), dtype=np.float32)
+        with self._lock:
+            if not gpu.device or not self.texture:
+                return np.zeros((self.height, self.width, 4), dtype=np.float32)
 
-        bytes_per_row = (self.width * 16 + 255) & ~255
-        size = bytes_per_row * self.height
+            bytes_per_row = (self.width * 16 + 255) & ~255
+            size = bytes_per_row * self.height
 
-        if self._readback_staging is None:
-            self._readback_staging = gpu.device.create_buffer(size=size, usage=wgpu.BufferUsage.COPY_DST | wgpu.BufferUsage.MAP_READ)
-        staging = self._readback_staging
+            if self._readback_staging is None:
+                self._readback_staging = gpu.device.create_buffer(size=size, usage=wgpu.BufferUsage.COPY_DST | wgpu.BufferUsage.MAP_READ)
+            staging = self._readback_staging
 
-        enc = gpu.device.create_command_encoder()
-        enc.copy_texture_to_buffer(
-            {"texture": self.texture},
-            {"buffer": staging, "bytes_per_row": bytes_per_row},
-            (self.width, self.height, 1),
-        )
-        gpu.device.queue.submit([enc.finish()])
+            enc = gpu.device.create_command_encoder()
+            enc.copy_texture_to_buffer(
+                {"texture": self.texture},
+                {"buffer": staging, "bytes_per_row": bytes_per_row},
+                (self.width, self.height, 1),
+            )
+            gpu.device.queue.submit([enc.finish()])
 
-        try:
-            staging.map_sync(mode=wgpu.MapMode.READ)
-            view = staging.read_mapped()
-            arr = np.frombuffer(view, dtype=np.float32).reshape((self.height, bytes_per_row // 4))
-            result = arr[:, : self.width * 4].reshape((self.height, self.width, 4)).copy()
-            staging.unmap()
-            return result
-        except Exception:
-            self._readback_staging = None
-            raise
+            try:
+                staging.map_sync(mode=wgpu.MapMode.READ)
+                view = staging.read_mapped()
+                arr = np.frombuffer(view, dtype=np.float32).reshape((self.height, bytes_per_row // 4))
+                result = arr[:, : self.width * 4].reshape((self.height, self.width, 4)).copy()
+                staging.unmap()
+                return result
+            except Exception:
+                self._readback_staging = None
+                raise
 
     def destroy(self) -> None:
         """Forces hardware resource release."""
-        try:
-            self.view = None
-            if self.texture:
-                self.texture.destroy()
-                self.texture = None
-        except Exception as e:
-            logger.warning("Failed to destroy GPU texture", exc_info=e)
-        for attr in ("_readback_staging", "_region_staging"):
-            buf = getattr(self, attr, None)
-            if buf is not None:
-                try:
-                    buf.destroy()
-                except Exception as e:
-                    logger.warning(f"Failed to destroy GPU buffer ({attr})", exc_info=e)
-                setattr(self, attr, None)
-        self._region_staging_size = 0
+        with self._lock:
+            try:
+                self.view = None
+                if self.texture:
+                    self.texture.destroy()
+                    self.texture = None
+            except Exception as e:
+                logger.warning("Failed to destroy GPU texture", exc_info=e)
+            for attr in ("_readback_staging", "_region_staging"):
+                buf = getattr(self, attr, None)
+                if buf is not None:
+                    try:
+                        buf.destroy()
+                    except Exception as e:
+                        logger.warning(f"Failed to destroy GPU buffer ({attr})", exc_info=e)
+                    setattr(self, attr, None)
+            self._region_staging_size = 0
 
 
 class GPUBuffer:

--- a/tests/test_gpu_engine.py
+++ b/tests/test_gpu_engine.py
@@ -296,6 +296,48 @@ class TestGPUEngine(unittest.TestCase):
         np.testing.assert_array_equal(hist_no_border, hist_black, err_msg="Black border pixels skewed the histogram")
         np.testing.assert_array_equal(hist_no_border, hist_white, err_msg="White border pixels skewed the histogram")
 
+    def test_readback_after_destroy_returns_zeros(self):
+        """A destroyed texture must answer readbacks with zeros, never touch dead wgpu objects."""
+        from negpy.infrastructure.gpu.resources import GPUTexture
+
+        tex = GPUTexture(16, 16)
+        tex.upload(np.random.rand(16, 16, 4).astype(np.float32))
+        tex.readback_region(0, 0, 1, 1)  # allocate the staging buffer pre-destroy
+        tex.destroy()
+        np.testing.assert_array_equal(tex.readback_region(0, 0, 1, 1), np.zeros((1, 1, 4), dtype=np.float32))
+        np.testing.assert_array_equal(tex.readback(), np.zeros((16, 16, 4), dtype=np.float32))
+
+    def test_concurrent_readback_and_destroy(self):
+        """UI-thread readbacks racing a worker-thread destroy must serialize, not panic.
+
+        Regression: the densitometer's hover readback overlapped the render worker's
+        engine cleanup; destroying the mapped staging buffer aborted the process
+        inside wgpu-native (uncatchable Rust panic)."""
+        import threading
+
+        from negpy.infrastructure.gpu.resources import GPUTexture
+
+        for _ in range(20):
+            tex = GPUTexture(64, 64)
+            tex.upload(np.random.rand(64, 64, 4).astype(np.float32))
+            start = threading.Barrier(2)
+
+            def probe(t=tex, s=start):
+                s.wait()
+                for _ in range(10):
+                    t.readback_region(3, 3, 1, 1)
+
+            def kill(t=tex, s=start):
+                s.wait()
+                t.destroy()
+
+            threads = [threading.Thread(target=probe), threading.Thread(target=kill)]
+            for th in threads:
+                th.start()
+            for th in threads:
+                th.join(timeout=30)
+            self.assertFalse(any(th.is_alive() for th in threads), "readback/destroy deadlocked")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Fixes a hard crash (process abort, not a Python exception) when switching files while the cursor is over the canvas.

### The race

On file switch, `load_file` asks the render worker to evacuate GPU resources (`GPUEngine.cleanup`), which destroys the cached textures — including the `normalized_log` texture that `state.last_metrics` still references. If the cursor is over the canvas at that moment, the spot densitometer's hover readout on the UI thread is probing that same texture via `readback_region`. When the worker's destroy lands between `map_sync` and `read_mapped`, wgpu-native panics in Rust and aborts the whole process — uncatchable from Python:

```
thread '<unnamed>' panicked at src\lib.rs:606:5:
Error in wgpuBufferGetMappedRange: Validation Error
Caused by: Buffer with '' label has been destroyed
Fatal Python error: Aborted
```

The same race exists for the pixel-RGB readout (`canvas/widget.py`) and the analysis spot sampling — any UI-thread readback against the render worker's cleanup.

### The fix

- **`GPUTexture` gets a per-texture lock** serializing `readback_region` / `readback` / `destroy`. A destroy now waits for an in-flight readback to complete; a readback that arrives after destroy sees `texture is None` under the lock and returns zeros instead of touching dead wgpu objects. Deadlock-free: the lock is only held across a single readback (the map wait is served by wgpu-py's poller thread) or a destroy.
- **`load_file` drops the stale `normalized_log` reference** from `last_metrics` when it requests cleanup, so hover readouts return `None` (readout goes quiet) during the load transition rather than reading zeros off a destroyed texture.

## Testing

Two regression tests in `test_gpu_engine.py`: destroy-then-readback returns zeros for both readback paths, and a 20-round two-thread readback-vs-destroy hammer — the hammer reproduced the abort on real hardware (Windows, DX12) before the fix and passes with it. Full `test_gpu_engine.py` (16), `test_densitometer.py` + `test_controller.py` (84) pass; ruff clean. Verified in-app: hovering the densitometer while rapidly switching files no longer crashes.
