### PR TITLE
UX polish: drag-to-heal, Enter confirms crop, cursor consistency, tooltip delay

### DIFF
--- a/negpy/desktop/main.py
+++ b/negpy/desktop/main.py
@@ -3,7 +3,7 @@ import sys
 
 from PyQt6.QtCore import Qt, qInstallMessageHandler
 from PyQt6.QtGui import QIcon
-from PyQt6.QtWidgets import QApplication
+from PyQt6.QtWidgets import QApplication, QProxyStyle, QStyle
 
 from negpy.desktop.controller import AppController
 from negpy.desktop.session import DesktopSessionManager
@@ -42,6 +42,18 @@ def _filter_qt_messages(mode, context, message: str) -> None:
     if message.startswith(_PAINTER_NOISE):
         return
     sys.stderr.write(message + "\n")
+
+
+class _AppStyle(QProxyStyle):
+    """Fusion with a longer tooltip hover delay — the default 700 ms pops tooltips
+    the moment the cursor crosses a toolbar, which reads as noise."""
+
+    _TOOLTIP_WAKEUP_MS = 1400
+
+    def styleHint(self, hint, option=None, widget=None, returnData=None):
+        if hint == QStyle.StyleHint.SH_ToolTip_WakeUpDelay:
+            return self._TOOLTIP_WAKEUP_MS
+        return super().styleHint(hint, option, widget, returnData)
 
 
 def _bootstrap_environment() -> None:
@@ -101,7 +113,7 @@ def main() -> None:
         qInstallMessageHandler(_filter_qt_messages)
         app = QApplication(sys.argv)
         app.setApplicationName("NegPy")
-        app.setStyle("Fusion")
+        app.setStyle(_AppStyle("Fusion"))
 
         icon_path = get_resource_path("media/icons/icon.png")
         if os.path.exists(icon_path):

--- a/negpy/desktop/view/canvas/overlay.py
+++ b/negpy/desktop/view/canvas/overlay.py
@@ -128,6 +128,7 @@ class CanvasOverlay(QWidget):
 
         # Scratch heal (open polyline) interaction state
         self._scratch_pts: List[QPointF] = []
+        self._heal_drag_pts: List[QPointF] = []
         self._local_mask_screen_polys: List[List[QPointF]] = []
         self._mask_img_cache: Dict[tuple, QImage] = {}
 
@@ -166,7 +167,8 @@ class CanvasOverlay(QWidget):
         self._escape_shortcut.setContext(Qt.ShortcutContext.WidgetShortcut)
         self._escape_shortcut.activated.connect(self._cancel_lasso)
 
-        # Enter finishes an in-progress scratch/lasso polyline, same as double-click.
+        # Enter finishes an in-progress scratch/lasso polyline or confirms the
+        # crop, same as double-click.
         for key in (Qt.Key.Key_Return, Qt.Key.Key_Enter):
             sc = QShortcut(QKeySequence(key), self)
             sc.setContext(Qt.ShortcutContext.WidgetShortcut)
@@ -227,6 +229,8 @@ class CanvasOverlay(QWidget):
             self._end_local_edit()
         if mode != ToolMode.SCRATCH_PICK:
             self._scratch_pts = []
+        if mode != ToolMode.DUST_PICK:
+            self._heal_drag_pts = []
         if mode != ToolMode.STRAIGHTEN:
             self._straighten_p1 = None
             self._straighten_p2 = None
@@ -340,6 +344,8 @@ class CanvasOverlay(QWidget):
             self._lasso_pts = [remap(p) for p in self._lasso_pts]
         if self._scratch_pts:
             self._scratch_pts = [remap(p) for p in self._scratch_pts]
+        if self._heal_drag_pts:
+            self._heal_drag_pts = [remap(p) for p in self._heal_drag_pts]
         if self._local_edit_verts is not None:
             self._local_edit_verts = [remap(p) for p in self._local_edit_verts]
         if self._straighten_p1 is not None:
@@ -424,6 +430,8 @@ class CanvasOverlay(QWidget):
             self._draw_placed_heals(painter)
         if self._tool_mode == ToolMode.SCRATCH_PICK:
             self._draw_scratch_in_progress(painter)
+        if self._tool_mode == ToolMode.DUST_PICK:
+            self._draw_heal_drag_in_progress(painter)
         if self._tool_mode == ToolMode.STRAIGHTEN:
             self._draw_straighten_line(painter)
 
@@ -522,6 +530,34 @@ class CanvasOverlay(QWidget):
         painter.setPen(Qt.PenStyle.NoPen)
         painter.drawEllipse(self._scratch_pts[0], 3.0, 3.0)
 
+    @staticmethod
+    def _heal_region_path(pts: List[QPointF], radius: float) -> QPainterPath:
+        """Union of brush dabs swept along `pts` — the mask silhouette of a heal
+        stroke (capsule chain). Drawn as one filled region, never a stroked
+        polyline: the line rendering reads jagged at drag-sample spacing."""
+        region = QPainterPath()
+        region.setFillRule(Qt.FillRule.WindingFill)
+        step = max(1.0, radius * 0.5)
+        for a, b in zip(pts, pts[1:]):
+            seg = math.hypot(b.x() - a.x(), b.y() - a.y())
+            n = max(1, int(seg / step))
+            for i in range(n):
+                t = i / n
+                region.addEllipse(QPointF(a.x() + (b.x() - a.x()) * t, a.y() + (b.y() - a.y()) * t), radius, radius)
+        region.addEllipse(pts[-1], radius, radius)
+        return region
+
+    def _draw_heal_drag_in_progress(self, painter: QPainter) -> None:
+        """Translucent mask of the area being painted with the heal tool (click-drag)."""
+        if len(self._heal_drag_pts) < 2:
+            return
+        radius = max(1.5, self._brush_screen_radius(self.state.config.retouch.manual_dust_size))
+        fill = QColor(THEME.accent_primary)
+        fill.setAlpha(60)
+        painter.setPen(Qt.PenStyle.NoPen)
+        painter.setBrush(fill)
+        painter.drawPath(self._heal_region_path(self._heal_drag_pts, radius))
+
     def _draw_straighten_line(self, painter: QPainter) -> None:
         """Reference line being dragged with the straighten tool, plus a badge
         previewing the correction (display convention: positive = clockwise)."""
@@ -576,19 +612,13 @@ class CanvasOverlay(QWidget):
             else:
                 if len(screen_pts) >= 3:
                     screen_pts = [QPointF(x, y) for x, y in smooth_polyline([(p.x(), p.y()) for p in screen_pts], closed=False)]
-                band = QPen(
-                    QColor(THEME.accent_primary), 2.0 * radius, Qt.PenStyle.SolidLine, Qt.PenCapStyle.RoundCap, Qt.PenJoinStyle.RoundJoin
-                )
-                band_color = QColor(THEME.accent_primary)
-                band_color.setAlpha(40)
-                band.setColor(band_color)
-                painter.setPen(band)
-                path = QPainterPath(screen_pts[0])
-                for pt in screen_pts[1:]:
-                    path.lineTo(pt)
-                painter.drawPath(path)
-                painter.setPen(pen)
-                painter.drawPath(path)
+                # Masked area only — no centerline, no outline.
+                fill = QColor(THEME.accent_primary)
+                fill.setAlpha(40)
+                painter.setPen(Qt.PenStyle.NoPen)
+                painter.setBrush(fill)
+                painter.drawPath(self._heal_region_path(screen_pts, radius))
+                painter.setBrush(Qt.BrushStyle.NoBrush)
 
         painter.setPen(pen)
         for rx, ry, size in conf.manual_dust_spots:
@@ -1081,6 +1111,15 @@ class CanvasOverlay(QWidget):
             event.accept()
             return
 
+        if self._tool_mode == ToolMode.DUST_PICK:
+            # Heal commits on release: a plain click heals the spot, a drag paints a
+            # continuous stroke healed as one region (one undo step, one render).
+            if self._view_rect.contains(event.position()):
+                self._heal_drag_pts = [event.position()]
+                self.update()
+            event.accept()
+            return
+
         if self._tool_mode == ToolMode.STRAIGHTEN:
             # Left-click draws the reference line; other buttons pass through.
             if event.button() == Qt.MouseButton.LeftButton:
@@ -1169,6 +1208,15 @@ class CanvasOverlay(QWidget):
         else:
             self.cursor_left.emit()
 
+        # Placement tools carry special cursors (blank brush, pen nib, WB picker) that
+        # read as broken over the empty canvas around the image — fall back to the
+        # normal arrow there and restore the tool cursor over the image itself.
+        if self._tool_mode in (ToolMode.DUST_PICK, ToolMode.SCRATCH_PICK, ToolMode.WB_PICK):
+            if coords is None:
+                self.setCursor(Qt.CursorShape.ArrowCursor)
+            else:
+                self.unsetCursor()
+
         if self.parent()._is_panning:
             delta = event.position() - self.parent()._last_mouse_pos
             self.parent()._last_mouse_pos = event.position()
@@ -1181,6 +1229,21 @@ class CanvasOverlay(QWidget):
             px = float(np.clip(event.position().x(), self._view_rect.left(), self._view_rect.right()))
             py = float(np.clip(event.position().y(), self._view_rect.top(), self._view_rect.bottom()))
             self._local_edit_verts[self._local_drag_vertex] = QPointF(px, py)
+            self.update()
+            event.accept()
+            return
+
+        # Painting a heal stroke: accumulate the drag path (spaced by half the brush
+        # radius so long drags stay a sane number of capsule segments), clamped to
+        # the image so the stroke can't run off into the border.
+        if self._tool_mode == ToolMode.DUST_PICK and self._heal_drag_pts and event.buttons() & Qt.MouseButton.LeftButton:
+            pos = QPointF(
+                float(np.clip(event.position().x(), self._view_rect.left(), self._view_rect.right())),
+                float(np.clip(event.position().y(), self._view_rect.top(), self._view_rect.bottom())),
+            )
+            spacing = max(6.0, self._brush_screen_radius(self.state.config.retouch.manual_dust_size) * 0.5)
+            if (pos - self._heal_drag_pts[-1]).manhattanLength() >= spacing:
+                self._heal_drag_pts.append(pos)
             self.update()
             event.accept()
             return
@@ -1418,6 +1481,9 @@ class CanvasOverlay(QWidget):
             self._finish_scratch()
         elif self._tool_mode == ToolMode.LOCAL_DRAW and self._lasso_drawing and len(self._lasso_pts) >= 3:
             self._finish_lasso()
+        elif self._tool_mode == ToolMode.CROP_MANUAL:
+            self._end_crop_drag()
+            self.crop_confirmed.emit()
 
     def has_scratch_points(self) -> bool:
         return bool(self._scratch_pts)
@@ -1490,6 +1556,26 @@ class CanvasOverlay(QWidget):
         if self.parent()._is_panning:
             self.parent()._is_panning = False
             self.parent().reset_tool_cursor()
+            event.accept()
+            return
+
+        if self._tool_mode == ToolMode.DUST_PICK and self._heal_drag_pts and event.button() == Qt.MouseButton.LeftButton:
+            pts = self._heal_drag_pts
+            self._heal_drag_pts = []
+            end = QPointF(
+                float(np.clip(event.position().x(), self._view_rect.left(), self._view_rect.right())),
+                float(np.clip(event.position().y(), self._view_rect.top(), self._view_rect.bottom())),
+            )
+            if (end - pts[-1]).manhattanLength() > 2.0:
+                pts.append(end)
+            vertices = [c for c in (self._map_to_image_coords(p) for p in pts) if c is not None]
+            if len(vertices) == 1:
+                # Plain click: the classic single-spot heal.
+                self.clicked.emit(*vertices[0])
+            elif len(vertices) > 1:
+                # Drag: the painted path becomes one multi-point heal stroke.
+                self.scratch_completed.emit(vertices)
+            self.update()
             event.accept()
             return
 

--- a/negpy/desktop/view/canvas/toolbar.py
+++ b/negpy/desktop/view/canvas/toolbar.py
@@ -269,6 +269,11 @@ class ActionToolbar(QWidget):
             btn.setFixedHeight(btn_height)
             btn.setCursor(Qt.CursorShape.PointingHandCursor)
 
+        # Custom-sized buttons skip the standard sizing above but must share the
+        # same hover cursor as the rest of the toolbar.
+        for btn in (self.btn_zoom_fit, self.btn_zoom_original, *self.canvas_color_btns):
+            btn.setCursor(Qt.CursorShape.PointingHandCursor)
+
         # Single-row layout: toggle_left · prev · next · sep1 · zoom+label · hq · swatches · sep2 · rot_l · rot_r · flip_h · flip_v · sep3 · undo · redo · compare · gpu · overflow · toggle_right
         row_layout.addWidget(self.btn_toggle_left)
         row_layout.addWidget(self.btn_prev)

--- a/negpy/desktop/view/canvas/widget.py
+++ b/negpy/desktop/view/canvas/widget.py
@@ -173,6 +173,9 @@ class ImageCanvas(QWidget):
     def set_floating_toolbar(self, toolbar: QWidget) -> None:
         """Adopts the action toolbar as a floating pill anchored to the canvas bottom."""
         toolbar.setParent(self)
+        # The canvas carries tool cursors (blank heal brush, pen nib, WB picker);
+        # the toolbar must not inherit them — buttons want the normal arrow.
+        toolbar.setCursor(Qt.CursorShape.ArrowCursor)
         toolbar.show()
         self._floating_toolbar = toolbar
         self._layout_floating_widgets()

--- a/negpy/desktop/view/sidebar/export.py
+++ b/negpy/desktop/view/sidebar/export.py
@@ -627,7 +627,7 @@ class ExportSidebar(BaseSidebar):
     _EXPORT_SCOPES = {
         "current": (
             "Export current frame",
-            " Export",
+            " Export Current Frame",
             "Export the current frame with the settings below  Ctrl+E",
         ),
         "selected": (

--- a/negpy/desktop/view/sidebar/scan.py
+++ b/negpy/desktop/view/sidebar/scan.py
@@ -433,11 +433,14 @@ class _ScanUnsupportedPlaceholder(QWidget):
 
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
+        # No layout alignment and no QSS padding: either one breaks the wrapped
+        # QLabel's height-for-width negotiation and clips the text — the label
+        # must be stretched to full width so it can report its wrapped height.
         layout = QVBoxLayout(self)
-        layout.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        layout.setContentsMargins(20, 20, 20, 20)
 
         label = QLabel("Scanner support not yet available on Windows.")
         label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         label.setWordWrap(True)
-        label.setStyleSheet(f"color: {THEME.text_muted}; font-size: {THEME.font_size_base}px; padding: 20px;")
+        label.setStyleSheet(f"color: {THEME.text_muted}; font-size: {THEME.font_size_base}px;")
         layout.addWidget(label)

--- a/tests/test_canvas_polyline_finish.py
+++ b/tests/test_canvas_polyline_finish.py
@@ -1,7 +1,12 @@
-from PyQt6.QtCore import QPointF, QRectF
+from PyQt6.QtCore import QEvent, QPointF, QRectF, Qt
+from PyQt6.QtGui import QMouseEvent
 
 from negpy.desktop.session import AppState, ToolMode
 from negpy.desktop.view.canvas.overlay import CanvasOverlay
+
+
+def _mouse_event(kind: QEvent.Type, pos: QPointF, buttons=Qt.MouseButton.LeftButton) -> QMouseEvent:
+    return QMouseEvent(kind, pos, Qt.MouseButton.LeftButton, buttons, Qt.KeyboardModifier.NoModifier)
 
 
 def _overlay_with_view() -> CanvasOverlay:
@@ -79,3 +84,76 @@ def test_enter_noop_without_active_draw() -> None:
     overlay._finish_draw_if_active()
 
     assert emitted == []
+
+
+def test_enter_confirms_crop() -> None:
+    overlay = _overlay_with_view()
+    overlay.set_tool_mode(ToolMode.CROP_MANUAL)
+
+    confirmed = []
+    overlay.crop_confirmed.connect(lambda: confirmed.append(True))
+    overlay._finish_draw_if_active()
+
+    assert confirmed == [True]
+
+
+def _overlay_with_parent() -> CanvasOverlay:
+    """Overlay whose move/release paths (which consult parent()._is_panning) work."""
+    from PyQt6.QtWidgets import QWidget
+
+    parent = QWidget()
+    parent._is_panning = False
+    overlay = CanvasOverlay(AppState(), parent)
+    overlay._view_rect = QRectF(0, 0, 100, 100)
+    overlay._test_parent = parent  # keep the parent alive for the overlay's lifetime
+    return overlay
+
+
+def test_heal_click_places_single_spot() -> None:
+    overlay = _overlay_with_parent()
+    overlay.set_tool_mode(ToolMode.DUST_PICK)
+
+    clicks: list = []
+    strokes: list = []
+    overlay.clicked.connect(lambda x, y: clicks.append((x, y)))
+    overlay.scratch_completed.connect(strokes.append)
+
+    overlay.mousePressEvent(_mouse_event(QEvent.Type.MouseButtonPress, QPointF(30, 30)))
+    overlay.mouseReleaseEvent(_mouse_event(QEvent.Type.MouseButtonRelease, QPointF(30, 30), Qt.MouseButton.NoButton))
+
+    assert strokes == []
+    assert len(clicks) == 1
+    assert abs(clicks[0][0] - 0.3) < 1e-6 and abs(clicks[0][1] - 0.3) < 1e-6
+
+
+def test_heal_drag_paints_continuous_stroke() -> None:
+    overlay = _overlay_with_parent()
+    overlay.set_tool_mode(ToolMode.DUST_PICK)
+
+    clicks: list = []
+    strokes: list = []
+    overlay.clicked.connect(lambda x, y: clicks.append((x, y)))
+    overlay.scratch_completed.connect(strokes.append)
+
+    overlay.mousePressEvent(_mouse_event(QEvent.Type.MouseButtonPress, QPointF(10, 10)))
+    for p in (QPointF(30, 30), QPointF(60, 60)):
+        overlay.mouseMoveEvent(_mouse_event(QEvent.Type.MouseMove, p))
+    overlay.mouseReleaseEvent(_mouse_event(QEvent.Type.MouseButtonRelease, QPointF(90, 90), Qt.MouseButton.NoButton))
+
+    assert clicks == []
+    assert len(strokes) == 1
+    assert len(strokes[0]) >= 3  # press + drag samples + release point
+    assert overlay._heal_drag_pts == []
+
+
+def test_heal_drag_outside_image_is_ignored() -> None:
+    overlay = _overlay_with_parent()
+    overlay.set_tool_mode(ToolMode.DUST_PICK)
+
+    clicks: list = []
+    overlay.clicked.connect(lambda x, y: clicks.append((x, y)))
+    overlay.mousePressEvent(_mouse_event(QEvent.Type.MouseButtonPress, QPointF(150, 150)))
+    overlay.mouseReleaseEvent(_mouse_event(QEvent.Type.MouseButtonRelease, QPointF(150, 150), Qt.MouseButton.NoButton))
+
+    assert clicks == []
+    assert overlay._heal_drag_pts == []


### PR DESCRIPTION
## Summary

A batch of small canvas/UI refinements, plus one continuous-healing feature.

### Heal tool: paint while dragging

The heal tool now commits on release instead of press: a plain click heals a single spot exactly as before, while click-and-drag paints along the cursor and commits the swept path as **one multi-point heal stroke** — one undo step, one render, healed by the same capsule-chain membrane clone the scratch tool uses. Drag samples are spaced at half the brush radius (so long drags stay a sane number of capsule segments), clamped to the image, and re-pinned correctly if the view zooms/pans mid-drag (`_remap_inflight_points`).

Both the live preview and committed strokes render as a **translucent mask region only** — a filled union of brush dabs along the path — with no centerline and no outline: a stroked polyline reads jagged at drag-sample spacing. Single-spot circles and dust-spot markers are unchanged.

### Enter confirms the crop

`Enter` now confirms the manual crop and closes the tool, exactly like double-clicking inside the box (same widget-scoped shortcut that already finishes scratch/lasso polylines).

### Cursor consistency

- The heal brush (intentionally blank — the brush circle is the cursor), scratch pen and WB picker cursors fall back to the **normal arrow over the empty canvas outside the image**, and return to the tool cursor over the image. Previously the heal cursor simply vanished outside the image, and the pen/picker floated over dead space.
- The floating bottom toolbar no longer inherits the canvas tool cursor — it's pinned to the arrow, consistent with the side panels.
- `Fit to Window`, `1:1`, and the canvas color swatches now share the pointing-hand hover cursor the rest of the toolbar buttons already had (they were skipped because they bypass the standard sizing loop).

### Windows SANE placeholder clipped its text

The "Scanner support not yet available on Windows." label rendered clipped: the placeholder's `layout.setAlignment(AlignCenter)` laid the word-wrapped label out at its *unwrapped* size hint, so it got one line of height while wrapping to two-plus. The label now stretches to full width (restoring height-for-width negotiation) and stays centered via its own alignment; spacing moved from QSS padding (also excluded from the height calculation) to layout margins. Verified headlessly with a rendered grab.

### Export button label

The Export split button's current-frame scope now reads **"Export Current Frame"** — the bare "Export" was ambiguous next to the other spelled-out scopes (Export Selected, Export All …).

### Tooltip delay

App-wide tooltip hover delay raised from Qt's 700 ms default to **1400 ms** via a `QProxyStyle` (`SH_ToolTip_WakeUpDelay`), so tooltips stop popping the instant the cursor crosses a toolbar.

## Testing

New overlay tests: Enter confirms crop (and stays a no-op for non-drawing tools), single click emits one spot heal, press-move-release emits one multi-point stroke, and drags starting outside the image are ignored. 105 canvas/overlay/controller tests pass; ruff clean. Exercised in-app on Windows: drag-healing over dust trails, crop Enter/double-click parity, cursor behaviour over empty canvas + bottom toolbar, SANE tab text, tooltip timing.
