### PR TITLE
Fix export crash from non-ASCII film format in EXIF metadata (#487)

### DIFF
--- a/negpy/features/metadata/writer.py
+++ b/negpy/features/metadata/writer.py
@@ -125,7 +125,7 @@ def _build_custom_exif(payload: MetadataPayload) -> dict:
 
     if user_comment_parts:
         lines = [f"{k.replace('_', ' ').title()}: {v}" for k, v in user_comment_parts.items()]
-        uc_bytes = b"ASCII\x00\x00\x00" + "\n".join(lines).encode("ascii")
+        uc_bytes = b"ASCII\x00\x00\x00" + "\n".join(lines).encode("ascii", "replace")
         exif[piexif.ExifIFD.UserComment] = uc_bytes
 
     if flags.exposure and payload.capture_exposure:
@@ -630,7 +630,9 @@ def _fold_user_comment_into_description(description: str | None, extratags: list
             continue
         raw = bytes(value)
         if raw[:8] == b"ASCII\x00\x00\x00":
-            uc_text = raw[8:].decode("ascii", "replace").rstrip("\x00").strip()
+            uc_text = _decode_ascii(raw[8:])
+            if uc_text is not None:
+                uc_text = uc_text.strip()
         break
 
     if not uc_text:

--- a/tests/metadata/test_writer.py
+++ b/tests/metadata/test_writer.py
@@ -278,3 +278,32 @@ class TestDecodeAscii:
             desc = tf.pages[0].tags.get("ImageDescription")
             # ASCII-safe -- tifffile would reject non-ASCII
             desc.value.encode("ascii")
+
+    def test_film_format_with_non_ascii_does_not_crash(self) -> None:
+        """Regression: FilmFormat uses x (U+00D7) in '4x5'/'8x10', must not crash export (#487)."""
+        image_bytes = _make_tiff_bytes()
+        config = MetadataConfig(format="4×5")
+        out = embed_metadata(image_bytes, config, None)
+        assert out != image_bytes
+        with tifffile.TiffFile(io.BytesIO(out)) as tf:
+            desc = tf.pages[0].tags.get("ImageDescription")
+            desc.value.encode("ascii")
+
+    def test_user_comment_fold_with_non_ascii_bytes(self) -> None:
+        """Regression: UserComment with non-ASCII bytes must not produce \ufffd in description (#487)."""
+        image_bytes = _make_tiff_bytes()
+        # Simulate source EXIF with a UserComment containing non-ASCII bytes
+        uc_body = b"Film: 4\xd75 - Portra 400"
+        uc_raw = b"ASCII\x00\x00\x00" + uc_body
+        source_exif = {
+            "0th": {},
+            "Exif": {piexif.ExifIFD.UserComment: uc_raw},
+            "GPS": {},
+            "Interop": {},
+            "1st": {},
+        }
+        out = embed_metadata(image_bytes, MetadataConfig(), source_exif)
+        assert out != image_bytes
+        with tifffile.TiffFile(io.BytesIO(out)) as tf:
+            desc = tf.pages[0].tags.get("ImageDescription")
+            desc.value.encode("ascii")


### PR DESCRIPTION
Fixes #487 -- the same `UnicodeEncodeError` still happened on JPG, TIFF, and PNG exports after #452 was merged. I only fixed half the problem.

## Root cause

The #452 fix covered strings read from source EXIF via `_decode_ascii`. What I missed is NegPy writes its own non-ASCII strings. The `FilmFormat` enum uses `×` (0xd7, multiplication sign) in `"4×5"` and `"8×10"` at `gear_models.py:15-16`. When a user has one of those formats, it flows through `build_metadata_payload` > `_build_custom_exif` > UserComment construction at `writer.py:128`, which had a bare `.encode("ascii")` and crashed.

There's a second crash site too; `_fold_user_comment_into_description` at `writer.py:633` used `raw[8:].decode("ascii", "replace")` to read the UserComment back out. That produces U+FFFD (replacement character) for any byte it can't decode, and U+FFFD isn't ASCII. When it hit `tifffile.imwrite(description=...)`, same crash.

DNG, JXL, and WebP weren't affected because `export.py:139-143` skips metadata for those three. That's why the reporter only saw it on JPG, TIFF, and PNG.

## Fix

Two lines in `negpy/features/metadata/writer.py`:

1. Line 128 -- `.encode("ascii")` > `.encode("ascii", "replace")`, same pattern `_exif_ascii` already uses at line 79.

2. Line 633 -- swapped the raw decode for `_decode_ascii(raw[8:])` then `.strip()`. That helper already round-trips through `encode("ascii", "replace")` so the output's guaranteed pure ASCII.

**Files changed:**
- `negpy/features/metadata/writer.py` -- both crash sites
- `tests/metadata/test_writer.py` -- 2 new regression tests

## Verification

- 18/18 pass in tests/metadata/test_writer.py (new tests cover FilmFormat crash and UserComment fold with non-ASCII bytes)
- 4/5 pass in tests/test_metadata_writer.py (1 skipped, needs exiftool)
- End-to-end simulation with `format="4×5"` on TIFF, JPEG, and PNG -- no crash
- Lint and format clean