### PR TITLE
Camera scanning follow-ups: RGB-only Scanlights, live-view polish, crash diagnostics

### DIFF
--- a/negpy/desktop/main.py
+++ b/negpy/desktop/main.py
@@ -44,6 +44,33 @@ def _filter_qt_messages(mode, context, message: str) -> None:
     sys.stderr.write(message + "\n")
 
 
+def _install_exception_hook() -> None:
+    """Log every unhandled exception — especially ones raised inside a Qt slot — to the file log and
+    show a non-fatal notice, instead of letting PyQt call qFatal() and abort with a native crash
+    report that hides the Python traceback. This is what surfaces user-side bugs we can't reproduce
+    (e.g. the Big Scanlight calibration crash): the traceback lands in negpy.log for them to attach."""
+
+    def _hook(exc_type, exc_value, exc_tb) -> None:
+        if issubclass(exc_type, KeyboardInterrupt):
+            sys.__excepthook__(exc_type, exc_value, exc_tb)
+            return
+        logger.critical("Unhandled exception", exc_info=(exc_type, exc_value, exc_tb))
+        try:
+            from PyQt6.QtWidgets import QMessageBox
+
+            QMessageBox.critical(
+                None,
+                "NegPy hit an error",
+                f"Something went wrong and was logged:\n\n{exc_type.__name__}: {exc_value}\n\n"
+                f"The app kept running. If it keeps happening, please attach the log file "
+                f"({os.path.join(BASE_USER_DIR, 'negpy.log')}) to a bug report on GitHub.",
+            )
+        except Exception:
+            logger.warning("could not show the error dialog", exc_info=True)
+
+    sys.excepthook = _hook
+
+
 def _bootstrap_environment() -> None:
     """Ensure user directories exist."""
     dirs = [
@@ -68,6 +95,7 @@ def main() -> None:
     """
     override_cfg = load_override(APP_CONFIG.override_toml_path)
     setup_logging(level=override_cfg.log_level_int)
+    _install_exception_hook()  # log unhandled slot exceptions to negpy.log instead of aborting
 
     if getattr(sys, "frozen", False):
         log_path = os.path.join(os.path.expanduser("~"), "negpy_boot.log")

--- a/negpy/desktop/view/sidebar/calibration_window.py
+++ b/negpy/desktop/view/sidebar/calibration_window.py
@@ -104,6 +104,10 @@ class CalibrationWindow(QDialog):
         """Reset and show the window for a fresh calibration."""
         self.name_edit.setText(default_name)
         self.image.clear_roi()
+        # Blank the previous session's frame before showing, so reopening goes straight to black +
+        # the buffering spinner instead of briefly flashing the stale image.
+        self.image.clear_frame()
+        self.image.set_loading(True)
         self.progress.setVisible(False)
         self.set_status("Click the clear film base (crosshair), name the stock, then Calibrate & Save.")
         self.show()

--- a/negpy/desktop/view/sidebar/scanlight.py
+++ b/negpy/desktop/view/sidebar/scanlight.py
@@ -817,6 +817,10 @@ class ScanlightSidebar(QWidget):
 
     def _start_live_view_worker(self) -> None:
         """Spawn the live-view stream subprocess (shared by toggle-on and resume)."""
+        # Blank the previous session's frame *before* the window is shown, so reopening live view
+        # goes straight to black + the buffering spinner instead of flashing the stale image until
+        # the first fresh frame lands (`_on_live_view_started` re-blanks + pins the mtime).
+        self._lv_target.clear_frame()
         self._lv_target.set_loading(True)  # buffering spinner until the first frame lands
         from negpy.desktop.workers.capture_worker import LiveViewRequest
 

--- a/negpy/desktop/view/sidebar/scanlight.py
+++ b/negpy/desktop/view/sidebar/scanlight.py
@@ -56,11 +56,6 @@ _MANUAL_PRESET = "\x00create-manual"
 # 400 ms was conservative). A fixed tuning constant, not a user/persisted setting.
 _LED_SETTLE_S = 0.15
 
-# Plain white to light the frame while framing/focusing an RGB scan in live view. It's fixed, not
-# taken from the W slider: the sliders configure the preset, so W reads 0 for an RGB preset, but you
-# still want light to focus by.
-_FRAMING_WHITE = 255
-
 
 class _NoWheel(QObject):
     """Event filter that swallows wheel events so scrolling can't change a value."""
@@ -87,6 +82,8 @@ class ScanlightSidebar(QWidget):
         self._magnifier_on = False  # camera focus magnifier state (driven by clicks on the live image)
         self._settings_loaded = False  # have the live camera-setting dropdowns been populated yet?
         self._slider_readouts: dict = {}  # slider → its value label (updated on preset apply, where signals are blocked)
+        self._slider_rows: dict = {}  # slider → its row widget, so the W row can be hidden on an RGB-only Scanlight
+        self._light_has_white = True  # does the connected Scanlight have a white LED? (False = v1-v3, RGB-only)
         self._suppress_camera_release = False  # true only mid hand-off between lv_window/calib_window
         self._no_wheel = _NoWheel(self)
 
@@ -169,7 +166,9 @@ class ScanlightSidebar(QWidget):
     # ── UI construction ───────────────────────────────────────────────
 
     def _slider_row(self, letter: str, value: int) -> QSlider:
-        row = QHBoxLayout()
+        row_widget = QWidget()  # wrapped so the whole row (W) can be hidden on an RGB-only Scanlight
+        row = QHBoxLayout(row_widget)
+        row.setContentsMargins(0, 0, 0, 0)
         tag = QLabel(letter)
         tag.setFixedWidth(14)
         tag.setStyleSheet(f"color: {_CHANNEL_COLORS[letter]}; font-weight: bold;")
@@ -182,8 +181,9 @@ class ScanlightSidebar(QWidget):
         row.addWidget(tag)
         row.addWidget(slider, 1)
         row.addWidget(readout)
-        self._light_layout.addLayout(row)
+        self._light_layout.addWidget(row_widget)
         self._slider_readouts[slider] = readout  # so preset apply (signals blocked) can refresh it
+        self._slider_rows[slider] = row_widget
         slider.valueChanged.connect(lambda v, lbl=readout: lbl.setText(str(v)))
         slider.valueChanged.connect(lambda _v: self._light_debounce.start())
         return slider
@@ -424,15 +424,11 @@ class ScanlightSidebar(QWidget):
         if self._settings.white_mode:
             # A white-light preset: the W slider is the scan light itself.
             self.controller.set_scanlight_color(0, 0, 0, self.w_slider.value(), self._settings.port)
-        elif self._manual_mode:
-            # Building an RGB preset by hand: show the R/G/B mix being dialled in so the sliders have
-            # a visible effect. White stays off — the Scanlight can't light white together with RGB.
-            self.controller.set_scanlight_color(self.r_slider.value(), self.g_slider.value(), self.b_slider.value(), 0, self._settings.port)
-        elif self.lv_btn.isChecked() or self.calib_window.isVisible():
-            # Framing/focusing an RGB scan: plain white to see by, independent of the RGB sliders
-            # (they configure the preset, so W reads 0, but you still want light to focus).
-            self.controller.set_scanlight_color(0, 0, 0, _FRAMING_WHITE, self._settings.port)
         else:
+            # Any RGB state — a selected preset, manual building, or framing/focusing in live view —
+            # lights the R/G/B mix from the sliders. The preset's own values are the framing light too
+            # (one light for scanning and focusing), so it works on every Scanlight and never assumes a
+            # white LED an RGB-only body lacks. White stays off: the Scanlight can't mix white with RGB.
             self.controller.set_scanlight_color(self.r_slider.value(), self.g_slider.value(), self.b_slider.value(), 0, self._settings.port)
         self._update_settings_from_ui()
 
@@ -1223,7 +1219,9 @@ class ScanlightSidebar(QWidget):
         was_verified = self._camera_verified
         self._set_conn_status(self.light_status, status["light_ok"], "Light", f"Scanlight: {status['light_detail']}")
         self._light_verified = status["light_ok"]
+        self._light_has_white = status.get("light_has_white", True)  # RGB-only Scanlights (v1-v3) have no white LED
         self._set_rgb_mode(status["light_ok"])  # Scanlight present → RGB scanning; absent → normal white-light
+        self._refresh_light_channels()  # show/hide the W slider + white preset for the connected model
         self._camera_verified = bool(status["usb_ok"])
         self._set_cam_status(self._camera_verified, status["usb_model"])
         if self._camera_verified and not was_verified:
@@ -1334,6 +1332,27 @@ class ScanlightSidebar(QWidget):
             item = model.item(manual_idx)
             if item is not None:
                 item.setEnabled(self._camera_verified)
+
+    def _refresh_light_channels(self) -> None:
+        """Adapt the light controls to the connected Scanlight. An RGB-only body (v1-v3, no white
+        LED) hides the W slider and greys out the white-light preset, since neither can do anything;
+        the live-view framing then lights all three RGB channels instead of a missing white one
+        (`_push_light`). A body with a white LED (v4 / Big) keeps them."""
+        has_white = self._light_has_white
+        w_row = self._slider_rows.get(self.w_slider)
+        if w_row is not None:
+            w_row.setVisible(has_white)
+        white_name = next(iter(_BUILTIN_WHITE_PRESETS))  # the built-in white-light preset
+        white_idx = self.preset_combo.findData(white_name)
+        model = self.preset_combo.model()
+        if white_idx >= 0 and isinstance(model, QStandardItemModel):
+            item = model.item(white_idx)
+            if item is not None:
+                item.setEnabled(has_white)
+        # If a white-light preset was somehow selected on an RGB-only body, drop it — it can't run.
+        if not has_white and self.preset_combo.currentData() in _BUILTIN_WHITE_PRESETS:
+            self.preset_combo.setCurrentIndex(0)
+            self._on_preset_selected(0)
 
     def _set_rgb_mode(self, on: bool) -> None:
         """Switch between RGB (Scanlight) and normal white-light scanning, driven by the

--- a/negpy/desktop/workers/capture_worker.py
+++ b/negpy/desktop/workers/capture_worker.py
@@ -14,7 +14,7 @@ from PyQt6.QtCore import QObject, pyqtSignal, pyqtSlot
 
 from negpy.infrastructure.capture.base import CaptureSettings
 from negpy.infrastructure.capture.gphoto import CameraUnavailable, GphotoCamera, list_cameras
-from negpy.infrastructure.capture.protocol import describe_hardware
+from negpy.infrastructure.capture.protocol import describe_hardware, has_white_channel
 from negpy.infrastructure.capture.scanlight import Scanlight
 from negpy.kernel.system.logging import get_logger
 from negpy.services.capture.calibration import CalibrationService, Roi
@@ -268,7 +268,7 @@ class CaptureWorker(QObject):
         """Lightweight presence check for the auto-connect UI: is a body enumerated, and is
         the light up? Off the UI thread; called on a timer. Enumerating does not claim the
         camera, so this is safe to run while live view streams."""
-        status = {"usb_ok": False, "usb_model": "", "light_ok": False, "light_detail": "not connected"}
+        status = {"usb_ok": False, "usb_model": "", "light_ok": False, "light_detail": "not connected", "light_has_white": True}
         try:
             # Always ask the bus, never our own handle: unplugging the camera leaves the
             # handle behind, and it would keep reporting "connected" forever. Enumerating
@@ -286,6 +286,7 @@ class CaptureWorker(QObject):
         try:
             fw, hw = self._ensure_light(port).get_fw_version()
             status["light_ok"], status["light_detail"] = True, f"{describe_hardware(hw)} (fw{fw})"
+            status["light_has_white"] = has_white_channel(hw)
         except Exception:
             pass
         self.poll_status.emit(status)

--- a/negpy/infrastructure/capture/protocol.py
+++ b/negpy/infrastructure/capture/protocol.py
@@ -84,8 +84,20 @@ def decode_fw_version(data: bytes) -> tuple[int, int]:
 # The family shares this wire protocol, so NegPy drives any of them identically.
 HARDWARE_NAMES = {0: "Big Scanlight", 1: "Scanlight v4"}
 
+# Models with a dedicated white LED. The white channel arrived with the v4, so the Big
+# Scanlight (0) and v4 (1) have it; the earlier v1/v2/v3 are RGB-only, as is any id we
+# don't recognise (a future white-capable model would just be added here).
+_WHITE_CAPABLE_HW = frozenset({0, 1})
+
 
 def describe_hardware(hw_id: int) -> str:
     """Friendly device name for a reported hardware ID (from `decode_fw_version`),
     or 'hw<n>' for an id we don't have a name for."""
     return HARDWARE_NAMES.get(hw_id, f"hw{hw_id}")
+
+
+def has_white_channel(hw_id: int) -> bool:
+    """Whether this Scanlight model has a dedicated white LED. RGB-only bodies (v1-v3, or
+    any unrecognised id) return False, so the UI can drop the white slider/preset and light
+    all three RGB channels for framing instead of a (non-existent) white one."""
+    return hw_id in _WHITE_CAPABLE_HW

--- a/negpy/kernel/system/logging.py
+++ b/negpy/kernel/system/logging.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import sys
 import io
 
@@ -52,6 +53,25 @@ def setup_logging(level: int = logging.INFO) -> logging.Logger:
 
     # Add handler to logger
     logger.addHandler(handler)
+
+    # File handler too: the console log is invisible in a packaged .app (no terminal), so also write
+    # to a rotating file under the user data dir. Users can attach it to bug reports, and the global
+    # exception hook (desktop/main.py) records unhandled slot exceptions here that would otherwise
+    # only abort with a native crash report that hides the Python traceback. Best-effort — a
+    # file-logging failure (read-only home, etc.) must never stop the app from starting.
+    try:
+        from logging.handlers import RotatingFileHandler
+
+        from negpy.kernel.system.paths import get_default_user_dir
+
+        log_dir = get_default_user_dir()
+        os.makedirs(log_dir, exist_ok=True)
+        file_handler = RotatingFileHandler(os.path.join(log_dir, "negpy.log"), maxBytes=2_000_000, backupCount=2, encoding="utf-8")
+        file_handler.setLevel(level)
+        file_handler.setFormatter(formatter)
+        logger.addHandler(file_handler)
+    except Exception:
+        logger.warning("could not set up file logging", exc_info=True)
 
     return logger
 

--- a/tests/test_capture_protocol.py
+++ b/tests/test_capture_protocol.py
@@ -54,6 +54,15 @@ def test_describe_hardware_known_and_unknown():
     assert proto.describe_hardware(7) == "hw7"
 
 
+def test_has_white_channel():
+    # Only the Big Scanlight (0) and v4 (1) have a dedicated white LED.
+    assert proto.has_white_channel(0) is True
+    assert proto.has_white_channel(1) is True
+    # v1-v3 (and any unrecognised id) are RGB-only.
+    assert proto.has_white_channel(2) is False
+    assert proto.has_white_channel(7) is False
+
+
 def test_big_scanlight_set_color_is_wire_identical_to_v4():
     # Big Scanlight SET_COLOR firmware reads 5 bytes (R,G,B,W,IR) + byte[5]=save,
     # exactly what encode_set_color emits — so one encoder drives both devices.

--- a/tests/test_exception_hook.py
+++ b/tests/test_exception_hook.py
@@ -1,0 +1,38 @@
+"""The global exception hook logs unhandled (slot) exceptions instead of letting PyQt abort."""
+
+import sys
+from unittest.mock import patch
+
+
+def test_exception_hook_logs_and_survives():
+    import negpy.desktop.main as m
+
+    old_hook = sys.excepthook
+    try:
+        with patch("PyQt6.QtWidgets.QMessageBox.critical") as box:
+            m._install_exception_hook()
+            hook = sys.excepthook
+            assert hook is not old_hook  # a custom hook is installed
+            with patch.object(m.logger, "critical") as crit:
+                try:
+                    raise ValueError("boom in a slot")
+                except ValueError:
+                    hook(*sys.exc_info())  # must NOT re-raise / abort the process
+                crit.assert_called_once()  # the full traceback was logged (to negpy.log)
+            box.assert_called_once()  # and the user got a non-fatal notice
+    finally:
+        sys.excepthook = old_hook
+
+
+def test_exception_hook_passes_keyboard_interrupt_through():
+    import negpy.desktop.main as m
+
+    old_hook = sys.excepthook
+    try:
+        m._install_exception_hook()
+        with patch("sys.__excepthook__") as default:
+            m_hook = sys.excepthook
+            m_hook(KeyboardInterrupt, KeyboardInterrupt(), None)  # Ctrl-C keeps the normal behaviour
+            default.assert_called_once()
+    finally:
+        sys.excepthook = old_hook

--- a/tests/test_scanlight_sidebar.py
+++ b/tests/test_scanlight_sidebar.py
@@ -598,15 +598,21 @@ def test_builtin_white_preset_turns_rgb_off_and_white_full():
     assert w.w_slider.value() == 255  # white on full
 
 
-def test_framing_white_is_fixed_regardless_of_the_slider():
+@pytest.mark.parametrize("has_white", [True, False])
+def test_live_view_frames_with_the_preset_rgb_values(has_white):
+    # The framing/focusing light IS the preset's RGB (one light for scanning and focusing), never
+    # white — so it works on every Scanlight, incl. an RGB-only body with no white LED (issue #455).
     w = _sidebar()
-    w._set_slider(w.w_slider, 0)  # RGB preset state: white off on the slider
+    w._light_has_white = has_white
+    w._set_slider(w.r_slider, 200)
+    w._set_slider(w.g_slider, 100)
+    w._set_slider(w.b_slider, 150)
     w.lv_btn.blockSignals(True)
     w.lv_btn.setChecked(True)  # live view → framing/focusing
     w.lv_btn.blockSignals(False)
     w.controller.set_scanlight_color.reset_mock()
     w._push_light()
-    assert w.controller.set_scanlight_color.call_args[0][:4] == (0, 0, 0, 255)  # plain white to focus by
+    assert w.controller.set_scanlight_color.call_args[0][:4] == (200, 100, 150, 0)
 
 
 def test_calibration_window_has_iso_and_aperture_but_no_shutter():
@@ -884,6 +890,39 @@ def test_selecting_manual_without_a_camera_is_refused():
     w._on_preset_selected(midx)
     assert not w._manual_mode  # refused — no body to source valid ISO/shutter/aperture from
     assert w.preset_combo.currentData() is None  # reverted to "— Select preset —"
+
+
+def _white_preset_item(w):
+    from PyQt6.QtGui import QStandardItemModel
+
+    import negpy.desktop.view.sidebar.scanlight as sl
+
+    idx = w.preset_combo.findData(next(iter(sl._BUILTIN_WHITE_PRESETS)))
+    model = w.preset_combo.model()
+    assert isinstance(model, QStandardItemModel)
+    return model.item(idx)
+
+
+def test_rgb_only_scanlight_hides_white_slider_and_preset():
+    w = _sidebar()
+    w._light_has_white = False  # a v1-v3 body: no white LED
+    w._refresh_light_channels()
+    assert w._slider_rows[w.w_slider].isHidden()  # W slider gone
+    assert not _white_preset_item(w).isEnabled()  # white-light preset greyed out
+
+
+def test_white_scanlight_keeps_white_slider_and_preset():
+    w = _sidebar()
+    w._light_has_white = True  # v4 / Big
+    w._refresh_light_channels()
+    assert not w._slider_rows[w.w_slider].isHidden()
+    assert _white_preset_item(w).isEnabled()
+
+
+def test_poll_status_carries_white_capability_to_the_ui():
+    w = _sidebar()
+    w._on_poll_status({"light_ok": True, "light_detail": "hw2 (fw1)", "light_has_white": False, "usb_ok": False, "usb_model": ""})
+    assert w._light_has_white is False and w._slider_rows[w.w_slider].isHidden()
 
 
 def test_rgb_preset_shows_the_exposure_fields(monkeypatch):


### PR DESCRIPTION
Follow-up fixes for the camera-scanning tab, from the issues that came in (#455, #478).

## RGB-only Scanlights (v1-v3), fixes #455
An RGB-only Scanlight (v1-v3, no white LED) went dark in live view: the focusing
light was a fixed white push, and with no white LED that turns everything off.

- The framing/focusing light is now the preset's own R/G/B values on every
  Scanlight (one light for scanning and focusing), so it works on all of them and
  the RGB sliders visibly drive the live-view light.
- On an RGB-only body (white capability derived from the reported hardware ID,
  since only the Big Scanlight and v4 carry a white LED), the W slider is hidden
  and the white-light preset greyed out.

## Live view: no stale frame on reopen
Reopening Live View (or the calibration pop-up) briefly flashed the previous
session's last frame before going black. The view is now blanked before the
window is shown.

## Crash diagnostics, toward #478
The two #478 crash reports are native SIGABRTs that hide the Python traceback (an
unhandled exception in a Qt slot makes PyQt abort). Added a rotating file log
(`<user data dir>/negpy.log`) and a global exception hook that logs unhandled
exceptions there and shows a non-fatal notice instead of aborting. Users can now
attach `negpy.log`, so the actual traceback (line and exception) is finally
visible; it also captures the `gphoto2 live view` warnings, which helps the Fuji
live-view report.

No vendor SDK is bundled or linked; `gphoto2` stays optional. `make all` green
with and without the camera group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
