### PR TITLE
fix(export): batch "Export All (saved settings)" respects session export format (#527)

### DIFF
--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -2376,9 +2376,10 @@ class AppController(QObject):
             if override_settings:
                 params = replace(params, export=current_export)
             else:
-                # Always use current session export path/mode even for per-file
-                # exports. Per-file configs from the DB bypass _apply_sticky_settings
-                # and may have stale ABSOLUTE/export_path values.
+                # Always use current session export path/mode/format even for
+                # per-file exports. Per-file configs from the DB bypass
+                # _apply_sticky_settings and may have stale ABSOLUTE/export_path
+                # or DNG export_fmt values that don't match what the UI shows.
                 params = replace(
                     params,
                     export=replace(
@@ -2386,6 +2387,8 @@ class AppController(QObject):
                         output_mode=current_export.output_mode,
                         export_path=current_export.export_path,
                         output_subfolder=current_export.output_subfolder,
+                        export_fmt=current_export.export_fmt,
+                        export_color_space=current_export.export_color_space,
                     ),
                 )
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -10,7 +10,7 @@ from PyQt6.QtWidgets import QApplication
 from negpy.desktop.controller import AppController
 from negpy.desktop.session import DesktopSessionManager, AppState, ToolMode
 from negpy.desktop.workers.export import ExportTask, resolve_export_target_path
-from negpy.domain.models import ExportConfig, ExportFormat, ExportPreset, ExportPresetOutputMode, WorkspaceConfig
+from negpy.domain.models import ColorSpace, ExportConfig, ExportFormat, ExportPreset, ExportPresetOutputMode, WorkspaceConfig
 from negpy.services.rendering.preview_manager import PreviewManager
 
 if not QApplication.instance():
@@ -589,29 +589,46 @@ class TestBatchExportFiltering(unittest.TestCase):
             self.assertEqual(t.params.export.export_path, "/tmp/out")
 
     def test_export_all_saved_overrides_path_with_session_values(self):
-        """all_saved scope uses session path/mode even when per-file configs are stale."""
+        """all_saved scope uses session path/mode/format even when per-file configs are stale."""
         self.visible_indices = [0, 1]
         session_export = self.controller.state.config.export
+        # Per-file config has stale SAME_AS_SOURCE (differs from session default
+        # ABSOLUTE) + stale DNG + stale AdobeRGB + stale jpeg_quality — delivery
+        # overrides (mode, fmt, color_space) must use session; sizing (quality) is
+        # preserved from per-file.
         stale_export = replace(
             session_export,
-            output_mode=ExportPresetOutputMode.ABSOLUTE,
+            output_mode=ExportPresetOutputMode.SAME_AS_SOURCE,
             export_path="/stale/default",
             output_subfolder="old_sub",
+            export_fmt=ExportFormat.DNG,
+            export_color_space=ColorSpace.ADOBE_RGB.value,
+            jpeg_quality=50,
         )
         stale_config = replace(self.controller.state.config, export=stale_export)
-        # Per-file config has stale ABSOLUTE; session has SAME_AS_SOURCE
         self.mock_session_manager.repo.load_file_settings.return_value = stale_config
         self.controller.request_batch_export(override_settings=False)
         tasks = self._captured_tasks()
         self.assertEqual(len(tasks), 2)
         for t in tasks:
-            # output_mode and output_subfolder come from session config
+            # output_mode is overridden from session (ABSOLUTE), NOT stale (SAME_AS_SOURCE)
             self.assertEqual(t.params.export.output_mode, session_export.output_mode)
+            self.assertNotEqual(t.params.export.output_mode, ExportPresetOutputMode.SAME_AS_SOURCE)
             self.assertEqual(t.params.export.output_subfolder, session_export.output_subfolder)
             # export_path is validated by _ensure_valid_export_path (mocked to /tmp/out)
             self.assertEqual(t.params.export.export_path, "/tmp/out")
-            # Format/quality from per-file config is preserved
-            self.assertEqual(t.params.export.export_fmt, stale_export.export_fmt)
+            # Format/color-space from session config overrides per-file values so
+            # the delivery format matches what the UI shows, not a stale per-file setting.
+            # Without the fix, stale_export.export_fmt=DNG would leak into the export.
+            self.assertEqual(t.params.export.export_fmt, session_export.export_fmt)
+            self.assertNotEqual(t.params.export.export_fmt, ExportFormat.DNG)
+            self.assertEqual(t.params.export.export_color_space, session_export.export_color_space)
+            self.assertNotEqual(t.params.export.export_color_space, ColorSpace.ADOBE_RGB.value)
+            # Quality/sizing from per-file config is preserved
+            self.assertEqual(t.params.export.jpeg_quality, stale_export.jpeg_quality)
+            # Verify export_settings (the delivery config the worker actually reads)
+            self.assertEqual(t.export_settings.export_fmt, session_export.export_fmt)
+            self.assertEqual(t.export_settings.export_color_space, session_export.export_color_space)
 
 
 class TestPresetBatchExport(unittest.TestCase):


### PR DESCRIPTION
Fixes #527 -- batch export intermittently writes unprocessed .dng instead of the JPEG/TIFF selected in the Export panel.

## Root cause

In `request_batch_export(override_settings=False)` (the "Export All (saved settings)" path), only `output_mode`, `export_path`, and `output_subfolder` were overridden from the session config. `export_fmt` and `export_color_space` stayed whatever the per-file DB config had. A file whose saved config had `export_fmt=DNG` (e.g. from a prior flat-export session) would export as .dng regardless of what the Export panel shows.

The override list was introduced in 1deeba6 to fix stale path/mode (issue #292) and intentionally preserved per-file format. But format and color space are delivery choices, not per-file develop settings.

## Fix

Added `export_fmt` and `export_color_space` to the session-override list so they always match what the user sees in the Export panel. Per-file sizing/quality settings (`jpeg_quality`, `export_resolution_mode`, etc.) are still preserved. The flat-master path runs after this and still correctly forces TIFF/DNG for flat exports. The `override_settings=True` and single-export paths are untouched.

## Files changed

- `negpy/desktop/controller.py` -- +2 lines in the `else` branch override list
- `tests/test_controller.py` -- strengthened the saved-settings test with distinct stale values (DNG vs JPEG, AdobeRGB vs sRGB, SAME_AS_SOURCE vs ABSOLUTE) so the assertions actually catch a regression

## Verification
- 1953 tests pass, no regressions
- Temporarily reverting the fix causes the test to fail with `DNG != JPEG` -- confirmed it catches the bug
- Lint and type checks clean