### PR TITLE
fix: persist dodge/burn mask visibility across image switches and restarts

### DIFF
--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -1553,10 +1553,13 @@ class AppController(QObject):
         """Show/hide one mask's outline on the canvas (view-only; no re-render)."""
         if not (0 <= index < len(self.state.config.local.masks)):
             return
+        hidden = set(self.state.local_hidden_masks)
         if visible:
-            self.state.local_hidden_masks.discard(index)
+            hidden.discard(index)
         else:
-            self.state.local_hidden_masks.add(index)
+            hidden.add(index)
+        self.state.local_hidden_masks = hidden
+        self.session.persist_hidden_masks()
         if self.canvas:
             self.canvas.overlay.update()
 
@@ -1575,6 +1578,7 @@ class AppController(QObject):
         sel = self.state.local_selected_mask
         self.state.local_selected_mask = -1 if sel == index else (sel - 1 if sel > index else sel)
         self.state.local_hidden_masks = {j - 1 if j > index else j for j in self.state.local_hidden_masks if j != index}
+        self.session.persist_hidden_masks()
 
         self.config_updated.emit()
         self.request_render()

--- a/negpy/desktop/session.py
+++ b/negpy/desktop/session.py
@@ -98,8 +98,11 @@ class AppState:
 
     # Local adjustments UI state (not persisted in workspace config)
     local_selected_mask: int = -1
-    # Indices of masks whose outline is hidden on the canvas; empty = all shown.
-    local_hidden_masks: set = field(default_factory=set)
+    # Per-file sets of mask indices whose outline is hidden on the canvas (keyed by
+    # content hash; empty/absent = all shown). Persisted as the "hidden_masks_by_hash"
+    # global setting (written through on every toggle) and reloaded on launch. Read the
+    # current file's set via the local_hidden_masks property below.
+    local_hidden_masks_by_hash: dict = field(default_factory=dict)
 
     # History tracking
     undo_index: int = 0
@@ -123,6 +126,27 @@ class AppState:
     flat_format: str = "TIFF"  # "TIFF" (16-bit) or "DNG" (linear)
     # Transient: preview is currently peeking the flat render (not persisted).
     flat_peek: bool = False
+
+    @property
+    def local_hidden_masks(self) -> set:
+        """The current file's hidden-mask indices (empty = all shown). Returns a fresh,
+        clamped copy: indices outside the current mask list are dropped, so a config swap
+        that shrinks the mask count (undo/redo/jump-to-step) can't leave stale entries
+        pointing past the end. Assign a set to update the current file's stored entry."""
+        stored = self.local_hidden_masks_by_hash.get(self.current_file_hash, ())
+        n = len(self.config.local.masks)
+        return {i for i in stored if 0 <= i < n}
+
+    @local_hidden_masks.setter
+    def local_hidden_masks(self, value: set) -> None:
+        h = self.current_file_hash
+        if h is None:
+            return
+        # Keep the store free of empty sets so "all shown" is a missing key, not {}.
+        if value:
+            self.local_hidden_masks_by_hash[h] = set(value)
+        else:
+            self.local_hidden_masks_by_hash.pop(h, None)
 
 
 class AssetListModel(QAbstractListModel):
@@ -457,6 +481,13 @@ class DesktopSessionManager(QObject):
         if saved_invert_zoom is not None:
             self.state.invert_zoom_scroll = bool(saved_invert_zoom)
 
+        # Per-file mask hide-state (hash -> hidden indices); JSON stores sets as lists.
+        saved_hidden = self.repo.get_global_setting("hidden_masks_by_hash")
+        if isinstance(saved_hidden, dict):
+            self.state.local_hidden_masks_by_hash = {
+                h: {int(i) for i in idxs} for h, idxs in saved_hidden.items() if isinstance(idxs, list) and idxs
+            }
+
         saved_icc_in = self.repo.get_global_setting("icc_input_path")
         if saved_icc_in and os.path.exists(saved_icc_in):
             self.state.icc_input_path = saved_icc_in
@@ -779,9 +810,6 @@ class DesktopSessionManager(QObject):
 
             self.state.config, self.state.current_file_is_new = self._hydrate_asset_config(file_info)
 
-            # Mask hide-state is keyed by index into this file's masks; the swap invalidates it.
-            self.state.local_hidden_masks = set()
-
             self.file_selected.emit(file_info["path"])
             self.state_changed.emit()
             self._persist_session()
@@ -1039,6 +1067,15 @@ class DesktopSessionManager(QObject):
 
             self.update_config(copy.deepcopy(self.state.clipboard), persist=True)
             self.settings_pasted.emit()
+
+    def persist_hidden_masks(self) -> None:
+        """Writes the per-file mask hide-state through to settings so it survives restarts.
+        Call after any change to local_hidden_masks_by_hash (the AppState setter keeps it
+        free of empty sets; the `if s` filter here is just defensive)."""
+        self.repo.save_global_setting(
+            "hidden_masks_by_hash",
+            {h: sorted(s) for h, s in self.state.local_hidden_masks_by_hash.items() if s},
+        )
 
     def _persist_session(self) -> None:
         """Saves the open-file manifest (paths + active) for restore on next launch."""

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -603,6 +603,8 @@ class TestAppController(unittest.TestCase):
             PolygonMask(vertices=verts, strength=-0.3, feather=0.02),
         )
         self.controller.state.config = replace(self.controller.state.config, local=LocalAdjustmentsConfig(masks=masks))
+        # Hidden-mask state is keyed by the open file's hash; give the tests one.
+        self.controller.state.current_file_hash = "hashA"
 
     def test_set_local_mask_visible_toggles_hidden_set(self):
         self._seed_two_masks()
@@ -610,6 +612,43 @@ class TestAppController(unittest.TestCase):
         self.controller.set_local_mask_visible(1, False)
         self.assertEqual(self.controller.state.local_hidden_masks, {1})
         self.controller.set_local_mask_visible(1, True)
+        self.assertEqual(self.controller.state.local_hidden_masks, set())
+
+    def test_hidden_masks_persist_per_file_hash(self):
+        self._seed_two_masks()
+        self.controller.canvas = None
+        self.controller.state.current_file_hash = "hashA"
+        self.controller.set_local_mask_visible(1, False)
+        self.assertEqual(self.controller.state.local_hidden_masks_by_hash["hashA"], {1})
+
+        # Simulate switching away: another file's set is independent.
+        self.controller.state.current_file_hash = "hashB"
+        self.controller.state.local_hidden_masks = set()
+        self.controller.set_local_mask_visible(0, False)
+        self.assertEqual(self.controller.state.local_hidden_masks_by_hash["hashB"], {0})
+        self.assertEqual(self.controller.state.local_hidden_masks_by_hash["hashA"], {1})
+
+    def test_hidden_masks_cleared_hash_is_pruned(self):
+        self._seed_two_masks()
+        self.controller.canvas = None
+        self.controller.state.current_file_hash = "hashA"
+        self.controller.set_local_mask_visible(1, False)
+        self.controller.set_local_mask_visible(1, True)
+        self.assertNotIn("hashA", self.controller.state.local_hidden_masks_by_hash)
+
+    def test_hidden_masks_clamped_when_mask_count_shrinks(self):
+        from negpy.features.local.models import LocalAdjustmentsConfig, PolygonMask
+
+        self._seed_two_masks()  # 2 masks under hashA
+        self.controller.canvas = None
+        self.controller.set_local_mask_visible(1, False)
+        self.assertEqual(self.controller.state.local_hidden_masks, {1})
+
+        # Simulate an undo/redo/jump that swaps in a config with fewer masks: the stored
+        # index 1 now points past the end and must be dropped from the returned set.
+        verts = ((0.1, 0.1), (0.9, 0.1), (0.5, 0.9))
+        one_mask = (PolygonMask(vertices=verts, strength=0.3, feather=0.02),)
+        self.controller.state.config = replace(self.controller.state.config, local=LocalAdjustmentsConfig(masks=one_mask))
         self.assertEqual(self.controller.state.local_hidden_masks, set())
 
     def test_delete_local_mask_confirmed_remaps_view_indices(self):

--- a/tests/test_desktop_session.py
+++ b/tests/test_desktop_session.py
@@ -905,6 +905,29 @@ class TestRollActionRecoveryRoundTrip(unittest.TestCase):
     def tearDown(self):
         self.tmp.cleanup()
 
+    def test_hidden_masks_survive_restart(self):
+        from negpy.features.local.models import LocalAdjustmentsConfig, PolygonMask
+
+        # hash1 has two masks on disk; index 1 is hidden. The property clamps against the
+        # hydrated mask list, so persistence only "counts" if that config reloads too.
+        verts = ((0.1, 0.1), (0.9, 0.1), (0.5, 0.9))
+        two_masks = (PolygonMask(vertices=verts), PolygonMask(vertices=verts, strength=-0.3))
+        cfg = replace(WorkspaceConfig(), local=LocalAdjustmentsConfig(masks=two_masks))
+        self.repo.save_file_settings("hash1", cfg, file_path=self.session.state.uploaded_files[0]["path"])
+
+        self.session.state.local_hidden_masks_by_hash = {"hash1": {1}, "hash2": set()}
+        self.session.persist_hidden_masks()
+
+        # A fresh manager on the same repo simulates an app restart.
+        restarted = DesktopSessionManager(self.repo)
+        self.assertEqual(restarted.state.local_hidden_masks_by_hash, {"hash1": {1}})
+
+        restarted.state.uploaded_files = self.session.state.uploaded_files
+        restarted.select_file(0)
+        self.assertEqual(restarted.state.local_hidden_masks, {1})
+        restarted.select_file(1)
+        self.assertEqual(restarted.state.local_hidden_masks, set())
+
     def test_sync_then_undo_restores_target(self):
         target_before = replace(WorkspaceConfig(), exposure=replace(WorkspaceConfig().exposure, density=2.0))
         self.repo.save_file_settings("hash2", target_before, file_path=self.session.state.uploaded_files[1]["path"])


### PR DESCRIPTION
## Summary

Fixes #540 — dodge/burn mask visibility now persists across image switches **and** app restarts.

Previously the per-mask "hide outline" toggle lived in a session-only `local_hidden_masks` set keyed by mask index into the *current* file, and it was cleared on every file switch. So visibility reset to "all shown" whenever you changed images, and never survived a restart.

## What changed

- **Per-file, persisted store.** Hidden state now lives in `AppState.local_hidden_masks_by_hash` (content hash → set of indices), written through to the `hidden_masks_by_hash` global setting on every toggle and reloaded on launch. It is deliberately kept out of `WorkspaceConfig`, so toggling an eye icon never dirties the edit/undo history or writes a `.negpy` sidecar — it's view-only state and never affects render or export.
- **Single source of truth.** `local_hidden_masks` is now a derived property over that store (getter returns the current file's set; setter writes it). Switching files needs no special restore step, and the manual two-copy sync that caused the original bug class is gone.
- **Stale-index clamp.** The getter returns a fresh copy clamped to the current mask count, so a config swap that shrinks the mask list (undo/redo/jump-to-step) can't surface an out-of-range index. Storage self-heals on the next toggle.

## Testing

- `make all` green — 1990 passed, 4 skipped.
- New tests: per-file persistence, restart round-trip, empty-set pruning, and the stale-index clamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
