### PR TITLE
feat: quieter status toasts, canvas-bg overflow-only, crop busy overlay

### DIFF
--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -266,9 +266,8 @@ class AppController(QObject):
         self._pending_render_task: Any = None
 
         # Last displayed render per frame — navigate-back paints it instantly
-        # while the authoritative render refreshes quietly (no spinner/toasts).
+        # while the authoritative render refreshes underneath.
         self._render_memo = RenderMemo()
-        self._memo_quiet = False
 
         self._render_debounce = QTimer()
         self._render_debounce.setSingleShot(True)
@@ -461,7 +460,6 @@ class AppController(QObject):
         self.batch_progress.emit(current, total, name)
 
     def _on_thumbnails_finished(self, new_thumbs: Dict[str, Any]) -> None:
-        self.set_status("GALLERIES UPDATED", 3000)
         self.status_progress_requested.emit(0, 0)
         self._end_batch()
         for name, pil_img in new_thumbs.items():
@@ -707,7 +705,6 @@ class AppController(QObject):
         if not preserve_zoom:
             self.zoom_requested.emit(1.0)
         if memo is None:
-            self.set_status(f"Loading {os.path.basename(file_path)}...")
             self.loading_started.emit()
         self._thumb_config = None
 
@@ -721,7 +718,6 @@ class AppController(QObject):
                 self.state.last_metrics["base_positive"] = memo["base_positive"]
                 self.state.last_metrics["content_rect"] = memo.get("content_rect")
                 self.state.last_metrics["splash"] = False
-            self._memo_quiet = True
             self.image_updated.emit()
 
         self.state.preview_raw = None
@@ -882,6 +878,12 @@ class AppController(QObject):
             self.session.update_config(replace(self.state.config, process=new_proc), render=False)
             self._crop_bounds_dirty = False
         if preview_mode_changed:
+            if leaving_crop:
+                # Same spinner/overlay treatment as an initial file load: the bounds
+                # recompute above plus this render can take a noticeable moment on a
+                # large HQ frame, and image_updated (fired when the render lands)
+                # dismisses it — guaranteed since request_render() runs right below.
+                self.loading_started.emit()
             self.request_render()
 
     def cancel_active_tool(self) -> None:
@@ -1013,6 +1015,9 @@ class AppController(QObject):
                 process=new_proc,
             )
         )
+        # Same spinner/overlay treatment as an initial file load: the bounds
+        # recompute above can take a noticeable moment on a large HQ frame.
+        self.loading_started.emit()
         self.request_render()
 
     def apply_auto_crop(self) -> None:
@@ -1033,6 +1038,7 @@ class AppController(QObject):
                 process=new_proc,
             )
         )
+        self.loading_started.emit()
         self.request_render()
 
     def detect_aspect_ratio(self) -> None:
@@ -1810,13 +1816,6 @@ class AppController(QObject):
         if self.state.preview_raw is None:
             return
 
-        # One-shot: the render right after a memo paint refreshes identical pixels —
-        # "Rendering..."/"READY" toasts would undercut the instant switch.
-        quiet = self._memo_quiet
-        self._memo_quiet = False
-        if not quiet:
-            self.set_status("Rendering...")
-
         preview_raw = self.state.preview_raw
         if preview_raw is None:
             return
@@ -1853,7 +1852,6 @@ class AppController(QObject):
             crop_preview_full=crop_preview_full,
             ephemeral=ephemeral,
             memo_key=memo_key,
-            quiet=quiet,
         )
 
         if self._is_rendering:
@@ -2491,8 +2489,6 @@ class AppController(QObject):
         if metrics.get("gpu_fallback") and not self._gpu_fallback_notified:
             self._gpu_fallback_notified = True
             self.set_status("GPU acceleration failed — using CPU", 5000)
-        elif not metrics.get("quiet"):
-            self.set_status("READY", 1000)
 
         self.image_updated.emit()
 

--- a/negpy/desktop/view/canvas/toolbar.py
+++ b/negpy/desktop/view/canvas/toolbar.py
@@ -2,7 +2,6 @@ import qtawesome as qta
 from PyQt6.QtCore import QSize, Qt
 from PyQt6.QtGui import QActionGroup
 from PyQt6.QtWidgets import (
-    QButtonGroup,
     QFrame,
     QHBoxLayout,
     QLabel,
@@ -18,7 +17,6 @@ from PyQt6.QtWidgets import (
 from negpy.desktop.controller import AppController
 from negpy.desktop.view.keyboard_shortcuts import _context_undo
 from negpy.desktop.view.shortcut_registry import key_for, tooltip_with_shortcut
-from negpy.desktop.view.styles.templates import swatch_qss
 from negpy.desktop.view.styles.theme import THEME
 from negpy.infrastructure.gpu.device import GPUDevice
 from negpy.kernel.system.config import APP_CONFIG
@@ -27,6 +25,7 @@ CANVAS_COLORS = [
     ("#050505", (0.02, 0.02, 0.02), "Black"),
     ("#1C1C1C", (0.11, 0.11, 0.11), "Dark Grey"),
     ("#404040", (0.25, 0.25, 0.25), "Mid Grey"),
+    ("#FFFFFF", (1.0, 1.0, 1.0), "White"),
 ]
 
 
@@ -173,21 +172,7 @@ class ActionToolbar(QWidget):
             self.btn_gpu.setChecked(False)
         self.btn_gpu.setToolTip("GPU Acceleration")
 
-        # 4. Canvas background swatches
-        self.canvas_color_btns: list[QToolButton] = []
-        self.canvas_color_group = QButtonGroup(self)
-        self.canvas_color_group.setExclusive(True)
-        for i, (hex_col, _, label) in enumerate(CANVAS_COLORS):
-            btn = QToolButton()
-            btn.setCheckable(True)
-            btn.setToolTip(f"Canvas: {label}")
-            btn.setFixedSize(20, 20)
-            btn.setStyleSheet(swatch_qss(hex_col))
-            self.canvas_color_group.addButton(btn, i)
-            self.canvas_color_btns.append(btn)
-        self.canvas_color_btns[self.session.state.canvas_bg_index].setChecked(True)
-
-        # 6. Overflow menu & responsive groups
+        # 4. Overflow menu & responsive groups
         self.btn_overflow = QToolButton()
         self.btn_overflow.setIcon(qta.icon("fa5s.ellipsis-h", color=icon_color))
         self.btn_overflow.setToolTip("More actions")
@@ -195,16 +180,24 @@ class ActionToolbar(QWidget):
 
         overflow_menu = QMenu(self.btn_overflow)
 
-        # Overflow: swatches + HQ group (<720px)
+        # Overflow: HQ group (<720px)
         self._ov_hq_action = overflow_menu.addAction("Toggle HQ Preview")
         self._ov_hq_action.setCheckable(True)
         self._ov_hq_action.setVisible(False)
         overflow_menu.addSeparator()
+
+        # Canvas background — overflow-only (no toolbar swatches), exclusive
+        # checkable group so the menu itself shows which color is active.
+        self._ov_color_group = QActionGroup(self)
+        self._ov_color_group.setExclusive(True)
         self._ov_color_actions: list = []
-        for i, (hex_col, _, label) in enumerate(CANVAS_COLORS):
+        for i, (_, _, label) in enumerate(CANVAS_COLORS):
             action = overflow_menu.addAction(f"Canvas: {label}")
-            action.setVisible(False)
+            action.setCheckable(True)
+            action.setChecked(i == self.session.state.canvas_bg_index)
+            self._ov_color_group.addAction(action)
             self._ov_color_actions.append(action)
+        overflow_menu.addSeparator()
 
         # Overflow: compare / flat peek / zoom extras / undo (collapsed when the pill
         # would exceed the canvas width — see set_available_width).
@@ -309,10 +302,10 @@ class ActionToolbar(QWidget):
 
         # Custom-sized buttons skip the standard sizing above but must share the
         # same hover cursor as the rest of the toolbar.
-        for btn in (self.btn_zoom_fit, self.btn_zoom_original, *self.canvas_color_btns):
+        for btn in (self.btn_zoom_fit, self.btn_zoom_original):
             btn.setCursor(Qt.CursorShape.PointingHandCursor)
 
-        # Single-row layout: toggle_left · prev · next · sep1 · zoom+label · hq · swatches · sep2 · rot_l · rot_r · flip_h · flip_v · sep3 · undo · redo · compare · gpu · overflow · toggle_right
+        # Single-row layout: toggle_left · prev · next · sep1 · zoom+label · hq · sep2 · rot_l · rot_r · flip_h · flip_v · sep3 · undo · redo · compare · gpu · overflow · toggle_right
         row_layout.addWidget(self.btn_toggle_left)
         row_layout.addWidget(self.btn_prev)
         row_layout.addWidget(self.btn_next)
@@ -323,8 +316,6 @@ class ActionToolbar(QWidget):
         row_layout.addWidget(self.btn_zoom_fit)
         row_layout.addWidget(self.btn_zoom_original)
         row_layout.addWidget(self.btn_hq)
-        for btn in self.canvas_color_btns:
-            row_layout.addWidget(btn)
         self._sep2 = self._create_separator()
         row_layout.addWidget(self._sep2)
         row_layout.addWidget(self.btn_rot_l)
@@ -345,13 +336,13 @@ class ActionToolbar(QWidget):
         self._ov_compare_peek: list = [self.btn_compare, self.btn_flat_peek]
         self._ov_undo_redo: list = [self._sep3, self.btn_undo, self.btn_redo]
         self._ov_zoom_extra: list = [self.btn_zoom_fit, self.btn_zoom_original]
-        self._ov_swatches_hq: list = [self.btn_hq] + self.canvas_color_btns + [self._sep2]
+        self._ov_hq_group: list = [self.btn_hq, self._sep2]
         self._ov_flip_rotate: list = [self.btn_rot_l, self.btn_rot_r, self.btn_flip_h, self.btn_flip_v, self._sep3]
         self._collapse_groups: list = [
             self._ov_compare_peek,
             self._ov_undo_redo,
             self._ov_zoom_extra,
-            self._ov_swatches_hq,
+            self._ov_hq_group,
             self._ov_flip_rotate,
         ]
 
@@ -379,8 +370,6 @@ class ActionToolbar(QWidget):
         # Same context routing as Ctrl+Z: heal-undo while a heal tool is in hand.
         self.btn_undo.clicked.connect(lambda: _context_undo(self.controller))
         self.btn_redo.clicked.connect(self.session.redo)
-
-        self.canvas_color_group.idToggled.connect(self._on_canvas_color_changed)
 
         self.zoom_slider.valueChanged.connect(lambda v: self.controller.zoom_requested.emit(float(v / 100.0)))
         self.btn_zoom_fit.clicked.connect(self._on_fit_clicked)
@@ -602,15 +591,13 @@ class ActionToolbar(QWidget):
 
     def _sync_responsive_overflow_menu(self) -> None:
         """Mirror collapsed toolbar groups into the overflow menu."""
-        show_swatches_hq = not all(not w.isVisible() for w in self._ov_swatches_hq)
+        show_hq = not all(not w.isVisible() for w in self._ov_hq_group)
         show_flip_rotate = not all(not w.isVisible() for w in self._ov_flip_rotate)
         show_compare_peek = not all(not w.isVisible() for w in self._ov_compare_peek)
         show_undo_redo = not all(not w.isVisible() for w in self._ov_undo_redo)
         show_zoom_extra = not all(not w.isVisible() for w in self._ov_zoom_extra)
 
-        self._ov_hq_action.setVisible(not show_swatches_hq)
-        for action in self._ov_color_actions:
-            action.setVisible(not show_swatches_hq)
+        self._ov_hq_action.setVisible(not show_hq)
 
         self._ov_sep_main.setVisible(not show_flip_rotate)
         self._ov_rot_l_action.setVisible(not show_flip_rotate)

--- a/negpy/desktop/view/styles/templates.py
+++ b/negpy/desktop/view/styles/templates.py
@@ -148,11 +148,3 @@ def slider_label_qss(color: str) -> str:
 def slider_handle_qss(color: str) -> str:
     """Recolors the handle only; geometry cascades from the app-wide QSlider style."""
     return f"QSlider::handle:horizontal {{background: {color};}}"
-
-
-def swatch_qss(hex_col: str) -> str:
-    return (
-        f"QToolButton {{background-color: {hex_col}; border: 1px solid #444; border-radius: 3px;}}"
-        f" QToolButton:checked {{border: 2px solid {THEME.text_muted};}}"
-        f" QToolButton:hover {{border: 1px solid #888;}}"
-    )

--- a/negpy/desktop/view/widgets/loading_overlay.py
+++ b/negpy/desktop/view/widgets/loading_overlay.py
@@ -32,7 +32,7 @@ class LoadingOverlay(QWidget):
         self._spinner.setIconSize(QSize(52, 52))
         layout.addWidget(self._spinner, alignment=Qt.AlignmentFlag.AlignCenter)
 
-        self._label = QLabel("processing…")
+        self._label = QLabel("Processing…")
         self._label.setStyleSheet(
             f"color: {THEME.text_primary}; font-size: {THEME.font_size_lg}px; font-weight: 600; "
             "background-color: rgba(10, 10, 10, 225); border: 1px solid rgba(255, 255, 255, 55); "

--- a/negpy/desktop/workers/render.py
+++ b/negpy/desktop/workers/render.py
@@ -42,8 +42,6 @@ class RenderTask:
     # Identity of everything that shaped these pixels; non-empty makes the result
     # eligible for the navigate-back render memo (echoed in metrics).
     memo_key: str = ""
-    # Quiet refresh behind a memo paint: no "Rendering..."/"READY" toasts.
-    quiet: bool = False
 
 
 @dataclass(frozen=True)
@@ -174,7 +172,6 @@ class RenderWorker(QObject):
             metrics["source_hash"] = task.source_hash
             metrics["ephemeral"] = task.ephemeral
             metrics["memo_key"] = task.memo_key
-            metrics["quiet"] = task.quiet
 
             self.finished.emit(result, metrics)
             self.metrics_updated.emit(metrics)


### PR DESCRIPTION
## Summary

**Quieter status toasts** — "Rendering...", "READY", "GALLERIES UPDATED", and "Loading ..." fired on nearly every frame switch and render settle, right on top of the progress bar already shown for the same activity. All four are gone; the `quiet`/`_memo_quiet` plumbing that existed solely to gate the render toast pair goes with it as dead code.

**Canvas background — overflow-only** — the three swatch buttons and their button group are out of the bottom toolbar entirely. The color picker now lives only in the "More actions" overflow menu, as a checkable exclusive action group so the menu shows a checkmark next to the active color (previously the overflow entries were plain and only appeared when the toolbar ran out of width). Adds a pure **White** option alongside Black/Dark Grey/Mid Grey.

**Crop actions get the busy overlay** — committing a manual crop (leaving the tool, Clear Crop, Auto Crop) can trigger a full-frame auto-exposure bounds recompute that's slow on large HQ files, previously with no feedback. It now shows the same spinner + "Processing..." overlay as an initial file load (label capitalized to match). Live dragging while the crop tool stays open is untouched — no spinner there, since that's meant to feel instant.

## Test plan
- [x] Verified end-to-end against the real desktop app (headless, real ARW files): confirmed no rendering/ready/galleries-updated/loading toast during file load or frame switch; confirmed the toolbar has no swatch buttons, the overflow menu lists all four colors with the correct one checked, and selecting White actually sets the canvas background to `(1.0, 1.0, 1.0)`; confirmed no spinner during live crop dragging but spinner shows-then-dismisses on crop commit and on `reset_crop()`
- [x] Existing `test_controller.py` / `test_canvas_toolbar.py` / `test_render_memo.py` suites pass unmodified
- [x] Full test suite green aside from one pre-existing, unrelated Windows path-separator failure in `test_export_presets.py` that reproduces on a clean checkout of `main`
- [x] `ruff check` / `ruff format --check` clean