### PR TITLE
feat(assets): half-frame mode — two frames per scan

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,10 @@ Every feature lives in `negpy/features/<name>/`:
 5. Add a sidebar and register it in `ControlsPanel`
 6. Add unit tests; if the feature has both CPU and GPU paths, add a parity test (pattern: `test_gpu_curve_parity.py`)
 
+## Style
+
+- **Comments minimal.** Comment only non-obvious constraints the code can't express (a cache contract, an ordering requirement, a rejected-alternative trap). No comments that narrate what the next line does, restate the diff, or justify a change to a reviewer. Prefer one dense line over a paragraph; docstrings short and factual.
+
 ## Invariants & gotchas
 
 - **CPU/GPU parity**: any change to a stage's math must land in both `logic.py` and its `.wgsl` shader. Constants mirrored as WGSL literals (histogram bins, zone density, metrics offsets) have parity tests — keep them in sync.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.39.0
 
+- New: **Half Frame mode** — a toggle in the Session panel for half-frame cameras (Pentax 17, Olympus Pen…) whose scans hold two photos side by side. Each scan appears as two frames in the contact sheet, split automatically at the gutter between them; every half gets its own edits, its own exposure measurement, its own sidecar, and exports as `name_1` / `name_2`. Toggling off puts the scans back together without losing the per-half edits.
+
 - New: **Set your own Auto Density and Auto Grade targets** — the autos used to aim at fixed numbers baked into the code, which suited one scanner and one taste. A **Set Targets** button next to the two toggles opens sliders for what they aim at: how bright the metered midtone prints, how punchy the roll comes out, and how far each meter is trusted (at zero you get a fixed setting for every frame, at full every frame is forced to the same key or contrast). The preview follows the sliders live, Cancel puts them back, and Restore Defaults returns to the shipped values. It's a calibration rather than an edit — it applies to every image, including ones you've already worked on, and is remembered between sessions.
 
 

--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -48,6 +48,7 @@ from negpy.domain.models import (
     preset_from_export_config,
     resolve_preset_export,
 )
+from negpy.services.assets.half_frame import base_hash, slice_half
 from negpy.services.assets.sidecar import load_or_promote, write_sidecar
 from negpy.features.exposure.logic import (
     calculate_wb_shifts,
@@ -124,6 +125,7 @@ class _DiscoveryRequest:
     replace_existing: bool
     reselect_path: Optional[str]
     rgb_scan: bool
+    half_frame: bool
 
 
 def baseline_compare_config(config: WorkspaceConfig) -> WorkspaceConfig:
@@ -645,6 +647,7 @@ class AppController(QObject):
             replace_existing=replace_existing,
             reselect_path=reselect_path,
             rgb_scan=bool(self.session.repo.get_global_setting("rgbscan_mode", False)),
+            half_frame=bool(self.session.repo.get_global_setting("half_frame_mode", False)),
         )
         if self._discovery_running:
             self._pending_asset_discoveries.append(request)
@@ -676,6 +679,7 @@ class AppController(QObject):
             supported_extensions=tuple(SUPPORTED_RAW_EXTENSIONS),
             rgb_scan=request.rgb_scan,
             restore_triplets=request.restore_triplets,
+            half_frame=request.half_frame,
         )
         self.asset_discovery_requested.emit(task)
 
@@ -699,6 +703,21 @@ class AppController(QObject):
                 replace(self.state.config, process=replace(self.state.config.process, narrowband_scan=True)), persist=True
             )
             self.request_render()
+        paths: List[str] = []
+        for f in files:
+            paths.append(f["path"])
+            for k in ("green_path", "blue_path"):
+                if f.get(k):
+                    paths.append(f[k])
+        self.request_asset_discovery(paths, replace_existing=True, reselect_path=self.state.current_file_path)
+
+    def set_half_frame_mode(self, enabled: bool) -> None:
+        """Persist the half-frame toggle and re-discover already-loaded assets so the
+        mode splits/collapses frames in place (not only on the next folder load)."""
+        self.session.repo.save_global_setting("half_frame_mode", bool(enabled))
+        files = self.session.state.uploaded_files
+        if not files:
+            return
         paths: List[str] = []
         for f in files:
             paths.append(f["path"])
@@ -786,6 +805,17 @@ class AppController(QObject):
                 return f.get("hash")
         return None
 
+    def _active_half(self) -> Optional[tuple[int, float]]:
+        """(half, split_x) of the active asset, or None for whole-frame assets."""
+        h = self.state.current_file_hash
+        if not h:
+            return None
+        for f in self.state.uploaded_files:
+            if f.get("hash") == h:
+                half = int(f.get("half") or 0)
+                return (half, float(f.get("split_x") or 0.5)) if half else None
+        return None
+
     def _render_memo_key(self) -> str:
         """Identity of everything that shapes the displayed render of the current
         config: the edit itself plus every display-path input. Any mismatch is a
@@ -864,7 +894,7 @@ class AppController(QObject):
                 workspace_color_space=self.state.workspace_color_space,
                 use_camera_wb=not self.state.config.process.linear_raw,
                 full_resolution=self.state.hq_preview,
-                file_hash=self._file_hash_for_path(file_path),
+                file_hash=base_hash(self._file_hash_for_path(file_path)),  # halves share the per-file decode cache
                 # A memoized frame is already painted — the embedded-JPEG splash
                 # would repaint stale pixels over it.
                 use_splash=memo is None,
@@ -879,9 +909,27 @@ class AppController(QObject):
             )
         )
 
+    def _split_active_half(self, raw: Any, dims: Any) -> tuple[Any, Any]:
+        """Slice a full-frame decode/splash down to the active half asset (no-op otherwise).
+
+        Both halves decode identically, so slicing by the current selection is safe
+        even for a stale same-path load; cached buffers are read-only, hence the copy.
+        """
+        half_info = self._active_half()
+        if half_info is None:
+            return raw, dims
+        half, split_x = half_info
+        raw = np.ascontiguousarray(slice_half(raw, half, split_x))
+        if dims is not None:
+            h0, w0 = dims
+            xs = min(max(int(round(w0 * split_x)), 1), w0 - 1)
+            dims = (h0, xs) if half == 1 else (h0, w0 - xs)
+        return raw, dims
+
     def _on_splash_preview(self, file_path: str, raw: Any, dims: Any) -> None:
         if self._requested_file_path != file_path:
             return
+        raw, dims = self._split_active_half(raw, dims)
         self.state.original_res = dims
         # Paint the embedded sRGB thumbnail directly — no pipeline; the real render replaces it.
         with self.state.metrics_lock:
@@ -907,6 +955,9 @@ class AppController(QObject):
             (time.perf_counter() - self._preview_load_t0) * 1000,
             file_path,
         )
+        raw, dims = self._split_active_half(raw, dims)
+        if ir_preview is not None:
+            ir_preview, _ = self._split_active_half(ir_preview, None)
         self.state.preview_raw = raw
         self.state.preview_ir = ir_preview
         self.state.has_ir = ir_preview is not None
@@ -946,7 +997,7 @@ class AppController(QObject):
                         # Half-size only: a full-res HQ neighbour (~720MB) evicts the
                         # active buffer; the cache key separates resolutions.
                         full_resolution=False,
-                        file_hash=h,
+                        file_hash=base_hash(h),
                         use_splash=False,
                         for_cache_warm=True,
                     )
@@ -2674,9 +2725,10 @@ class AppController(QObject):
         repo = self.session.repo
         written = 0
         for f in files:
-            params = load_or_promote(repo, f["hash"], f["path"]) or self.state.config
+            half = int(f.get("half") or 0)
+            params = load_or_promote(repo, f["hash"], f["path"], half=half) or self.state.config
             try:
-                write_sidecar(f["path"], params)
+                write_sidecar(f["path"], params, half=half)
                 written += 1
             except Exception as exc:
                 logger.warning("Sidecar write failed for %s: %s", f.get("path"), exc)

--- a/negpy/desktop/session.py
+++ b/negpy/desktop/session.py
@@ -770,7 +770,7 @@ class DesktopSessionManager(QObject):
 
     def _hydrate_asset_config(self, asset: dict) -> tuple[WorkspaceConfig, bool]:
         """Build an asset's effective config and report whether it had saved edits."""
-        saved_config = load_or_promote(self.repo, asset["hash"], asset["path"])
+        saved_config = load_or_promote(self.repo, asset["hash"], asset["path"], half=int(asset.get("half") or 0))
         is_new = saved_config is None
         if saved_config is not None:
             config = self._apply_sticky_settings(saved_config, only_global=True)
@@ -1113,7 +1113,12 @@ class DesktopSessionManager(QObject):
         if validated_info:
             for info in validated_info:
                 same_path_idx = next(
-                    (i for i, existing in enumerate(self.state.uploaded_files) if existing["path"] == info["path"]),
+                    (
+                        i
+                        for i, existing in enumerate(self.state.uploaded_files)
+                        # half-frame assets share a path — match per half
+                        if existing["path"] == info["path"] and existing.get("half") == info.get("half")
+                    ),
                     None,
                 )
                 if same_path_idx is not None:

--- a/negpy/desktop/view/sidebar/files.py
+++ b/negpy/desktop/view/sidebar/files.py
@@ -260,6 +260,13 @@ class FileBrowser(QWidget):
         self.rgb_scan_btn.setChecked(bool(self.session.repo.get_global_setting("rgbscan_mode", False)))
         self._update_rgb_scan_style(self.rgb_scan_btn.isChecked())
 
+        self.half_frame_btn = QToolButton()
+        self.half_frame_btn.setCheckable(True)
+        self.half_frame_btn.setIcon(qta.icon("mdi.view-split-vertical", color=THEME.text_primary))
+        self.half_frame_btn.setToolTip("Half Frame — split each scan into two frames, edited and measured separately")
+        self.half_frame_btn.setChecked(bool(self.session.repo.get_global_setting("half_frame_mode", False)))
+        self._update_half_frame_style(self.half_frame_btn.isChecked())
+
         self.apply_btn = QToolButton()
         self.apply_btn.setIcon(qta.icon("fa5s.clone", color=THEME.text_primary))
         self.apply_btn.setToolTip("Apply settings from the current frame to selected frames or the whole roll")
@@ -317,6 +324,7 @@ class FileBrowser(QWidget):
             self.unload_btn,
             self.hot_folder_btn,
             self.rgb_scan_btn,
+            self.half_frame_btn,
             self.apply_btn,
             self.sheet_btn,
             self.sort_btn,
@@ -331,6 +339,7 @@ class FileBrowser(QWidget):
         toolbar_row.addWidget(self._create_separator())
         toolbar_row.addWidget(self.hot_folder_btn)
         toolbar_row.addWidget(self.rgb_scan_btn)
+        toolbar_row.addWidget(self.half_frame_btn)
         toolbar_row.addWidget(self.apply_btn)
         toolbar_row.addStretch()
         toolbar_row.addWidget(self._create_separator())
@@ -389,6 +398,7 @@ class FileBrowser(QWidget):
         self.list_view.selectionModel().selectionChanged.connect(self._on_selection_changed)
         self.hot_folder_btn.toggled.connect(self._on_hot_folder_toggled)
         self.rgb_scan_btn.toggled.connect(self._on_rgb_scan_toggled)
+        self.half_frame_btn.toggled.connect(self._on_half_frame_toggled)
         self.session.state_changed.connect(self.sync_ui)
         self.session.files_changed.connect(self._on_files_changed)
         self.search_input.textChanged.connect(lambda _: self.filter_timer.start())
@@ -568,6 +578,14 @@ class FileBrowser(QWidget):
     def _on_rgb_scan_toggled(self, checked: bool) -> None:
         self._update_rgb_scan_style(checked)
         self.controller.set_rgb_scan_mode(checked)
+
+    def _update_half_frame_style(self, checked: bool) -> None:
+        icon_color = "white" if checked else THEME.text_primary
+        self.half_frame_btn.setIcon(qta.icon("mdi.view-split-vertical", color=icon_color))
+
+    def _on_half_frame_toggled(self, checked: bool) -> None:
+        self._update_half_frame_style(checked)
+        self.controller.set_half_frame_mode(checked)
 
     def _scan_folder(self) -> None:
         if not self.session.state.uploaded_files:

--- a/negpy/desktop/view/widgets/tutorial_steps.py
+++ b/negpy/desktop/view/widgets/tutorial_steps.py
@@ -40,6 +40,9 @@ def build(window: "MainWindow") -> list[TutorialStep]:
     def _rgbscan(w: "MainWindow") -> Optional[QWidget]:
         return w.session_panel.file_browser.rgb_scan_btn
 
+    def _half_frame(w: "MainWindow") -> Optional[QWidget]:
+        return w.session_panel.file_browser.half_frame_btn
+
     def _flatfield(w: "MainWindow") -> Optional[QWidget]:
         return w.controls_panel.flatfield_sidebar.enable_btn
 
@@ -134,6 +137,21 @@ def build(window: "MainWindow") -> list[TutorialStep]:
                 "run through the normal conversion."
             ),
             target=_rgbscan,
+        ),
+        TutorialStep(
+            title="Half Frame — Two Photos per Scan",
+            body=(
+                "Shooting a half-frame camera — a Pentax 17, an Olympus Pen? Each scan "
+                "holds <b>two photos side by side</b>.<br><br>"
+                "Toggle <b>Half Frame</b> in the Files toolbar and every scan appears as "
+                "two frames on the contact sheet, split automatically at the gutter "
+                "between them. Each half is a full citizen: its own exposure metering, "
+                "its own edits and history, its own sidecar, and exports as "
+                "<code>name_1</code> / <code>name_2</code>.<br><br>"
+                "Toggling off puts the scans back together — per-half edits are kept and "
+                "return when you switch it back on."
+            ),
+            target=_half_frame,
         ),
         TutorialStep(
             title="Keep & Reject — Culling the Roll",

--- a/negpy/desktop/workers/export.py
+++ b/negpy/desktop/workers/export.py
@@ -66,7 +66,12 @@ def resolve_export_naming(task: ExportTask) -> tuple[str, str, str]:
     both conflict detection and the actual write, so they can never disagree."""
     out_dir = resolve_export_dir(task)
     ext = _EXT.get(task.export_settings.export_fmt, "jpg")
-    filename = render_export_filename(task.file_info["path"], task.export_settings, border_size=task.params.finish.border_size)
+    filename = render_export_filename(
+        task.file_info["path"],
+        task.export_settings,
+        border_size=task.params.finish.border_size,
+        half=int(task.file_info.get("half") or 0),
+    )
     return out_dir, filename, ext
 
 
@@ -124,6 +129,8 @@ class ExportWorker(QObject):
                     prefer_gpu=task.gpu_enabled,
                     bounds_override=task.bounds_override,
                     working_color_space=task.working_color_space,
+                    half=int(task.file_info.get("half") or 0),
+                    split_x=float(task.file_info.get("split_x") or 0.5),
                 )
 
                 if not bits:
@@ -209,6 +216,8 @@ class ExportWorker(QObject):
                     working_color_space=task.working_color_space,
                     # half-size decode is visually identical at ~600px proof tiles
                     fast_decode=True,
+                    half=int(task.file_info.get("half") or 0),
+                    split_x=float(task.file_info.get("split_x") or 0.5),
                 )
                 if tile is not None:
                     tiles.append(tile)

--- a/negpy/desktop/workers/render.py
+++ b/negpy/desktop/workers/render.py
@@ -114,6 +114,7 @@ class AssetDiscoveryTask:
     supported_extensions: tuple[str, ...]
     rgb_scan: bool = False  # Group discovered files into R/G/B triplets (one asset per frame).
     restore_triplets: dict | None = None  # {red_path: [green, blue]} — rebuild known triplets (session restore).
+    half_frame: bool = False  # Expand each file into two half-frame assets (left/right).
 
 
 @dataclass(frozen=True)
@@ -302,6 +303,8 @@ class AssetDiscoveryWorker(QObject):
                         discovered_paths.append(path)
             except Exception as e:
                 logger.error(f"Discovery error for {path}: {e}")
+        # Half-frame re-discovery passes both halves' (identical) paths — hash once.
+        discovered_paths = list(dict.fromkeys(discovered_paths))
 
         total = len(discovered_paths)
         valid_assets = []
@@ -322,7 +325,26 @@ class AssetDiscoveryWorker(QObject):
         elif task.rgb_scan and valid_assets:
             valid_assets = self._group_rgb_triplets(valid_assets)
 
+        if task.half_frame and valid_assets:
+            valid_assets = self._expand_half_frames(valid_assets)
+
         self.finished.emit(valid_assets)
+
+    def _expand_half_frames(self, assets: list) -> list:
+        """Expand each file into two half-frame assets sharing the path, with
+        per-half hash/name identities. Triplet assets stay whole (unsupported combo)."""
+        from negpy.services.assets.half_frame import detect_split_x_for_file, half_hash, half_name
+
+        out = []
+        for i, a in enumerate(assets):
+            if a.get("green_path"):
+                out.append(a)
+                continue
+            self.progress.emit(i + 1, len(assets), f"Split {a['name']}")
+            split_x = detect_split_x_for_file(a["path"])
+            for half in (1, 2):
+                out.append({**a, "name": half_name(a["name"], half), "hash": half_hash(a["hash"], half), "half": half, "split_x": split_x})
+        return out
 
     def _attach_restored_triplets(self, assets: list, triplets: dict) -> list:
         """Re-attach saved green/blue exposures to restored red assets (no reclassification)."""
@@ -536,13 +558,15 @@ class BatchAutoCropWorker(QObject):
             self.cancelled.emit()
 
     def _decode(self, frame: BatchAutoCropInput, workspace_color_space: str) -> np.ndarray:
+        from negpy.services.assets.half_frame import base_hash, slice_for_asset
+
         file_info = frame.file_info
         config = frame.config
         rgbscan = config.rgbscan
         common = {
             "use_camera_wb": not config.process.linear_raw,
             "full_resolution": False,
-            "file_hash": file_info.get("hash"),
+            "file_hash": base_hash(file_info.get("hash")),  # halves share one decode
         }
         if rgbscan.enabled and rgbscan.green_path and rgbscan.blue_path:
             raw, _, _ = self._preview_service.load_linear_preview_rgb(
@@ -559,7 +583,7 @@ class BatchAutoCropWorker(QObject):
                 workspace_color_space,
                 **common,
             )
-        return raw
+        return slice_for_asset(raw, file_info)
 
     @pyqtSlot(BatchAutoCropTask)
     def process(self, task: BatchAutoCropTask) -> None:
@@ -691,6 +715,7 @@ class NormalizationWorker(QObject):
         from negpy.domain.interfaces import PipelineContext
         from negpy.features.exposure.normalization import analyze_log_exposure_bounds, resolve_crosstalk_matrix
         from negpy.features.geometry.processor import GeometryProcessor
+        from negpy.services.assets.half_frame import base_hash, slice_for_asset
 
         self._cancel.clear()
         total = len(task.files)
@@ -727,8 +752,9 @@ class NormalizationWorker(QObject):
                         task.workspace_color_space,
                         not linear_raw,  # use_camera_wb
                         False,  # full_resolution
-                        f_info.get("hash"),
+                        base_hash(f_info.get("hash")),  # halves share one decode
                     )
+                    raw = slice_for_asset(raw, f_info)
 
                     ctx = PipelineContext(
                         original_size=(raw.shape[1], raw.shape[0]),

--- a/negpy/infrastructure/storage/repository.py
+++ b/negpy/infrastructure/storage/repository.py
@@ -210,8 +210,10 @@ class StorageRepository(IRepository):
         if not file_path:
             return None
         with self._connect(self.edits_db_path) as conn:
+            # Half-frame rows ('<hash>#<n>') share the scan's path; rehoming one onto
+            # the whole-file identity would steal that half's edit — exclude them.
             cursor = conn.execute(
-                "SELECT file_hash, settings_json FROM file_settings WHERE file_path = ?",
+                "SELECT file_hash, settings_json FROM file_settings WHERE file_path = ? AND file_hash NOT LIKE '%#%'",
                 (file_path,),
             )
             row = cursor.fetchone()

--- a/negpy/services/assets/half_frame.py
+++ b/negpy/services/assets/half_frame.py
@@ -1,0 +1,114 @@
+"""Half-frame scans: one file holds two frames side by side.
+
+A half asset is a normal asset dict plus ``half`` (1 = left, 2 = right) and
+``split_x`` (normalized gutter position). Its identity is the file hash
+suffixed with ``#<half>``, so every hash-keyed store (edits, history, marks,
+thumbnails) is per-frame automatically. Decode caches key on the unsuffixed
+hash so both halves share one decode.
+"""
+
+from typing import Any, Dict, Optional
+
+import numpy as np
+
+from negpy.kernel.system.logging import get_logger
+
+logger = get_logger(__name__)
+
+_SEP = "#"
+
+
+def half_hash(file_hash: str, half: int) -> str:
+    return f"{file_hash}{_SEP}{half}"
+
+
+def base_hash(file_hash: Optional[str]) -> Optional[str]:
+    """The unsuffixed file hash — the decode-cache identity shared by both halves."""
+    return file_hash.split(_SEP, 1)[0] if file_hash else file_hash
+
+
+def half_name(name: str, half: int) -> str:
+    return f"{name} [{half}]"
+
+
+def slice_half(buf: np.ndarray, half: int, split_x: float) -> np.ndarray:
+    """View of one half of a decoded buffer, split at the normalized gutter x."""
+    w = buf.shape[1]
+    xs = min(max(int(round(w * split_x)), 1), w - 1)
+    return buf[:, :xs] if half == 1 else buf[:, xs:]
+
+
+def slice_for_asset(buf: np.ndarray, file_info: Dict[str, Any]) -> np.ndarray:
+    """Apply the asset's half slice; no-op for whole-frame assets."""
+    half = int(file_info.get("half") or 0)
+    if not half:
+        return buf
+    return slice_half(buf, half, float(file_info.get("split_x") or 0.5))
+
+
+def detect_split_x(buf: np.ndarray) -> float:
+    """Normalized x of the unexposed gutter between the two frames.
+
+    The gutter is a narrow column extremal against its surroundings in either
+    polarity (bright film base on negatives, dark on positives), so pick the
+    column whose smoothed luma deviates most from a local running-median
+    background — a window much wider than the gutter, so broad brightness
+    differences between the two frames don't register. Returns 0.5 when no
+    clear gutter stands out in the central band.
+    """
+    # ponytail: 1-D local-deviation heuristic; upgrade to variance+edge profile if it misses
+    a = np.asarray(buf)
+    if a.ndim == 3:
+        a = a.mean(axis=2)
+    a = a.astype(np.float32, copy=False)
+    h, w = a.shape[:2]
+    if w < 64 or h < 8:
+        return 0.5
+    peak_val = float(a.max())
+    if peak_val <= 0:
+        return 0.5
+    sub = a[:: max(1, h // 512)] / peak_val
+    col = sub.mean(axis=0)
+    k = max(3, w // 150)
+    sm = np.convolve(col, np.ones(k, np.float32) / k, mode="same")
+    win = max(9, (w // 8) | 1)
+    padded = np.pad(sm, win // 2, mode="edge")
+    bg = np.median(np.lib.stride_tricks.sliding_window_view(padded, win), axis=1)
+    dev = np.abs(sm - bg)
+    lo, hi = int(w * 0.35), int(w * 0.65)
+    peak = lo + int(np.argmax(dev[lo:hi]))
+    # Take the deviating band's center so the ±delta taps below land outside the gutter.
+    thr = 0.5 * dev[peak]
+    i0 = peak
+    while i0 > 0 and dev[i0 - 1] >= thr:
+        i0 -= 1
+    i1 = peak
+    while i1 < w - 1 and dev[i1 + 1] >= thr:
+        i1 += 1
+    center = (i0 + i1) // 2
+    # A gutter is extremal against BOTH sides; a step edge (up one side, down the
+    # other) is in-scene — reject it.
+    delta = max(3, int(w * 0.05))
+    d1 = float(sm[center] - sm[max(0, center - delta)])
+    d2 = float(sm[center] - sm[min(w - 1, center + delta)])
+    if min(abs(d1), abs(d2)) < 0.04 or d1 * d2 <= 0:
+        return 0.5
+    # Unexposed film is uniform top to bottom; a bright/dark in-scene feature isn't.
+    if float(sub[:, center].std()) > 0.10:
+        return 0.5
+    return center / w
+
+
+def detect_split_x_for_file(file_path: str) -> float:
+    """Gutter position from a small decode of the file; 0.5 on any failure."""
+    try:
+        from negpy.services.assets.thumbnails import decode_source_image
+
+        img = decode_source_image(file_path)
+        if img is None:
+            return 0.5
+        img.thumbnail((1024, 1024))
+        return detect_split_x(np.asarray(img))
+    except Exception as e:
+        logger.warning("Half-frame split detection failed for %s: %s", file_path, e)
+        return 0.5

--- a/negpy/services/assets/sidecar.py
+++ b/negpy/services/assets/sidecar.py
@@ -11,15 +11,16 @@ logger = get_logger(__name__)
 SIDECAR_EXT = ".negpy"
 
 
-def sidecar_path_for(source_path: str) -> str:
-    """Sidecar path next to the source file: ``<basename>.negpy``."""
+def sidecar_path_for(source_path: str, half: int = 0) -> str:
+    """Sidecar path next to the source file: ``<basename>.negpy`` (``<basename>.<half>.negpy`` for half-frame assets)."""
     base = os.path.splitext(os.path.basename(source_path))[0]
-    return os.path.join(os.path.dirname(source_path), base + SIDECAR_EXT)
+    suffix = f".{half}" if half else ""
+    return os.path.join(os.path.dirname(source_path), base + suffix + SIDECAR_EXT)
 
 
-def write_sidecar(source_path: str, config: WorkspaceConfig) -> str:
+def write_sidecar(source_path: str, config: WorkspaceConfig, half: int = 0) -> str:
     """Write the full edit (``config.to_dict()``) as JSON next to the source. Returns the path written."""
-    path = sidecar_path_for(source_path)
+    path = sidecar_path_for(source_path, half)
     os.makedirs(os.path.dirname(path), exist_ok=True)
     payload = json.dumps(config.to_dict(), default=str, indent=2)
     tmp_path = None
@@ -35,9 +36,9 @@ def write_sidecar(source_path: str, config: WorkspaceConfig) -> str:
     return path
 
 
-def load_sidecar(source_path: str) -> Optional[WorkspaceConfig]:
+def load_sidecar(source_path: str, half: int = 0) -> Optional[WorkspaceConfig]:
     """Load edits from a sidecar next to the source file. None if absent or malformed."""
-    path = sidecar_path_for(source_path)
+    path = sidecar_path_for(source_path, half)
     if not os.path.exists(path):
         return None
     try:
@@ -51,22 +52,24 @@ def load_sidecar(source_path: str) -> Optional[WorkspaceConfig]:
         return None
 
 
-def load_or_promote(repo, file_hash: str, source_path: str) -> Optional[WorkspaceConfig]:
+def load_or_promote(repo, file_hash: str, source_path: str, half: int = 0) -> Optional[WorkspaceConfig]:
     """DB first; on miss, try path-based fallback (handles EXIF-modified files),
     then fall back to sidecar. Re-homes on successful path match."""
     cfg = repo.load_file_settings(file_hash)
     if cfg is not None:
         return cfg
 
-    # Path-based fallback: hash changed due to EXIF edits
-    path_result = repo.load_file_settings_by_path(source_path)
-    if path_result is not None:
-        old_hash, cfg = path_result
-        repo.rehome_file_settings(old_hash, file_hash, source_path)
-        return cfg
+    # Path-based fallback: hash changed due to EXIF edits. Half-frame assets share
+    # a path, so a path match would steal the sibling half's edit — skip it.
+    if not half:
+        path_result = repo.load_file_settings_by_path(source_path)
+        if path_result is not None:
+            old_hash, cfg = path_result
+            repo.rehome_file_settings(old_hash, file_hash, source_path)
+            return cfg
 
     # Sidecar fallback
-    cfg = load_sidecar(source_path)
+    cfg = load_sidecar(source_path, half)
     if cfg is not None:
         repo.save_file_settings(file_hash, cfg, file_path=source_path)
     return cfg

--- a/negpy/services/assets/thumbnails.py
+++ b/negpy/services/assets/thumbnails.py
@@ -27,7 +27,14 @@ async def generate_batch_thumbnails(
     async def _worker(f_info: Dict[str, str]) -> Tuple[str, Optional[Image.Image]]:
         nonlocal completed
         async with semaphore:
-            thumb = await asyncio.to_thread(get_thumbnail_worker, f_info["path"], f_info["hash"], asset_store)
+            thumb = await asyncio.to_thread(
+                get_thumbnail_worker,
+                f_info["path"],
+                f_info["hash"],
+                asset_store,
+                int(f_info.get("half") or 0),
+                float(f_info.get("split_x") or 0.5),
+            )
             completed += 1
             if progress_callback:
                 if asyncio.iscoroutinefunction(progress_callback):
@@ -42,7 +49,49 @@ async def generate_batch_thumbnails(
     return {name: thumb for name, thumb in results if isinstance(thumb, Image.Image)}
 
 
-def get_thumbnail_worker(file_path: str, file_hash: str, asset_store: Any = None) -> Optional[Image.Image]:
+def decode_source_image(file_path: str) -> Optional[Image.Image]:
+    """Small EXIF-oriented preview of a source file (embedded thumb, else fast decode)."""
+    ctx_mgr, metadata = loader_factory.get_loader(file_path)
+    with ctx_mgr as raw:
+        img: Optional[Image.Image] = None
+
+        if hasattr(raw, "extract_thumb"):
+            try:
+                thumb = raw.extract_thumb()
+                if thumb.format == rawpy.ThumbFormat.JPEG:
+                    import io
+
+                    img = Image.open(io.BytesIO(thumb.data))
+                elif thumb.format == rawpy.ThumbFormat.BITMAP:
+                    img = Image.fromarray(thumb.data)
+            except Exception:
+                pass
+
+        if img is None:
+            algo = rawpy.DemosaicAlgorithm.LINEAR
+
+            rgb = raw.postprocess(
+                use_camera_wb=True,
+                user_wb=None,
+                half_size=True,
+                no_auto_bright=True,
+                bright=1.0,
+                demosaic_algorithm=algo,
+                user_flip=0,
+            )
+            rgb = ensure_rgb(rgb)
+            img = Image.fromarray(rgb)
+
+        orientation = metadata.get("orientation", 1)
+        if orientation and orientation != 1:
+            img = Image.fromarray(apply_exif_orientation(np.asarray(img), orientation))
+
+        return img
+
+
+def get_thumbnail_worker(
+    file_path: str, file_hash: str, asset_store: Any = None, half: int = 0, split_x: float = 0.5
+) -> Optional[Image.Image]:
     """
     Checks cache -> extracts/renders -> resize.
     """
@@ -53,47 +102,21 @@ def get_thumbnail_worker(file_path: str, file_hash: str, asset_store: Any = None
                 return cached
 
         ts = APP_CONFIG.thumbnail_size
-        ctx_mgr, metadata = loader_factory.get_loader(file_path)
-        with ctx_mgr as raw:
-            img: Optional[Image.Image] = None
+        img = decode_source_image(file_path)
+        if img is None:
+            return None
 
-            if hasattr(raw, "extract_thumb"):
-                try:
-                    thumb = raw.extract_thumb()
-                    if thumb.format == rawpy.ThumbFormat.JPEG:
-                        import io
+        if half:
+            from negpy.services.assets.half_frame import slice_half
 
-                        img = Image.open(io.BytesIO(thumb.data))
-                    elif thumb.format == rawpy.ThumbFormat.BITMAP:
-                        img = Image.fromarray(thumb.data)
-                except Exception:
-                    pass
+            img = Image.fromarray(slice_half(np.asarray(img), half, split_x))
 
-            if img is None:
-                algo = rawpy.DemosaicAlgorithm.LINEAR
+        square_img: Image.Image = prepare_thumbnail(img, ts)
 
-                rgb = raw.postprocess(
-                    use_camera_wb=True,
-                    user_wb=None,
-                    half_size=True,
-                    no_auto_bright=True,
-                    bright=1.0,
-                    demosaic_algorithm=algo,
-                    user_flip=0,
-                )
-                rgb = ensure_rgb(rgb)
-                img = Image.fromarray(rgb)
+        if asset_store:
+            asset_store.save_thumbnail(file_hash, square_img)
 
-            orientation = metadata.get("orientation", 1)
-            if orientation and orientation != 1:
-                img = Image.fromarray(apply_exif_orientation(np.asarray(img), orientation))
-
-            square_img: Image.Image = prepare_thumbnail(img, ts)
-
-            if asset_store:
-                asset_store.save_thumbnail(file_hash, square_img)
-
-            return square_img
+        return square_img
     except Exception as e:
         logger.error(f"Thumbnail Error for {file_path}: {e}")
         return None

--- a/negpy/services/export/templating.py
+++ b/negpy/services/export/templating.py
@@ -10,6 +10,7 @@ def render_export_filename(
     original_path: str,
     export_settings: Union[ExportConfig, ExportPreset],
     border_size: float = 0.0,
+    half: int = 0,
 ) -> str:
     """
     Renders the export filename using Jinja2 templates.
@@ -25,6 +26,9 @@ def render_export_filename(
     - date: Current date in YYYYMMDD format
     """
     original_name = os.path.splitext(os.path.basename(original_path))[0]
+    if half:
+        # halves share the source file — suffix so outputs don't collide
+        original_name = f"{original_name}_{half}"
 
     # Null-byte placeholder protects original_name from the cleanup regex.
     # Null bytes cannot appear in filesystem paths, so collision is impossible.

--- a/negpy/services/rendering/image_processor.py
+++ b/negpy/services/rendering/image_processor.py
@@ -489,6 +489,21 @@ class ImageProcessor:
         self._source_cache_value = result
         return result
 
+    @staticmethod
+    def _slice_half_source(
+        f32_buffer: np.ndarray, ir_full: Optional[np.ndarray], half: int, split_x: float
+    ) -> Tuple[np.ndarray, Optional[np.ndarray]]:
+        """Slice a decoded source down to one half-frame; copies so the shared
+        per-file decode cache is never mutated downstream. No-op when half == 0."""
+        if not half:
+            return f32_buffer, ir_full
+        from negpy.services.assets.half_frame import slice_half
+
+        f32_buffer = np.ascontiguousarray(slice_half(f32_buffer, half, split_x))
+        if ir_full is not None:
+            ir_full = np.ascontiguousarray(slice_half(ir_full, half, split_x))
+        return f32_buffer, ir_full
+
     def process_export(
         self,
         file_path: str,
@@ -499,6 +514,8 @@ class ImageProcessor:
         prefer_gpu: bool = True,
         bounds_override: Optional[Any] = None,
         working_color_space: str = WORKING_COLOR_SPACE,
+        half: int = 0,
+        split_x: float = 0.5,
     ) -> Tuple[Optional[bytes], str]:
         """Performs high-resolution export with color management."""
         try:
@@ -506,6 +523,7 @@ class ImageProcessor:
             params = dc_replace(params, export=export_settings)
 
             f32_buffer, ir_full, source_cs = self._load_source_f32(file_path, params)
+            f32_buffer, ir_full = self._slice_half_source(f32_buffer, ir_full, half, split_x)
             target_cs = export_settings.export_color_space
             if target_cs == ColorSpace.SAME_AS_SOURCE.value:
                 target_cs = source_cs
@@ -716,6 +734,8 @@ class ImageProcessor:
         prefer_gpu: bool = True,
         working_color_space: str = WORKING_COLOR_SPACE,
         fast_decode: bool = False,
+        half: int = 0,
+        split_x: float = 0.5,
     ) -> Optional[np.ndarray]:
         """Render a file (with its edits) to a small sRGB uint8 RGB array for tiling.
 
@@ -726,6 +746,7 @@ class ImageProcessor:
             from negpy.infrastructure.display.color_mgmt import apply_display_transform
 
             f32_buffer, ir_full, _ = self._load_source_f32(file_path, params, fast_decode=fast_decode)
+            f32_buffer, ir_full = self._slice_half_source(f32_buffer, ir_full, half, split_x)
             h_raw, w_raw = f32_buffer.shape[:2]
             scale_factor = max(1.0, max(h_raw, w_raw) / float(target_long_px))
 

--- a/tests/test_desktop_session.py
+++ b/tests/test_desktop_session.py
@@ -77,7 +77,7 @@ class TestDesktopSessionSync(unittest.TestCase):
         with patch("negpy.desktop.session.load_or_promote", return_value=saved) as hydrate:
             config = self.session.config_for_asset(asset)
 
-        hydrate.assert_called_once_with(self.mock_repo, "saved-hash", "/roll/saved.dng")
+        hydrate.assert_called_once_with(self.mock_repo, "saved-hash", "/roll/saved.dng", half=0)
         self.assertEqual(config.exposure.density, 1.7)
         self.assertEqual(config.process.process_mode, "E-6")
         self.assertEqual(config.geometry.autocrop_ratio, "4:3")

--- a/tests/test_half_frame.py
+++ b/tests/test_half_frame.py
@@ -1,0 +1,175 @@
+"""Half-frame mode: split detection, slicing, identities, and per-half plumbing."""
+
+import numpy as np
+import pytest
+from unittest.mock import MagicMock
+
+from negpy.domain.models import ExportConfig, WorkspaceConfig
+from negpy.services.assets.half_frame import (
+    base_hash,
+    detect_split_x,
+    half_hash,
+    half_name,
+    slice_for_asset,
+    slice_half,
+)
+from negpy.services.assets.sidecar import load_or_promote, sidecar_path_for
+from negpy.services.export.templating import render_export_filename
+
+
+def _two_frame_scan(gutter_value: float, w: int = 400, gutter_w: int = 16) -> np.ndarray:
+    rng = np.random.default_rng(0)
+    h = 200
+    side = (w - gutter_w) // 2
+    left = 0.35 + 0.3 * rng.random((h, side, 3))
+    right = 0.4 + 0.3 * rng.random((h, w - gutter_w - side, 3))
+    gutter = np.full((h, gutter_w, 3), gutter_value)
+    return np.concatenate([left, gutter, right], axis=1).astype(np.float32)
+
+
+class TestDetectSplitX:
+    def test_dark_gutter(self):
+        sx = detect_split_x(_two_frame_scan(0.02))
+        assert abs(sx - 0.5) < 0.03 and sx != 0.5
+
+    def test_bright_gutter(self):
+        sx = detect_split_x(_two_frame_scan(0.98))
+        assert abs(sx - 0.5) < 0.03 and sx != 0.5
+
+    def test_off_center_gutter(self):
+        scan = _two_frame_scan(0.98)
+        scan = np.roll(scan, 40, axis=1)  # gutter at ~0.6
+        assert abs(detect_split_x(scan) - 0.6) < 0.03
+
+    def test_no_gutter_falls_back_to_center(self):
+        rng = np.random.default_rng(1)
+        flat = (0.4 + 0.2 * rng.random((200, 400, 3))).astype(np.float32)
+        assert detect_split_x(flat) == 0.5
+
+    def test_in_scene_step_edge_rejected(self):
+        # Bright left frame, dark right frame, no gutter: the brightness step
+        # must not be mistaken for a gutter.
+        rng = np.random.default_rng(2)
+        left = 0.7 + 0.2 * rng.random((200, 200, 3))
+        right = 0.05 + 0.1 * rng.random((200, 200, 3))
+        scan = np.concatenate([left, right], axis=1).astype(np.float32)
+        assert detect_split_x(scan) == 0.5
+
+    def test_textured_vertical_feature_rejected(self):
+        # A narrow bright band that varies along y (in-scene feature, not film base).
+        scan = _two_frame_scan(0.5)
+        h, w = scan.shape[:2]
+        band = slice(w // 2 - 8, w // 2 + 8)
+        scan[:, band] = np.linspace(0.0, 1.0, h, dtype=np.float32)[:, None, None]
+        assert detect_split_x(scan) == 0.5
+
+    def test_tiny_image_falls_back(self):
+        assert detect_split_x(np.zeros((4, 20, 3), np.float32)) == 0.5
+
+
+class TestSliceHalf:
+    @pytest.mark.parametrize("w", [100, 101])
+    def test_halves_partition_width(self, w):
+        buf = np.arange(2 * w * 3, dtype=np.float32).reshape(2, w, 3)
+        h1 = slice_half(buf, 1, 0.5)
+        h2 = slice_half(buf, 2, 0.5)
+        assert h1.shape[1] + h2.shape[1] == w
+        np.testing.assert_array_equal(np.concatenate([h1, h2], axis=1), buf)
+
+    def test_extreme_split_never_empty(self):
+        buf = np.zeros((2, 50, 3), np.float32)
+        assert slice_half(buf, 1, 0.0).shape[1] == 1
+        assert slice_half(buf, 2, 1.0).shape[1] == 1
+
+    def test_slice_for_asset(self):
+        buf = np.zeros((2, 100, 3), np.float32)
+        assert slice_for_asset(buf, {"path": "p"}) is buf
+        assert slice_for_asset(buf, {"half": 2, "split_x": 0.25}).shape[1] == 75
+
+
+class TestIdentities:
+    def test_hash_roundtrip(self):
+        assert half_hash("abc", 1) == "abc#1"
+        assert base_hash("abc#2") == "abc"
+        assert base_hash("abc") == "abc"
+        assert base_hash(None) is None
+
+    def test_half_name(self):
+        assert half_name("IMG420.tif", 2) == "IMG420.tif [2]"
+
+    def test_sidecar_path(self):
+        assert sidecar_path_for("/a/roll.tif") == "/a/roll.negpy"
+        assert sidecar_path_for("/a/roll.tif", 1) == "/a/roll.1.negpy"
+
+    def test_export_filename_suffix(self):
+        plain = render_export_filename("/x/IMG420.tif", ExportConfig())
+        halved = render_export_filename("/x/IMG420.tif", ExportConfig(), half=2)
+        assert "IMG420" in plain and "IMG420_2" not in plain
+        assert "IMG420_2" in halved
+
+
+def test_expand_half_frames(monkeypatch):
+    from negpy.desktop.workers import render as render_mod
+
+    monkeypatch.setattr("negpy.services.assets.half_frame.detect_split_x_for_file", lambda p: 0.48)
+    worker = render_mod.AssetDiscoveryWorker()
+    assets = [
+        {"name": "a.tif", "path": "/p/a.tif", "hash": "ha"},
+        {"name": "t.raw", "path": "/p/t.raw", "hash": "ht", "green_path": "/p/g.raw", "blue_path": "/p/b.raw"},
+    ]
+    out = worker._expand_half_frames(assets)
+    assert [a["hash"] for a in out] == ["ha#1", "ha#2", "ht"]
+    assert out[0]["name"] == "a.tif [1]" and out[1]["name"] == "a.tif [2]"
+    assert out[0]["path"] == out[1]["path"] == "/p/a.tif"
+    assert out[0]["split_x"] == out[1]["split_x"] == 0.48
+
+
+def test_add_files_keeps_both_halves():
+    from negpy.desktop.session import DesktopSessionManager
+    from negpy.infrastructure.storage.repository import StorageRepository
+
+    repo = MagicMock(spec=StorageRepository)
+    repo.get_global_setting.side_effect = lambda key, default=None: default
+    repo.load_file_marks.return_value = {}
+    session = DesktopSessionManager(repo)
+
+    halves = [
+        {"name": "a.tif [1]", "path": "/p/a.tif", "hash": "ha#1", "half": 1, "split_x": 0.5},
+        {"name": "a.tif [2]", "path": "/p/a.tif", "hash": "ha#2", "half": 2, "split_x": 0.5},
+    ]
+    session.add_files([], validated_info=halves)
+    assert len(session.state.uploaded_files) == 2
+    # Re-adding replaces in place instead of clobbering the sibling half.
+    session.add_files([], validated_info=halves)
+    assert [f["hash"] for f in session.state.uploaded_files] == ["ha#1", "ha#2"]
+
+
+def test_load_or_promote_half_skips_path_fallback(tmp_path):
+    repo = MagicMock()
+    repo.load_file_settings.return_value = None
+    repo.load_file_settings_by_path.return_value = ("old_hash", WorkspaceConfig())
+    src = tmp_path / "roll.tif"
+    src.write_bytes(b"x")
+
+    assert load_or_promote(repo, "h#1", str(src), half=1) is None
+    repo.rehome_file_settings.assert_not_called()
+
+    assert load_or_promote(repo, "h2", str(src)) is not None
+    repo.rehome_file_settings.assert_called_once()
+
+
+def test_halves_measure_independent_bounds():
+    from negpy.features.exposure.normalization import analyze_log_exposure_bounds
+
+    rng = np.random.default_rng(3)
+    left = 0.08 + 0.05 * rng.random((240, 160, 3))
+    right = 0.5 + 0.4 * rng.random((240, 160, 3))
+    gutter = np.full((240, 12, 3), 0.95)
+    scan = np.concatenate([left, gutter, right], axis=1).astype(np.float32)
+
+    sx = detect_split_x(scan)
+    b1 = analyze_log_exposure_bounds(np.ascontiguousarray(slice_half(scan, 1, sx)))
+    b2 = analyze_log_exposure_bounds(np.ascontiguousarray(slice_half(scan, 2, sx)))
+    # Floors differ per half (dark vs bright frame). Ceils can legitimately agree:
+    # both halves keep a sliver of the bright gutter at the slice boundary.
+    assert not np.allclose(b1.floors, b2.floors)


### PR DESCRIPTION
## What

Half-frame cameras (Pentax 17, Olympus Pen…) expose two photos per 35mm frame; scans arrive as one file with two images separated by an unexposed gutter. This adds a **Half Frame** toggle (Files toolbar, mirrors RGB-scan end to end): each scan appears as two frames on the contact sheet, each with independent edits, bounds metering, thumbnails, sidecars, and exports.

## How

- **Identity**: discovery expands each file into two assets with hash `<base>#1` / `#2` (`negpy/services/assets/half_frame.py`). Every hash-keyed store — `file_settings`, `edit_history`, `file_marks`, disk thumbnails, EXIF, render memo — becomes per-half with no schema changes.
- **Independent bounds**: the decoded buffer is sliced at the gutter before the pipeline, so full-frame metering *is* per-half metering. No shader changes; GPU caches keyed by the suffixed `source_hash`.
- **Shared decode**: decode/preview caches key on the unsuffixed hash (`base_hash()`), so both halves reuse one decode. Slices are copied — cached buffers stay read-only.
- **Gutter auto-detect**: 1-D column-luma heuristic with three gates — local-median deviation (immune to frame-brightness differences), extremal-vs-both-sides (rejects in-scene step edges), full-height uniformity (rejects textured features). Center-split fallback; the crop tool trims residue.
- **Collision guards**: per-half sidecars `name.N.negpy`; export stems `name_1`/`name_2`; `add_files` same-path guard matches per half; EXIF path-fallback rehoming excludes `#` hashes so it can't steal a half's edit.
- Toggling off re-collapses to whole scans; per-half edits stay in the DB and return on re-enable.

## Validation

- 19 new tests (`tests/test_half_frame.py`): detector polarities/fallbacks/rejections, slice partition, identities, sidecar/export suffixes, discovery expansion, dedup guard, per-half bounds independence.
- Detector validated on all 7 `samples/half_frame` Pentax 17 scans: 6 split dead-center in the gutter; IMG428 (invisible gutter, night frames) correctly falls back to center.
- Headless app run (Xvfb): 7 files → 14 filmstrip entries, both halves of one scan rendered independently at half-width with distinct stats.
- `make all` green — 2022 passed.

## Out of scope (v1)

Divider-drag UI, per-file split (mode is global like RGB-scan), RGB-triplet + half-frame combination (triplets stay whole).

closes #553