### PR TITLE
fix: True Black now sticks across frames

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Change: **Naming and panel tidy-up** — visible labels standardize on "colour", and the white-balance section is renamed **Filtration** so "Colour" unambiguously means the Lab & Toning tab; Tone's four "Width" sliders become "Toe Width" / "Shoulder Width"; editing presets and contact-sheet templates can be deleted from their panels; the Roll Analysis section gets a header reset; drag-and-drop opens the first frame like Add Files.
 - Fix: **Scanner TIFFs now develop exactly like their DNGs** — 16-bit TIFFs without an embedded colour profile were wrongly treated as sRGB, so the same scan rendered and exported differently as TIFF and DNG. They now load as linear scanner data (existing ones will render slightly differently), and scanner-TIFF and JPEG thumbnails no longer appear nearly black.
 - Fix: **Colour no longer squeezed on output** — a stale Adobe RGB override stood in for the ProPhoto RGB working space on the way out (preview, exports and thumbnails), compressing the gamut and leaving everything darker and more muted than intended. Scans and RAWs also no longer claim to be Adobe RGB when they carry no colour profile at all, so **Same as Source** keeps them at full width instead of squeezing them on the way out; a file with an embedded profile still exports to that profile. Re-export older edits to pick up the correction.
+- Fix: **True Black sticks across frames** — it was the one toggle in its group that reset on every frame; it now carries to the next like the Snap, Auto Density, Auto Grade and Paper White toggles it sits beside.
 
 ## 0.37.2
 

--- a/negpy/desktop/session.py
+++ b/negpy/desktop/session.py
@@ -648,13 +648,14 @@ class DesktopSessionManager(QObject):
             config = replace(config, process=replace(config.process, linear_raw=bool(sticky_linear_raw)))
 
         # Processing toggles (Auto Density / Auto Grade / Shadow Neutral / Paper
-        # White) are workflow preferences, not per-image looks: carry them to
-        # fresh files unless explicitly changed per file.
+        # White / True Black) are workflow preferences, not per-image looks: carry
+        # them to fresh files unless explicitly changed per file.
         new_exp = config.exposure
         for key, attr in (
             ("last_auto_exposure", "auto_exposure"),
             ("last_auto_normalize_contrast", "auto_normalize_contrast"),
             ("last_paper_dmin", "paper_dmin"),
+            ("last_true_black", "true_black"),
         ):
             val = self.repo.get_global_setting(key)
             if val is not None:
@@ -697,6 +698,7 @@ class DesktopSessionManager(QObject):
                 "last_auto_exposure": config.exposure.auto_exposure,
                 "last_auto_normalize_contrast": config.exposure.auto_normalize_contrast,
                 "last_paper_dmin": config.exposure.paper_dmin,
+                "last_true_black": config.exposure.true_black,
                 "last_paper_profile": config.exposure.paper_profile,
                 "last_toe": config.exposure.toe,
                 "last_toe_width": config.exposure.toe_width,

--- a/tests/test_desktop_session.py
+++ b/tests/test_desktop_session.py
@@ -77,6 +77,7 @@ class TestDesktopSessionSync(unittest.TestCase):
         self.assertIn("last_process_mode", saved)
         self.assertIn("last_export_config", saved)
         self.assertIn("last_dust_remove", saved)
+        self.assertIn("last_true_black", saved)
         self.assertIn("last_protect_original_metadata", saved)
 
     def test_protect_original_metadata_carries_globally(self):
@@ -105,6 +106,7 @@ class TestDesktopSessionSync(unittest.TestCase):
             "last_auto_exposure": True,
             "last_auto_normalize_contrast": True,
             "last_paper_dmin": True,
+            "last_true_black": True,
             "last_paper_profile": "ilford_mg_rc",
         }
         self.mock_repo.get_global_setting.side_effect = lambda key, default=None: sticky.get(key, default)
@@ -112,7 +114,16 @@ class TestDesktopSessionSync(unittest.TestCase):
         self.assertTrue(config.exposure.auto_exposure)
         self.assertTrue(config.exposure.auto_normalize_contrast)
         self.assertTrue(config.exposure.paper_dmin)
+        self.assertTrue(config.exposure.true_black)
         self.assertEqual(config.exposure.paper_profile, "ilford_mg_rc")
+
+    def test_true_black_off_carries_to_new_files(self):
+        """Sticky must carry an explicit off, not just on — default is already False."""
+        sticky = {"last_export_config": {}, "last_true_black": False}
+        self.mock_repo.get_global_setting.side_effect = lambda key, default=None: sticky.get(key, default)
+        base = WorkspaceConfig(exposure=replace(WorkspaceConfig().exposure, true_black=True))
+        config = self.session._apply_sticky_settings(base, only_global=False)
+        self.assertFalse(config.exposure.true_black)
 
     def test_roll_average_not_seeded_onto_fresh_files(self):
         # A roll baseline must not leak onto a fresh (sidecar-less) file.


### PR DESCRIPTION
## Problem

True Black is a workflow preference — black point compensation on or off — not a per-image look. But it reset on every frame.

`tone.py:284-288` wires four toggles together as one group:

| Toggle | Field | Sticky before this PR |
|---|---|---|
| Paper White | `paper_dmin` | yes |
| Auto Density | `auto_exposure` | yes |
| Auto Grade | `auto_normalize_contrast` | yes |
| **True Black** | `true_black` | **no** |

Three of the four already carried to the next frame. True Black was the lone holdout in its own UI group, so this reads as an oversight rather than a decision.

## Fix

`session.py` already has the mechanism: `_apply_sticky_settings` loops over exposure processing toggles documented as *"workflow preferences, not per-image looks: carry them to fresh files unless explicitly changed per file"*. True Black is exactly that shape, so it joins the loop:

```python
for key, attr in (
    ("last_auto_exposure", "auto_exposure"),
    ("last_auto_normalize_contrast", "auto_normalize_contrast"),
    ("last_paper_dmin", "paper_dmin"),
    ("last_true_black", "true_black"),
):
```

plus one line in `_persist_sticky_settings` to save it alongside the others. No new mechanism, no new persistence layer.

## Tests

Extends the existing coverage in `tests/test_desktop_session.py`:

- `test_processing_toggles_carry_to_new_files` — now asserts `true_black` carries.
- `test_persist_writes_sticky_settings_in_one_batch` — asserts `last_true_black` is in the batch.
- `test_true_black_off_carries_to_new_files` (new) — sticky must carry an explicit **off**, not just on. The default is already `False`, so a naive `if val:` would pass the on-case while silently failing to turn it back off.

All three fail before the change. `make lint` / `make type` clean; 1845 passed, 4 skipped.

## Notes

Branched off `main`, independent of #518 — that one carries a look shift and is better kept separate.

The `_apply_sticky_settings` docstring says exposure is excluded as a per-image look, but that predates the processing-toggle block below it, which already carves out `auto_exposure` / `auto_normalize_contrast` / `paper_dmin` on exactly this reasoning. This follows the established carve-out rather than widening it.
