### PR TITLE
feat: consolidate crop ratio picker, add common print/screen sizes

### DIFF
--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -41,6 +41,7 @@ from negpy.domain.models import (
     ExportPresetOutputMode,
     ExportResolutionMode,
     WorkspaceConfig,
+    canonical_crop_ratio,
     export_blocked,
     flat_export_config,
     flat_master_config,
@@ -1309,7 +1310,11 @@ class AppController(QObject):
         if geom.fine_rotation != 0.0:
             transformed = apply_fine_rotation(transformed, geom.fine_rotation)
 
-        new_ratio = detect_closest_aspect_ratio(transformed, fallback=geom.autocrop_ratio)
+        # Detection can match a portrait-oriented frame to a portrait-only AspectRatio
+        # (e.g. "2:3") that the ratio picker doesn't display — canonicalize so the
+        # stored ratio always matches an entry the picker can show (see
+        # domain.models.CROP_RATIO_CHOICES; the crop tool auto-orients regardless).
+        new_ratio = canonical_crop_ratio(detect_closest_aspect_ratio(transformed, fallback=geom.autocrop_ratio))
         if new_ratio == geom.autocrop_ratio:
             return
 

--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -55,7 +55,7 @@ from negpy.features.exposure.logic import (
 )
 from negpy.features.exposure.models import ExposureConfig
 from negpy.features.finish.models import FinishConfig
-from negpy.features.geometry.logic import apply_fine_rotation, detect_closest_aspect_ratio
+from negpy.features.geometry.logic import apply_fine_rotation, detect_closest_aspect_ratio, enforce_roi_aspect_ratio
 from negpy.features.geometry.models import FINE_ROTATION_LIMIT, AutocropMode
 from negpy.features.lab.models import LabConfig
 from negpy.features.local.models import LocalAdjustmentsConfig
@@ -1082,6 +1082,36 @@ class AppController(QObject):
         inside the crop box so the user needn't return to the Crop button."""
         if self.state.active_tool == ToolMode.CROP_MANUAL:
             self.set_active_tool(ToolMode.NONE)
+
+    def set_crop_ratio(self, ratio: str) -> None:
+        """Sets the sidebar Ratio picker's target ratio. If a manual crop box is
+        already drawn, reshapes it to the new ratio in place — same center, shrunk
+        to fit within its current footprint (enforce_roi_aspect_ratio, the same
+        centered-reshape auto-crop uses) — instead of leaving the box visually
+        stale until the user redrags it."""
+        geom = self.state.config.geometry
+        if ratio == geom.autocrop_ratio:
+            return
+        new_geo = replace(geom, autocrop_ratio=ratio)
+
+        rect = geom.manual_crop_rect
+        img = self.state.preview_raw
+        if rect is not None and img is not None:
+            h, w = img.shape[:2]
+            if geom.rotation in (1, 3):
+                h, w = w, h
+            nx1, ny1, nx2, ny2 = rect
+            roi_px = (round(ny1 * h), round(ny2 * h), round(nx1 * w), round(nx2 * w))
+            y1, y2, x1, x2 = enforce_roi_aspect_ratio(roi_px, h, w, ratio)
+            new_geo = replace(new_geo, manual_crop_rect=(x1 / w, y1 / h, x2 / w, y2 / h))
+
+        self._crop_bounds_dirty = False
+        new_proc = replace(self.state.config.process, **invalidate_local_bounds(self.state.config.process))
+        self.session.update_config(replace(self.state.config, geometry=new_geo, process=new_proc), persist=True)
+        # Same spinner/overlay treatment as reset_crop/apply_auto_crop: the bounds
+        # recompute above can take a noticeable moment on a large HQ frame.
+        self.loading_started.emit()
+        self.request_render()
 
     def handle_analysis_rect_changed(self, nx1: float, ny1: float, nx2: float, ny2: float, persist: bool) -> None:
         """Live-update (persist=False) or commit (persist=True) the freehand analysis

--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -1088,7 +1088,17 @@ class AppController(QObject):
         already drawn, reshapes it to the new ratio in place — same center, shrunk
         to fit within its current footprint (enforce_roi_aspect_ratio, the same
         centered-reshape auto-crop uses) — instead of leaving the box visually
-        stale until the user redrags it."""
+        stale until the user redrags it.
+
+        Deliberately does NOT invalidate the metering bounds, unlike the other crop
+        entry points. Those clear them because the crop decides whether the film
+        rebate is inside the metered region (resolve_analysis_region meters within
+        context.active_roi), and letting clear base into the meter wrecks the
+        bounds. A ratio change can't do that: both this reshape and autocrop's
+        _enforce_ratio_by_occupancy only ever shrink the box inside a footprint
+        that already excludes the rebate, so the new ROI is a subset of the old
+        one. Re-metering there can only drift the per-channel floors/ceils — i.e.
+        a visible colour shift from what is supposed to be a pure reframe."""
         geom = self.state.config.geometry
         if ratio == geom.autocrop_ratio:
             return
@@ -1105,11 +1115,10 @@ class AppController(QObject):
             y1, y2, x1, x2 = enforce_roi_aspect_ratio(roi_px, h, w, ratio)
             new_geo = replace(new_geo, manual_crop_rect=(x1 / w, y1 / h, x2 / w, y2 / h))
 
-        self._crop_bounds_dirty = False
-        new_proc = replace(self.state.config.process, **invalidate_local_bounds(self.state.config.process))
-        self.session.update_config(replace(self.state.config, geometry=new_geo, process=new_proc), persist=True)
-        # Same spinner/overlay treatment as reset_crop/apply_auto_crop: the bounds
-        # recompute above can take a noticeable moment on a large HQ frame.
+        self.session.update_config(replace(self.state.config, geometry=new_geo), persist=True)
+        # Same spinner/overlay treatment as reset_crop/apply_auto_crop: the base
+        # stage still re-runs (geometry is part of its cache key), which can take a
+        # noticeable moment on a large HQ frame.
         self.loading_started.emit()
         self.request_render()
 

--- a/negpy/desktop/view/sidebar/geometry.py
+++ b/negpy/desktop/view/sidebar/geometry.py
@@ -187,13 +187,7 @@ class GeometrySidebar(BaseSidebar):
         )
 
     def _on_ratio_changed(self, ratio: str) -> None:
-        new_config = replace(
-            self.state.config,
-            geometry=replace(self.state.config.geometry, autocrop_ratio=ratio),
-            process=replace(self.state.config.process, **invalidate_local_bounds(self.state.config.process)),
-        )
-        self.controller.session.update_config(new_config, persist=True)
-        self.controller.request_render()
+        self.controller.set_crop_ratio(ratio)
 
     def _on_mode_changed(self, idx: int) -> None:
         self.auto_crop_all_btn.setEnabled(self.mode_combo.itemData(idx) == AutocropMode.IMAGE)

--- a/negpy/desktop/view/sidebar/geometry.py
+++ b/negpy/desktop/view/sidebar/geometry.py
@@ -16,7 +16,7 @@ from negpy.desktop.view.sidebar.base import BaseSidebar
 from negpy.desktop.view.styles.templates import EditedDot, default_button_height, field_label, section_subheader
 from negpy.desktop.view.styles.theme import THEME
 from negpy.desktop.view.widgets.sliders import CompactSlider
-from negpy.domain.models import AspectRatio
+from negpy.domain.models import CROP_RATIO_CHOICES, canonical_crop_ratio
 from negpy.features.geometry.models import FINE_ROTATION_LIMIT, AutocropMode
 from negpy.features.process.models import invalidate_local_bounds
 
@@ -52,10 +52,11 @@ class GeometrySidebar(BaseSidebar):
         ratio_row = QHBoxLayout()
         ratio_row.addWidget(self._field_label("Ratio"))
         self.ratio_combo = QComboBox()
-        # Filter out 'Original' as it's not a crop ratio (usually 'Free' is used for no constraint)
-        ratios = [r.value for r in AspectRatio if r != AspectRatio.ORIGINAL]
-        self.ratio_combo.addItems(ratios)
-        self.ratio_combo.setCurrentText(conf.autocrop_ratio)
+        # One entry per shape (see CROP_RATIO_CHOICES) — the crop tool auto-orients
+        # to match the current drag, so a separate portrait entry for every ratio
+        # would just duplicate the same shape twice.
+        self.ratio_combo.addItems([r.value for r in CROP_RATIO_CHOICES])
+        self.ratio_combo.setCurrentText(canonical_crop_ratio(conf.autocrop_ratio))
         self.ratio_combo.setPlaceholderText("Select Ratio...")
         ratio_row.addWidget(self.ratio_combo, 1)
 
@@ -232,7 +233,7 @@ class GeometrySidebar(BaseSidebar):
         try:
             self.guide_combo.setCurrentIndex(self.guide_combo.findData(self.state.crop_guide))
             self._sync_guide_orient_btn()
-            self.ratio_combo.setCurrentText(conf.autocrop_ratio)
+            self.ratio_combo.setCurrentText(canonical_crop_ratio(conf.autocrop_ratio))
             self.mode_combo.setCurrentIndex(self.mode_combo.findData(conf.autocrop_mode))
 
             self.offset_slider.setValue(float(conf.autocrop_offset))

--- a/negpy/domain/models.py
+++ b/negpy/domain/models.py
@@ -40,18 +40,76 @@ MIGRATIONS: Dict[str, str] = {
 class AspectRatio(StrEnum):
     FREE = "Free"
     ORIGINAL = "Original"
+    R_1_1 = "1:1"
     R_3_2 = "3:2"
     R_4_3 = "4:3"
     R_5_4 = "5:4"
     R_6_7 = "6:7"
-    R_1_1 = "1:1"
+    R_7_5 = "7:5"
     R_65_24 = "65:24"
-    # Verticals
+    R_16_9 = "16:9"
+    R_16_10 = "16:10"
+    R_8_5_11 = "8.5:11"
+    # Reciprocal (portrait) mirrors of the ratios above. Not offered in the crop
+    # tool's ratio picker (see CROP_RATIO_CHOICES) — the crop tool auto-orients
+    # a ratio to match the current drag/box (overlay._oriented_target_ratio,
+    # geometry.logic._resolve_ratio_dims), so showing both forms there would just
+    # duplicate the same shape twice. Kept as real members because (a) the export
+    # "Paper ratio" picker does NOT auto-orient — a portrait vs. landscape paper
+    # size are genuinely different choices there — and (b) "Detect closest aspect
+    # ratio" needs both forms to match a portrait-oriented film frame correctly.
     R_2_3 = "2:3"
     R_3_4 = "3:4"
     R_4_5 = "4:5"
     R_7_6 = "7:6"
+    R_5_7 = "5:7"
     R_24_65 = "24:65"
+    R_9_16 = "9:16"
+    R_10_16 = "10:16"
+    R_11_8_5 = "11:8.5"
+
+
+# Ratios offered in the crop tool's ratio picker: one canonical entry per shape
+# (see the AspectRatio docstring above for why the reciprocal forms exist but
+# aren't listed here). FREE is included since it's the "no constraint" choice.
+CROP_RATIO_CHOICES: list[AspectRatio] = [
+    AspectRatio.FREE,
+    AspectRatio.R_1_1,
+    AspectRatio.R_3_2,
+    AspectRatio.R_4_3,
+    AspectRatio.R_5_4,
+    AspectRatio.R_6_7,
+    AspectRatio.R_7_5,
+    AspectRatio.R_65_24,
+    AspectRatio.R_16_9,
+    AspectRatio.R_16_10,
+    AspectRatio.R_8_5_11,
+]
+
+# Maps each reciprocal (portrait) AspectRatio to the canonical entry shown in
+# CROP_RATIO_CHOICES, so a value that only exists in its portrait form (e.g. from
+# "Detect closest aspect ratio" matching a portrait-oriented frame, or a ratio
+# saved before this consolidation) always resolves to something the ratio picker
+# can display.
+_PORTRAIT_TO_CANONICAL_CROP_RATIO: dict[str, str] = {
+    AspectRatio.R_2_3: AspectRatio.R_3_2,
+    AspectRatio.R_3_4: AspectRatio.R_4_3,
+    AspectRatio.R_4_5: AspectRatio.R_5_4,
+    AspectRatio.R_7_6: AspectRatio.R_6_7,
+    AspectRatio.R_5_7: AspectRatio.R_7_5,
+    AspectRatio.R_24_65: AspectRatio.R_65_24,
+    AspectRatio.R_9_16: AspectRatio.R_16_9,
+    AspectRatio.R_10_16: AspectRatio.R_16_10,
+    AspectRatio.R_11_8_5: AspectRatio.R_8_5_11,
+}
+
+
+def canonical_crop_ratio(ratio: str) -> str:
+    """Maps a ratio to the form shown in the crop tool's ratio picker. Portrait-
+    oriented AspectRatio values collapse to their landscape/canonical counterpart
+    (see _PORTRAIT_TO_CANONICAL_CROP_RATIO); "Free", "Original", and anything
+    already canonical pass through unchanged."""
+    return _PORTRAIT_TO_CANONICAL_CROP_RATIO.get(ratio, ratio)
 
 
 class ExportFormat(StrEnum):

--- a/negpy/domain/models.py
+++ b/negpy/domain/models.py
@@ -112,6 +112,28 @@ def canonical_crop_ratio(ratio: str) -> str:
     return _PORTRAIT_TO_CANONICAL_CROP_RATIO.get(ratio, ratio)
 
 
+# Candidates for "Detect closest aspect ratio" (geometry.logic._closest_standard_ratio):
+# real film/scan formats only, both orientations. 7:5, 16:9, 16:10 and 8.5:11 are
+# print/screen *output* sizes, not scannable film formats, and sit close enough to
+# 3:2 (1.4, 1.778, 1.6) and 5:4 (0.773) in log-ratio space that ordinary contour-
+# detection noise on a real 3:2 or 5:4 frame tips the match onto one of them instead
+# — including them here regressed detection to reliably misclassify 35mm scans as
+# "7:5". Keep this set to formats a camera/scanner could actually produce.
+FILM_FORMAT_RATIOS: list[AspectRatio] = [
+    AspectRatio.R_1_1,
+    AspectRatio.R_3_2,
+    AspectRatio.R_2_3,
+    AspectRatio.R_4_3,
+    AspectRatio.R_3_4,
+    AspectRatio.R_5_4,
+    AspectRatio.R_4_5,
+    AspectRatio.R_6_7,
+    AspectRatio.R_7_6,
+    AspectRatio.R_65_24,
+    AspectRatio.R_24_65,
+]
+
+
 class ExportFormat(StrEnum):
     JPEG = "JPEG"
     TIFF = "TIFF"

--- a/negpy/features/geometry/logic.py
+++ b/negpy/features/geometry/logic.py
@@ -5,7 +5,7 @@ from typing import List, NamedTuple, Optional, Tuple
 import cv2
 import numpy as np
 
-from negpy.domain.models import AspectRatio
+from negpy.domain.models import AspectRatio, FILM_FORMAT_RATIOS
 from negpy.domain.types import ROI, ImageBuffer
 from negpy.features.geometry.models import FINE_ROTATION_LIMIT, AutocropMode, GeometryConfig
 from negpy.kernel.image.logic import get_luminance
@@ -1801,10 +1801,12 @@ def _closest_standard_ratio(roi: ROI, img_shape: Tuple[int, int], fallback: str 
     detected = cw / ch
     is_landscape = cw >= ch
 
+    # FILM_FORMAT_RATIOS, not the full AspectRatio enum: the crop-ratio picker's
+    # print/screen sizes (7:5, 16:9, 16:10, 8.5:11) aren't formats a camera/scanner
+    # produces, and sit close enough to 3:2/5:4 in log-ratio space that including
+    # them here made ordinary detection noise on a real 3:2 frame misclassify it.
     candidates: list[tuple[AspectRatio, float]] = []
-    for ratio in AspectRatio:
-        if ratio in (AspectRatio.FREE, AspectRatio.ORIGINAL):
-            continue
+    for ratio in FILM_FORMAT_RATIOS:
         try:
             w_r, h_r = map(float, ratio.value.split(":"))
         except ValueError:

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -272,6 +272,75 @@ class TestAppController(unittest.TestCase):
         self.assertIsNone(saved_config.geometry.manual_crop_rect)
         self.controller.request_render.assert_called_once_with()
 
+    def test_set_crop_ratio_updates_config_when_no_manual_rect(self):
+        self.controller.request_render = MagicMock()
+
+        self.controller.set_crop_ratio("4:3")
+
+        saved_config = self.mock_session_manager.update_config.call_args.args[0]
+        self.assertEqual(saved_config.geometry.autocrop_ratio, "4:3")
+        self.assertIsNone(saved_config.geometry.manual_crop_rect)
+        self.controller.request_render.assert_called_once_with()
+
+    def test_set_crop_ratio_is_noop_when_unchanged(self):
+        geometry = replace(self.controller.state.config.geometry, autocrop_ratio="3:2")
+        self.controller.state.config = replace(self.controller.state.config, geometry=geometry)
+        self.controller.request_render = MagicMock()
+
+        self.controller.set_crop_ratio("3:2")
+
+        self.mock_session_manager.update_config.assert_not_called()
+        self.controller.request_render.assert_not_called()
+
+    def test_set_crop_ratio_reshapes_manual_rect_centered_pixel_aware(self):
+        """Reshaping must use real pixel dimensions, not normalized fractions —
+        a non-square display image means "1:1" in normalized space isn't actually
+        square on screen, so the controller (which has the image shape) must do
+        this, not the sidebar."""
+        import numpy as np
+
+        self.controller.state.preview_raw = np.empty((800, 1200, 3), dtype=np.float32)  # h=800, w=1200
+        geometry = replace(self.controller.state.config.geometry, manual_crop_rect=(0.25, 0.25, 0.75, 0.75))
+        self.controller.state.config = replace(self.controller.state.config, geometry=geometry)
+        self.controller.request_render = MagicMock()
+
+        self.controller.set_crop_ratio("1:1")
+
+        saved_config = self.mock_session_manager.update_config.call_args.args[0]
+        self.assertEqual(saved_config.geometry.autocrop_ratio, "1:1")
+        nx1, ny1, nx2, ny2 = saved_config.geometry.manual_crop_rect
+        # Center unchanged.
+        self.assertAlmostEqual((nx1 + nx2) / 2, 0.5, places=3)
+        self.assertAlmostEqual((ny1 + ny2) / 2, 0.5, places=3)
+        # True pixel square: (nx2-nx1)*1200 == (ny2-ny1)*800.
+        px_w = (nx2 - nx1) * 1200
+        px_h = (ny2 - ny1) * 800
+        self.assertAlmostEqual(px_w, px_h, delta=1.0)
+        self.controller.request_render.assert_called_once_with()
+
+    def test_set_crop_ratio_accounts_for_90_degree_rotation(self):
+        import numpy as np
+
+        # Source is landscape (h=800, w=1200); a 90 rotation makes the display
+        # portrait (h=1200, w=800) — the reshape must use the rotated dims.
+        self.controller.state.preview_raw = np.empty((800, 1200, 3), dtype=np.float32)
+        geometry = replace(
+            self.controller.state.config.geometry,
+            rotation=1,
+            manual_crop_rect=(0.25, 0.25, 0.75, 0.75),
+        )
+        self.controller.state.config = replace(self.controller.state.config, geometry=geometry)
+        self.controller.request_render = MagicMock()
+
+        self.controller.set_crop_ratio("1:1")
+
+        saved_config = self.mock_session_manager.update_config.call_args.args[0]
+        nx1, ny1, nx2, ny2 = saved_config.geometry.manual_crop_rect
+        # Display dims after a 90 rotation: h=1200, w=800.
+        px_w = (nx2 - nx1) * 800
+        px_h = (ny2 - ny1) * 1200
+        self.assertAlmostEqual(px_w, px_h, delta=1.0)
+
     def _export_task(self, path, overwrite=False):
         preset = ExportPreset(
             name="t",

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -292,6 +292,56 @@ class TestAppController(unittest.TestCase):
         self.mock_session_manager.update_config.assert_not_called()
         self.controller.request_render.assert_not_called()
 
+    def test_set_crop_ratio_preserves_metering_bounds(self):
+        """A ratio change is a pure reframe and must not re-meter. Clearing the
+        per-file bounds makes the next render re-analyze over the new (smaller) ROI,
+        which lands on different per-channel floors/ceils — a visible colour cast
+        shift on the canvas from an operation that only changed the frame."""
+        import numpy as np
+
+        self.controller.state.preview_raw = np.empty((800, 1200, 3), dtype=np.float32)
+        floors, ceils = (-2.3, -2.4, -2.8), (-1.3, -1.2, -1.6)
+        config = replace(
+            self.controller.state.config, process=replace(self.controller.state.config.process, local_floors=floors, local_ceils=ceils)
+        )
+        config = replace(config, geometry=replace(config.geometry, manual_crop_rect=(0.15, 0.15, 0.85, 0.85)))
+        self.controller.state.config = config
+        self.controller.request_render = MagicMock()
+
+        self.controller.set_crop_ratio("4:3")
+
+        saved_config = self.mock_session_manager.update_config.call_args.args[0]
+        self.assertEqual(saved_config.process.local_floors, floors)
+        self.assertEqual(saved_config.process.local_ceils, ceils)
+        self.assertTrue(saved_config.process.is_local_initialized)
+
+    def test_set_crop_ratio_reshape_never_grows_the_box(self):
+        """The no-re-meter rule above is only safe because the reshape shrinks within
+        the existing footprint — a box that could grow might pull film rebate into the
+        metered region, which is exactly what the bounds invalidation elsewhere guards."""
+        import numpy as np
+
+        self.controller.state.preview_raw = np.empty((800, 1200, 3), dtype=np.float32)
+        rect = (0.15, 0.15, 0.85, 0.85)
+        self.controller.state.config = replace(
+            self.controller.state.config,
+            geometry=replace(self.controller.state.config.geometry, manual_crop_rect=rect),
+        )
+        self.controller.request_render = MagicMock()
+
+        for ratio in ("1:1", "4:3", "16:9", "65:24", "5:4"):
+            self.mock_session_manager.reset_mock()
+            self.controller.state.config = replace(
+                self.controller.state.config,
+                geometry=replace(self.controller.state.config.geometry, autocrop_ratio="Free", manual_crop_rect=rect),
+            )
+            self.controller.set_crop_ratio(ratio)
+            nx1, ny1, nx2, ny2 = self.mock_session_manager.update_config.call_args.args[0].geometry.manual_crop_rect
+            self.assertGreaterEqual(nx1, rect[0] - 1e-6, f"{ratio}: box grew left")
+            self.assertGreaterEqual(ny1, rect[1] - 1e-6, f"{ratio}: box grew up")
+            self.assertLessEqual(nx2, rect[2] + 1e-6, f"{ratio}: box grew right")
+            self.assertLessEqual(ny2, rect[3] + 1e-6, f"{ratio}: box grew down")
+
     def test_set_crop_ratio_reshapes_manual_rect_centered_pixel_aware(self):
         """Reshaping must use real pixel dimensions, not normalized fractions —
         a non-square display image means "1:1" in normalized space isn't actually

--- a/tests/test_geometry_logic.py
+++ b/tests/test_geometry_logic.py
@@ -1,7 +1,13 @@
 import cv2
 import numpy as np
 import pytest
-from negpy.features.geometry.logic import detect_closest_aspect_ratio, get_autocrop_coords, get_manual_crop_coords, get_manual_rect_coords
+from negpy.features.geometry.logic import (
+    _closest_standard_ratio,
+    detect_closest_aspect_ratio,
+    get_autocrop_coords,
+    get_manual_crop_coords,
+    get_manual_rect_coords,
+)
 from negpy.features.geometry.processor import CropProcessor, GeometryProcessor
 from negpy.features.geometry.models import GeometryConfig
 from negpy.domain.interfaces import PipelineContext
@@ -559,6 +565,22 @@ def test_detect_closest_aspect_ratio_image_dims_sanity_check():
     img[90:150, 20:340] = 0.05  # 60h × 320w ≈ 5.3:1 dark band
     ratio = detect_closest_aspect_ratio(img)
     assert ratio == "3:2"
+
+
+def test_closest_standard_ratio_noisy_3_2_scan_not_misclassified():
+    # Regression: 7:5 (1.4) and 16:10 (1.6) were added to the crop-ratio *picker*
+    # (CROP_RATIO_CHOICES) but ended up in the same enum _closest_standard_ratio
+    # scanned for detection candidates too — close enough to 3:2 (1.5) in log-ratio
+    # space that ordinary contour-detection noise (sprocket holes, margin trimming)
+    # on a genuine 35mm 3:2 scan got misclassified as "7:5" or "16:10" instead of
+    # "3:2". Detection must only consider FILM_FORMAT_RATIOS (real scan formats),
+    # not print/screen output sizes — this sweeps ROIs measuring a few percent off
+    # an exact 3:2 in both directions and checks none of them flip.
+    img_shape = (1000, 1500)  # h, w — image itself is exactly 3:2
+    for cw in (1420, 1450, 1480, 1500, 1520, 1550, 1580):
+        roi = (0, 1000, 0, cw)  # y1, y2, x1, x2
+        ratio = _closest_standard_ratio(roi, img_shape)
+        assert ratio == "3:2", f"cw={cw} (ratio={cw / 1000:.3f}) misclassified as {ratio!r}"
 
 
 def _normalized_roi(roi, h, w):

--- a/tests/test_geometry_logic.py
+++ b/tests/test_geometry_logic.py
@@ -5,7 +5,7 @@ from negpy.features.geometry.logic import detect_closest_aspect_ratio, get_autoc
 from negpy.features.geometry.processor import CropProcessor, GeometryProcessor
 from negpy.features.geometry.models import GeometryConfig
 from negpy.domain.interfaces import PipelineContext
-from negpy.domain.models import AspectRatio
+from negpy.domain.models import CROP_RATIO_CHOICES, AspectRatio, canonical_crop_ratio
 
 
 def test_get_manual_crop_coords_zero_offset():
@@ -1090,3 +1090,46 @@ def test_flip_with_negated_angle_mirrors_rendered_image():
     # Interior comparison: the rotation's border-replicate wedges differ at the edges.
     m = 40
     np.testing.assert_allclose(out_b[m:-m, m:-m], np.fliplr(out_a)[m:-m, m:-m], atol=0.01)
+
+
+def test_crop_ratio_choices_has_no_reciprocal_duplicates():
+    # The crop tool auto-orients a ratio to match the current drag (see
+    # overlay._oriented_target_ratio / geometry.logic._resolve_ratio_dims), so the
+    # picker must never offer both a shape and its reciprocal (e.g. "3:2" and "2:3")
+    # — that would just be the same crop twice.
+    seen: set[float] = set()
+    for ratio in CROP_RATIO_CHOICES:
+        if ratio in (AspectRatio.FREE,):
+            continue
+        w_r, h_r = map(float, ratio.value.split(":"))
+        shape = round(min(w_r / h_r, h_r / w_r), 6)  # orientation-independent
+        assert shape not in seen, f"{ratio.value!r} duplicates a shape already in CROP_RATIO_CHOICES"
+        seen.add(shape)
+
+
+def test_crop_ratio_choices_covers_common_print_and_screen_sizes():
+    values = {r.value for r in CROP_RATIO_CHOICES}
+    for expected in ("7:5", "16:9", "16:10", "8.5:11"):
+        assert expected in values
+
+
+def test_canonical_crop_ratio_maps_portrait_forms_to_the_picker_entry():
+    choice_values = {r.value for r in CROP_RATIO_CHOICES}
+    for hidden, canonical in (
+        ("2:3", "3:2"),
+        ("3:4", "4:3"),
+        ("4:5", "5:4"),
+        ("7:6", "6:7"),
+        ("5:7", "7:5"),
+        ("24:65", "65:24"),
+        ("9:16", "16:9"),
+        ("10:16", "16:10"),
+        ("11:8.5", "8.5:11"),
+    ):
+        assert canonical_crop_ratio(hidden) == canonical
+        assert canonical in choice_values
+
+
+def test_canonical_crop_ratio_passes_through_unrecognized_values():
+    assert canonical_crop_ratio("Free") == "Free"
+    assert canonical_crop_ratio("3:2") == "3:2"


### PR DESCRIPTION
## Summary

Three related changes to the crop-ratio picker and auto-detection:

**1. Consolidated the ratio picker, added common print/screen sizes.** The dropdown listed every ratio in both orientations (3:2 *and* 2:3, 4:3 *and* 3:4, …) even though the crop tool already auto-orients to match the drag — the reversed entries never did anything a single canonical entry couldn't. Now one entry per shape, plus 7:5, 16:9, 16:10 and 8.5:11 which were missing entirely. The full `AspectRatio` enum keeps every reciprocal, because the Export "Paper ratio" picker doesn't auto-orient and genuinely needs both. `canonical_crop_ratio()` maps legacy/portrait stored values onto the visible entry.

**2. The crop box now reshapes when you pick a new ratio.** Previously it stayed visually stale until you redragged it. New `AppController.set_crop_ratio()` reshapes in place around the box's existing center, reusing `enforce_roi_aspect_ratio` (the same centered-reshape auto-crop uses). The math runs in real pixel space and accounts for 90° rotation, since a normalized "square" isn't square on a non-square image.

**3. Fixed auto-detect misclassifying 35mm scans as 7:5.** `_closest_standard_ratio` matched against the whole `AspectRatio` enum, which after change 1 included print/screen output sizes. 7:5 (1.4) and 16:10 (1.6) sit close enough to 3:2 (1.5) in log-ratio space that ordinary contour noise — sprocket holes, margin trimming — tipped a genuine 3:2 frame onto them. Detection now uses a dedicated `FILM_FORMAT_RATIOS` list of formats a camera/scanner can actually produce; the picker keeps the full list.

**4. Fixed a colour shift on ratio change.** Changing the ratio visibly shifted colour on the canvas. `set_crop_ratio` was clearing the per-file metering bounds, and since normalization meters *within* the crop ROI (`resolve_analysis_region`), re-analyzing over the new smaller ROI landed on different per-channel floors/ceils. On a real scan going 3:2 → 4:3 the red floor moved `+0.0058` while blue moved `-0.0056` — opposite directions, a cast shift rather than a brightness change. The other crop paths clear the bounds because the crop decides whether the film rebate is inside the metered region; a ratio change can't pull rebate in, since both the reshape and autocrop's `_enforce_ratio_by_occupancy` only ever shrink within a footprint that already excludes it. So the invalidation there could only ever drift. **This predates the branch** — with auto crop on, the ratio has always fed `get_autocrop_coords` and re-metered; change 2 extended the same fault to the manual-crop path.

## Test plan
- [x] **Colour shift**, verified against the real app on both the manual-crop and auto-crop paths: rendered floors/ceils are now bit-identical across a ratio change, and the shift reproduces when the invalidation is put back
- [x] **Reshape**, verified against the real app: a 0.6×0.7 box at (0.4, 0.55) becomes a true 747×747 pixel square on a 1600×1067 preview, center preserved
- [x] **Detection**: regression test sweeps ROIs measuring 1.42–1.58 (a real 3:2 frame plus plausible detection noise) and confirms none flip to 7:5/16:10
- [x] **Picker**, verified against the real app: dropdown matches `CROP_RATIO_CHOICES` with no reciprocal duplicates, and a legacy `"2:3"` stored value displays as `"3:2"`
- [x] 8 new unit tests across `test_controller.py` and `test_geometry_logic.py`, including a guard that the reshape never grows the box (the invariant change 4 depends on)
- [x] Full suite: 1963 passed. The one failure, `test_export_presets.py::test_output_dir_subfolder_of_source`, is a pre-existing Windows path-separator issue that reproduces on a clean `main`
- [x] `ruff check` / `ruff format --check` clean