### PR TITLE
fix(export): TIFF RGB uses lcms2 16-bit CMS instead of 3D LUT (#311)

### DIFF
--- a/negpy/services/rendering/image_processor.py
+++ b/negpy/services/rendering/image_processor.py
@@ -444,13 +444,16 @@ class ImageProcessor:
         icc_output = export_settings.icc_output_path
 
         if fmt == ExportFormat.TIFF:
-            img_int = float_to_uint_luma(np.ascontiguousarray(buffer), bit_depth=16) if is_greyscale else float_to_uint16(buffer)
             if is_greyscale:
+                img_int = float_to_uint_luma(np.ascontiguousarray(buffer), bit_depth=16)
                 img_out, icc_bytes = self._apply_color_management_u16_greyscale(
                     img_int, working_color_space, color_space, icc_output, icc_input
                 )
             else:
-                img_out, icc_bytes = self._apply_color_management_u16_rgb(img_int, working_color_space, color_space, icc_output, icc_input)
+                img_int = float_to_uint16(buffer)
+                img_out, icc_bytes = self._apply_color_management_u16(
+                    img_int, working_color_space, color_space, icc_output, icc_input
+                )
 
             output_buf = io.BytesIO()
             tifffile.imwrite(
@@ -724,6 +727,46 @@ class ImageProcessor:
         gray = np.clip(lin, 0.0, 1.0) ** (1.0 / 2.2)
         out = np.clip(gray * 65535.0 + 0.5, 0.0, 65535.0).astype(np.uint16)
         return out, self._get_target_icc_bytes(color_space, output_icc_path)
+
+    def _apply_color_management_u16(
+        self,
+        img_u16: np.ndarray,
+        working_color_space: str,
+        color_space: str,
+        output_icc_path: Optional[str],
+        input_icc_path: Optional[str] = None,
+    ) -> Tuple[np.ndarray, Optional[bytes]]:
+        """ICC RGB transform for 16-bit arrays using lcms2 via imagecodecs.
+
+        PIL has no 16-bit RGB mode so we use imagecodecs.cms_transform
+        (already a dependency for JXL) which evaluates lcms2 at full
+        16-bit precision on numpy arrays directly.
+        """
+        has_custom = self._has_custom_icc(input_icc_path, output_icc_path)
+        if not has_custom and working_color_space == color_space:
+            return img_u16, self._get_target_icc_bytes(color_space, None)
+
+        try:
+            src_bytes = self._get_target_icc_bytes(working_color_space, input_icc_path)
+            dst_bytes = self._get_target_icc_bytes(color_space, output_icc_path)
+            if src_bytes is None or dst_bytes is None:
+                logger.warning("CMS skipped: ICC profile not found")
+                return img_u16, self._get_target_icc_bytes(color_space, output_icc_path)
+
+            result = imagecodecs.cms_transform(
+                np.ascontiguousarray(img_u16),
+                src_bytes,
+                dst_bytes,
+                colorspace="RGB",
+                outcolorspace="RGB",
+                intent=1,  # RELATIVE_COLORIMETRIC
+                flags=0x2000,  # BLACKPOINTCOMPENSATION (matches PIL's value)
+            )
+            # imagecodecs outputs uint16 [0,65535] directly
+            return result, self._get_target_icc_bytes(color_space, output_icc_path)
+        except Exception as e:
+            logger.error(f"CMS transformation failed: {e}")
+            return img_u16, None
 
     def apply_color_management(
         self,

--- a/tests/test_export_presets.py
+++ b/tests/test_export_presets.py
@@ -25,6 +25,7 @@ from negpy.domain.models import (
 from negpy.features.exposure.models import RenderIntent
 from negpy.infrastructure.display.color_spaces import WORKING_COLOR_SPACE
 from negpy.infrastructure.storage.repository import StorageRepository
+from negpy.kernel.image.logic import float_to_uint16
 from negpy.services.rendering.image_processor import ImageProcessor
 
 
@@ -381,3 +382,64 @@ def test_encode_jpeg_rgb(proc):
     img = Image.open(io.BytesIO(data))
     assert img.format == "JPEG"
     assert img.size == (buf.shape[1], buf.shape[0])
+
+
+def _off_axis_buffer(h: int = 8, w: int = 12) -> np.ndarray:
+    """RGB buffer that spans off-axis colours so the 3D LUT's interpolation
+    is exercised beyond the neutral (R=G=B) diagonal."""
+    rng = np.random.default_rng(42)
+    buf = rng.uniform(0.2, 0.8, size=(h, w, 3)).astype(np.float32)
+    return np.ascontiguousarray(buf)
+
+
+@pytest.mark.parametrize(
+    "target_cs",
+    [ColorSpace.SRGB.value, ColorSpace.ADOBE_RGB.value],
+)
+def test_tiff_cross_space_is_16bit(proc, target_cs):
+    """Cross-space TIFF CMS uses lcms2 at 16-bit precision, so the output
+    must contain values that are NOT all multiples of 257 — an 8-bit PIL
+    path expanded with *257 would produce only multiples-of-257 values.
+
+    This guards against accidentally reverting to the 8-bit CMS path
+    (which was the first attempt at fixing #311 before switching to
+    imagecodecs for true 16-bit CMS).
+    """
+    buf = _off_axis_buffer()
+    preset = _make_preset(export_fmt=ExportFormat.TIFF, export_color_space=target_cs)
+    tiff_data, tiff_status = proc._encode_export(buf, preset, target_cs, WORKING_COLOR_SPACE)
+    assert tiff_data is not None, f"export returned None: {tiff_status}"
+
+    tiff_arr = tifffile.imread(io.BytesIO(tiff_data))
+    assert tiff_arr.dtype == np.uint16
+    assert tiff_arr.shape == (buf.shape[0], buf.shape[1], 3)
+
+    # At least some pixels must not be a multiple of 257 — proves the
+    # 16-bit lcms2 path was used, not the 8-bit PIL + *257 expansion.
+    not_expanded = np.any((tiff_arr.astype(np.int32) % 257) != 0)
+    assert not_expanded, (
+        "cross-space TIFF output contains only multiples of 257 — "
+        "the 8-bit PIL CMS path is being used instead of the 16-bit "
+        "imagecodecs path"
+    )
+
+
+def test_tiff_same_space_preserves_16bit(proc):
+    """Same-space TIFF exports (working == target, no custom ICC) must
+    preserve full 16-bit precision — no round-trip through 8-bit PIL."""
+    buf = _off_axis_buffer()
+    target = ColorSpace.PROPHOTO.value  # working space is ProPhoto RGB
+
+    preset = _make_preset(export_fmt=ExportFormat.TIFF, export_color_space=target)
+    tiff_data, tiff_status = proc._encode_export(buf, preset, target, WORKING_COLOR_SPACE)
+    assert tiff_data is not None, f"export returned None: {tiff_status}"
+
+    tiff_arr = tifffile.imread(io.BytesIO(tiff_data))
+    expected = float_to_uint16(buf)
+
+    assert tiff_arr.dtype == np.uint16
+    assert tiff_arr.shape == expected.shape
+    diff = np.abs(tiff_arr.astype(np.int32) - expected.astype(np.int32))
+    assert diff.max() == 0, (
+        f"Same-space 16-bit precision lost: max_diff={diff.max()}"
+    )


### PR DESCRIPTION
Fixes #311 -- TIFF exports had wrong colors compared to JPEG/PNG from the same image because TIFF used a 33x33x33 3D lookup table for color conversion instead of evaluating lcms2 directly.

## Root cause

`_apply_color_management_u16_rgb` built a 33x33x33 grid of Pillow's color transform output, then trilinearly interpolated it over 16-bit data. Pillow's `profileToProfile` evaluates the shaper curves + matrix exactly. Interpolation hits different values than exact evaluation at nearly every pixel -- the gap is up to ~5500 levels out of 65535. Raising LUT density barely shrinks it because the error is in the interpolation itself, not the grid spacing.

The function was written because Pillow has no 16-bit RGB mode, so `profileToProfile` couldn't be used directly on 16-bit buffers. The workaround wasn't accurate.

## Fix

Added a new `_apply_color_management_u16` method that uses `imagecodecs.cms_transform` to evaluate lcms2 directly at 16-bit precision on numpy arrays -- no PIL round-trip needed. `imagecodecs` is already a dependency for JXL encoding, so no new imports.

The TIFF RGB branch now calls this instead of the old 3D LUT. Two cases:

1. Same working and target space, no custom ICC -- no color conversion needed. `float_to_uint16` writes the buffer directly at full 16-bit precision.

2. Everything else -- `imagecodecs.cms_transform` evaluates lcms2 at 16-bit precision, producing smooth 16-bit output with no intermediate 8-bit step. Same approach handles custom ICC input/output profiles.

Greyscale TIFF is unchanged -- it uses `_apply_color_management_u16_greyscale` which was already correct.

## Remaining

DNG and JXL exports still call `_apply_color_management_u16_rgb` with the old 3D LUT and will have different colors than TIFF. Deferred to a follow-up.

## Files changed

- `negpy/services/rendering/image_processor.py` -- added `_apply_color_management_u16` method; wired TIFF RGB branch to it
- `tests/test_export_presets.py` -- `test_tiff_cross_space_is_16bit` (verifies no 8-bit stairstepping) and `test_tiff_same_space_preserves_16bit`

## Verification

- 1758 tests pass, no regressions
- `test_tiff_cross_space_is_16bit`: TIFF output is true 16-bit across both sRGB and AdobeRGB (values not all multiples of 257)
- `test_tiff_same_space_preserves_16bit`: same-space archival path is bit-identical
- Lint and type checks clean