### PR TITLE
fix: unify CPU and GPU CLAHE into one Lab-L algorithm

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ Edits persist in SQLite (`edits.db`, keyed by content hash), optionally mirrored
 
 ### Pipeline
 
-- **CPU**: `DarkroomEngine.process()` (`negpy/services/rendering/engine.py`) — base (geometry + normalization) → exposure (incl. dodge/burn) → retouch → lab → toning → crop → finish. The first four stages are cached per config-hash via `_run_stage()`; the rest run unconditionally.
+- **CPU**: `DarkroomEngine.process()` (`negpy/services/rendering/engine.py`) — base (geometry + normalization) → exposure (incl. dodge/burn) → clahe → retouch → lab → toning → crop → finish. The first five stages are cached per config-hash via `_run_stage()`; the rest run unconditionally.
 - **GPU**: `GPUEngine` (`negpy/services/rendering/gpu_engine.py`) — same logical stages as WGSL compute shaders from `negpy/features/<name>/shaders/`, with its own config-diff change detection.
 - **Orchestration**: `ImageProcessor` (`image_processor.py`) tries GPU first, falls back to CPU; export always runs full-res. `PipelineContext` carries `scale_factor`, `process_mode`, `active_roi`, and a `metrics` dict between stages.
 - **Working space**: scene-linear internally; the working OETF (ProPhoto ROMM TRC) is applied only as the final engine step. Lab/toning compute CIELAB directly from linear.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 
 
+## Unreleased
+
+
 ## 0.38.0
 
 - New: **Keep / Reject triage on the contact sheet** — cull a roll where you see it: `K` marks a frame as a keeper (small check badge), `Shift+X` rejects it (cross badge + dim). Rejected frames stay on the sheet but drop out of batch exports and sidecar writes; a Sheet filter (All / Keepers only / Hide rejected) sits next to Sort, a tally counts the roll, and marks persist across sessions.
@@ -9,8 +12,9 @@
 - Change: **One grammar for the canvas tools** — first `Esc` clears in-progress points, second puts the tool down (fixes Esc going dead mid-draw); toolbar Undo matches `Ctrl+Z`; a stray click outside a tuned crop no longer wipes it. New keys: `Shift+S` Scratch, `Shift+B` Dodge & Burn, `Shift+R` Analysis Region, `|` flat-master peek (plus a toolbar button).
 - Change: **Naming and panel tidy-up** — visible labels standardize on "colour", and the white-balance section is renamed **Filtration** so "Colour" unambiguously means the Lab & Toning tab; Tone's four "Width" sliders become "Toe Width" / "Shoulder Width"; editing presets and contact-sheet templates can be deleted from their panels; the Roll Analysis section gets a header reset; drag-and-drop opens the first frame like Add Files.
 - Fix: **Scanner TIFFs now develop exactly like their DNGs** — 16-bit TIFFs without an embedded colour profile were wrongly treated as sRGB, so the same scan rendered and exported differently as TIFF and DNG. They now load as linear scanner data (existing ones will render slightly differently), and scanner-TIFF and JPEG thumbnails no longer appear nearly black.
-- Fix: **Colour no longer squeezed on output** — a stale Adobe RGB override stood in for the ProPhoto RGB working space on the way out (preview, exports and thumbnails), compressing the gamut and leaving everything darker and more muted than intended. Scans and RAWs also no longer claim to be Adobe RGB when they carry no colour profile at all, so **Same as Source** keeps them at full width instead of squeezing them on the way out; a file with an embedded profile still exports to that profile. Re-export older edits to pick up the correction.
+- Fix: **Colour no longer squeezed on output** — a stale Adobe RGB override stood in for the ProPhoto RGB working space on the way out (preview, exports and thumbnails), compressing the gamut and leaving everything darker and more muted than intended. **OLDER EDITS WILL SHIFT - RESETING THEM RECOMMENDED**
 - Fix: **True Black sticks across frames** — it was the one toggle in its group that reset on every frame; it now carries to the next like the Snap, Auto Density, Auto Grade and Paper White toggles it sits beside.
+- Fix: **CLAHE now renders the same everywhere** — the GPU preview and the CPU fallback used two slightly different local-contrast algorithms, so the same slider value could look noticeably different between them, worst at high strength. Both now run one identical algorithm on the CIELAB lightness channel: local contrast no longer over-saturates boosted areas, the preview predicts the export at every zoom level, and the effect at high strength is cleaner. Expect a subtle look shift on frames with CLAHE above zero.
 
 ## 0.37.2
 

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -105,7 +105,23 @@ Both are **fixed** (no per-frame metering) so an evenly-exposed roll renders ide
 
 ---
 
-## 4. Retouching
+## 4. Local Contrast (CLAHE)
+**Code**: `negpy.features.lab.logic.apply_clahe` (CPU) / `negpy/features/lab/shaders/clahe_{hist,cdf,apply}.wgsl` (GPU)
+
+Contrast Limited Adaptive Histogram Equalization on the CIELAB $L^{\ast}$ channel (computed from linear working RGB, ProPhoto/D50). Chroma ($a^{\ast}/b^{\ast}$) is untouched, so boosted local contrast never pumps saturation. The algorithm is **identical on CPU and GPU** (mirrored bin-for-bin; the parity test pins them to ~1e-6):
+
+*   **Fixed $8\times8$ tile grid** over the full frame at every render scale (tile fraction constant → preview predicts export), 256 histogram bins over $L^{\ast} \in [0, 100]$.
+*   **Clip limit**: $\max(1, \lfloor \text{strength} \cdot 2.5 \cdot N_{tile} / 256 \rfloor)$ counts; the clipped excess is redistributed evenly across all bins (remainder to the lowest bins), conserving the tile total exactly.
+*   **Per-pixel remap**: smoothstep-weighted bilinear blend of the four neighbouring tile CDFs (tile centres at $(\text{pos}/\text{dims}) \cdot 8 - 0.5$, edge-clamped), then
+    $$L_{final} = (1 - \alpha) \cdot L + \alpha \cdot \text{CDF}(L) \cdot 100$$
+    with $\alpha$ = `clahe_strength`.
+*   The GPU keeps the CDF from the preview render and reuses it for tiled full-res export (`clahe_cdf_override`), so export tiles share one seam-free global mapping.
+
+The control lives in the Lab sidebar (`lab.clahe_strength`), but the stage runs **before Retouching** so dust healing operates on the final local-contrast rendition.
+
+---
+
+## 5. Retouching
 **Code**: `negpy.features.retouch`
 
 This stage removes physical artifacts like dust, hairs, and scratches from the negative. We use two complementary approaches:
@@ -135,7 +151,7 @@ This stage removes physical artifacts like dust, hairs, and scratches from the n
 
 ---
 
-## 5. Lab Scanner Mode
+## 6. Lab Scanner Mode
 **Code**: `negpy.features.lab`
 
 This mimics what lab scanners like Frontier or Noritsu do automatically. For maximum signal quality, the steps are applied in the following sequence:
@@ -145,13 +161,7 @@ This mimics what lab scanners like Frontier or Noritsu do automatically. For max
 
 2.  **Vibrance**: Selectively boosts the saturation of muted colors using a chroma mask. The mask is strongest at zero chroma and fades to zero for already vibrant colors, preventing over-saturation of sensitive areas like skin tones.
 3.  **Global Saturation**: A linear boost applied to all colors via the HSV saturation channel.
-4.  **CLAHE**: Adaptive histogram equalization. It boosts local contrast in the luminance channel.
-  
-    $$L_{final} = (1 - \alpha) \cdot L + \alpha \cdot \text{CLAHE}(L)$$
-    *   $L$: Luminance channel.
-    *   $\alpha$: Blending strength.
-
-5.  **Sharpening**: We sharpen just the Lightness channel ($L$) in LAB space using Unsharp Masking (USM). We apply a threshold to avoid amplifying noise.
+4.  **Sharpening**: We sharpen just the Lightness channel ($L$) in LAB space using Unsharp Masking (USM). We apply a threshold to avoid amplifying noise.
 
     $$L_{diff} = L - \text{GaussianBlur}(L, \sigma)$$
     $$L_{final} = L + L_{diff} \cdot \text{amount} \cdot 2.5 \quad \text{if } |L_{diff}| > 2.0$$
@@ -159,7 +169,7 @@ This mimics what lab scanners like Frontier or Noritsu do automatically. For max
     *   $2.5$: Hardcoded USM boosting factor.
     *   $2.0$: Noise threshold.
 
-6.  **Glow**: Simulates lens bloom (a print-side effect) by blurring highlights and adding them back in linear light.
+5.  **Glow**: Simulates lens bloom (a print-side effect) by blurring highlights and adding them back in linear light.
 
     $$I_{out} = I + B_{glow} \cdot s_{glow}$$
     $$B_{glow} = \text{GaussianBlur}(I \cdot m_{hl})$$
@@ -167,7 +177,7 @@ This mimics what lab scanners like Frontier or Noritsu do automatically. For max
     *   $m_{hl}$: **Display-domain** highlight mask (lens bloom follows perceived print brightness), quadratically ramped from code value 0.5 to 1.0.
     *   Applied equally to all three channels; the sum is clamped at the stage output.
 
-7.  **Halation**: Simulates the red scatter caused by light reflecting back through the film base at capture. Uses a larger-radius Gaussian than Glow and a strongly red-biased highlight source. Because scattered light is *added exposure*, the composite is additive in linear light (not a screen blend), and the mask thresholds **linear reflectance** ($t = 0.65$) so the halation footprint is fixed by scene exposure instead of moving with Grade/Density.
+6.  **Halation**: Simulates the red scatter caused by light reflecting back through the film base at capture. Uses a larger-radius Gaussian than Glow and a strongly red-biased highlight source. Because scattered light is *added exposure*, the composite is additive in linear light (not a screen blend), and the mask thresholds **linear reflectance** ($t = 0.65$) so the halation footprint is fixed by scene exposure instead of moving with Grade/Density.
 
     $$I_{out} = I + B_{hal} \cdot s_{hal}$$
     $$B_{hal} = \text{GaussianBlur}(I_R \cdot m_{lin} \cdot C_{hal})$$
@@ -178,7 +188,7 @@ This mimics what lab scanners like Frontier or Noritsu do automatically. For max
 
 ---
 
-## 6. Toning
+## 7. Toning
 **Code**: `negpy.features.toning`
 
 *   **Chemical Toning** (B&W mode only): We simulate toner by blending the original pixel with a tinted version based on luminance ($Y$, Rec. 709) masks.

--- a/negpy/features/lab/logic.py
+++ b/negpy/features/lab/logic.py
@@ -7,31 +7,71 @@ from negpy.kernel.image.logic import lab_to_rgb_working, rgb_to_lab_working, wor
 from negpy.kernel.image.validation import ensure_image
 
 
-def apply_clahe(img: ImageBuffer, strength: float, scale_factor: float = 1.0) -> ImageBuffer:
+CLAHE_GRID = 8
+CLAHE_BINS = 256
+
+
+def _clahe_cdfs(bins: np.ndarray, clip_limit: float) -> np.ndarray:
+    """
+    Per-tile clipped CDFs, (64, 256) float32. Mirrors clahe_hist.wgsl /
+    clahe_cdf.wgsl exactly (integer counts, f32-truncated limit, excess
+    redistributed evenly with the remainder going to the first bins).
+    """
+    h, w = bins.shape
+    tsy, tsx = (h + CLAHE_GRID - 1) // CLAHE_GRID, (w + CLAHE_GRID - 1) // CLAHE_GRID
+    ty = (np.arange(h) // tsy).astype(np.int32)
+    tx = (np.arange(w) // tsx).astype(np.int32)
+    comb = (ty[:, None] * CLAHE_GRID + tx[None, :]) * CLAHE_BINS + bins
+    hist = np.bincount(comb.ravel(), minlength=CLAHE_GRID * CLAHE_GRID * CLAHE_BINS)
+    hist = hist.reshape(CLAHE_GRID * CLAHE_GRID, CLAHE_BINS)
+
+    total = hist.sum(axis=1)
+    limit = np.maximum(1, (np.float32(clip_limit) * total.astype(np.float32) / np.float32(CLAHE_BINS)).astype(np.int64))
+    clipped = np.minimum(hist, limit[:, None])
+    excess = (hist - clipped).sum(axis=1)
+    inc, rem = excess // CLAHE_BINS, excess % CLAHE_BINS
+    counts = clipped + inc[:, None] + (np.arange(CLAHE_BINS)[None, :] < rem[:, None])
+    return np.cumsum(counts, axis=1).astype(np.float32) / np.maximum(total, 1)[:, None].astype(np.float32)
+
+
+def _clahe_axis(n: int) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    # tile_pos = pos/dims*8 - 0.5, smoothstep frac; true floor (can be -1), clamp 0..7.
+    tp = np.arange(n, dtype=np.float32) / np.float32(n) * np.float32(CLAHE_GRID) - np.float32(0.5)
+    tf = np.floor(tp)
+    rf = tp - tf
+    fr = rf * rf * (np.float32(3.0) - np.float32(2.0) * rf)
+    lo = np.maximum(tf.astype(np.int32), 0)
+    hi = np.minimum(tf.astype(np.int32) + 1, CLAHE_GRID - 1)
+    return lo, hi, fr
+
+
+def apply_clahe(img: ImageBuffer, strength: float) -> ImageBuffer:
     """
     L-channel Contrast Limited Adaptive Histogram Equalization.
+    Fixed 8x8 tile grid over the full frame at every scale; mirrors the
+    clahe_*.wgsl shaders bin-for-bin so CPU and GPU stay in parity.
     """
     if strength <= 0:
         return img
 
     lab = rgb_to_lab_working(img)
-    l_chan, a, b = cv2.split(lab)
+    l_chan = lab[..., 0]
+    h, w = l_chan.shape
+    bins = np.clip(l_chan / np.float32(100.0) * np.float32(255.0), 0.0, 255.0).astype(np.int32)
+    cdfs = _clahe_cdfs(bins, strength * 2.5).reshape(-1)
 
-    l_u16 = (l_chan * (65535.0 / 100.0)).astype(np.uint16)
+    y0, y1, fy = _clahe_axis(h)
+    x0, x1, fx = _clahe_axis(w)
+    v00 = cdfs[(y0[:, None] * CLAHE_GRID + x0[None, :]) * CLAHE_BINS + bins]
+    v10 = cdfs[(y0[:, None] * CLAHE_GRID + x1[None, :]) * CLAHE_BINS + bins]
+    v01 = cdfs[(y1[:, None] * CLAHE_GRID + x0[None, :]) * CLAHE_BINS + bins]
+    v11 = cdfs[(y1[:, None] * CLAHE_GRID + x1[None, :]) * CLAHE_BINS + bins]
+    top = v00 + (v10 - v00) * fx[None, :]
+    bot = v01 + (v11 - v01) * fx[None, :]
+    cdf_l = top + (bot - top) * fy[:, None]
 
-    clip_limit = strength * 2.5
-    grid_dim = max(2, int(8 * scale_factor))
-    clahe = cv2.createCLAHE(clipLimit=clip_limit, tileGridSize=(grid_dim, grid_dim))
-    l_enhanced_u16 = clahe.apply(l_u16)
-
-    l_enhanced = l_enhanced_u16.astype(np.float32) * (100.0 / 65535.0)
-
-    l_final = l_chan * (1.0 - strength) + l_enhanced * strength
-
-    lab_enhanced = cv2.merge([l_final, a, b])
-    res = lab_to_rgb_working(lab_enhanced)
-
-    return ensure_image(np.clip(res, 0.0, 1.0))
+    lab[..., 0] = l_chan + (cdf_l * np.float32(100.0) - l_chan) * np.float32(strength)
+    return ensure_image(np.clip(lab_to_rgb_working(lab), 0.0, 1.0))
 
 
 @njit(cache=True, fastmath=True)

--- a/negpy/features/lab/processor.py
+++ b/negpy/features/lab/processor.py
@@ -4,7 +4,6 @@ from negpy.domain.interfaces import PipelineContext
 from negpy.domain.types import ImageBuffer
 from negpy.features.lab.logic import (
     apply_chroma_denoise,
-    apply_clahe,
     apply_glow_and_halation,
     apply_output_sharpening,
     apply_saturation,
@@ -31,9 +30,6 @@ class PhotoLabProcessor:
 
         if self.config.saturation != 1.0:
             img = apply_saturation(img, self.config.saturation)
-
-        if self.config.clahe_strength > 0:
-            img = apply_clahe(img, self.config.clahe_strength, context.scale_factor)
 
         if self.config.sharpen > 0:
             img = apply_output_sharpening(img, self.config.sharpen, context.scale_factor)

--- a/negpy/features/lab/shaders/clahe_apply.wgsl
+++ b/negpy/features/lab/shaders/clahe_apply.wgsl
@@ -11,12 +11,62 @@ struct ClaheUniforms {
 @group(0) @binding(2) var<storage, read> cdfs: array<f32>;
 @group(0) @binding(3) var<uniform> params: ClaheUniforms;
 
-fn to_perceptual(c: vec3<f32>) -> vec3<f32> {
-    return pow(max(c, vec3<f32>(0.0)), vec3<f32>(1.0 / 2.2));
+// Working-space TRC (ProPhoto ROMM) — input/output texels stay OETF-encoded
+// (retouch and lab downstream decode on load).
+fn oetf_encode(c: vec3<f32>) -> vec3<f32> {
+    let x = clamp(c, vec3<f32>(0.0), vec3<f32>(1.0));
+    return select(pow(x, vec3<f32>(0.55555556)), x * 16.0, x < vec3<f32>(0.001953125));
 }
 
-fn to_linear(c: vec3<f32>) -> vec3<f32> {
-    return pow(max(c, vec3<f32>(0.0)), vec3<f32>(2.2));
+fn oetf_decode(c: vec3<f32>) -> vec3<f32> {
+    let e = max(c, vec3<f32>(0.0));
+    return select(pow(e, vec3<f32>(1.8)), e / 16.0, e < vec3<f32>(0.03125));
+}
+
+fn rgb_to_lab(rgb: vec3<f32>) -> vec3<f32> {
+    let r = max(rgb.r, 0.0);
+    let g = max(rgb.g, 0.0);
+    let b = max(rgb.b, 0.0);
+
+    // ProPhoto RGB (ROMM) -> XYZ, D50 (working-space primaries; matches CPU rgb_to_lab_working).
+    var x = r * 0.7976749 + g * 0.1351917 + b * 0.0313534;
+    var y = r * 0.2880402 + g * 0.7118741 + b * 0.0000857;
+    var z = r * 0.0000000 + g * 0.0000000 + b * 0.8252100;
+
+    x = x / 0.96422;
+    y = y / 1.00000;
+    z = z / 0.82521;
+
+    if (x > 0.008856) { x = pow(x, 1.0/3.0); } else { x = (7.787 * x) + (16.0 / 116.0); }
+    if (y > 0.008856) { y = pow(y, 1.0/3.0); } else { y = (7.787 * y) + (16.0 / 116.0); }
+    if (z > 0.008856) { z = pow(z, 1.0/3.0); } else { z = (7.787 * z) + (16.0 / 116.0); }
+
+    let l = (116.0 * y) - 16.0;
+    let a = 500.0 * (x - y);
+    let b_lab = 200.0 * (y - z);
+
+    return vec3<f32>(l, a, b_lab);
+}
+
+fn lab_to_rgb(lab: vec3<f32>) -> vec3<f32> {
+    var y = (lab.x + 16.0) / 116.0;
+    var x = lab.y / 500.0 + y;
+    var z = y - lab.z / 200.0;
+
+    if (pow(x, 3.0) > 0.008856) { x = pow(x, 3.0); } else { x = (x - 16.0 / 116.0) / 7.787; }
+    if (pow(y, 3.0) > 0.008856) { y = pow(y, 3.0); } else { y = (y - 16.0 / 116.0) / 7.787; }
+    if (pow(z, 3.0) > 0.008856) { z = pow(z, 3.0); } else { z = (z - 16.0 / 116.0) / 7.787; }
+
+    x = x * 0.96422;
+    y = y * 1.00000;
+    z = z * 0.82521;
+
+    // XYZ -> ProPhoto RGB (ROMM), D50. Returns scene-linear (no encode).
+    let r = x * 1.3459433 + y * -0.2556075 + z * -0.0511118;
+    let g = x * -0.5445989 + y * 1.5081673 + z * 0.0205351;
+    let b = x * 0.0000000 + y * 0.0000000 + z * 1.2118128;
+
+    return max(vec3<f32>(r, g, b), vec3<f32>(0.0));
 }
 
 fn get_cdf_val(tile_x: u32, tile_y: u32, bin: u32) -> f32 {
@@ -33,10 +83,9 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
 
     let coords = vec2<i32>(i32(gid.x), i32(gid.y));
     let color = textureLoad(input_tex, coords, 0).rgb;
-    
-    let p_color = to_perceptual(color);
-    let luma = dot(p_color, vec3<f32>(0.2126, 0.7152, 0.0722));
-    let bin = u32(clamp(luma * 255.0, 0.0, 255.0));
+
+    let lab = rgb_to_lab(oetf_decode(color));
+    let bin = u32(clamp(lab.x / 100.0 * 255.0, 0.0, 255.0));
 
     let global_pos = vec2<f32>(f32(coords.x + params.global_offset.x), f32(coords.y + params.global_offset.y));
     let full_fdims = vec2<f32>(f32(params.full_dims.x), f32(params.full_dims.y));
@@ -54,8 +103,8 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
     let v11 = get_cdf_val(u32(min(t_ceil.x, 7)),  u32(min(t_ceil.y, 7)),  bin);
 
     let cdf_luma = mix(mix(v00, v10, frac.x), mix(v01, v11, frac.x), frac.y);
-    let final_luma = mix(luma, cdf_luma, params.strength);
-    let ratio = final_luma / max(luma, 1e-6);
-    
-    textureStore(output_tex, coords, vec4<f32>(clamp(to_linear(p_color * ratio), vec3<f32>(0.0), vec3<f32>(1.0)), 1.0));
+    let l_new = mix(lab.x, cdf_luma * 100.0, params.strength);
+    let rgb = lab_to_rgb(vec3<f32>(l_new, lab.y, lab.z));
+
+    textureStore(output_tex, coords, vec4<f32>(oetf_encode(clamp(rgb, vec3<f32>(0.0), vec3<f32>(1.0))), 1.0));
 }

--- a/negpy/features/lab/shaders/clahe_hist.wgsl
+++ b/negpy/features/lab/shaders/clahe_hist.wgsl
@@ -3,8 +3,22 @@
 
 var<workgroup> local_hist: array<atomic<u32>, 256>;
 
-fn to_perceptual(c: vec3<f32>) -> vec3<f32> {
-    return pow(max(c, vec3<f32>(0.0)), vec3<f32>(1.0 / 2.2));
+// Working-space TRC (ProPhoto ROMM) — input texels arrive OETF-encoded.
+fn oetf_decode(c: vec3<f32>) -> vec3<f32> {
+    let e = max(c, vec3<f32>(0.0));
+    return select(pow(e, vec3<f32>(1.8)), e / 16.0, e < vec3<f32>(0.03125));
+}
+
+// CIELAB L* (Y row of the ProPhoto->XYZ matrix only — a*/b* unused here).
+// Must mirror rgb_to_lab in clahe_apply.wgsl / lab.wgsl op-for-op so hist
+// and apply agree on bins.
+fn lab_l(rgb: vec3<f32>) -> f32 {
+    let r = max(rgb.r, 0.0);
+    let g = max(rgb.g, 0.0);
+    let b = max(rgb.b, 0.0);
+    var y = r * 0.2880402 + g * 0.7118741 + b * 0.0000857;
+    if (y > 0.008856) { y = pow(y, 1.0/3.0); } else { y = (7.787 * y) + (16.0 / 116.0); }
+    return (116.0 * y) - 16.0;
 }
 
 @compute @workgroup_size(16, 16)
@@ -29,10 +43,8 @@ fn main(
     for (var y = y_start + (lid / 16u); y < y_end; y += 16u) {
         for (var x = x_start + (lid % 16u); x < x_end; x += 16u) {
             let color = textureLoad(input_tex, vec2<i32>(i32(x), i32(y)), 0).rgb;
-            // Calculate luma in perceptual space for histogram
-            let p_color = to_perceptual(color);
-            let luma = dot(p_color, vec3<f32>(0.2126, 0.7152, 0.0722));
-            let bin = u32(clamp(luma * 255.0, 0.0, 255.0));
+            let l = lab_l(oetf_decode(color));
+            let bin = u32(clamp(l / 100.0 * 255.0, 0.0, 255.0));
             atomicAdd(&local_hist[bin], 1u);
         }
     }

--- a/negpy/features/lab/shaders/lab.wgsl
+++ b/negpy/features/lab/shaders/lab.wgsl
@@ -115,7 +115,7 @@ fn reflect_101(c: i32, n: i32) -> i32 {
 }
 
 fn rgb_to_lab(rgb: vec3<f32>) -> vec3<f32> {
-    // Linear Adobe RGB -> CIELAB (D65). Input is scene-linear (no sRGB decode).
+    // Linear ProPhoto RGB -> CIELAB (D50). Input is scene-linear (no TRC decode).
     let r = max(rgb.r, 0.0);
     let g = max(rgb.g, 0.0);
     let b = max(rgb.b, 0.0);

--- a/negpy/features/toning/shaders/toning.wgsl
+++ b/negpy/features/toning/shaders/toning.wgsl
@@ -20,7 +20,7 @@ struct ToningUniforms {
 @group(0) @binding(2) var<uniform> params: ToningUniforms;
 
 fn rgb_to_lab(rgb: vec3<f32>) -> vec3<f32> {
-    // Linear Adobe RGB -> CIELAB (D65). Input is scene-linear (no sRGB decode).
+    // Linear ProPhoto RGB -> CIELAB (D50). Input is scene-linear (no TRC decode).
     let r = max(rgb.r, 0.0);
     let g = max(rgb.g, 0.0);
     let b = max(rgb.b, 0.0);

--- a/negpy/kernel/caching/manager.py
+++ b/negpy/kernel/caching/manager.py
@@ -13,12 +13,14 @@ class PipelineCache:
     # Checkpoints
     base: Optional[CacheEntry] = None
     exposure: Optional[CacheEntry] = None
+    clahe: Optional[CacheEntry] = None
     retouch: Optional[CacheEntry] = None
     lab: Optional[CacheEntry] = None
 
     def clear(self) -> None:
         self.base = None
         self.exposure = None
+        self.clahe = None
         self.retouch = None
         self.lab = None
         self.source_hash = ""

--- a/negpy/kernel/system/config.py
+++ b/negpy/kernel/system/config.py
@@ -64,7 +64,7 @@ DEFAULT_WORKSPACE_CONFIG = WorkspaceConfig(
         autocrop_ratio=AspectRatio.R_3_2,
     ),
     lab=LabConfig(
-        clahe_strength=0.25,
+        clahe_strength=0.0,
         saturation=1.0,
         sharpen=0.25,
     ),

--- a/negpy/services/rendering/engine.py
+++ b/negpy/services/rendering/engine.py
@@ -14,6 +14,7 @@ from negpy.features.exposure.processor import (
     PhotometricProcessor,
 )
 from negpy.features.toning.processor import ToningProcessor
+from negpy.features.lab.logic import apply_clahe
 from negpy.features.lab.processor import PhotoLabProcessor
 from negpy.features.retouch.processor import RetouchProcessor
 from negpy.features.finish.processor import FinishProcessor
@@ -82,6 +83,7 @@ class DarkroomEngine:
             self.cache.process_mode = settings.process.process_mode
             self.cache.base = None
             self.cache.exposure = None
+            self.cache.clahe = None
             self.cache.retouch = None
             self.cache.lab = None
             pipeline_changed = True
@@ -166,6 +168,20 @@ class DarkroomEngine:
         flat_intent = settings.exposure.render_intent == RenderIntent.FLAT
 
         if not flat_intent:
+
+            def run_clahe(img_in: ImageBuffer, ctx: PipelineContext) -> ImageBuffer:
+                return apply_clahe(img_in, settings.lab.clahe_strength)
+
+            # Keyed on the bare float: the full settings.lab would wrongly invalidate
+            # this stage (and retouch/lab behind it) on saturation/sharpen edits.
+            current_img, pipeline_changed = self._run_stage(
+                current_img,
+                settings.lab.clahe_strength,
+                "clahe",
+                run_clahe,
+                context,
+                pipeline_changed,
+            )
 
             def run_retouch(img_in: ImageBuffer, ctx: PipelineContext) -> ImageBuffer:
                 return RetouchProcessor(settings.retouch).process(img_in, ctx)

--- a/negpy/services/rendering/gpu_engine.py
+++ b/negpy/services/rendering/gpu_engine.py
@@ -1212,7 +1212,7 @@ class GPUEngine:
             struct.pack(
                 "ffiiii",
                 cls,
-                max(1.0, cls * 2.5),
+                cls * 2.5,
                 offset[0],
                 offset[1],
                 full_dims[0],

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -50,6 +50,31 @@ class TestDarkroomEngine(unittest.TestCase):
         assert engine.cache.source_hash == "file2"
         assert not np.array_equal(res1, res3)
 
+    def test_clahe_stage_cache_invalidation(self):
+        """CLAHE cache survives lab-only edits; a strength change invalidates
+        clahe and the stages behind it (retouch, lab)."""
+        from dataclasses import replace
+
+        engine = DarkroomEngine()
+        img = np.random.rand(100, 100, 3).astype(np.float32)
+        settings = WorkspaceConfig()
+        settings = replace(settings, lab=replace(settings.lab, clahe_strength=0.5))
+
+        engine.process(img, settings, source_hash="file1")
+        assert engine.cache.clahe is not None
+        clahe_id = id(engine.cache.clahe.data)
+        retouch_id = id(engine.cache.retouch.data)
+
+        settings_sat = replace(settings, lab=replace(settings.lab, saturation=1.5))
+        engine.process(img, settings_sat, source_hash="file1")
+        assert id(engine.cache.clahe.data) == clahe_id
+        assert id(engine.cache.retouch.data) == retouch_id
+
+        settings_strength = replace(settings_sat, lab=replace(settings_sat.lab, clahe_strength=0.9))
+        engine.process(img, settings_strength, source_hash="file1")
+        assert id(engine.cache.clahe.data) != clahe_id
+        assert id(engine.cache.retouch.data) != retouch_id
+
     def test_pipeline_produces_metrics(self):
         """Verify pipeline populates expected metrics."""
         from negpy.domain.interfaces import PipelineContext

--- a/tests/test_gpu_curve_parity.py
+++ b/tests/test_gpu_curve_parity.py
@@ -109,6 +109,34 @@ class TestGpuCurveParity(unittest.TestCase):
         self.assertLess(mad, 0.01, f"mean abs diff {mad:.4f}")
         self.assertLess(mx, 0.04, f"max abs diff {mx:.4f}")
 
+    def test_cpu_gpu_match_clahe(self):
+        """CLAHE at full strength (issue #524 regression). 128x128 keeps each
+        8x8 tile at >=256 samples so a handful of upstream f32/f64 bin flips
+        can't move a tile CDF anywhere near the tolerance gate."""
+        from negpy.services.rendering.image_processor import ImageProcessor
+
+        processor = ImageProcessor()
+        if processor.engine_gpu is None:
+            self.skipTest("GPU engine not initialised")
+
+        rng = np.random.default_rng(3)
+        h, w = 128, 128
+        grad = np.linspace(0.05, 0.9, w, dtype=np.float32)
+        img = np.repeat(grad[None, :], h, axis=0)
+        img = np.stack([img, img * 0.95, img * 0.9], axis=-1)
+        img = np.ascontiguousarray(img + rng.uniform(0, 0.01, img.shape).astype(np.float32))
+
+        settings = WorkspaceConfig()
+        settings = replace(settings, lab=replace(settings.lab, clahe_strength=1.0))
+        cpu = self._render(processor, settings, img, prefer_gpu=False)
+        gpu = self._render(processor, settings, img, prefer_gpu=True)
+
+        self.assertEqual(cpu.shape, gpu.shape)
+        mad = float(np.mean(np.abs(cpu - gpu)))
+        mx = float(np.max(np.abs(cpu - gpu)))
+        self.assertLess(mad, 0.01, f"mean abs diff {mad:.4f}")
+        self.assertLess(mx, 0.04, f"max abs diff {mx:.4f}")
+
     def test_cpu_gpu_match_bw_trims(self):
         """B&W end-to-end parity under per-channel trims + a chroma lab op.
         The tight tolerance catches any CPU-only or GPU-only B&W grading step

--- a/tests/test_lab_logic.py
+++ b/tests/test_lab_logic.py
@@ -39,6 +39,30 @@ class TestLabLogic(unittest.TestCase):
         # Should be different
         assert not np.allclose(res, img)
 
+    def test_clahe_zero_strength_passthrough(self) -> None:
+        img = np.random.rand(32, 32, 3).astype(np.float32)
+        assert apply_clahe(img, 0.0) is img
+
+    def test_clahe_flat_image_near_identity(self) -> None:
+        """Clipping redistributes a constant image's single-bin mass, so the CDF
+        approximates the identity ramp (cdf[b] ≈ (b+1)/256 + limit/total). Needs
+        realistic tile sizes: 256x256 → 32x32 tiles, like the 200px preview tiles."""
+        img = np.full((256, 256, 3), 0.35, dtype=np.float32)
+        res = apply_clahe(img, 1.0)
+        np.testing.assert_allclose(res, img, atol=0.02)
+
+    def test_clahe_cdf_invariants(self) -> None:
+        """Per-tile CDFs are monotone and end exactly at 1.0 — the excess
+        redistribution conserves the tile total, mirroring clahe_cdf.wgsl."""
+        from negpy.features.lab.logic import _clahe_cdfs
+
+        rng = np.random.default_rng(7)
+        bins = rng.integers(0, 256, (128, 128)).astype(np.int32)
+        cdfs = _clahe_cdfs(bins, 2.5)
+        self.assertEqual(cdfs.shape, (64, 256))
+        self.assertTrue(np.all(np.diff(cdfs, axis=1) >= 0))
+        self.assertTrue(np.all(cdfs[:, -1] == 1.0))
+
     def test_output_sharpening(self) -> None:
         """Sharpening should increase local variance."""
         # Create a simple square


### PR DESCRIPTION
GPU histogrammed gamma-2.2 Rec.709 luma on ROMM-encoded texels and ratio-scaled RGB (chroma pumping); CPU ran OpenCV on CIELAB L with 65536 bins and a resolution-scaled grid — two unrelated looks, worst at high strength. Both sides now mirror one spec: CIELAB L* (ProPhoto D50), 256 bins, fixed 8x8 grid, smoothstep bilinear, L-only remap with a*/b* preserved, shared clip formula.

- CPU: numpy mirror of the WGSL replaces cv2.createCLAHE; CLAHE moves out of the lab processor into its own cached engine stage after exposure, matching the GPU stage order
- GPU: clahe_hist/clahe_apply switch to oetf_decode -> Lab-L ->
  L-merge -> oetf_encode; clip-limit uniform floor dropped
- real-photo parity at strength 1.0: mad 0.085 -> 2e-6
- fix stale "Adobe RGB (D65)" comments on the ProPhoto-D50 matrices in lab.wgsl/toning.wgsl

Closes #524