### PR TITLE
fix(camera-scanning): calibration measured light it never received

### DIFF
--- a/negpy/desktop/view/sidebar/calibration_window.py
+++ b/negpy/desktop/view/sidebar/calibration_window.py
@@ -93,6 +93,15 @@ class CalibrationWindow(QDialog):
     def _emit_calibrate(self) -> None:
         self.calibrateRequested.emit(self.name_edit.text().strip())
 
+    def set_inputs_locked(self, locked: bool) -> None:
+        """Freeze the calibration inputs while a run is in progress: the film-stock name, the base
+        ROI (clicking the image must not move the patch being metered), and the ISO/aperture the
+        base is metered at. Re-enabled at any terminal outcome so a failed run can be retried."""
+        self.name_edit.setEnabled(not locked)
+        self.iso_stepper.setEnabled(not locked)
+        self.aperture_stepper.setEnabled(not locked)
+        self.image.set_roi_locked(locked)
+
     def set_status(self, text: str) -> None:
         self.status.setText(text)
 
@@ -102,6 +111,7 @@ class CalibrationWindow(QDialog):
 
     def start(self, default_name: str = "") -> None:
         """Reset and show the window for a fresh calibration."""
+        self.set_inputs_locked(False)  # a fresh window always starts editable
         self.name_edit.setText(default_name)
         self.image.clear_roi()
         # Blank the previous session's frame before showing, so reopening goes straight to black +

--- a/negpy/desktop/view/sidebar/roi_image.py
+++ b/negpy/desktop/view/sidebar/roi_image.py
@@ -36,6 +36,7 @@ class RoiImageLabel(QLabel):
         # roi_mode=True drops the calibration crosshair patch on click (calib window);
         # False just emits `clicked` (scan pop-up → aim the focus magnifier).
         self.roi_mode = True
+        self._roi_locked = False  # true while a calibration runs → clicks must not move the patch
         self._pixmap: Optional[QPixmap] = None
         self._roi: Optional[tuple[float, float, float, float]] = None
         self._drag_start: Optional[QPoint] = None
@@ -70,6 +71,12 @@ class RoiImageLabel(QLabel):
     def _advance_spinner(self) -> None:
         self._spin_angle = (self._spin_angle + 30) % 360
         self.update()
+
+    def set_roi_locked(self, locked: bool) -> None:
+        """Freeze the base ROI while a calibration is metering it: a click no longer moves the
+        sampling patch. The cursor drops the crosshair so it's clear the target is fixed."""
+        self._roi_locked = locked
+        self.setCursor(Qt.CursorShape.ArrowCursor if locked else Qt.CursorShape.CrossCursor)
 
     def clear_roi(self) -> None:
         self._roi = None
@@ -129,7 +136,8 @@ class RoiImageLabel(QLabel):
         if self._drag_start is not None and draw_rect is not None:
             cx, cy = self._to_fraction(ev.pos(), draw_rect)
             if self.roi_mode:
-                self._set_crosshair(cx, cy)  # calibration: drop the small base-sampling patch (no drag-box)
+                if not self._roi_locked:  # locked while a calibration meters the patch
+                    self._set_crosshair(cx, cy)  # calibration: drop the small base-sampling patch (no drag-box)
             elif (ev.pos() - self._drag_start).manhattanLength() < _CLICK_SLOP:
                 self.clicked.emit(cx, cy)  # scan pop-up: a click toggles the focus magnifier
         self._drag_start = None

--- a/negpy/desktop/view/sidebar/scanlight.py
+++ b/negpy/desktop/view/sidebar/scanlight.py
@@ -79,6 +79,7 @@ class ScanlightSidebar(QWidget):
         self._manual_mode = False  # True while building a preset by hand (sliders + exposure editable)
         self._manual_populate_pending = False  # seed the sidebar exposure steppers from the body once, then let the user drive
         self._calibrating_preset = ""  # non-empty while the "+" calibration flow is saving a new preset
+        self._status_pinned = False  # a pinned status (calibration outcome) outranks the light echo
         self._magnifier_on = False  # camera focus magnifier state (driven by clicks on the live image)
         self._settings_loaded = False  # have the live camera-setting dropdowns been populated yet?
         self._slider_readouts: dict = {}  # slider → its value label (updated on preset apply, where signals are blocked)
@@ -437,6 +438,12 @@ class ScanlightSidebar(QWidget):
 
     @pyqtSlot(int, int, int, int)
     def _on_light_set(self, r: int, g: int, b: int, w: int) -> None:
+        # Ambient echo, not a user action: _on_calibration_finished sets the R/G/B sliders, each of
+        # which starts the light debounce, and this slot fires ~60 ms later — right after the
+        # calibration outcome ("Saved preset … ⚠ over-exposed …") was written. Declining to replace
+        # a pinned outcome is what keeps that advice on screen; the slider readouts echo the levels.
+        if self._status_pinned:
+            return
         self._set_status(f"Light: W{w}" if w else f"Light: R{r} G{g} B{b}")
 
     # ── presets ───────────────────────────────────────────────────────
@@ -1069,7 +1076,10 @@ class ScanlightSidebar(QWidget):
             self._save_current_as_preset(name)  # persist + reload + select + re-gate (bakes settings.iso/aperture)
             self._lv_target = self.lv_image
             self.calib_window.hide()
-            self._set_status(f"Saved preset “{name}”.{warn}")
+            # Pinned: the slider writes above armed the 60 ms light debounce, whose light_set echo
+            # lands right after this line — without the pin it replaced this outcome (and its
+            # aperture advice) with "Light: R… G… B…" before anyone could read it.
+            self._set_status(f"Saved preset “{name}”.{warn}", pinned=True)
         self._stop_calibration_live_view()  # calibration ran inside live view → tear it down
 
     # ── browse ────────────────────────────────────────────────────────
@@ -1230,8 +1240,13 @@ class ScanlightSidebar(QWidget):
     def _on_status(self, msg: str) -> None:
         self._set_status(msg)
 
-    def _set_status(self, text: str) -> None:
-        """Show a status line on the panel and mirror it into the live-view pop-up."""
+    def _set_status(self, text: str, *, pinned: bool = False) -> None:
+        """Show a status line on the panel and mirror it into the live-view pop-up.
+
+        `pinned` marks a message the user must not miss (the calibration outcome, possibly carrying
+        the over/under aperture advice): the ambient light echo (_on_light_set) declines to replace
+        it. Any other write — every one of them user-driven — replaces and unpins as usual."""
+        self._status_pinned = pinned and bool(text)
         self.status_label.setText(text)
         self.status_label.setVisible(bool(text))  # collapse the strip when there's no message
         self.lv_window.set_status(text)

--- a/negpy/desktop/view/sidebar/scanlight.py
+++ b/negpy/desktop/view/sidebar/scanlight.py
@@ -35,7 +35,7 @@ from negpy.desktop.view.styles.templates import section_subheader
 from negpy.desktop.view.styles.theme import THEME
 from negpy.infrastructure.capture.gphoto import default_settings_path
 from negpy.infrastructure.capture.settings import ScanlightSettings
-from negpy.services.capture.calibration import REFERENCE_LEVELS, SHUTTER_CANDIDATES, normalize_start_point, shutter_seconds
+from negpy.services.capture.calibration import REFERENCE_LEVELS, SHUTTER_CANDIDATES, normalize_start_point, shutter_seconds, usable_ladder
 from negpy.services.capture.presets import PresetStore, ScanlightPreset
 
 _CHANNEL_COLORS = {"R": "#E24B4A", "G": "#639922", "B": "#378ADD", "W": "#B4B2A9"}
@@ -712,16 +712,10 @@ class ScanlightSidebar(QWidget):
         and meters noise instead of light."""
         data = self._settings_json()
         floor, ceiling = shutter_seconds(SHUTTER_CANDIDATES[0]), shutter_seconds(SHUTTER_CANDIDATES[-1])
-        by_seconds: dict[str, float] = {}
-        for o in (data.get("shutter") or {}).get("options", []):
-            label = str(o.get("label", "")).strip()
-            try:
-                seconds = shutter_seconds(label)
-            except (TypeError, ValueError, ZeroDivisionError):
-                continue
-            if floor <= seconds <= ceiling:
-                by_seconds[label] = seconds
-        return tuple(sorted(by_seconds, key=by_seconds.__getitem__))
+        labels = tuple(str(o.get("label", "")).strip() for o in (data.get("shutter") or {}).get("options", []))
+        # usable_ladder drops the unparseables (bulb-like "1/0", "Bulb", "") and returns ascending =
+        # fastest-first; the range clamp on top is this UI's own policy, not the solver's.
+        return tuple(label for label in usable_ladder(labels) if floor <= shutter_seconds(label) <= ceiling)
 
     def _on_calibrate_new_preset(self, name: str) -> None:
         if self._scanning:

--- a/negpy/desktop/view/sidebar/scanlight.py
+++ b/negpy/desktop/view/sidebar/scanlight.py
@@ -1235,14 +1235,16 @@ class ScanlightSidebar(QWidget):
 
     @pyqtSlot(object)
     def _on_light_temp(self, temp) -> None:
-        """Show the live Scanlight LED temperature next to the Light status (amber when warm)."""
-        if isinstance(temp, (int, float)):
+        """Show the live Scanlight LED temperature next to the Light status (amber when warm).
+        RGB-only bodies (v1-v3) have no temperature sensor and report a bogus 0 °C, so hide it there
+        (no white channel is our proxy for those models)."""
+        if isinstance(temp, (int, float)) and self._light_has_white:
             color = "#C8922E" if temp >= 55 else THEME.text_muted  # amber once it's getting warm
             self.light_temp.setStyleSheet(f"color: {color}; font-size: {THEME.font_size_small}px;")
             self.light_temp.setText(f"{temp:.0f} °C")
             self.light_temp.show()
         else:
-            self.light_temp.setText("")  # no light / no telemetry yet
+            self.light_temp.setText("")  # no light / no telemetry yet / RGB-only (no sensor)
             self.light_temp.hide()  # hide the widget entirely so no dark placeholder box lingers
 
     def _set_cam_status(self, ok: bool, model: str) -> None:

--- a/negpy/desktop/view/sidebar/scanlight.py
+++ b/negpy/desktop/view/sidebar/scanlight.py
@@ -35,7 +35,7 @@ from negpy.desktop.view.styles.templates import section_subheader
 from negpy.desktop.view.styles.theme import THEME
 from negpy.infrastructure.capture.gphoto import default_settings_path
 from negpy.infrastructure.capture.settings import ScanlightSettings
-from negpy.services.capture.calibration import shutter_seconds
+from negpy.services.capture.calibration import REFERENCE_LEVELS, SHUTTER_CANDIDATES, normalize_start_point, shutter_seconds
 from negpy.services.capture.presets import PresetStore, ScanlightPreset
 
 _CHANNEL_COLORS = {"R": "#E24B4A", "G": "#639922", "B": "#378ADD", "W": "#B4B2A9"}
@@ -642,8 +642,13 @@ class ScanlightSidebar(QWidget):
         self._update_settings_from_ui()
         self._lv_target = self.calib_window.image
         self.calib_window.start()
-        self._start_live_view_worker()  # white-light framing for the crosshair
-        self._push_light()
+        self._start_live_view_worker()  # live-view stream for the crosshair
+        # Framing light = the calibration's own fixed start point (REFERENCE_LEVELS), so the crosshair
+        # is placed under the very light the probe will begin from — not the previously selected
+        # preset's leftover RGB, nor an arbitrary neutral grey. Pushed DIRECTLY, leaving the shared
+        # R/G/B/W sliders on the selected preset, so cancelling the calibration (or handing off to the
+        # scan window) restores the preset's own light. Calibration overwrites R/G/B on success.
+        self.controller.set_scanlight_color(*REFERENCE_LEVELS, 0, self._settings.port)
         self._set_status("Calibrating a new preset — see the pop-up.")
 
     def _settings_json(self) -> dict:
@@ -695,17 +700,26 @@ class ScanlightSidebar(QWidget):
                     break
 
     def _available_shutters(self) -> tuple[str, ...]:
-        """The camera's writable shutter labels (from the live-view settings JSON), fastest-first
-        and ≤ 1 s, so calibration solves on *this* body's ladder. Empty → built-in fallback."""
+        """The camera's writable shutter labels (from the live-view settings JSON), fastest-first,
+        clamped to the solver's own ladder span, so calibration solves on *this* body's ladder.
+
+        The bounds are read from SHUTTER_CANDIDATES rather than repeated here: this per-body ladder
+        takes precedence over the built-in fallback, so any limit the solver relies on must hold for
+        it too, or the two silently disagree depending on whether live view had published a ladder.
+        Both ends carry a reason — the ceiling keeps the under-exposure cure reachable (a stopped-down
+        aperture needs the slow end), and the floor keeps the PWM-lit LED out of banding: at the
+        Scanlight's 40 kHz a 1/250 s frame integrates ~160 pulses, but a body's 1/8000 s catches ~5
+        and meters noise instead of light."""
         data = self._settings_json()
+        floor, ceiling = shutter_seconds(SHUTTER_CANDIDATES[0]), shutter_seconds(SHUTTER_CANDIDATES[-1])
         by_seconds: dict[str, float] = {}
         for o in (data.get("shutter") or {}).get("options", []):
             label = str(o.get("label", "")).strip()
             try:
                 seconds = shutter_seconds(label)
-            except (TypeError, ValueError):
+            except (TypeError, ValueError, ZeroDivisionError):
                 continue
-            if 0.0 < seconds <= 1.0:
+            if floor <= seconds <= ceiling:
                 by_seconds[label] = seconds
         return tuple(sorted(by_seconds, key=by_seconds.__getitem__))
 
@@ -725,18 +739,30 @@ class ScanlightSidebar(QWidget):
         # It's torn down when calibration finishes/fails (_stop_calibration_live_view).
         self._calibrating_preset = name
         self._apply_gating()  # a running calibration locks Scan / Retake
+        self.calib_window.set_inputs_locked(True)  # freeze name / ROI / ISO / aperture while it meters
         self._update_settings_from_ui()
         from negpy.desktop.workers.capture_worker import CalibrationRequest
 
         s = self._settings
         self.calib_window.set_progress(0.0)
+        # Phase 1: scale the fixed reference start point to the body's live ISO/aperture so the probe
+        # begins near target (fewer captures). Levels stay fixed; only the shutter is corrected. On a
+        # manual lens the aperture reads blank → ISO-only correction, and the probe absorbs the rest.
+        candidates = self._available_shutters()
+        start_levels, start_shutter = normalize_start_point(
+            self._current_setting_label("iso"),
+            self._current_setting_label("aperture", require_writable=True),
+            candidates=candidates,
+        )
         self.controller.start_calibration(
             CalibrationRequest(
                 roi=roi,
                 output_folder=s.output_folder or "",
                 port=s.port,
                 settle_s=_LED_SETTLE_S,
-                shutter_candidates=self._available_shutters(),
+                shutter_candidates=candidates,
+                start_levels=start_levels,
+                start_shutter=start_shutter,
             )
         )
 
@@ -872,8 +898,13 @@ class ScanlightSidebar(QWidget):
         self._lv_last_mtime = mtime
         self._lv_frames_seen += 1
         self._lv_target.set_frame(pixmap)  # scan pop-up or the calibration window
-        if self._lv_target is self.lv_image and self._lv_frames_seen % 12 == 0:
-            self._refresh_camera_settings()  # ~1×/s: keep the ISO/shutter/aperture dropdowns fresh
+        if self._lv_frames_seen % 12 == 0:
+            # ~1×/s: keep the ISO/shutter/aperture dropdowns fresh in whichever pop-up is streaming.
+            # This was gated to the scan window, so opening the calibration pop-up straight after
+            # camera idle left its ISO/aperture greyed out (the body reports them non-writable for
+            # the first frames and nothing re-read the flag) until the scan window was opened once —
+            # Bug 1. _refresh_camera_settings still skips the calib steppers while a run locks them.
+            self._refresh_camera_settings()
 
     def _after_capture_live_view(self) -> None:
         """Re-light the preview after a scan. An in-session capture leaves the Scanlight
@@ -941,10 +972,16 @@ class ScanlightSidebar(QWidget):
         except (OSError, ValueError):
             return
         steppers = {
-            "iso": [self.lv_window.iso_stepper, self.calib_window.iso_stepper],
+            "iso": [self.lv_window.iso_stepper],
             "shutter": [self.lv_window.shutter_stepper],
-            "aperture": [self.lv_window.aperture_stepper, self.calib_window.aperture_stepper],
+            "aperture": [self.lv_window.aperture_stepper],
         }
+        # The calibration pop-up's ISO/aperture are frozen while it meters at them (set_inputs_locked);
+        # only mirror the body onto them when no calibration is running, or the refresh would re-enable
+        # the disabled steppers mid-run.
+        if not self._calibrating_preset:
+            steppers["iso"].append(self.calib_window.iso_stepper)
+            steppers["aperture"].append(self.calib_window.aperture_stepper)
         # The sidebar steppers are *controllers* in manual mode (the body follows them), not mirrors,
         # so seed them from the body's choices only once — otherwise this periodic refresh would snap
         # the user's picks back to the body whenever a write hasn't landed (e.g. no live session yet).
@@ -1008,6 +1045,9 @@ class ScanlightSidebar(QWidget):
         self.r_slider.setValue(int(levels[0]))
         self.g_slider.setValue(int(levels[1]))
         self.b_slider.setValue(int(levels[2]))
+        # RGB preset → white LED off. Without this the W slider keeps a prior white preset's 255,
+        # which _update_settings_from_ui below would then bake into the saved preset as w_level=255.
+        self._set_slider(self.w_slider, 0)
         shutter = shutters[0]  # one shared shutter (all three are equal)
         self._show_lone(self.shutter_stepper, shutter)
         self._settings = replace(
@@ -1018,15 +1058,24 @@ class ScanlightSidebar(QWidget):
         self._apply_preset_exposure(self._current_setting_label("iso"), self._current_setting_label("aperture", require_writable=True))
         self._update_settings_from_ui()
         self._save_settings()
+        # Graceful exposure warning: a channel that couldn't reach ETTR at the hardware limits is
+        # saved anyway (best effort) but the user is told which way to move the aperture.
+        warn = {
+            "over": " ⚠ over-exposed — close the aperture (e.g. f/11) and recalibrate.",
+            "under": " ⚠ under-exposed — open the aperture (e.g. f/5.6) and recalibrate.",
+        }.get(getattr(result, "status", "target"), "")
+        # A finished run always carries its preset name: the flow refuses to start without one, and
+        # the marker is cleared only on a terminal outcome (the worker emits exactly one of
+        # finished/cancelled/error). The guard remains because saving under an empty name would
+        # write a nameless preset into the store — but there is deliberately no else-branch to
+        # "review and save later"; that flow no longer exists.
         if self._calibrating_preset:
             name = self._calibrating_preset
             self._calibrating_preset = ""
             self._save_current_as_preset(name)  # persist + reload + select + re-gate (bakes settings.iso/aperture)
             self._lv_target = self.lv_image
             self.calib_window.hide()
-            self._set_status(f"Saved preset “{name}”.")
-        else:
-            self._set_status("Calibrated — review, then Save as a preset.")
+            self._set_status(f"Saved preset “{name}”.{warn}")
         self._stop_calibration_live_view()  # calibration ran inside live view → tear it down
 
     # ── browse ────────────────────────────────────────────────────────
@@ -1161,6 +1210,7 @@ class ScanlightSidebar(QWidget):
     def _finish_calibration_terminal(self, status: str) -> None:
         """Restore the scan UI after calibration stops without producing a preset."""
         self._calibrating_preset = ""
+        self.calib_window.set_inputs_locked(False)  # re-enable name / ROI / ISO / aperture for a retry
         self.calib_window.set_status(status)
         self.calib_window.progress.setVisible(False)
         self._lv_target = self.lv_image

--- a/negpy/desktop/workers/capture_worker.py
+++ b/negpy/desktop/workers/capture_worker.py
@@ -17,7 +17,7 @@ from negpy.infrastructure.capture.gphoto import CameraUnavailable, GphotoCamera,
 from negpy.infrastructure.capture.protocol import describe_hardware, has_white_channel
 from negpy.infrastructure.capture.scanlight import Scanlight
 from negpy.kernel.system.logging import get_logger
-from negpy.services.capture.calibration import CalibrationService, Roi
+from negpy.services.capture.calibration import REFERENCE_LEVELS, REFERENCE_SHUTTER, CalibrationService, Roi
 from negpy.services.capture.service import CaptureService, capture_single
 
 logger = get_logger(__name__)
@@ -55,6 +55,10 @@ class CalibrationRequest:
     settle_s: float = 0.4
     target_fraction: float = 0.9
     shutter_candidates: tuple[str, ...] = ()  # this body's writable shutter ladder (from the live-view JSON)
+    # Phase-1 start point, already normalized to the live ISO/aperture by the sidebar. Defaults keep
+    # the fixed reference (ISO 100 / f8) when the caller doesn't supply one.
+    start_levels: tuple[int, int, int] = REFERENCE_LEVELS
+    start_shutter: str = REFERENCE_SHUTTER
 
 
 def _shutters_or_none(shutters: tuple[str, str, str]):
@@ -387,6 +391,8 @@ class CaptureWorker(QObject):
                 result = service.calibrate(
                     req.roi,
                     scratch,
+                    start_levels=req.start_levels,
+                    start_shutter=req.start_shutter,  # normalized to the live ISO/aperture by the sidebar
                     target_fraction=req.target_fraction,
                     candidates=req.shutter_candidates,  # empty → calibrate falls back to the built-in ladder
                     progress=self.calibration_progress.emit,

--- a/negpy/infrastructure/capture/raw_demosaic.py
+++ b/negpy/infrastructure/capture/raw_demosaic.py
@@ -70,7 +70,12 @@ def raw_channel_clip_fraction(path: str, channel_index: int, roi, saturation_mar
     with rawpy.imread(path) as raw:
         img = raw.raw_image_visible
         colors = raw.raw_colors_visible
-        white = int(raw.white_level or 0) or int(img.max())
+        # No white level → no raw refinement (the demosaiced clip guard still runs). Never guess
+        # img.max() instead: that is an image-dependent reference (the adjust_maximum_thr failure
+        # class), and on a uniform base the guess sits inside the noise — the quieter the sensor,
+        # the more photosites land within `saturation_margin` of their own maximum, reading as
+        # heavy clipping on a frame that clips nowhere (measured: ~0.9 % at σ=8 DN, ~40 % at σ=4).
+        white = int(raw.white_level or 0)
         if white <= 0:
             return 0.0
         letter = "RGB"[channel_index]

--- a/negpy/infrastructure/capture/raw_demosaic.py
+++ b/negpy/infrastructure/capture/raw_demosaic.py
@@ -1,9 +1,15 @@
 """Linear sensor-RGB demosaic for calibration metering.
 
-Mirrors NegPy's canonical RAW decode (`ImageProcessor._decode_sensor_rgb`):
-sensor-native `output_color=raw`, no white balance, linear gamma, 16-bit. This
-makes the calibration meter the film base the same way the RGB-Scan merge later
-reads the channels. rawpy is imported lazily so the module stays import-safe.
+Follows NegPy's canonical RAW decode (`ImageProcessor._decode_sensor_rgb`): sensor-native
+`output_color=raw`, no white balance, linear gamma, 16-bit — so calibration meters the film base
+the same way the RGB-Scan merge later reads the channels. rawpy is imported lazily so the module
+stays import-safe.
+
+It deviates in one parameter, deliberately: `adjust_maximum_thr=0.0` (see `linear_demosaic`). The
+canonical decode still runs LibRaw's default, where each frame is scaled by its own brightest
+pixel — harmless for a single rendered image, fatal for a meter comparing frames. Whether the
+canonical path wants the same fix is a separate question (it changes rendered output, so it needs
+its own verification); it is NOT covered here.
 """
 
 from __future__ import annotations
@@ -29,6 +35,16 @@ def linear_demosaic(path: str, half_size: bool = False) -> np.ndarray:
         rgb = raw.postprocess(
             gamma=(1, 1),
             no_auto_bright=True,
+            # Scale against the camera's white level ONLY — never the frame's own brightest pixel.
+            # LibRaw's default (adjust_maximum_thr=0.75) silently switches the scaling reference to
+            # the image maximum once that exceeds 75 % of the white level, so each frame is
+            # normalised by its own content. That makes the decode non-linear in exposure: rig data
+            # showed the metered base pinned at ~34400 across LED levels 128-160 (the scaling grew
+            # exactly as fast as the light), which reads as an LED/shutter defect and is neither.
+            # 0.0 disables the substitution, making the demosaiced scale a fixed multiple of the raw
+            # counts — which is what a meter measuring absolute light requires, and what
+            # CLIP_CEILING assumes.
+            adjust_maximum_thr=0.0,
             use_camera_wb=False,
             user_wb=[1, 1, 1, 1],
             output_bps=16,

--- a/negpy/services/capture/calibration.py
+++ b/negpy/services/capture/calibration.py
@@ -1,19 +1,26 @@
 """Per-channel ETTR exposure auto-calibration for RGB narrowband film scanning.
 
-Rewrite — see `calibration_redesign.md`. The film base is metered inside a user ROI and each of
-R/G/B is exposed just below clipping ("expose to the right"). The key idea is a **linear model**:
+The film base is metered inside a user ROI and each of R/G/B is exposed just below clipping
+("expose to the right"). The key idea is a **linear model**:
 
     Signal_c = k_c · Level_c · t
 
 where `k_c` (the channel response) is *measured*, never assumed, so any sensor (Sony, Fuji
 X-Trans, …) is handled automatically. With one **shared** shutter `t` and three per-channel LED
 levels there are 4 knobs and 3 targets, leaving one degree of freedom (the shutter). It is fixed
-uniquely by putting the **dimmest** channel near PWM_MAX (fastest shutter + highest levels at
-once — no quality/speed trade-off). Everything is then solved in one shot instead of searched.
+uniquely by putting the **dimmest** channel near PWM_MAX_SAFE (fastest shutter + highest levels at
+once — no quality/speed trade-off; the gap to PWM_MAX is the verify trim's headroom). Everything
+is then solved in one shot instead of searched.
 
-No dark frame: rawpy already subtracts the sensor bias, so `black = 0`. Physical limits degrade
-gracefully (best result + per-channel status) rather than raising. Hardware-free: light, camera
-and a `demosaic` callable are injected.
+Two representations of a shutter coexist deliberately. Labels are rounded display names for a
+geometric ladder ("1/3" exposes 0.315 s, not 0.333 s): ordering/snapping read the label literally
+(`shutter_seconds`), anything multiplied into the physics uses the rung's true time
+(`true_seconds`). The model above only holds in the second representation.
+
+No dark frame: rawpy already subtracts the sensor bias, so `black = 0` (and the injected demosaic
+must scale by the camera's white level, never per-frame — see `linear_demosaic`). Physical limits
+degrade gracefully (best result + per-channel status) rather than raising. Hardware-free: light,
+camera and a `demosaic` callable are injected.
 """
 
 from __future__ import annotations
@@ -66,7 +73,11 @@ MAX_CLIP_FRACTION = 0.002
 # slowest shutter, or a clip-guard that pulled the LED down hard. Reported as status "under"; a
 # small clip-guard undershoot within this margin still counts as "target".
 MAX_TARGET_UNDER_FRACTION = 0.2
-_MAX_PROBE_STEPS = 8  # geometric back-off to bring a probe into the measurable range
+# Probe budget = the whole reachable range, so the loop can only end by resolving (in-range return,
+# graceful-over return, or the dark-side break) — never by exhaustion, which would mislabel a
+# blinding over-exposure as "no signal". Worst case is a deeply-over scene from the slowest start:
+# ~9 shutter halvings (2 s → 1/250) + 3 LED halvings (255 → 40) + the final in-range measurement.
+_MAX_PROBE_STEPS = 14
 _MAX_CLIP_GUARD_STEPS = 12  # LED-down steps (PWM_MAX→PWM_MIN at 0.85×) — keeps captures hard-bounded
 
 # Shutter ladder, fastest first (third-stops). Extends to 2 s (up from 1 s) so a closed-down
@@ -128,8 +139,9 @@ def shutter_seconds(label: str) -> float:
     """Parse a shutter label ('1/100', '0.4', '1') into its *nominal* seconds.
 
     This is the label read literally — the value to sort, snap and filter by, since the ladder is
-    monotonic whether or not the labels are rounded. It is NOT the exposure time: see
-    `true_seconds`, which the three places that treat the number as physics must use instead.
+    monotonic whether or not the labels are rounded. It is NOT the exposure time: anywhere the
+    number is multiplied into the physics (k, the level solve, shutter_at_least's ≥-comparison)
+    must use `true_seconds` instead.
     """
     label = label.strip()
     if "/" in label:
@@ -245,8 +257,10 @@ def normalize_start_point(
     if f_now is not None:
         t *= (f_now / REFERENCE_APERTURE) ** 2
     # Snap the raw seconds value straight onto the ladder (no label round-trip, which mislabels
-    # e.g. 0.8 s as "1/1").
-    return levels, _nearest_by_seconds(t, candidates or SHUTTER_CANDIDATES)
+    # e.g. 0.8 s as "1/1"). Like calibrate(), clean the body's ladder on the way in — this is a
+    # public entry point receiving camera-reported labels, and one bulb-like "1/0" must degrade to
+    # a dropped entry, not a ValueError (#478).
+    return levels, _nearest_by_seconds(t, usable_ladder(tuple(candidates)) or SHUTTER_CANDIDATES)
 
 
 def _nearest_by_seconds(seconds: float, candidates: tuple[str, ...]) -> str:

--- a/negpy/services/capture/calibration.py
+++ b/negpy/services/capture/calibration.py
@@ -1,21 +1,27 @@
-"""Per-channel ETTR exposure auto-calibration (ported from TriRGB's approach).
+"""Per-channel ETTR exposure auto-calibration for RGB narrowband film scanning.
 
-For a film stock, meter the clear film base inside a user-drawn ROI and solve **one camera
-shutter shared across R/G/B** plus a per-channel Scanlight LED level so each channel's base
-sits just below clipping ("expose to the right"). One probe per channel estimates its
-response; the shared shutter is chosen so the *dimmest* channel reaches target within the LED
-range (the RGB channels differ by ~1 stop — orange mask minus the Scanlight's per-channel LED
-balance — well inside the LED's ~2.7-stop range). Then each channel's LED is solved + verified
-+ one proportional trim, with a clip guard (pull the LED down) and, if the whole set doesn't
-fit the LED window, a shared-shutter escalation. Keeping the shutter constant makes presets a
-single shutter + three LED levels. The black level is the dark-frame median (robust to hot
-pixels). Hardware-free: light, camera, and a `demosaic` callable are injected.
+Rewrite — see `calibration_redesign.md`. The film base is metered inside a user ROI and each of
+R/G/B is exposed just below clipping ("expose to the right"). The key idea is a **linear model**:
+
+    Signal_c = k_c · Level_c · t
+
+where `k_c` (the channel response) is *measured*, never assumed, so any sensor (Sony, Fuji
+X-Trans, …) is handled automatically. With one **shared** shutter `t` and three per-channel LED
+levels there are 4 knobs and 3 targets, leaving one degree of freedom (the shutter). It is fixed
+uniquely by putting the **dimmest** channel near PWM_MAX (fastest shutter + highest levels at
+once — no quality/speed trade-off). Everything is then solved in one shot instead of searched.
+
+No dark frame: rawpy already subtracts the sensor bias, so `black = 0`. Physical limits degrade
+gracefully (best result + per-channel status) rather than raising. Hardware-free: light, camera
+and a `demosaic` callable are injected.
 """
 
 from __future__ import annotations
 
+import re
 import time
 from dataclasses import dataclass
+from functools import lru_cache
 from typing import Callable, Optional
 
 import numpy as np
@@ -25,28 +31,48 @@ from negpy.kernel.system.logging import get_logger
 
 logger = get_logger(__name__)
 
-# 16-bit demosaiced range; PWM range and probe match TriRGB's calibrate_exposure.
+# The decode normalises the camera's white level to full 16-bit, so the *demosaiced* saturation
+# point is camera-independent (65535). This only holds because `linear_demosaic` pins
+# adjust_maximum_thr=0.0 — on LibRaw's default the reference silently becomes the frame's own
+# brightest pixel, every frame gets its own scale, and nothing below is comparable between shots
+# (that bug read as an LED plateau for a whole rig session). The camera-SPECIFIC saturation — the
+# raw sensor white level, which differs per body (full-well capacity + ADC bit depth) — is handled
+# separately by the raw-Bayer check (raw_channel_clip_fraction, which reads the real per-camera
+# white_level and also catches clipped photosites the demosaic averages away). This demosaiced
+# ceiling is a fast secondary guard on the normalised scale.
 CLIP_CEILING = 65535
-SATURATION_VALUE = 65400  # counts; a demosaiced pixel at/above this is treated as clipped
-MAX_CLIP_FRACTION = 0.002  # the base is metered at p99.9 (meter_base), which already discards the
-# top 0.1% of pixels, so a clip up to ~0.1% cannot move the whitepoint→blackpoint anchor at all;
-# 0.2% keeps a small margin over that p99.9 cut while staying essentially harmless. A tiny base clip
-# is also unavoidable with discrete LED steps. The old 0.01% was 10x stricter than the metering cut
-# and failed usable calibrations (e.g. green just clipping at the only shutter fast enough for red).
+# A demosaiced pixel this close to the normalised ceiling counts as clipped; the ~0.2 % margin
+# absorbs demosaic interpolation + read noise just below saturation.
+SATURATION_VALUE = int(CLIP_CEILING * 0.998)  # ≈ 65404
 PWM_MIN = 40
 PWM_MAX = 255
-PROBE_LEVEL = 200
-PROBE_SHUTTER = "1/15"
-TARGET_FRACTION = 0.9  # aim the film base at 90% of usable range
+# Aim the dimmest channel here, not at 255 — this is the phase-4 trim's headroom, not an LED limit.
+# A measured level ramp (40→255 per channel, on the fixed decode — see raw_demosaic) shows the LEDs
+# do not saturate: they are gently concave, red losing only ~2 % of k_eff between levels 200 and 250.
+# So `k`, measured at the probe level, slightly over-states the light at the solved level and the
+# first shot lands ~2 % under target; the trim corrects that by raising the level, which needs room
+# above. 250 leaves ~3 % (a solved ~247 can still reach the 255 clamp) — enough for the measured
+# curvature — and it is the lowest ceiling that still buys a full shutter step: on a C-41 base at
+# ISO 100 / f8 the solved shutter snaps to 1/3 rather than 4/10. Above 250 nothing more is gained
+# (the level follows from the snapped shutter), and the LED itself is near its limit there: level
+# 255 yields only ~21 % more light than the ~206 a 4/10 solve lands on.
+PWM_MAX_SAFE = 250
+TARGET_FRACTION = 0.9  # expose the film base to 90 % of the usable range
 MIN_SIGNAL = 10.0  # counts; below this the channel read no real signal
-# A clean clip-guard adjustment can intentionally land a little below the ETTR target.
-# Beyond this margin the preset is materially mis-exposed and must not be saved.
+# ETTR meters p99.9 (ignores the top 0.1 %), so the base can read on-target while a sliver clips.
+# The base is the whitepoint (blackpoint after inversion) and must stay just below clipping.
+MAX_CLIP_FRACTION = 0.002
+# A channel this far under target is materially under-exposed, from any cause — maxed LED at the
+# slowest shutter, or a clip-guard that pulled the LED down hard. Reported as status "under"; a
+# small clip-guard undershoot within this margin still counts as "target".
 MAX_TARGET_UNDER_FRACTION = 0.2
-# There is much less safe headroom above a 90% ETTR target; 10% is already near clipping.
-MAX_TARGET_OVER_FRACTION = 0.1
+_MAX_PROBE_STEPS = 8  # geometric back-off to bring a probe into the measurable range
+_MAX_CLIP_GUARD_STEPS = 12  # LED-down steps (PWM_MAX→PWM_MIN at 0.85×) — keeps captures hard-bounded
 
-# Fallback shutter ladder, fastest first (third-stops). The body's own ladder is
-# preferred when live view has published it.
+# Shutter ladder, fastest first (third-stops). Extends to 2 s (up from 1 s) so a closed-down
+# aperture can still reach target on the dim channel instead of failing (dark current at ISO 100
+# / ≤2 s is negligible). Faster than 1/250 s is avoided (PWM-LED banding). The body's own writable
+# ladder is preferred when live view has published it.
 SHUTTER_CANDIDATES: tuple[str, ...] = (
     "1/250",
     "1/200",
@@ -73,19 +99,140 @@ SHUTTER_CANDIDATES: tuple[str, ...] = (
     "0.6",
     "0.8",
     "1",
+    "1.3",
+    "1.6",
+    "2",
 )
+
+# --- Fixed start point (Phase 1) ------------------------------------------------------------
+# A neutral reference the calibration always starts from, normalized to the live ISO/aperture.
+# Rig-measured on a Portra 400 clear base at ISO 100 / f8 (two runs, kR 694…716, solving to levels
+# 206…213 / 94…96 / 82…83 at 4/10) and rounded to tidy numbers for the UI. The exact values matter
+# little — the probe only measures `k` from here and the phase-4 trim absorbs the rest; a few levels
+# either way is well inside the ~3 % run-to-run spread of k itself. What matters is that the start
+# point sits close to where the solve lands, so `k` is measured at roughly the level the channel
+# ends up at and the LEDs' gentle concavity cancels instead of biasing the solve. Never a previous
+# preset — a badly placed ROI in a past run must not poison the next calibration.
+REFERENCE_ISO = 100.0
+REFERENCE_APERTURE = 8.0
+# 0.4 s, spelled in SHUTTER_CANDIDATES' vocabulary — bodies name this speed differently (the a7C II
+# publishes "4/10"), and normalize_start_point re-snaps onto whatever ladder the body reports.
+REFERENCE_SHUTTER = "0.4"
+REFERENCE_LEVELS = (210, 95, 80)  # (R, G, B); R needs the most drive (665 nm, low sensor QE)
 
 DemosaicFn = Callable[[str], np.ndarray]  # path -> HxWx3 linear array (0..CLIP_CEILING)
 ProgressCb = Callable[[float, str], None]
 
 
 def shutter_seconds(label: str) -> float:
-    """Parse a shutter label ('1/100', '0.4', '1') into seconds."""
+    """Parse a shutter label ('1/100', '0.4', '1') into its *nominal* seconds.
+
+    This is the label read literally — the value to sort, snap and filter by, since the ladder is
+    monotonic whether or not the labels are rounded. It is NOT the exposure time: see
+    `true_seconds`, which the three places that treat the number as physics must use instead.
+    """
     label = label.strip()
     if "/" in label:
         num, den = label.split("/", 1)
-        return float(num) / float(den)
+        denominator = float(den)
+        if denominator == 0:
+            # Some bodies (e.g. the a7 IV) publish a bulb-like shutter label with a zero
+            # denominator. Raise ValueError (not a bare ZeroDivisionError) so the shutter-ladder
+            # filter in _available_shutters drops the label instead of crashing calibration.
+            raise ValueError(f"invalid shutter label {label!r}: zero denominator")
+        return float(num) / denominator
     return float(label)
+
+
+@lru_cache(maxsize=8)
+def _ladder_stops(candidates: tuple[str, ...]) -> float:
+    """The ladder's spacing in stops, measured from the body's own labels — never assumed.
+
+    Bodies step the shutter in thirds (the common default) or halves, and which one it is decides
+    what a rounded label actually means. Reading it off the ladder keeps `true_seconds` camera-
+    agnostic. Labels are individually rounded by up to ~7 %, so the *median* neighbour ratio is
+    taken — it ignores that jitter. Falls back to thirds when the ladder is too short to read.
+    """
+    secs = sorted(s for s in (shutter_seconds(c) for c in candidates) if s > 0)
+    ratios = [b / a for a, b in zip(secs, secs[1:]) if b > a]
+    if len(ratios) < 3:
+        return 1.0 / 3.0
+    step = np.log2(float(np.median(ratios)))
+    return min((1.0 / 3.0, 1.0 / 2.0), key=lambda s: abs(s - step))
+
+
+def true_seconds(label: str, candidates: tuple[str, ...] = SHUTTER_CANDIDATES) -> float:
+    """The label's TRUE exposure time, undoing the display rounding.
+
+    Shutter labels are rounded names for a geometric ladder, not exact times: on a third-stop
+    ladder "1/6" means 2^(-8/3) = 0.157 s (the fraction says 0.167) and "1/3" means 0.315 s (the
+    fraction says 0.333) — up to 6.7 % off. The solver multiplies `k` by this number, so the
+    rounding lands straight in the exposure: a rig run that probed at "0.4" (0.8 % off) and solved
+    at "1/3" (5.8 % off) came out ~4 % under target with the LED already at the 255 clamp.
+
+    Only the physics needs this. Ordering/snapping keep using the nominal `shutter_seconds`.
+    """
+    nominal = shutter_seconds(label)
+    if nominal <= 0:
+        return nominal
+    stops = _ladder_stops(tuple(candidates) or SHUTTER_CANDIDATES)
+    exact = float(2.0 ** (round(np.log2(nominal) / stops) * stops))
+    # Only correct what is plausibly the same rung. A label rounds by ≲7 %; a wider gap means this
+    # value isn't on this ladder (a bulb entry, an oddly labelled body), and then the label itself
+    # is the better guess — never invent a correction larger than the rounding it undoes.
+    return exact if abs(exact / nominal - 1.0) <= 0.08 else nominal
+
+
+def aperture_fnumber(label: str) -> Optional[float]:
+    """Parse an aperture label ('f/8', 'F8', '8', 'f/5.6') into an f-number, or None.
+
+    None when the lens has no electronic aperture (manual enlarging glass) — the caller then
+    skips the aperture term of the start-point normalization and lets the probe adjust."""
+    if not label:
+        return None
+    m = re.search(r"([0-9]+(?:\.[0-9]+)?)", str(label))
+    if not m:
+        return None
+    try:
+        f = float(m.group(1))
+    except ValueError:
+        return None
+    return f if f > 0 else None
+
+
+def normalize_start_point(
+    iso: str,
+    aperture: str,
+    *,
+    levels: tuple[int, int, int] = REFERENCE_LEVELS,
+    shutter: str = REFERENCE_SHUTTER,
+    candidates: tuple[str, ...] = SHUTTER_CANDIDATES,
+) -> tuple[tuple[int, int, int], str]:
+    """Scale the fixed reference start point to the live ISO/aperture (Phase 1, no capture).
+
+    Exposure ∝ ISO · t / f², so to keep the same sensor exposure the shutter scales by
+    (ISO_ref/ISO)·(f/f_ref)². Levels stay fixed (same Scanlight for everyone); only the shutter
+    moves (the camera-side difference). ISO or aperture unreadable → that term is skipped and the
+    probe absorbs the rest. Returns (levels, shutter snapped to the ladder)."""
+    t = shutter_seconds(shutter)
+    try:
+        iso_now = float(re.sub(r"[^0-9.]", "", str(iso)) or REFERENCE_ISO)
+    except ValueError:
+        iso_now = REFERENCE_ISO
+    if iso_now > 0:
+        t *= REFERENCE_ISO / iso_now
+    f_now = aperture_fnumber(aperture)
+    if f_now is not None:
+        t *= (f_now / REFERENCE_APERTURE) ** 2
+    # Snap the raw seconds value straight onto the ladder (no label round-trip, which mislabels
+    # e.g. 0.8 s as "1/1").
+    return levels, _nearest_by_seconds(t, candidates or SHUTTER_CANDIDATES)
+
+
+def _nearest_by_seconds(seconds: float, candidates: tuple[str, ...]) -> str:
+    """The candidate closest to a raw seconds value (no shutter-label round-trip)."""
+    ladder = candidates or SHUTTER_CANDIDATES
+    return min(ladder, key=lambda c: abs(shutter_seconds(c) - seconds))
 
 
 @dataclass(frozen=True)
@@ -115,16 +262,17 @@ class Roi:
 class ChannelCalibration:
     channel: str  # "R" / "G" / "B"
     level: int  # solved LED level 0-255
-    shutter: str  # solved camera shutter label
+    shutter: str  # solved camera shutter label (shared across channels)
     signal: float  # measured base p99.9 at the solved settings
     target: int  # target signal
     clip_fraction: float = 0.0  # fraction of base pixels at/above saturation (ETTR keeps this ~0)
+    status: str = "target"  # "target" | "under" | "over" — for graceful UI messaging
 
 
 @dataclass(frozen=True)
 class CalibrationResult:
     channels: dict[str, ChannelCalibration]
-    black_levels: dict[str, float]
+    spread_stops: float = 0.0  # measured k spread in stops (confirms the shared-shutter assumption)
 
     @property
     def levels(self) -> tuple[int, int, int]:
@@ -134,43 +282,36 @@ class CalibrationResult:
     def shutters(self) -> tuple[str, str, str]:
         return (self.channels["R"].shutter, self.channels["G"].shutter, self.channels["B"].shutter)
 
-
-def target_for_black_level(black_level: float, fraction: float = TARGET_FRACTION) -> int:
-    usable = max(1.0, float(CLIP_CEILING) - float(black_level))
-    return int(round(fraction * usable))
-
-
-def meter_base(plane: np.ndarray, roi: Roi, black_level: float) -> float:
-    """Black-subtracted p99.9 of the ROI on one demosaiced channel plane."""
-    h, w = plane.shape[:2]
-    x0, y0, x1, y1 = roi.pixels(w, h)
-    patch = plane[y0:y1, x0:x1].astype(np.float64) - float(black_level)
-    np.clip(patch, 0, None, out=patch)
-    if patch.size == 0:
-        return 0.0
-    return float(np.percentile(patch, 99.9))
+    @property
+    def status(self) -> str:
+        """Worst channel status, for a single headline message."""
+        for s in ("over", "under"):
+            if any(c.status == s for c in self.channels.values()):
+                return s
+        return "target"
 
 
-def meter_black(plane: np.ndarray, roi: Roi) -> float:
-    """Median of the ROI on a dark-frame channel plane → the per-channel black level.
+def target_signal(target_fraction: float = TARGET_FRACTION) -> int:
+    """ETTR target in counts. black = 0 (rawpy already removed the sensor bias)."""
+    return int(round(target_fraction * CLIP_CEILING))
 
-    Median (not p99.9) is robust to hot pixels / stuck columns in the dark frame — matching
-    TriRGB's calibrate_exposure. p99.9 would let a few hot pixels inflate the black estimate,
-    which then under-states the signal (T% = 10^-A references this black floor)."""
+
+def meter_base(plane: np.ndarray, roi: Roi) -> float:
+    """p99.9 of the ROI on one demosaiced channel plane (black already 0 after rawpy)."""
     h, w = plane.shape[:2]
     x0, y0, x1, y1 = roi.pixels(w, h)
     patch = plane[y0:y1, x0:x1]
     if patch.size == 0:
         return 0.0
-    return float(np.median(patch))
+    return float(np.percentile(patch, 99.9))
 
 
 def clip_fraction(plane: np.ndarray, roi: Roi, saturation: float = SATURATION_VALUE) -> float:
     """Fraction of ROI pixels at/above saturation on one demosaiced channel plane.
 
-    ETTR meters p99.9, which ignores the top 0.1% by design — so a base can read on-target
-    while a sliver saturates. The clear base is the whitepoint reference (blackpoint after
-    inversion), so it must stay just *below* clipping; this metric catches what p99.9 hides."""
+    ETTR meters p99.9, which ignores the top 0.1 % by design — so a base can read on-target while
+    a sliver saturates. The clear base is the whitepoint (blackpoint after inversion), so it must
+    stay just *below* clipping; this metric catches what p99.9 hides."""
     h, w = plane.shape[:2]
     x0, y0, x1, y1 = roi.pixels(w, h)
     patch = plane[y0:y1, x0:x1]
@@ -179,42 +320,25 @@ def clip_fraction(plane: np.ndarray, roi: Roi, saturation: float = SATURATION_VA
     return float(np.mean(patch >= saturation))
 
 
-def faster_shutter(label: str, candidates: tuple[str, ...] = SHUTTER_CANDIDATES) -> Optional[str]:
-    """The next-faster shutter in the ladder (candidates are fastest-first), or None."""
-    try:
-        idx = candidates.index(label)
-    except ValueError:
-        return None
-    return candidates[idx - 1] if idx > 0 else None
-
-
 def nearest_shutter(label: str, candidates: tuple[str, ...]) -> str:
-    """The candidate closest (in seconds) to `label`, snapping onto the camera's own ladder.
-
-    Different bodies expose different writable shutter sets, so the probe/solve must pick
-    from *this* camera's list (passed by the caller), not a hardcoded one."""
+    """The candidate closest (in seconds) to `label`, snapping onto the camera's own ladder."""
     if not candidates or label in candidates:
         return label
     target = shutter_seconds(label)
     return min(candidates, key=lambda c: abs(shutter_seconds(c) - target))
 
 
-def slower_shutter(label: str, candidates: tuple[str, ...] = SHUTTER_CANDIDATES) -> Optional[str]:
-    """The next-slower shutter in the ladder (candidates are fastest-first), or None."""
-    try:
-        idx = candidates.index(label)
-    except ValueError:
-        return None
-    return candidates[idx + 1] if idx + 1 < len(candidates) else None
-
-
 def shutter_at_least(seconds: float, candidates: tuple[str, ...] = SHUTTER_CANDIDATES) -> str:
     """The fastest candidate whose exposure time is ≥ `seconds` (candidates are fastest-first).
 
-    Picks the shared shutter: as fast as possible while still letting the dimmest channel reach
-    target within the LED range. Falls back to the slowest candidate if none is slow enough."""
+    This is the shared-shutter pick: as fast as possible while the dimmest channel still reaches
+    target within the LED range. Falls back to the slowest candidate if none is slow enough.
+
+    Compares TRUE exposure, not the label: "≥ seconds" is a claim about light. A body's "1/3"
+    reads as 0.333 s but exposes 0.315 s, so trusting the label picks a rung that is really too
+    fast, and the channel then cannot reach target however far the LED is pushed."""
     for c in candidates:
-        if shutter_seconds(c) >= seconds:
+        if true_seconds(c, candidates) >= seconds:
             return c
     return candidates[-1]
 
@@ -227,45 +351,8 @@ def correct_led_level(current_level: int, signal: float, target: int) -> int:
     return int(np.clip(corrected, PWM_MIN, PWM_MAX))
 
 
-def _calibration_issue(channels: dict[str, ChannelCalibration]) -> Optional[str]:
-    """The first reason a solution is unusable, or None if every channel is within spec. The
-    shutter search accepts a shutter the moment this is None; the same checks gate the result."""
-    for c in channels.values():
-        if not np.isfinite(c.signal) or not np.isfinite(c.clip_fraction):
-            return f"calibration failed: {c.channel} channel produced a non-finite final measurement"
-        if c.clip_fraction > MAX_CLIP_FRACTION:
-            return f"calibration failed: {c.channel} channel is still clipping at shared shutter {c.shutter}"
-        if c.signal < (1.0 - MAX_TARGET_UNDER_FRACTION) * c.target:
-            return f"calibration failed: {c.channel} channel remains materially below target ({c.signal:.0f} vs {c.target})"
-        if c.signal > (1.0 + MAX_TARGET_OVER_FRACTION) * c.target:
-            return f"calibration failed: {c.channel} channel remains materially above target ({c.signal:.0f} vs {c.target})"
-    return None
-
-
-def _calibration_badness(channels: dict[str, ChannelCalibration]) -> float:
-    """Rank a candidate shutter for the search: 0 is on-target and clean, larger is worse. The
-    ETTR distance from target drives fine improvement (so a channel whose LED has saturated
-    escalates onto target), while anything the final guards reject gets a heavy penalty — so the
-    search never trades a clean channel for a clipping or out-of-tolerance one, and a two-shutter
-    oscillation (one clips, the neighbour leaves a channel a touch under) settles on the clean
-    side instead of churning through every attempt."""
-    total = 0.0
-    for c in channels.values():
-        if not np.isfinite(c.signal) or not np.isfinite(c.clip_fraction):
-            return float("inf")
-        if c.target > 0:
-            total += abs(c.signal - c.target) / c.target
-        if c.clip_fraction > MAX_CLIP_FRACTION:
-            total += 1000.0
-        if c.signal < (1.0 - MAX_TARGET_UNDER_FRACTION) * c.target:
-            total += 1000.0
-        if c.signal > (1.0 + MAX_TARGET_OVER_FRACTION) * c.target:
-            total += 1000.0
-    return total
-
-
 class CalibrationService:
-    """Drives a dark frame + per-channel probe/verify to solve ETTR exposures."""
+    """Solves ETTR exposures: measure per-channel response, solve analytically, verify."""
 
     def __init__(
         self,
@@ -286,6 +373,153 @@ class CalibrationService:
         self._sleep = sleep
         self._settle_s = settle_s
 
+    def calibrate(
+        self,
+        roi: Roi,
+        scratch_path: str,
+        *,
+        start_levels: tuple[int, int, int] = REFERENCE_LEVELS,
+        start_shutter: str = REFERENCE_SHUTTER,
+        target_fraction: float = TARGET_FRACTION,
+        candidates: tuple[str, ...] = SHUTTER_CANDIDATES,
+        progress: Optional[ProgressCb] = None,
+        cancel=None,
+    ) -> CalibrationResult:
+        candidates = tuple(candidates) or SHUTTER_CANDIDATES
+        start_shutter = nearest_shutter(start_shutter, candidates)
+        T = target_signal(target_fraction)
+
+        def _check_cancel():
+            if cancel is not None and cancel.is_set():
+                raise RuntimeError("calibration cancelled")
+
+        _floor = [0.0]
+
+        def _report(frac: float, msg: str):
+            _floor[0] = max(_floor[0], frac)
+            if progress is not None:
+                progress(_floor[0], msg)
+
+        def _shoot(i: int, ch, level: int, shutter: str) -> tuple[float, float]:
+            """Light channel `ch` at `level`, capture at `shutter`, meter → (base p99.9, clip)."""
+            self._light.set_color(*ch.rgb(level))
+            self._sleep(self._settle_s)
+            img, written = self._capture(scratch_path, shutter=shutter)
+            clip = max(clip_fraction(img[..., i], roi), self._source_clip_fraction(written, i, roi))
+            return meter_base(img[..., i], roi), clip
+
+        try:
+            # --- Phase 2: measure the response k per channel (adaptive probe) ------------------
+            k: dict[str, float] = {}
+            for i, ch in enumerate(CAPTURE_ORDER):
+                _check_cancel()
+                _report(0.1 + 0.2 * i, f"Probing {ch.letter}…")
+                k[ch.letter] = self._measure_response(i, ch, start_levels[i], start_shutter, candidates, _shoot)
+
+            spread = _spread_stops(k)
+            logger.info("calibration response: kR=%.1f kG=%.1f kB=%.1f (spread %.2f stops)", k["R"], k["G"], k["B"], spread)
+
+            # --- Phase 3: solve the shared shutter + per-channel levels analytically -----------
+            _report(0.7, "Solving…")
+            shutter, levels = _solve_shared(k, T, candidates)
+
+            # --- Phase 4: verify + one trim + clip guard --------------------------------------
+            channels: dict[str, ChannelCalibration] = {}
+            for i, ch in enumerate(CAPTURE_ORDER):
+                _check_cancel()
+                _report(0.75 + 0.08 * i, f"Setting {ch.letter}…")
+                channels[ch.letter] = self._verify_channel(i, ch, levels[ch.letter], shutter, T, _shoot)
+
+            _report(1.0, "Calibration done")
+            return CalibrationResult(channels=channels, spread_stops=spread)
+        finally:
+            try:
+                self._light.off()
+            except Exception:
+                logger.exception("failed to turn the Scanlight off after calibration")
+
+    def _measure_response(self, i, ch, start_level, start_shutter, candidates, shoot) -> float:
+        """Bring a probe into the measurable range (not clipped, above noise), then return
+        k = signal / (level · seconds). k is exposure-normalized, so a faster/slower probe gives the
+        same k, just clean. A clipped read is used only as a lower bound when even minimum exposure
+        clips (over-exposure → graceful "over"); no signal at maximum exposure raises."""
+        level, shutter = start_level, start_shutter
+        for _ in range(_MAX_PROBE_STEPS):
+            signal, clip = shoot(i, ch, level, shutter)
+            # Halve/double the exposure per step (log-convergence: 8 steps span 8 stops), moving the
+            # shutter first and only dropping to the LED when the ladder end is reached. A 1-stop
+            # step can't jump the ~12.6-stop measurable window, so it never overshoots clip↔no-signal.
+            if clip > MAX_CLIP_FRACTION or signal >= SATURATION_VALUE:  # too bright → halve exposure
+                faster = _nearest_by_seconds(shutter_seconds(shutter) * 0.5, candidates)
+                if shutter_seconds(faster) < shutter_seconds(shutter):
+                    shutter = faster
+                    continue
+                if level > PWM_MIN:
+                    level = max(PWM_MIN, level // 2)
+                    continue
+                # Minimum exposure (fastest shutter + lowest LED) still clips → the aperture is too
+                # open. Return the clipped (lower-bound) response so the solver seats this channel at
+                # minimum exposure and _verify_channel reports "over" (the UI tells the user to stop
+                # down). Graceful, like under-exposure — not a hard error.
+                return signal / (level * true_seconds(shutter, candidates))
+            if signal < MIN_SIGNAL:  # too dark → double exposure
+                slower = _nearest_by_seconds(shutter_seconds(shutter) * 2.0, candidates)
+                if shutter_seconds(slower) > shutter_seconds(shutter):
+                    shutter = slower
+                    continue
+                if level < PWM_MAX:
+                    level = PWM_MAX
+                    continue
+                break  # slowest shutter + max LED and still no signal — dead LED / ROI off the base
+            # k is exposure-normalised, so it must divide by the TRUE exposure, not the rounded
+            # label — otherwise k inherits the label's error and the solver spends it elsewhere.
+            return signal / (level * true_seconds(shutter, candidates))
+        # Only "no signal even at maximum exposure" reaches here (over-exposure returns gracefully
+        # above, under-exposure is handled by the solver + _verify_channel's "under" status).
+        raise RuntimeError(
+            f"calibration failed: no signal from the {ch.letter} channel even at maximum exposure "
+            f"(check the ROI is on the clear film base and the Scanlight is on)"
+        )
+
+    def _verify_channel(self, i, ch, level, shutter, T, shoot) -> ChannelCalibration:
+        """Capture at the solved settings, one proportional trim, then a clip guard. Returns the
+        channel calibration with a graceful status (never raises on a physical limit)."""
+        tol = 0.05 * T
+        measured, clip = shoot(i, ch, level, shutter)
+        if clip <= MAX_CLIP_FRACTION and abs(measured - T) > tol:
+            level = correct_led_level(level, measured, T)
+            measured, clip = shoot(i, ch, level, shutter)
+        # Clip guard: pull the LED down until the base sits below clipping (p99.9 can read on-target
+        # while the top 0.1 % saturates). Iterate — a dense base overshoots — re-measuring each time.
+        # Bounded by _MAX_CLIP_GUARD_STEPS so the capture budget stays hard-bounded even in the worst
+        # case (a level solved near PWM_MAX that still clips).
+        for _ in range(_MAX_CLIP_GUARD_STEPS):
+            if clip <= MAX_CLIP_FRACTION or level <= PWM_MIN:
+                break
+            level = max(PWM_MIN, int(round(level * 0.85)))
+            measured, clip = shoot(i, ch, level, shutter)
+
+        status = _channel_status(measured, clip, T)
+        logger.info(
+            "calibrated %s → level %d, shutter %s (target %d, got %.0f, clip %.3f%%, %s)",
+            ch.letter,
+            level,
+            shutter,
+            T,
+            measured,
+            clip * 100,
+            status,
+        )
+        return ChannelCalibration(
+            channel=ch.letter,
+            level=level,
+            shutter=shutter,
+            signal=measured,
+            target=T,
+            clip_fraction=clip,
+            status=status,
+        )
+
     def _source_clip_fraction(self, path: str, channel_index: int, roi: Roi) -> float:
         """Raw-Bayer source clip for one channel (catches clipped photosites the demosaic hides)."""
         if self._source_clip is not None:
@@ -301,159 +535,43 @@ class CalibrationService:
             raise RuntimeError(f"calibration failed: non-finite raw source-clip measurement for {path}")
         return measured
 
-    def calibrate(
-        self,
-        roi: Roi,
-        scratch_path: str,
-        *,
-        probe_level: int = PROBE_LEVEL,
-        probe_shutter: str = PROBE_SHUTTER,
-        target_fraction: float = TARGET_FRACTION,
-        candidates: tuple[str, ...] = SHUTTER_CANDIDATES,
-        progress: Optional[ProgressCb] = None,
-        cancel=None,
-    ) -> CalibrationResult:
-        # Solve/verify on THIS camera's writable shutter ladder (multi-camera), snapping the
-        # probe onto it too; falls back to the built-in ladder when the caller has no list.
-        candidates = tuple(candidates) or SHUTTER_CANDIDATES
-        probe_shutter = nearest_shutter(probe_shutter, candidates)
-
-        def _check_cancel():
-            if cancel is not None and cancel.is_set():
-                raise RuntimeError("calibration cancelled")
-
-        _floor = [0.0]
-
-        def _report(frac: float, msg: str):
-            # Never let the bar jump backward: the shutter search re-measures all three channels
-            # per attempt (0.4→0.8 each time), which used to yank it from 80% back to 40%.
-            _floor[0] = max(_floor[0], frac)
-            if progress is not None:
-                progress(_floor[0], msg)
-
-        try:
-            # 1) Dark frame → per-channel black level inside the ROI.
-            _check_cancel()
-            _report(0.05, "Dark frame…")
-            self._light.off()
-            self._sleep(self._settle_s)
-            dark, _ = self._capture(scratch_path, shutter=probe_shutter)
-            black = {ch.letter: meter_black(dark[..., i], roi) for i, ch in enumerate(CAPTURE_ORDER)}
-
-            def _shoot(ch, i: int, base: float, level_: int, shutter_: str) -> tuple[float, float]:
-                """Light the channel, capture, and meter it → (base p99.9, max clip fraction).
-
-                Clip is the worse of the demosaiced output and the raw-Bayer source photosites."""
-                self._light.set_color(*ch.rgb(level_))
-                self._sleep(self._settle_s)
-                img, written = self._capture(scratch_path, shutter=shutter_)
-                clip = max(clip_fraction(img[..., i], roi), self._source_clip_fraction(written, i, roi))
-                return meter_base(img[..., i], roi, base), clip
-
-            targets = {ch.letter: target_for_black_level(black[ch.letter], target_fraction) for ch in CAPTURE_ORDER}
-
-            # 2) Probe each channel once → its response k (counts per LED-level per second).
-            k: dict[str, float] = {}
-            for i, ch in enumerate(CAPTURE_ORDER):
-                _check_cancel()
-                _report(0.1 + 0.1 * i, f"Probing {ch.letter}…")
-                signal, _ = _shoot(ch, i, black[ch.letter], probe_level, probe_shutter)
-                if not np.isfinite(signal) or signal < MIN_SIGNAL:
-                    raise RuntimeError(f"calibration failed: no signal from {ch.letter} channel")
-                k[ch.letter] = signal / (probe_level * shutter_seconds(probe_shutter))
-
-            # 3) One shutter, shared across R/G/B: slow enough that the dimmest channel reaches
-            #    its target at LED ≤ PWM_MAX; the LED alone then balances each channel.
-            shutter = shutter_at_least(max(targets[c] / (k[c] * PWM_MAX) for c in "RGB"), candidates)
-
-            # 4) Solve each channel's LED at the shared shutter (verify + one trim + clip guard).
-            #    If the set can't fit the LED window, step the *shared* shutter and re-solve all.
-            best_channels: dict[str, ChannelCalibration] = {}
-            best_badness = float("inf")
-            tried: set[str] = set()
-            for _attempt in range(4):
-                _check_cancel()
-                if shutter in tried:  # returned to a shutter we've already tried → a cycle, so stop
-                    break
-                tried.add(shutter)
-                channels: dict[str, ChannelCalibration] = {}
-                too_dim = too_bright = False
-                for i, ch in enumerate(CAPTURE_ORDER):
-                    base, target = black[ch.letter], targets[ch.letter]
-                    tol = 0.05 * target
-                    _report(0.4 + 0.2 * i, f"Setting {ch.letter}…")
-                    level = int(np.clip(round(target / max(k[ch.letter] * shutter_seconds(shutter), 1e-9)), PWM_MIN, PWM_MAX))
-                    measured, clip = _shoot(ch, i, base, level, shutter)
-                    # One proportional LED trim toward target (LED only — the shutter is shared).
-                    if clip <= MAX_CLIP_FRACTION and abs(measured - target) > tol:
-                        level = correct_led_level(level, measured, target)
-                        measured, clip = _shoot(ch, i, base, level, shutter)
-                    # Clip guard: p99.9 can read on-target while the top 0.1% saturates. The clear
-                    # base is the whitepoint (blackpoint after inversion) and must stay below
-                    # clipping, so pull the LED down until it does. A single step often isn't enough
-                    # (green on a dense base overshoots hard); iterate, re-measuring each time to
-                    # self-correct the under-read a clipped shot gives. Landing a touch under target
-                    # is fine (within tolerance); still clipping at PWM_MIN means the shared shutter
-                    # is genuinely too slow for this channel.
-                    while clip > MAX_CLIP_FRACTION and level > PWM_MIN:
-                        level = max(PWM_MIN, int(round(level * 0.85)))
-                        measured, clip = _shoot(ch, i, base, level, shutter)
-                    if clip > MAX_CLIP_FRACTION:  # still clipping at PWM_MIN → shared shutter too slow
-                        too_bright = True
-                    if level >= PWM_MAX and measured < target - tol:  # maxed LED, still under → too fast
-                        too_dim = True
-                    channels[ch.letter] = ChannelCalibration(
-                        channel=ch.letter, level=level, shutter=shutter, signal=measured, target=target, clip_fraction=clip
-                    )
-                    logger.info(
-                        "calibrated %s → level %d, shutter %s (base %.0f, target %d, got %.0f, clip %.3f%%)",
-                        ch.letter,
-                        level,
-                        shutter,
-                        base,
-                        target,
-                        measured,
-                        clip * 100,
-                    )
-                # Keep the best-scoring attempt and stop when a step stops improving (a step that
-                # would revisit a shutter is caught at the top of the loop). Without this the search
-                # oscillates between two shutters until it runs out of tries; it still escalates
-                # while a step genuinely lowers the score (moving a saturated channel onto target).
-                badness = _calibration_badness(channels)
-                if not best_channels or badness < best_badness:
-                    best_badness, best_channels = badness, channels
-                else:
-                    break
-                # A single shutter can't span > ~2.7 stops; nudge it toward whichever rail was hit.
-                if too_dim and not too_bright:
-                    step = slower_shutter(shutter, candidates)
-                elif too_bright and not too_dim:
-                    step = faster_shutter(shutter, candidates)
-                else:
-                    step = None
-                if step is None:
-                    break
-                shutter = step
-
-            channels = best_channels
-            issue = _calibration_issue(channels)
-            if issue is not None:
-                raise RuntimeError(issue)
-
-            _report(1.0, "Calibration done")
-            return CalibrationResult(channels=channels, black_levels=black)
-        finally:
-            try:
-                self._light.off()
-            except Exception:
-                logger.exception("failed to turn the Scanlight off after calibration")
-
     def _capture(self, path: str, shutter: Optional[str]) -> tuple[np.ndarray, str]:
-        """Capture, decode, and report *where the file landed*.
-
-        The camera names it after its own RAW format, so the path handed in is only a
-        stem: the raw-Bayer clip check must read the file that exists, not the one asked
-        for. Returning both is the only way the caller can.
-        """
+        """Capture, decode, and report *where the file landed* (the camera names it after its own
+        RAW format, so the handed-in path is only a stem; the clip check must read what exists)."""
         written = self._camera.capture(path, shutter=shutter)
         return self._demosaic(written), written
+
+
+def _channel_status(measured: float, clip: float, target: int) -> str:
+    """Graceful per-channel status from the *measured signal*, not the level. 'over' if the base
+    still clips; 'under' if it is materially below target from any cause — a maxed LED at the
+    slowest shutter, OR a clip-guard that pulled the LED well below PWM_MAX; else 'target' (a small
+    clip-guard undershoot within the margin stays 'target')."""
+    if clip > MAX_CLIP_FRACTION:
+        return "over"
+    if measured < (1.0 - MAX_TARGET_UNDER_FRACTION) * target:
+        return "under"
+    return "target"
+
+
+def _spread_stops(k: dict[str, float]) -> float:
+    """Channel response spread in stops = log2(max k / min k). Confirms one shutter can serve all
+    three (must stay below the ~2.7-stop LED window)."""
+    vals = [v for v in k.values() if v > 0]
+    if len(vals) < 2:
+        return 0.0
+    return float(np.log2(max(vals) / min(vals)))
+
+
+def _solve_shared(k: dict[str, float], T: int, candidates: tuple[str, ...]) -> tuple[str, dict[str, int]]:
+    """Analytic core: pick the fastest shutter that keeps the dimmest channel at ≤ PWM_MAX_SAFE,
+    then set each level = T / (k·t). One shot, no search."""
+    k_min = min(k.values())
+    t_ideal = T / (k_min * PWM_MAX_SAFE)  # dimmest channel sits at ~PWM_MAX_SAFE here
+    shutter = shutter_at_least(t_ideal, candidates)
+    # Solve the levels against the shutter's TRUE time: the ladder is snapped by nominal label, but
+    # what the sensor actually receives is the rounded-off time (a "1/3" pick exposes 0.315 s, not
+    # 0.333 s — 5.8 % less light than the label promises).
+    secs = true_seconds(shutter, candidates)
+    levels = {c: int(np.clip(round(T / (k[c] * secs)), PWM_MIN, PWM_MAX)) for c in k}
+    return shutter, levels

--- a/negpy/services/capture/calibration.py
+++ b/negpy/services/capture/calibration.py
@@ -144,6 +144,26 @@ def shutter_seconds(label: str) -> float:
     return float(label)
 
 
+def usable_ladder(candidates: tuple[str, ...]) -> tuple[str, ...]:
+    """The parseable, ascending subset of a body's shutter labels; empty if none are usable.
+
+    A body's ladder is untrusted input — the a7 IV publishes a bulb-like "1/0", others publish
+    "Bulb" or "" — and one such label used to kill calibration before it started (#478). The UI
+    filters them out before handing the ladder over, but every function below indexes and parses
+    this tuple, so it is cleaned once here as well: a second caller passing a raw ladder must not
+    reopen that bug.
+    """
+    parsed: dict[str, float] = {}
+    for label in candidates:
+        try:
+            seconds = shutter_seconds(label)
+        except (TypeError, ValueError):
+            continue  # bulb-like or non-numeric — not an exposure this solver can reason about
+        if seconds > 0:
+            parsed[label] = seconds
+    return tuple(sorted(parsed, key=parsed.__getitem__))
+
+
 @lru_cache(maxsize=8)
 def _ladder_stops(candidates: tuple[str, ...]) -> float:
     """The ladder's spacing in stops, measured from the body's own labels — never assumed.
@@ -153,7 +173,7 @@ def _ladder_stops(candidates: tuple[str, ...]) -> float:
     agnostic. Labels are individually rounded by up to ~7 %, so the *median* neighbour ratio is
     taken — it ignores that jitter. Falls back to thirds when the ladder is too short to read.
     """
-    secs = sorted(s for s in (shutter_seconds(c) for c in candidates) if s > 0)
+    secs = [shutter_seconds(c) for c in usable_ladder(candidates)]  # ascending, unparseables dropped
     ratios = [b / a for a, b in zip(secs, secs[1:]) if b > a]
     if len(ratios) < 3:
         return 1.0 / 3.0
@@ -385,7 +405,10 @@ class CalibrationService:
         progress: Optional[ProgressCb] = None,
         cancel=None,
     ) -> CalibrationResult:
-        candidates = tuple(candidates) or SHUTTER_CANDIDATES
+        # Clean once, here: everything downstream parses and indexes this ladder, and an unparseable
+        # label from the body would otherwise surface as a crash mid-run (#478) rather than a dropped
+        # entry. Empty (or entirely unusable) → the built-in ladder.
+        candidates = usable_ladder(tuple(candidates)) or SHUTTER_CANDIDATES
         start_shutter = nearest_shutter(start_shutter, candidates)
         T = target_signal(target_fraction)
 

--- a/tests/test_capture_calibration.py
+++ b/tests/test_capture_calibration.py
@@ -1,31 +1,49 @@
-"""ETTR auto-calibration unit tests (fake light + camera + linear demosaic)."""
+"""ETTR auto-calibration unit tests (rewrite — see calibration_redesign.md).
+
+Fake linear sensor: Signal = k · level · true_seconds, no bias (rawpy removes it → black = 0). It
+meters the ladder's true exposure, like a real body — NOT the rounded label, which is a display
+name ("1/3" exposes 0.315 s).
+Only the lit channel gets signal (one LED on per probe, as on the real rig). `k_scale` scales all
+three uniformly, like opening the aperture; per-channel k models the deep-red weakness (R lowest).
+"""
 
 import os
+
 import numpy as np
 import pytest
 
 from negpy.services.capture.calibration import (
     MAX_CLIP_FRACTION,
+    PWM_MAX,
+    PWM_MAX_SAFE,
+    PWM_MIN,
+    REFERENCE_LEVELS,
+    REFERENCE_SHUTTER,
+    SHUTTER_CANDIDATES,
     CalibrationService,
     ChannelCalibration,
     Roi,
-    _calibration_badness,
-    _calibration_issue,
+    _channel_status,
+    _solve_shared,
+    _spread_stops,
+    aperture_fnumber,
     clip_fraction,
-    faster_shutter,
     meter_base,
-    meter_black,
+    _ladder_stops,
+    nearest_shutter,
+    normalize_start_point,
     shutter_at_least,
     shutter_seconds,
-    slower_shutter,
-    target_for_black_level,
+    target_signal,
+    true_seconds,
 )
 
-BLACK = 512.0
-# Per-channel linear response (counts per LED-level per second). Blue is the dimmest (orange
-# mask), so it needs the most exposure — but only ~1 stop below red, within the LED's ~2.7-stop
-# range, so one shared shutter fits all three (matches the real Portra/Vision3 measurements).
-K = {0: 2250.0, 1: 1700.0, 2: 1200.0}
+# Per-channel response (counts per LED-level per second). R is the weakest (665 nm, low sensor QE),
+# G≈B — the ~1.6-stop spread measured from Robin's f/8 C-41 logs.
+K = {"R": 250.0, "G": 700.0, "B": 760.0}
+
+
+# ---- pure functions -------------------------------------------------------
 
 
 def test_shutter_seconds():
@@ -34,54 +52,143 @@ def test_shutter_seconds():
     assert shutter_seconds("1") == 1.0
 
 
-def test_target_for_black_level():
-    assert target_for_black_level(512.0, 0.9) == round(0.9 * (65535 - 512))
+def test_shutter_seconds_rejects_zero_denominator():
+    # The a7 IV publishes a bulb-like "1/0"; it must raise ValueError (not ZeroDivisionError) so the
+    # shutter-ladder filter drops it instead of crashing calibration.
+    with pytest.raises(ValueError):
+        shutter_seconds("1/0")
 
 
-def test_roi_pixels_clamps_and_orders():
-    assert Roi(0.0, 0.0, 1.0, 1.0).pixels(100, 80) == (0, 0, 100, 80)
-    assert Roi(0.25, 0.5, 0.5, 0.25).pixels(100, 80) == (25, 40, 75, 60)
-    # Degenerate / out-of-range still yields a non-empty crop.
-    x0, y0, x1, y1 = Roi(0.99, 0.99, 0.5, 0.5).pixels(100, 80)
-    assert x1 > x0 and y1 > y0
+# Real third-stop ladder as published by the a7C II (slowest first).
+_THIRDS = ("1", "8/10", "6/10", "5/10", "4/10", "1/3", "1/4", "1/5", "1/6", "1/8", "1/10", "1/13", "1/15", "1/20")
+# A half-stop body: same style of labels, different rungs — "1/3" here is 2^(-3/2) s, not 2^(-5/3).
+_HALVES = ("1", "1/1.5", "1/2", "1/3", "1/4", "1/6", "1/8", "1/11", "1/15", "1/22", "1/30")
 
 
-def test_meter_base_p999_ignores_hot_pixels():
-    plane = np.full((100, 100), 1000.0)
-    plane.flat[:3] = 60000.0  # 3 hot pixels = 0.03% < 0.1%, above the p99.9 cut
-    # whole-frame ROI, black 200 → ~800 counts of base signal
-    assert abs(meter_base(plane, Roi(0, 0, 1, 1), 200.0) - 800.0) < 1.0
+def test_true_seconds_undoes_the_label_rounding():
+    # Labels are rounded display names for a geometric ladder. Metering against the fraction put a
+    # rig run ~4 % under target with the LED clamped: it probed at "0.4" (0.8 % off) and solved at
+    # "1/3" (5.8 % off), and the difference went straight into k.
+    assert true_seconds("1", _THIRDS) == pytest.approx(1.0, rel=1e-3)  # exact rungs stay exact
+    assert true_seconds("1/4", _THIRDS) == pytest.approx(0.25, rel=1e-3)
+    assert true_seconds("1/8", _THIRDS) == pytest.approx(0.125, rel=1e-3)
+    assert true_seconds("1/3", _THIRDS) == pytest.approx(2 ** (-5 / 3), rel=0.01)  # 0.315, not 0.333
+    assert true_seconds("1/6", _THIRDS) == pytest.approx(2 ** (-8 / 3), rel=0.01)  # 0.157, not 0.167
+    assert true_seconds("4/10", _THIRDS) == pytest.approx(2 ** (-4 / 3), rel=0.01)  # 0.397, not 0.4
+    # The nominal parse is untouched — ordering/snapping still use it, and the ladder is monotonic
+    # either way, so no caller that only sorts is affected.
+    assert shutter_seconds("1/3") == pytest.approx(1 / 3)
 
 
-def test_meter_black_median_robust_to_hot_pixels():
-    plane = np.full((100, 100), 512.0)
-    plane.flat[:50] = 65535.0  # 0.5% hot pixels would wreck a p99.9 black estimate
-    assert meter_black(plane, Roi(0, 0, 1, 1)) == 512.0  # the median ignores them
+def test_ladder_stops_is_measured_from_the_body_not_assumed():
+    # Which rung a rounded label denotes depends on the ladder's spacing, so it is read off the
+    # body's own labels. Assuming thirds on a half-stop body would be worse than not correcting at
+    # all (it would "fix" 1/3 to 0.315 when the body really exposes 0.354).
+    assert _ladder_stops(_THIRDS) == pytest.approx(1 / 3)
+    assert _ladder_stops(_HALVES) == pytest.approx(1 / 2)
+    assert true_seconds("1/3", _HALVES) == pytest.approx(2 ** (-3 / 2), rel=0.02)  # 0.354, not 0.315
+    # Too short to read → falls back to thirds rather than inventing a spacing.
+    assert _ladder_stops(("1/4", "1/8")) == pytest.approx(1 / 3)
 
 
-def test_clip_fraction_counts_saturated_pixels():
-    plane = np.full((100, 100), 1000.0)
-    plane.flat[:5] = 65535.0  # 5 / 10000 = 0.05% at the ceiling
-    assert abs(clip_fraction(plane, Roi(0, 0, 1, 1)) - 0.0005) < 1e-9
-    assert clip_fraction(np.full((10, 10), 1000.0), Roi(0, 0, 1, 1)) == 0.0  # nothing saturated
+def test_true_seconds_leaves_labels_that_are_not_on_the_ladder_alone():
+    # A correction may never exceed the rounding it undoes. A value that sits nowhere near a rung
+    # isn't a rounded rung — it's something else (bulb, an oddly labelled body), and then the label
+    # is the better guess.
+    assert true_seconds("0.7", _THIRDS) == pytest.approx(0.7, rel=1e-6)
+    for label in _THIRDS:  # every real rung IS corrected, and only slightly
+        assert true_seconds(label, _THIRDS) == pytest.approx(shutter_seconds(label), rel=0.08)
 
 
-def test_faster_shutter_steps_up_the_ladder():
-    assert faster_shutter("0.8") == "0.6"
-    assert faster_shutter("1/15") == "1/20"  # ladder is fastest-first
-    assert faster_shutter("1/250") is None  # already the fastest
+def test_solve_uses_the_true_exposure_not_the_rounded_label():
+    # The regression this fixes: solving levels against the label over-states the light by up to
+    # 5.8 %, the channel lands under target, and the trim runs into the PWM_MAX clamp.
+    T = target_signal()
+    shutter, levels = _solve_shared(K, T, _THIRDS)
+    secs = true_seconds(shutter, _THIRDS)
+    for c, level in levels.items():
+        if PWM_MIN < level < PWM_MAX:  # unclamped channels must land on target at the TRUE exposure
+            assert K[c] * level * secs == pytest.approx(T, rel=0.02)
 
 
-def test_slower_shutter_steps_down_the_ladder():
-    assert slower_shutter("0.8") == "1"
-    assert slower_shutter("1/250") == "1/200"
-    assert slower_shutter("1") is None  # already the slowest
+def test_aperture_fnumber_parses_labels_and_manual_lens():
+    assert aperture_fnumber("f/8") == 8.0
+    assert aperture_fnumber("F5.6") == 5.6
+    assert aperture_fnumber("11") == 11.0
+    assert aperture_fnumber("") is None  # manual lens, no electronic aperture
+    assert aperture_fnumber("—") is None
+
+
+def test_normalize_start_point_scales_shutter_by_iso_and_aperture():
+    # Reference is ISO 100 / f8 / 0.4 s. Exposure ∝ ISO·t/f², so t scales by (100/ISO)·(f/8)².
+    levels, shutter = normalize_start_point("100", "f/8")
+    assert levels == REFERENCE_LEVELS and shutter == REFERENCE_SHUTTER
+    # ISO 400 = 2 stops more sensitive → 2 stops faster (0.4 s → 1/10).
+    assert normalize_start_point("400", "f/8")[1] == "1/10"
+    # f/11 ≈ 1 stop less light → ~1 stop slower (0.4 s → 0.8 s), NOT mislabelled as "1/1".
+    assert normalize_start_point("100", "f/11")[1] == "0.8"
+    # f/16 = 2 stops less light → 2 stops slower (0.4 s → 1.6 s), still on the ladder.
+    assert normalize_start_point("100", "f/16")[1] == "1.6"
+    # Manual lens (aperture unreadable) → ISO-only correction, no crash.
+    assert normalize_start_point("200", "")[1] == "1/5"
+
+
+def test_channel_status_is_measured_based_not_level_based():
+    # Bug caught in review: a clip-guard can pull the LED well below PWM_MAX yet leave the signal
+    # materially under target — that must read "under", not "target". The status keys off the
+    # measured signal, not the level.
+    T = target_signal()
+    assert _channel_status(T, 0.0, T) == "target"
+    assert _channel_status(0.85 * T, 0.0, T) == "target"  # small undershoot within the margin
+    assert _channel_status(0.5 * T, 0.0, T) == "under"  # materially under (level irrelevant here)
+    assert _channel_status(T, 0.01, T) == "over"  # still clipping → over
+
+
+def test_spread_stops():
+    assert _spread_stops({"R": 250.0, "G": 700.0, "B": 760.0}) == pytest.approx(1.60, abs=0.02)
+    assert _spread_stops({"R": 100.0, "G": 100.0, "B": 100.0}) == 0.0
+
+
+def test_solve_shared_seats_the_dimmest_channel_near_pwm_max_safe():
+    T = target_signal()
+    shutter, levels = _solve_shared(K, T, SHUTTER_CANDIDATES)
+    # Dimmest channel (R) gets the highest level, seated just under PWM_MAX_SAFE (not 255 — the red
+    # LED saturates up there); brighter G/B lower. Never above PWM_MAX_SAFE, and at most one ladder
+    # third-stop below it after the shutter snap.
+    assert levels["R"] > levels["G"] > levels["B"]
+    assert PWM_MAX_SAFE * 0.79 <= levels["R"] <= PWM_MAX_SAFE
+    # Every channel is inside the LED window at the chosen shutter.
+    secs = shutter_seconds(shutter)
+    for c, lvl in levels.items():
+        assert 40 <= lvl <= 255
+        assert K[c] * lvl * secs == pytest.approx(T, rel=0.06)
+
+
+def test_nearest_shutter_snaps_to_the_closest_candidate():
+    assert nearest_shutter("0.16", ("1/8", "1/6", "1/5")) == "1/6"  # 0.16 s closest to 1/6 (0.167)
+    assert nearest_shutter("1/5", ("1/8", "1/6", "1/5")) == "1/5"  # already a candidate → unchanged
 
 
 def test_shutter_at_least_picks_fastest_that_fits():
-    assert shutter_at_least(0.2) == "1/5"  # 1/5 = 0.2 s, the fastest candidate ≥ 0.2 s
-    assert shutter_at_least(0.19) == "1/5"  # 1/8=0.125 too fast, 1/5=0.2 is the first ≥ 0.19
-    assert shutter_at_least(999.0) == "1"  # nothing slow enough → the slowest candidate
+    # "≥ seconds" is a claim about light, so it compares TRUE exposure. "1/5" exposes 2^(-7/3) =
+    # 0.198 s — it does NOT satisfy a 0.2 s demand, however its label reads. Trusting the label
+    # here is what let the solved level exceed PWM_MAX_SAFE and pin R at the 255 clamp on the rig.
+    assert shutter_at_least(0.198) == "1/5"
+    assert shutter_at_least(0.19) == "1/5"
+    assert shutter_at_least(0.2) == "1/4"  # 1/5 is really 0.198 s → too fast, take the next rung
+    assert shutter_at_least(999.0) == "2"  # nothing slow enough → slowest candidate (now 2 s)
+
+
+def test_solve_never_exceeds_pwm_max_safe_on_the_dimmest_channel():
+    # The guarantee shutter_at_least exists for: t_ideal is derived so the dimmest channel sits at
+    # PWM_MAX_SAFE, so any rung that truly exposes ≥ t_ideal keeps it at or below that. Comparing
+    # nominal labels broke the guarantee (the rung exposed less than promised), the level overshot,
+    # and the trim then had no headroom left.
+    T = target_signal()
+    for ladder in (_THIRDS, SHUTTER_CANDIDATES):
+        _shutter, levels = _solve_shared(K, T, ladder)
+        dimmest = min(K, key=lambda c: K[c])
+        assert levels[dimmest] <= PWM_MAX_SAFE
 
 
 # ---- full loop with injected hardware -------------------------------------
@@ -102,8 +209,8 @@ class FakeLight:
 
 
 class FakeCamera:
-    def __init__(self):
-        self.last_shutter = "1/15"
+    def __init__(self, start="1/5"):
+        self.last_shutter = start
 
     def capture(self, out_path, shutter=None, iso=None, aperture=None):
         if shutter:
@@ -114,16 +221,21 @@ class FakeCamera:
         pass
 
 
-def _make_demosaic(light, camera, sliver: int = 0):
-    """Linear fake sensor: 128×128 so a sub-0.1% clip sliver fits below the p99.9 cut.
-    `sliver` over-bright pixels (base × 1.25) clip at the ETTR solve but the clip guard's
-    LED-down resolves them (exposure-dependent, unlike a fixed hot pixel)."""
+def _make_demosaic(light, camera, *, k_scale=1.0, level_cap=None, sliver=0):
+    """Linear fake sensor (128×128 so a sub-0.1 % clip sliver fits below the p99.9 cut). No bias.
+    `k_scale` scales all channels uniformly (like aperture); `level_cap` saturates the LED above a
+    level (a channel solved to max LED lands under target → under-exposed); `sliver` over-bright
+    pixels clip at the solve but the LED-down clip guard resolves them."""
 
     def demosaic(_path):
-        sec = shutter_seconds(camera.last_shutter)
-        img = np.full((128, 128, 3), BLACK)
+        # A body exposes the ladder's TRUE time, not the label's fraction ("1/3" is 0.315 s). The
+        # fake sensor must do the same, or it silently absorbs the rounding the solver has to
+        # handle — and the rig failure it caused would be untestable here.
+        sec = true_seconds(camera.last_shutter, SHUTTER_CANDIDATES)
+        img = np.zeros((128, 128, 3))
         for i, level in enumerate(light.last):
-            val = BLACK + K[i] * level * sec
+            eff = min(level, level_cap) if level_cap is not None else level
+            val = K["RGB"[i]] * k_scale * eff * sec
             img[..., i] = val
             if sliver:
                 img.reshape(-1, 3)[:sliver, i] = min(65535.0, val * 1.25)
@@ -133,31 +245,98 @@ def _make_demosaic(light, camera, sliver: int = 0):
     return demosaic
 
 
-def _make_capped_demosaic(light, camera, level_cap: int = 200):
-    """Linear in shutter but LED response saturates above `level_cap`: raising the LED past it
-    adds nothing, so a channel solved to max LED can land under target → shutter escalation
-    (a slower shutter) is the only way to add exposure."""
-
-    def demosaic(_path):
-        sec = shutter_seconds(camera.last_shutter)
-        img = np.full((32, 32, 3), BLACK)
-        for i, level in enumerate(light.last):
-            img[..., i] = BLACK + K[i] * min(level, level_cap) * sec
-        np.clip(img, 0, 65535, out=img)
-        return img
-
-    return demosaic
-
-
-def _service(light, cam, sliver: int = 0):
+def _service(light, cam, **demo):
     # source_clip stubbed to 0 → the hardware-free path never touches rawpy.
-    return CalibrationService(light, cam, _make_demosaic(light, cam, sliver), source_clip=lambda *_a: 0.0, sleep=lambda _s: None)
+    return CalibrationService(light, cam, _make_demosaic(light, cam, **demo), source_clip=lambda *_a: 0.0, sleep=lambda _s: None)
+
+
+def _calibrate(service, roi=Roi(0, 0, 1, 1)):
+    return service.calibrate(roi, "/tmp/_negpy_cal.raw")
+
+
+def test_calibrate_converges_with_one_shared_shutter():
+    light, cam = FakeLight(), FakeCamera()
+    result = _calibrate(_service(light, cam))
+    T = target_signal()
+    # One shared shutter, every channel on target, R (dimmest) at the highest level.
+    assert len(set(result.shutters)) == 1
+    assert result.levels[0] > result.levels[1] and result.levels[0] > result.levels[2]
+    for ch in result.channels.values():
+        assert ch.status == "target"
+        assert ch.signal == pytest.approx(T, rel=0.06)
+    assert result.spread_stops == pytest.approx(1.60, abs=0.05)
+
+
+def test_calibrate_recovers_from_a_much_brighter_than_expected_start():
+    # Aperture way open (~6 stops brighter than the start point) → the probe clips hard. The halving
+    # back-off must recover within the step budget — a 1/3-stop walk would run out of steps here.
+    light, cam = FakeLight(), FakeCamera()
+    result = _calibrate(_service(light, cam, k_scale=64.0))
+    for ch in result.channels.values():
+        assert ch.status == "target"
+        assert ch.clip_fraction <= MAX_CLIP_FRACTION
+
+
+def test_calibrate_recovers_from_a_too_fast_start_shutter():
+    # Start shutter far too fast (1/250) but the light is fine — the analytic solve still lands on
+    # target from the probe's clean (if dim) reading, no ladder walk needed.
+    light, cam = FakeLight(), FakeCamera(start="1/250")
+    result = _service(light, cam).calibrate(Roi(0, 0, 1, 1), "/tmp/_negpy_cal.raw", start_shutter="1/250")
+    for ch in result.channels.values():
+        assert ch.status == "target"
+
+
+def test_calibrate_is_graceful_when_a_channel_cannot_reach_target():
+    # Aperture too closed: even max LED at the slowest shutter (2 s) leaves the dim R channel short.
+    # Must not raise — return a best-effort result with R flagged "under".
+    light, cam = FakeLight(), FakeCamera()
+    result = _calibrate(_service(light, cam, k_scale=0.02))
+    assert result.channels["R"].status == "under"
+    assert result.channels["R"].level == PWM_MAX
+    assert result.status == "under"  # headline reflects the worst channel
+
+
+def test_calibrate_is_graceful_when_over_exposed():
+    # Aperture way too open: even the fastest shutter + lowest LED clips. Must not raise (symmetric
+    # to under-exposure) — return a best-effort result at minimum exposure with the channels flagged
+    # "over", so the UI can tell the user to stop down.
+    light, cam = FakeLight(), FakeCamera(start="1/250")
+    result = _service(light, cam, k_scale=3000.0).calibrate(Roi(0, 0, 1, 1), "/tmp/_negpy_cal.raw", start_shutter="1/250")
+    assert result.status == "over"
+    assert all(ch.status == "over" for ch in result.channels.values())
+    assert all(ch.level == PWM_MIN for ch in result.channels.values())  # seated at minimum LED
+
+
+def test_calibrate_raises_only_when_a_channel_has_no_signal_at_all():
+    # A dead LED / ROI off the base gives no signal even at max exposure — the one case that still
+    # errors clearly (nothing can be calibrated), distinct from graceful over/under-exposure.
+    light, cam = FakeLight(), FakeCamera()
+    with pytest.raises(RuntimeError, match="no signal from the R channel"):
+        _calibrate(_service(light, cam, k_scale=0.0))
+
+
+def test_calibrate_clip_guard_pulls_the_led_down_below_clipping():
+    # A bright sliver clips at the solved level; the guard lowers the LED until the base is clean.
+    light, cam = FakeLight(), FakeCamera()
+    result = _calibrate(_service(light, cam, sliver=40))
+    for ch in result.channels.values():
+        assert ch.clip_fraction <= MAX_CLIP_FRACTION
+
+
+def test_calibrate_measures_spread_matching_the_channel_responses():
+    light, cam = FakeLight(), FakeCamera()
+    result = _calibrate(_service(light, cam))
+    # log2(760/250) ≈ 1.60 — the value that confirms one shutter can serve all three (< 2.7).
+    assert result.spread_stops == pytest.approx(1.60, abs=0.05)
+    assert result.spread_stops < 2.7
+
+
+# ---- source-clip guard (fail-closed) --------------------------------------
 
 
 def test_source_clip_reads_the_file_the_camera_actually_wrote():
-    """The camera names the file after its own RAW format, so the raw-Bayer clip check
-    must be handed the path it returned — not the stem we asked for. Getting this wrong
-    silently disables the clip guard: rawpy raises, the error is logged, and clip reads 0."""
+    """The raw-Bayer clip check must be handed the path the camera returned (its own RAW suffix),
+    not the stem we asked for — else the clip guard is silently disabled."""
     light, cam = FakeLight(), FakeCamera()
     seen: list[str] = []
 
@@ -165,11 +344,9 @@ def test_source_clip_reads_the_file_the_camera_actually_wrote():
         seen.append(path)
         return 0.0
 
-    service = CalibrationService(light, cam, _make_demosaic(light, cam, 0), source_clip=record, sleep=lambda _s: None)
-    service.calibrate(Roi(0, 0, 1, 1), "/tmp/_negpy_calibration.raw")
-
-    assert seen, "the clip guard never ran"
-    assert all(p.endswith(".ARW") for p in seen), seen  # the fake camera's suffix, not ".raw"
+    service = CalibrationService(light, cam, _make_demosaic(light, cam), source_clip=record, sleep=lambda _s: None)
+    _calibrate(service)
+    assert seen and all(p.endswith(".ARW") for p in seen), seen
 
 
 def test_calibrate_fails_closed_when_the_raw_clip_check_errors(monkeypatch):
@@ -180,217 +357,33 @@ def test_calibrate_fails_closed_when_the_raw_clip_check_errors(monkeypatch):
 
     monkeypatch.setattr("negpy.infrastructure.capture.raw_demosaic.raw_channel_clip_fraction", unavailable)
     service = CalibrationService(light, cam, _make_demosaic(light, cam), sleep=lambda _s: None)
-
     with pytest.raises(RuntimeError, match="raw source-clip check failed") as caught:
-        service.calibrate(Roi(0, 0, 1, 1), "/tmp/cal.ARW")
-
+        _calibrate(service)
     assert isinstance(caught.value.__cause__, OSError)
 
 
 def test_calibrate_fails_closed_on_a_nonfinite_raw_clip_measurement():
     light, cam = FakeLight(), FakeCamera()
-    service = CalibrationService(
-        light,
-        cam,
-        _make_demosaic(light, cam),
-        source_clip=lambda *_args: np.nan,
-        sleep=lambda _s: None,
-    )
-
+    service = CalibrationService(light, cam, _make_demosaic(light, cam), source_clip=lambda *_a: np.nan, sleep=lambda _s: None)
     with pytest.raises(RuntimeError, match="non-finite raw source-clip"):
-        service.calibrate(Roi(0, 0, 1, 1), "/tmp/cal.ARW")
+        _calibrate(service)
 
 
-def test_calibrate_converges_with_one_shared_shutter():
-    light, cam = FakeLight(), FakeCamera()
-    result = _service(light, cam).calibrate(Roi(0, 0, 1, 1), "/tmp/cal.ARW")
-
-    for letter in ("R", "G", "B"):
-        c = result.channels[letter]
-        assert 40 <= c.level <= 255
-        assert abs(c.signal - c.target) <= 0.06 * c.target  # each channel hit ETTR target via LED
-
-    r, g, b = result.shutters
-    assert r == g == b  # ONE shutter shared across R/G/B — the whole point of the rebuild
-    assert result.channels["B"].level > result.channels["R"].level  # blue dimmest → most LED
-    assert light.last == (0, 0, 0)  # light off when done
+# ---- metering helpers -----------------------------------------------------
 
 
-def test_calibrate_rejects_a_probe_with_no_signal():
-    light, cam = FakeLight(), FakeCamera()
-
-    def dark_frame(_path):
-        return np.full((16, 16, 3), BLACK)
-
-    service = CalibrationService(light, cam, dark_frame, source_clip=lambda *_a: 0.0, sleep=lambda _s: None)
-
-    with pytest.raises(RuntimeError, match="no signal from R"):
-        service.calibrate(Roi(0, 0, 1, 1), "/tmp/cal.ARW")
-
-    assert light.last == (0, 0, 0)
+def test_meter_base_is_p999_of_the_roi():
+    plane = np.full((100, 100), 30000.0)
+    plane.reshape(-1)[:5] = 65000.0  # 0.05 % bright — inside the top 0.1 % that p99.9 discards
+    assert meter_base(plane, Roi(0, 0, 1, 1)) == pytest.approx(30000.0, abs=1.0)
 
 
-def test_calibrate_tolerates_a_sub_threshold_base_clip():
-    clean = _service(FakeLight(), FakeCamera()).calibrate(Roi(0, 0, 1, 1), "/tmp/cal.ARW")
-    tolerated = _service(FakeLight(), FakeCamera(), sliver=8).calibrate(Roi(0, 0, 1, 1), "/tmp/cal.ARW")
-
-    # A fraction-of-a-percent sliver (below MAX_CLIP_FRACTION) is recorded but tolerated: the LED is
-    # NOT pulled down (the blackpoint is median-derived), so the base lands on the same target as the
-    # clean run. It used to trip the old 0.01% ceiling and needlessly reduce the LED.
-    for c in tolerated.channels.values():
-        assert c.clip_fraction <= MAX_CLIP_FRACTION
-    assert tolerated.channels["B"].clip_fraction > 0.0  # the sliver was measured…
-    assert tolerated.channels["B"].signal == clean.channels["B"].signal  # …but not corrected away
+def test_clip_fraction_counts_saturated_pixels():
+    plane = np.zeros((100, 100))
+    plane.reshape(-1)[:100] = 65500.0  # 1 % at/above saturation
+    assert clip_fraction(plane, Roi(0, 0, 1, 1)) == pytest.approx(0.01, abs=1e-4)
 
 
-def test_calibrate_respects_camera_shutter_ladder():
-    ladder = ("1/100", "1/50", "1/25", "1/10", "1/4", "1")  # a sparse, camera-specific ladder
-    result = _service(FakeLight(), FakeCamera()).calibrate(Roi(0, 0, 1, 1), "/tmp/cal.ARW", candidates=ladder)
-    r, g, b = result.shutters
-    assert r == g == b and r in ladder  # one shared shutter, from the camera's own set
-
-
-def test_source_clip_pulls_led_down_when_demosaic_is_clean():
-    clean = _service(FakeLight(), FakeCamera()).calibrate(Roi(0, 0, 1, 1), "/tmp/cal.ARW")
-    # Demosaic reads clean, but the injected raw-Bayer check reports blue's photosites clipping
-    # on the first look (resolving once the LED is pulled down) — the hidden-source-clip case.
-    calls = {"b": 0}
-
-    def src(_p, ch_i, _roi):
-        if ch_i != 2:
-            return 0.0
-        calls["b"] += 1  # blue: 1=probe, 2=solve (clip here), 3=after LED-down (resolved)
-        return 0.02 if calls["b"] == 2 else 0.0
-
-    light, cam = FakeLight(), FakeCamera()
-    guarded = CalibrationService(light, cam, _make_demosaic(light, cam), source_clip=src, sleep=lambda _s: None).calibrate(
-        Roi(0, 0, 1, 1), "/tmp/cal.ARW"
-    )
-    assert guarded.channels["B"].clip_fraction == 0.0  # resolved after the LED-down
-    assert guarded.channels["B"].signal < clean.channels["B"].signal  # LED was reduced to clear it
-
-
-def test_calibrate_escalates_shared_shutter_when_led_saturates():
-    clean = _service(FakeLight(), FakeCamera()).calibrate(Roi(0, 0, 1, 1), "/tmp/cal.ARW")
-    light, cam = FakeLight(), FakeCamera()
-    capped = CalibrationService(
-        light, cam, _make_capped_demosaic(light, cam), source_clip=lambda *_a: 0.0, sleep=lambda _s: None
-    ).calibrate(Roi(0, 0, 1, 1), "/tmp/cal.ARW")
-
-    r, g, b = capped.shutters
-    assert r == g == b  # still one shared shutter
-    # LED saturates above 200 → blue can't reach target at the clean run's shutter, so the SHARED
-    # shutter escalates to a slower one, and every channel is re-solved onto target.
-    assert shutter_seconds(b) > shutter_seconds(clean.shutters[2])
-    assert abs(capped.channels["B"].signal - capped.channels["B"].target) < 0.1 * capped.channels["B"].target
-
-
-def test_calibrate_rejects_a_channel_below_target_at_the_hardware_limit():
-    light, cam = FakeLight(), FakeCamera()
-    service = CalibrationService(
-        light,
-        cam,
-        _make_capped_demosaic(light, cam, level_cap=1),
-        source_clip=lambda *_a: 0.0,
-        sleep=lambda _s: None,
-    )
-
-    with pytest.raises(RuntimeError, match="R channel.*below target"):
-        service.calibrate(Roi(0, 0, 1, 1), "/tmp/cal.ARW")
-
-
-def _chan(letter, signal, clip=0.0, target=58978):
-    return ChannelCalibration(channel=letter, level=100, shutter="1/5", signal=signal, target=target, clip_fraction=clip)
-
-
-def test_calibration_issue_flags_the_first_out_of_spec_channel():
-    ok = {c: _chan(c, 58000) for c in "RGB"}  # all a touch under target, clean → usable
-    assert _calibration_issue(ok) is None
-    assert "G channel is still clipping" in _calibration_issue({**ok, "G": _chan("G", 58000, clip=0.01)})
-    assert "R channel remains materially below target" in _calibration_issue({**ok, "R": _chan("R", 40000)})
-    assert "B channel remains materially above target" in _calibration_issue({**ok, "B": _chan("B", 66000)})
-
-
-def test_calibration_badness_prefers_a_clean_under_channel_over_a_clipping_one():
-    # This ordering is the whole point of the search fix: a shutter that leaves a channel a touch
-    # under (but clean, within spec) must beat a shutter that clips the base, so the search settles
-    # on the clean side instead of oscillating toward the clipping one.
-    on_target = {c: _chan(c, 58978) for c in "RGB"}
-    slightly_under = {**on_target, "R": _chan("R", 54868)}  # 7% under: within spec, clean
-    clipping = {**on_target, "G": _chan("G", 58978, clip=0.01)}  # on-signal but clips the base
-    assert _calibration_badness(on_target) < _calibration_badness(slightly_under) < _calibration_badness(clipping)
-    assert _calibration_badness({**on_target, "R": _chan("R", float("nan"))}) == float("inf")
-
-
-def test_calibrate_rejects_a_final_channel_materially_above_target():
-    light, cam = FakeLight(), FakeCamera()
-    ordinary = _make_demosaic(light, cam)
-    calls = 0
-
-    def nonlinear_response(path):
-        nonlocal calls
-        calls += 1
-        if calls <= 4:  # dark frame + the three response probes
-            return ordinary(path)
-        img = np.full((32, 32, 3), BLACK)
-        for i, level in enumerate(light.last):
-            if level:
-                img[..., i] = BLACK + 64500.0  # above ETTR, just below SATURATION_VALUE
-        return img
-
-    service = CalibrationService(light, cam, nonlinear_response, source_clip=lambda *_a: 0.0, sleep=lambda _s: None)
-
-    with pytest.raises(RuntimeError, match="R channel.*above target"):
-        service.calibrate(Roi(0, 0, 1, 1), "/tmp/cal.ARW")
-
-
-def test_a_tiny_base_clip_is_tolerated_not_a_hard_failure():
-    # A fraction-of-a-percent clip on the clear base is harmless (the blackpoint is the base
-    # median, not its top pixels) and unavoidable with discrete LED steps — it must not fail an
-    # otherwise-usable calibration the way the old 0.01% ceiling did (green clipping 0.1% at the
-    # only shutter fast enough to keep red on target).
-    light, cam = FakeLight(), FakeCamera()
-    result = CalibrationService(
-        light,
-        cam,
-        _make_demosaic(light, cam),
-        source_clip=lambda _p, ch_i, _roi: 0.001 if ch_i == 1 else 0.0,  # green clips 0.1% persistently
-        sleep=lambda _s: None,
-    ).calibrate(Roi(0, 0, 1, 1), "/tmp/cal.ARW")
-    assert 0.0 < result.channels["G"].clip_fraction <= MAX_CLIP_FRACTION  # tolerated and recorded
-
-
-def test_calibrate_rejects_a_final_channel_that_is_still_clipping():
-    light, cam = FakeLight(), FakeCamera()
-    service = CalibrationService(
-        light,
-        cam,
-        _make_demosaic(light, cam),
-        source_clip=lambda *_a: 0.02,
-        sleep=lambda _s: None,
-    )
-
-    with pytest.raises(RuntimeError, match="R channel.*still clipping"):
-        service.calibrate(Roi(0, 0, 1, 1), "/tmp/cal.ARW")
-
-
-def test_calibrate_rejects_a_nonfinite_final_channel():
-    light, cam = FakeLight(), FakeCamera()
-    ordinary = _make_demosaic(light, cam)
-    calls = 0
-
-    def nonfinite_response(path):
-        nonlocal calls
-        calls += 1
-        if calls <= 4:  # dark frame + the three response probes
-            return ordinary(path)
-        img = np.full((32, 32, 3), BLACK)
-        for i, level in enumerate(light.last):
-            if level:
-                img[..., i] = np.nan
-        return img
-
-    service = CalibrationService(light, cam, nonfinite_response, source_clip=lambda *_a: 0.0, sleep=lambda _s: None)
-
-    with pytest.raises(RuntimeError, match="R channel.*non-finite"):
-        service.calibrate(Roi(0, 0, 1, 1), "/tmp/cal.ARW")
+def test_channel_calibration_defaults_to_target_status():
+    c = ChannelCalibration(channel="R", level=200, shutter="1/5", signal=59000, target=58982)
+    assert c.status == "target"

--- a/tests/test_capture_calibration.py
+++ b/tests/test_capture_calibration.py
@@ -36,6 +36,7 @@ from negpy.services.capture.calibration import (
     shutter_seconds,
     target_signal,
     true_seconds,
+    usable_ladder,
 )
 
 # Per-channel response (counts per LED-level per second). R is the weakest (665 nm, low sensor QE),
@@ -98,6 +99,30 @@ def test_true_seconds_leaves_labels_that_are_not_on_the_ladder_alone():
     assert true_seconds("0.7", _THIRDS) == pytest.approx(0.7, rel=1e-6)
     for label in _THIRDS:  # every real rung IS corrected, and only slightly
         assert true_seconds(label, _THIRDS) == pytest.approx(shutter_seconds(label), rel=0.08)
+
+
+def test_calibrate_survives_a_raw_unfiltered_ladder_from_the_body():
+    # #478 was exactly this: a body publishes "1/0" (bulb-like) and calibration died while building
+    # the ladder. The UI filters those out, but the solver must not depend on that — a second caller
+    # handing over a raw ladder would reopen the bug. The ladder is cleaned on the way in instead.
+    raw = ("1/250", "1/0", "Bulb", "", "1/60", "1/4", "2", "30")
+    # Only unparseable labels go: this cleans, it does not range-filter. Which speeds are *sensible*
+    # (the PWM-banding floor, the 2 s ceiling) is the UI's call in _available_shutters — the solver
+    # solves on whatever ladder it is handed, it just must not choke on it.
+    assert usable_ladder(raw) == ("1/250", "1/60", "1/4", "2", "30")  # junk dropped, ascending
+    assert _ladder_stops(raw) > 0  # no ValueError from the unparseable entries
+    assert shutter_at_least(0.5, usable_ladder(raw)) == "2"
+    light, cam = FakeLight(), FakeCamera()
+    result = _service(light, cam).calibrate(Roi(0, 0, 1, 1), "/tmp/_negpy_cal.raw", candidates=raw)
+    assert set(result.channels) == {"R", "G", "B"}
+
+
+def test_calibrate_falls_back_when_no_ladder_entry_is_usable():
+    # A body that publishes only bulb-like labels leaves nothing to solve on. Falling back to the
+    # built-in ladder beats crashing on an empty tuple (shutter_at_least indexes candidates[-1]).
+    light, cam = FakeLight(), FakeCamera()
+    result = _service(light, cam).calibrate(Roi(0, 0, 1, 1), "/tmp/_negpy_cal.raw", candidates=("1/0", "Bulb", ""))
+    assert result.channels["R"].shutter in SHUTTER_CANDIDATES
 
 
 def test_solve_uses_the_true_exposure_not_the_rounded_label():

--- a/tests/test_capture_calibration.py
+++ b/tests/test_capture_calibration.py
@@ -1,4 +1,4 @@
-"""ETTR auto-calibration unit tests (rewrite — see calibration_redesign.md).
+"""ETTR auto-calibration unit tests.
 
 Fake linear sensor: Signal = k · level · true_seconds, no bias (rawpy removes it → black = 0). It
 meters the ladder's true exposure, like a real body — NOT the rounded label, which is a display
@@ -330,6 +330,24 @@ def test_calibrate_is_graceful_when_over_exposed():
     assert result.status == "over"
     assert all(ch.status == "over" for ch in result.channels.values())
     assert all(ch.level == PWM_MIN for ch in result.channels.values())  # seated at minimum LED
+
+
+def test_deep_over_exposure_from_the_default_start_never_exhausts_the_probe():
+    # The probe budget must cover the whole reachable range (ladder + LED), or a deeply-over scene
+    # exhausts it mid-descent and raises "no signal … check the Scanlight is on" — the exact
+    # opposite of what is happening. Both cases below did exactly that with the old 8-step budget.
+    #
+    # ~8 stops over (manual f/1.4 lens the body can't report, no film in the holder): within the
+    # ladder's ~9-stop reach below the start, so with enough steps it now CALIBRATES, on target.
+    light, cam = FakeLight(), FakeCamera()
+    result = _calibrate(_service(light, cam, k_scale=300.0))
+    assert result.status == "target"
+    T = target_signal()
+    assert all(abs(ch.signal - T) <= 0.06 * T for ch in result.channels.values())
+    # ~11.6 stops over: beyond even minimum exposure — must degrade to "over", never raise.
+    light, cam = FakeLight(), FakeCamera()
+    result = _calibrate(_service(light, cam, k_scale=3000.0))
+    assert result.status == "over"
 
 
 def test_calibrate_raises_only_when_a_channel_has_no_signal_at_all():

--- a/tests/test_capture_raw_demosaic.py
+++ b/tests/test_capture_raw_demosaic.py
@@ -3,7 +3,7 @@
 import numpy as np
 import rawpy
 
-from negpy.infrastructure.capture.raw_demosaic import linear_demosaic
+from negpy.infrastructure.capture.raw_demosaic import linear_demosaic, raw_channel_clip_fraction
 
 
 class _FakeRaw:
@@ -21,9 +21,72 @@ class _FakeRaw:
         return np.zeros((side, side, 3), dtype=np.uint16)
 
 
+class _FullRoi:
+    """The whole frame, duck-typing calibration's Roi (no services import in an infra test)."""
+
+    def pixels(self, w, h):
+        return 0, 0, w, h
+
+
+class _FakeBayer:
+    """A uniform base patch on a Bayer sensor, with a controllable white level."""
+
+    color_desc = b"RGBG"
+
+    def __init__(self, white_level, base=3000.0, sigma=4.0, clipped_rows=0):
+        self.white_level = white_level
+        rng = np.random.default_rng(7)
+        img = base + rng.normal(0.0, sigma, (64, 64))
+        if clipped_rows:  # pin some photosites to the ceiling — genuine clipping
+            img[:clipped_rows] = 16383
+        self.raw_image_visible = img.astype(np.uint16)
+        self.raw_colors_visible = np.zeros((64, 64), dtype=np.uint8)  # every site is "R"
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        pass
+
+
 def test_linear_demosaic_disables_half_size_for_xtrans(monkeypatch):
     monkeypatch.setattr(rawpy, "imread", lambda _path: _FakeRaw())
 
     decoded = linear_demosaic("frame.RAF", half_size=True)
 
     assert decoded.shape == (8, 8, 3)
+
+
+def test_linear_demosaic_pins_the_scale_to_the_white_level(monkeypatch):
+    # THE decode fix: LibRaw's default (adjust_maximum_thr=0.75) silently rescales each frame by its
+    # own brightest pixel, so a meter comparing frames compares nothing — on the rig it faked a hard
+    # LED plateau. The calibration decode must pin the reference to the camera's white level.
+    seen = {}
+
+    class _Spy(_FakeRaw):
+        def postprocess(self, **kwargs):
+            seen.update(kwargs)
+            return super().postprocess(**kwargs)
+
+    monkeypatch.setattr(rawpy, "imread", lambda _path: _Spy())
+    linear_demosaic("frame.ARW")
+    assert seen["adjust_maximum_thr"] == 0.0
+
+
+def test_raw_clip_returns_zero_when_the_body_reports_no_white_level(monkeypatch):
+    # The documented contract ("Returns 0.0 if the channel/white level can't be resolved") — the code
+    # used to guess img.max() instead, an image-dependent reference (the adjust_maximum_thr failure
+    # class). On a uniform base the guess sits inside the noise, so the quieter the sensor the more
+    # photosites read as clipped (~40 % at σ=4 DN): the probe then halves a frame that clips nowhere.
+    monkeypatch.setattr(rawpy, "imread", lambda _path: _FakeBayer(white_level=None))
+    assert raw_channel_clip_fraction("x.ARW", 0, _FullRoi()) == 0.0
+
+
+def test_raw_clip_still_catches_genuine_clipping(monkeypatch):
+    # The positive path must survive the contract fix: photosites at the ceiling are reported.
+    monkeypatch.setattr(rawpy, "imread", lambda _path: _FakeBayer(white_level=16383, clipped_rows=8))
+    frac = raw_channel_clip_fraction("x.ARW", 0, _FullRoi())
+    assert frac > 0.1  # 8 of 64 rows pinned to the ceiling
+    # And a clean frame with a proper white level reads ~0, not noise-tail false positives.
+    monkeypatch.setattr(rawpy, "imread", lambda _path: _FakeBayer(white_level=16383))
+    assert raw_channel_clip_fraction("x.ARW", 0, _FullRoi()) == 0.0

--- a/tests/test_scanlight_sidebar.py
+++ b/tests/test_scanlight_sidebar.py
@@ -209,6 +209,91 @@ def test_closing_running_calibration_waits_for_worker_terminal_signal():
     assert w._lv_target is w.lv_image
 
 
+def test_running_calibration_locks_the_window_inputs():
+    """A calibration meters a fixed base at a fixed ISO/aperture, so the film-stock name, the base
+    ROI and the ISO/aperture must not change under it mid-run. They lock when it starts and unlock
+    on a terminal outcome (here a cancel) so a failed run can be adjusted and retried."""
+    w = _sidebar()
+    w._camera_verified = True
+    w._light_verified = True
+    w.calib_window.image._set_crosshair(0.5, 0.5)  # place the base patch so the run can start
+
+    w._on_calibrate_new_preset("Portra 400")
+
+    assert w._calibrating_preset == "Portra 400"
+    w.controller.start_calibration.assert_called_once()
+    assert not w.calib_window.name_edit.isEnabled()
+    assert not w.calib_window.iso_stepper.isEnabled()
+    assert not w.calib_window.aperture_stepper.isEnabled()
+    assert w.calib_window.image._roi_locked  # a click no longer moves the metered patch
+
+    w._on_cancelled()  # terminal → unlock for a retry
+
+    assert w.calib_window.name_edit.isEnabled()
+    assert not w.calib_window.image._roi_locked
+
+
+def test_settings_refresh_does_not_reenable_locked_calibration_inputs(tmp_path, monkeypatch):
+    """The periodic camera-settings poll mirrors the body onto the ISO/aperture steppers. While a
+    calibration is metering at those settings they are frozen, so the poll must skip the calibration
+    pop-up's steppers — otherwise it would re-enable what the run just locked."""
+    import json
+
+    import negpy.desktop.view.sidebar.scanlight as sl
+
+    p = tmp_path / "settings.json"
+    p.write_text(
+        json.dumps(
+            {
+                "iso": {"cur": 100, "writable": True, "options": [{"raw": 100, "label": "ISO 100"}]},
+                "aperture": {"cur": 8, "writable": True, "options": [{"raw": 8, "label": "F8"}]},
+            }
+        )
+    )
+    monkeypatch.setattr(sl, "default_settings_path", lambda: str(p))
+    w = _sidebar()
+    w._calibrating_preset = "Portra 400"
+    w.calib_window.set_inputs_locked(True)
+
+    w._refresh_camera_settings()
+
+    assert not w.calib_window.iso_stepper.isEnabled()  # stayed locked despite a writable body value
+    assert not w.calib_window.aperture_stepper.isEnabled()
+    assert w.lv_window.iso_stepper.isEnabled()  # the live-view stepper still refreshes normally
+
+
+def test_roi_image_ignores_clicks_while_locked():
+    from PyQt6.QtCore import QEvent, QPointF, Qt
+    from PyQt6.QtGui import QMouseEvent, QPixmap
+
+    from negpy.desktop.view.sidebar.roi_image import RoiImageLabel
+
+    img = RoiImageLabel()
+    img.resize(200, 200)
+    img.set_frame(QPixmap(100, 100))  # a frame so _display() maps clicks onto fractions
+
+    def _click(x, y):
+        pos = QPointF(x, y)
+        img.mousePressEvent(
+            QMouseEvent(
+                QEvent.Type.MouseButtonPress, pos, Qt.MouseButton.LeftButton, Qt.MouseButton.LeftButton, Qt.KeyboardModifier.NoModifier
+            )
+        )
+        img.mouseReleaseEvent(
+            QMouseEvent(
+                QEvent.Type.MouseButtonRelease, pos, Qt.MouseButton.LeftButton, Qt.MouseButton.NoButton, Qt.KeyboardModifier.NoModifier
+            )
+        )
+
+    _click(100, 100)
+    assert img.roi() is not None  # unlocked → a click drops the sampling patch
+
+    img.clear_roi()
+    img.set_roi_locked(True)
+    _click(120, 120)
+    assert img.roi() is None  # locked → the click is ignored, no patch placed
+
+
 def test_capture_error_closes_the_stale_live_view_session():
     w = _sidebar()
     w.set_scanning(True)
@@ -674,7 +759,7 @@ def test_normal_mode_keeps_the_scan_live_view_steppers():
     assert not w.lv_window.settings_widget.isHidden()
 
 
-def _calibrate(w, monkeypatch, name="Portra 400"):
+def _calibrate(w, monkeypatch, name="Portra 400", status="target"):
     """Drive _on_calibration_finished as the worker would, returning the baked preset."""
     import types
 
@@ -683,8 +768,28 @@ def _calibrate(w, monkeypatch, name="Portra 400"):
     monkeypatch.setattr(w._presets, "get", lambda _n: None)
     monkeypatch.setattr(w, "_reload_presets", lambda **_k: None)
     w._calibrating_preset = name
-    w._on_calibration_finished(types.SimpleNamespace(levels=(200, 180, 90), shutters=("1/5", "1/5", "1/5")))
+    w._on_calibration_finished(types.SimpleNamespace(levels=(200, 180, 90), shutters=("1/5", "1/5", "1/5"), status=status))
     return saved["preset"]
+
+
+def test_calibration_shows_an_aperture_warning_when_over_exposed(monkeypatch):
+    # Graceful over-exposure: the preset is still saved, but the status line tells the user to stop
+    # down (mirrors the solver's "over" status → a clear message, not a silent bad preset).
+    w = _sidebar()
+    _calibrate(w, monkeypatch, status="over")
+    assert "over-exposed" in w.status_label.text() and "close the aperture" in w.status_label.text()
+
+
+def test_calibration_shows_an_aperture_warning_when_under_exposed(monkeypatch):
+    w = _sidebar()
+    _calibrate(w, monkeypatch, status="under")
+    assert "under-exposed" in w.status_label.text() and "open the aperture" in w.status_label.text()
+
+
+def test_calibration_on_target_has_no_warning(monkeypatch):
+    w = _sidebar()
+    _calibrate(w, monkeypatch, status="target")
+    assert "⚠" not in w.status_label.text()
 
 
 def test_calibration_bakes_the_metered_iso_and_aperture(tmp_path, monkeypatch):
@@ -957,3 +1062,182 @@ def test_scan_request_carries_the_preset_exposure(tmp_path):
     w._start_capture(retake=False)
     req = w.controller.start_capture.call_args[0][0]
     assert req.iso == "100" and req.aperture == "f/8"  # the worker forces these on the body
+
+
+def test_available_shutters_drops_unparseable_labels_from_any_body(monkeypatch):
+    # The camera's shutter ladder is untrusted input: the a7 IV publishes "1/0" (a bulb-like label
+    # with a zero denominator), other bodies publish "Bulb"/"" etc. _available_shutters must skip
+    # every unparseable label without crashing and keep the usable ones, whatever the model. This
+    # guards Bug 4 generically (any body), not just the specific a7 IV "1/0" that was reported.
+    w = _sidebar()
+    monkeypatch.setattr(
+        w,
+        "_settings_json",
+        lambda: {
+            "shutter": {
+                "options": [
+                    {"label": "1/250"},
+                    {"label": "1/0"},  # a7 IV bulb-like: zero denominator (was an uncaught crash)
+                    {"label": "Bulb"},  # string bulb: non-numeric
+                    {"label": ""},  # empty label
+                    {"label": "1/60"},
+                    {"label": "2"},  # 2 s: within the calibration range (under-exposure cure) → kept
+                    {"label": "30"},  # 30 s: parses fine but outside the solver's ladder → dropped
+                ]
+            }
+        },
+    )
+    # No exception, junk dropped, usable labels kept fastest-first — INCLUDING the 2 s label (the
+    # under-exposure cure needs it; a <=1 s cap here would silently block it).
+    assert w._available_shutters() == ("1/250", "1/60", "2")
+
+
+def test_available_shutters_clamps_to_the_solver_ladder_at_both_ends(monkeypatch):
+    # This per-body ladder overrides the built-in one, so every limit the solver relies on must hold
+    # here too. The floor is the PWM-banding guard: the Scanlight dims at 40 kHz, so a 1/250 s frame
+    # integrates ~160 pulses while a body's 1/8000 s catches ~5 and meters noise. Bodies publish down
+    # to 1/8000, so without this clamp the probe could halve its way there and poison k.
+    from negpy.services.capture.calibration import SHUTTER_CANDIDATES, shutter_seconds
+
+    w = _sidebar()
+    monkeypatch.setattr(
+        w,
+        "_settings_json",
+        lambda: {
+            "shutter": {
+                "options": [
+                    {"label": "1/8000"},  # far below the solver's floor → dropped (PWM banding)
+                    {"label": "1/1000"},  # still faster than the ladder's floor → dropped
+                    {"label": "1/250"},  # exactly the floor → kept
+                    {"label": "1/60"},
+                    {"label": "2"},  # exactly the ceiling → kept
+                    {"label": "4"},  # beyond the ceiling → dropped
+                ]
+            }
+        },
+    )
+    assert w._available_shutters() == ("1/250", "1/60", "2")
+    # Bounds are derived from the solver's ladder, never restated — extending SHUTTER_CANDIDATES
+    # must widen this automatically, or the two silently disagree depending on whether live view
+    # published a ladder.
+    assert shutter_seconds(SHUTTER_CANDIDATES[0]) <= shutter_seconds("1/250")
+    assert shutter_seconds("2") <= shutter_seconds(SHUTTER_CANDIDATES[-1])
+
+
+def test_calibration_finish_zeroes_the_white_slider_and_preset(monkeypatch):
+    # A calibrated preset is RGB-only (the Scanlight can't mix white with RGB). If the W slider
+    # still carries a prior white preset's 255, it must not leak into the saved preset. Regression:
+    # the calibrated preset stored w_level=255 and the slider kept showing white on (Bug 2).
+    w = _sidebar()
+    w._set_slider(w.w_slider, 255)  # as a previously selected white-light preset would leave it
+    preset = _calibrate(w, monkeypatch)
+    assert preset.w_level == 0  # baked preset carries no white
+    assert w.w_slider.value() == 0  # and the slider reflects it
+
+
+def test_new_preset_frames_with_the_calibration_start_point_not_the_preset(monkeypatch):
+    # Opening the calibration pop-up frames with the calibration's fixed start point
+    # (REFERENCE_LEVELS) — not the leftover R/G/B of the previously selected preset (Bug 5). It
+    # pushes that light DIRECTLY and leaves the shared R/G/B/W sliders on the selected preset, so
+    # the preset's own light is restored on cancel/hand-off (the shared-slider regression).
+    from negpy.services.capture.calibration import REFERENCE_LEVELS
+
+    w = _sidebar()  # RGB mode is the default
+    for slider, value in ((w.r_slider, 40), (w.g_slider, 30), (w.b_slider, 250), (w.w_slider, 0)):
+        w._set_slider(slider, value)  # the selected preset — distinct from REFERENCE_LEVELS
+    w._on_preset_new()
+    r, g, b, wl, _port = w.controller.set_scanlight_color.call_args[0]
+    assert (r, g, b, wl) == (*REFERENCE_LEVELS, 0)  # framed at the calibration start point
+    assert (w.r_slider.value(), w.g_slider.value(), w.b_slider.value()) == (40, 30, 250)  # preset untouched
+
+
+def test_cancelling_calibration_leaves_scan_framing_on_the_preset():
+    # The scan window frames on the selected preset's RGB. Cancelling the calibration pop-up must not
+    # leave the scan framing stuck on the calibration start-point light — the shared R/G/B/W sliders
+    # are why the direct-push framing light matters (guards the regression Bug 5's first fix caused).
+    w = _sidebar()
+    for slider, value in ((w.r_slider, 40), (w.g_slider, 30), (w.b_slider, 250), (w.w_slider, 0)):
+        w._set_slider(slider, value)  # the selected preset — distinct from REFERENCE_LEVELS
+    w._on_preset_new()  # frames at the start point (pushed directly, sliders untouched)
+    w._on_calib_window_closed()  # cancel
+    w.controller.set_scanlight_color.reset_mock()
+    w._on_live_view_toggled(True)  # open the scan live view
+    r, g, b, wl, _port = w.controller.set_scanlight_color.call_args[0]
+    assert (r, g, b, wl) == (40, 30, 250, 0)  # the preset's light, not the start-point framing light
+
+
+def test_calibration_pop_up_settings_poll_re_enables_iso_and_aperture(tmp_path, monkeypatch):
+    # Bug 1: after camera idle, opening the calibration pop-up directly used to leave ISO/aperture
+    # greyed out because the ~1/s settings poll only ran while the SCAN window streamed. It now runs
+    # for the calibration window too, so a fresh writable settings JSON re-enables its ISO/aperture
+    # without first opening the scan window (Robin's workaround). Guards against re-gating the poll.
+    import json
+
+    from PyQt6.QtGui import QPixmap
+
+    import negpy.desktop.view.sidebar.scanlight as sl
+
+    p = tmp_path / "settings.json"
+    p.write_text(
+        json.dumps(
+            {
+                "iso": {"cur": 2, "writable": True, "options": [{"raw": 0, "label": "Auto"}, {"raw": 2, "label": "100"}]},
+                "aperture": {"cur": 8, "writable": True, "options": [{"raw": 8, "label": "f/8"}]},
+            }
+        )
+    )
+    monkeypatch.setattr(sl, "default_settings_path", lambda: str(p))
+
+    w = _sidebar()
+    w.calib_window.iso_stepper.setEnabled(False)  # camera-idle: greyed out
+    w.calib_window.aperture_stepper.setEnabled(False)
+    w._lv_target = w.calib_window.image  # the calibration pop-up is the streaming target
+    w._calibrating_preset = ""  # not mid-run (a run would legitimately keep them locked)
+
+    # Drive one live-view frame landing on the ~1/s poll boundary.
+    img = tmp_path / "frame.png"
+    pm = QPixmap(8, 8)
+    pm.fill()
+    assert pm.save(str(img), "PNG")  # a valid image so _refresh_live_view gets past the null check
+    w._lv_jpeg_path = str(img)
+    w._lv_last_mtime = 0.0
+    w._lv_frames_seen = 11  # +1 → 12 → the poll fires
+
+    w._refresh_live_view()
+
+    assert w.calib_window.iso_stepper.isEnabled()  # writable body value → re-enabled by the poll
+    assert w.calib_window.aperture_stepper.isEnabled()
+    assert w.calib_window.iso_stepper.count() == 2  # and populated from the body's options
+
+
+def test_calibrate_request_carries_the_iso_aperture_normalized_start_point(tmp_path, monkeypatch):
+    # Phase-1 wiring: the sidebar reads the body's live ISO/aperture and hands the solver a start
+    # point scaled to them. ISO 400 (2 stops more sensitive) → start shutter 2 stops faster (1/5 → 1/20);
+    # levels stay fixed (same Scanlight).
+    import json
+
+    import negpy.desktop.view.sidebar.scanlight as sl
+    from negpy.services.capture.calibration import REFERENCE_LEVELS
+
+    p = tmp_path / "settings.json"
+    p.write_text(
+        json.dumps(
+            {
+                "iso": {"cur": 4, "writable": True, "options": [{"raw": 4, "label": "400"}]},
+                "aperture": {"cur": 8, "writable": True, "options": [{"raw": 8, "label": "f/8"}]},
+                "shutter": {"options": [{"label": "1/250"}, {"label": "1/20"}, {"label": "1/5"}]},
+            }
+        )
+    )
+    monkeypatch.setattr(sl, "default_settings_path", lambda: str(p))
+
+    w = _sidebar()
+    roi_sentinel = object()
+    monkeypatch.setattr(w.calib_window.image, "roi", lambda: roi_sentinel)
+    w._on_calibrate_new_preset("Portra 400")
+
+    req = w.controller.start_calibration.call_args[0][0]
+    assert req.roi is roi_sentinel
+    assert req.start_shutter == "1/20"  # 1/5 scaled 2 stops faster for ISO 400
+    assert req.start_levels == REFERENCE_LEVELS  # unchanged — same light for every body
+    assert req.shutter_candidates == ("1/250", "1/20", "1/5")

--- a/tests/test_scanlight_sidebar.py
+++ b/tests/test_scanlight_sidebar.py
@@ -925,6 +925,20 @@ def test_poll_status_carries_white_capability_to_the_ui():
     assert w._light_has_white is False and w._slider_rows[w.w_slider].isHidden()
 
 
+def test_rgb_only_scanlight_hides_the_temperature():
+    w = _sidebar()
+    w._light_has_white = False  # v1-v3: no temperature sensor, reports a bogus 0 °C
+    w._on_light_temp(0.0)
+    assert w.light_temp.isHidden()  # not shown as "0 °C"
+
+
+def test_white_scanlight_shows_the_temperature():
+    w = _sidebar()
+    w._light_has_white = True  # v4 / Big have a thermistor
+    w._on_light_temp(42.0)
+    assert not w.light_temp.isHidden() and "42" in w.light_temp.text()
+
+
 def test_rgb_preset_shows_the_exposure_fields(monkeypatch):
     w = _sidebar()
     monkeypatch.setattr(w._presets, "get", lambda _n: _rgb_preset(iso="100", aperture="f/8"))

--- a/tests/test_scanlight_sidebar.py
+++ b/tests/test_scanlight_sidebar.py
@@ -792,6 +792,23 @@ def test_calibration_on_target_has_no_warning(monkeypatch):
     assert "⚠" not in w.status_label.text()
 
 
+def test_calibration_warning_survives_the_light_echo(monkeypatch):
+    # The bug this pins: _on_calibration_finished sets the R/G/B sliders, each start()s the 60 ms
+    # light debounce; the worker's light_set echo then wrote "Light: R… G… B…" over the warning —
+    # so the one line telling the user their preset is over-exposed lived for a blink and vanished.
+    # The tests above never caught it because the echo arrives after the handler returns.
+    w = _sidebar()
+    _calibrate(w, monkeypatch, status="over")
+    assert "over-exposed" in w.status_label.text()
+    w._on_light_set(213, 92, 78, 0)  # the async echo, exactly as the worker delivers it
+    assert "over-exposed" in w.status_label.text(), "the light echo must not clobber the calibration outcome"
+    # The pin is not forever: the next user-driven status (a new flow) replaces it, and the ambient
+    # light echo works again afterwards.
+    w._set_status("Calibrating a new preset — see the pop-up.")
+    w._on_light_set(10, 20, 30, 0)
+    assert w.status_label.text() == "Light: R10 G20 B30"
+
+
 def test_calibration_bakes_the_metered_iso_and_aperture(tmp_path, monkeypatch):
     import json
 


### PR DESCRIPTION
## The bug

Calibration never converged reliably, and every fix surfaced another symptom. All of it came from one place: **the calibration was not measuring light.**

`linear_demosaic` ran LibRaw's default `adjust_maximum_thr=0.75`, which silently switches the scaling reference from the camera's white level to *the frame's own brightest pixel* once that exceeds 75% of it. Every frame got normalised by its own content, so a meter comparing frames compared nothing.

On the rig this looked exactly like a hardware fault:

| LED level | raw Bayer | demosaiced |
|---|---|---|
| 128 | 6818 | 34315 |
| 140 | 7359 | **34296** |
| 160 | 8249 | **34350** |

The sensor sees the light rise, the decode flattens it. Hours went into diagnosing an "LED plateau" that never existed.

## Three faults, none of which crash

1. **Decode.** `adjust_maximum_thr=0.0` pins the scale to the camera's white level, which is what `CLIP_CEILING` always assumed, and what the module comment already claimed (wrongly).

2. **Shutter labels are rounded names, not times.** The ladder is geometric: `"1/3"` exposes `2^(-5/3)` = 0.315s, not 0.333s, up to 6.7% off. `k` is exposure-normalised, so the error entered `k` at the probe and got spent again at the solve. `true_seconds()` undoes it and derives the ladder spacing (thirds or halves) from the body's own labels instead of assuming. `shutter_at_least()` compared nominal labels against a real time and accepted rungs exposing *less* than demanded, breaking the guarantee that the dimmest channel stays at or below `PWM_MAX_SAFE`. That is why R pinned at the 255 clamp.

3. **The per-body ladder ignored the solver's floor.** `_available_shutters` mirrored the 2s ceiling but not the 1/250s floor, and it overrides the built-in ladder, so the probe could halve its way to 1/8000s, catching ~5 pulses of the Scanlight's 40 kHz PWM. Both bounds now derive from `SHUTTER_CANDIDATES`.

## Fixes #478

The a7 IV publishes a bulb-like `"1/0"` shutter label; `shutter_seconds` divided by zero while building the ladder, killing calibration before it started. Two users hit this independently, and @cimelab's log confirms it:

```
scanlight.py:739  in _on_calibrate_new_preset
scanlight.py:705  in _available_shutters
calibration.py:87 in shutter_seconds
ZeroDivisionError: float division by zero
```

Three of the five symptoms in #478 are this single bug: the preset-button crash, "Calibrate & Save" crashing, and calibration not completing.

**Still open in #478:** @noisy-ctrl's Fuji GFX live view. That belongs to #479, not this PR.

## Verification

Portra 400, ISO 100 / f8:

```
kR=699.2  kG=1617.2  kB=1895.3  (spread 1.44 stops)
R -> level 213, shutter 4/10  (target 58982, got 59679, +1.2%)
G -> level  92, shutter 4/10  (got 59263, +0.5%)
B -> level  78, shutter 4/10  (got 58814, -0.3%)
```

All three channels within 1.2% of target, R clear of the clamp, no trim correction needed. The same film previously pinned R at 255 and missed by 9%. 1873 tests pass.

## Also in here

Solver rebuilt on the measured linear model (analytic solve, graceful over/under status instead of raising), rig-measured reference start point, calibration inputs/ROI frozen while metering, live-view settings refresh no longer gated to the scan window, white slider zeroed on an RGB preset.

## Not in here

`image_processor.py` and `preview_manager.py` run the same LibRaw default. Harmless for a single rendered image, but the RGB-scan merge decodes three exposures that could each get their own scale. Whether real scans are affected is measurable (compare `rawmax` across a triplet) and left out deliberately: it changes rendered output and needs its own verification.
