### PR TITLE
Camera scanning: faster triplet cadence and clearer scan feedback while rolling

### DIFF
--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -205,6 +205,7 @@ class AppController(QObject):
     capture_requested = pyqtSignal(CaptureRequest)
     capture_light_set = pyqtSignal(int, int, int, int)
     capture_progress = pyqtSignal(float)
+    capture_channel = pyqtSignal(str)  # "R"/"G"/"B" as each triplet channel starts
     capture_finished = pyqtSignal(list)
     capture_cancelled = pyqtSignal()
     capture_error = pyqtSignal(str)
@@ -474,6 +475,7 @@ class AppController(QObject):
         self.capture_requested.connect(self.capture_worker.run_capture)
         self.capture_worker.light_set.connect(self.capture_light_set.emit)
         self.capture_worker.progress.connect(self.capture_progress.emit)
+        self.capture_worker.channel.connect(self.capture_channel.emit)
         self.capture_worker.finished.connect(self._on_capture_finished)
         self.capture_worker.cancelled.connect(self.capture_cancelled.emit)
         self.capture_worker.error.connect(self.capture_error.emit)

--- a/negpy/desktop/view/sidebar/live_view_window.py
+++ b/negpy/desktop/view/sidebar/live_view_window.py
@@ -138,15 +138,6 @@ class LiveViewWindow(QDialog):
         bar.addWidget(self.retake_btn, 1)
         layout.addLayout(bar)
 
-        # Capture progress lives here too (not only on the side panel): while scanning a roll
-        # the operator watches this window, and the bar reaching 100% is the "film may be
-        # advanced / next Scan may be pressed" signal.
-        self.progress = QProgressBar()
-        self.progress.setRange(0, 100)
-        self.progress.setFormat("Capturing… %p%")
-        self.progress.setVisible(False)
-        layout.addWidget(self.progress)
-
         self.image = RoiImageLabel()
         self.image.roi_mode = False  # clicks aim the magnifier here, not a calibration ROI
         # Magnifier cursor over the live image → signals "click to magnify here".
@@ -183,6 +174,16 @@ class LiveViewWindow(QDialog):
             col.addWidget(stepper)
             settings_row.addLayout(col, 1)
         layout.addWidget(self.settings_widget)
+
+        # Capture progress lives here too (not only on the side panel): while scanning a roll
+        # the operator watches this window, and the bar reaching 100% is the "film may be
+        # advanced / next Scan may be pressed" signal. Below the view, mirroring the
+        # calibration window's bar placement.
+        self.progress = QProgressBar()
+        self.progress.setRange(0, 100)
+        self.progress.setFormat("Capturing… %p%")
+        self.progress.setVisible(False)
+        layout.addWidget(self.progress)
 
         self.status = QLabel("")
         self.status.setStyleSheet(f"color: {THEME.text_muted}; font-size: {THEME.font_size_small}px;")

--- a/negpy/desktop/view/sidebar/live_view_window.py
+++ b/negpy/desktop/view/sidebar/live_view_window.py
@@ -10,12 +10,19 @@ emit signals; `ScanlightSidebar` wires them and mirrors scanning state + status.
 import time
 
 import qtawesome as qta
-from PyQt6.QtCore import Qt, pyqtSignal
+from PyQt6.QtCore import Qt, QTimer, pyqtSignal
 from PyQt6.QtGui import QCursor, QKeySequence, QShortcut
 from PyQt6.QtWidgets import QDialog, QHBoxLayout, QLabel, QProgressBar, QPushButton, QToolButton, QVBoxLayout, QWidget
 
 from negpy.desktop.view.sidebar.roi_image import RoiImageLabel
 from negpy.desktop.view.styles.theme import THEME
+
+#: Progress-bar chunk colour per triplet channel. The live view freezes during a triplet
+#: (the capture holds the camera without gaps now), so the bar carries the R→G→B switch
+#: the preview frames used to show. Muted tones, readable on the dark theme.
+_CHANNEL_COLORS = {"R": "#B5443C", "G": "#3F8F4A", "B": "#3C6FB5"}
+_DONE_COLOR = "#3F8F4A"
+_FLASH_MS = 1500
 
 
 class SettingStepper(QWidget):
@@ -184,6 +191,8 @@ class LiveViewWindow(QDialog):
         self.progress.setFormat("Capturing… %p%")
         self.progress.setVisible(False)
         layout.addWidget(self.progress)
+        # Invalidates a pending post-capture flash when a new capture starts underneath it.
+        self._flash_token = 0
 
         self.status = QLabel("")
         self.status.setStyleSheet(f"color: {THEME.text_muted}; font-size: {THEME.font_size_small}px;")
@@ -201,11 +210,38 @@ class LiveViewWindow(QDialog):
         self.retake_btn.setToolTip("Re-capture the current frame without advancing the counter  (shortcut: R)")
 
     def set_progress(self, frac: float) -> None:
+        self._flash_token += 1
         self.progress.setVisible(True)
         self.progress.setValue(int(frac * 100))
 
+    def set_channel(self, letter: str) -> None:
+        """Tint the bar in the channel being exposed and name it in the bar text."""
+        self._flash_token += 1
+        color = _CHANNEL_COLORS.get(letter)
+        if color:
+            self.progress.setStyleSheet(f"QProgressBar::chunk {{ background-color: {color}; }}")
+            self.progress.setFormat(f"Capturing {letter}… %p%")
+
+    def flash_captured(self, frame: str) -> None:
+        """Fill the bar green with a checkmark for a beat, then hide it — the 'frame is
+        in the can, film may be advanced' moment the frozen live view can't show."""
+        self._flash_token += 1
+        token = self._flash_token
+        self.progress.setStyleSheet(f"QProgressBar::chunk {{ background-color: {_DONE_COLOR}; }}")
+        self.progress.setFormat(f"✓ Frame {frame} captured" if frame else "✓ Captured")
+        self.progress.setValue(100)
+        self.progress.setVisible(True)
+        QTimer.singleShot(_FLASH_MS, lambda: self._end_flash(token))
+
+    def _end_flash(self, token: int) -> None:
+        if token == self._flash_token:  # stale flashes must not hide a newer capture's bar
+            self.clear_progress()
+
     def clear_progress(self) -> None:
+        self._flash_token += 1
         self.progress.setVisible(False)
+        self.progress.setStyleSheet("")
+        self.progress.setFormat("Capturing… %p%")
 
     def set_scanning(self, active: bool) -> None:
         """Mirror the panel's Scan/Stop toggle on the pop-up button."""

--- a/negpy/desktop/view/sidebar/live_view_window.py
+++ b/negpy/desktop/view/sidebar/live_view_window.py
@@ -1,6 +1,6 @@
 """Large pop-out window for the Scanlight live view.
 
-Hosts a `RoiImageLabel` plus an inline toolbar (Scan / Retake) and a status line,
+Hosts a `RoiImageLabel` plus an inline toolbar (Scan / Retake), a capture progress bar and a status line,
 so a whole roll can be framed, focused, and scanned without switching back to the
 side panel. The live image carries a magnifier cursor: a click aims the camera
 focus magnifier at that spot, a double-click returns to full frame. The buttons
@@ -12,7 +12,7 @@ import time
 import qtawesome as qta
 from PyQt6.QtCore import Qt, pyqtSignal
 from PyQt6.QtGui import QCursor, QKeySequence, QShortcut
-from PyQt6.QtWidgets import QDialog, QHBoxLayout, QLabel, QPushButton, QToolButton, QVBoxLayout, QWidget
+from PyQt6.QtWidgets import QDialog, QHBoxLayout, QLabel, QProgressBar, QPushButton, QToolButton, QVBoxLayout, QWidget
 
 from negpy.desktop.view.sidebar.roi_image import RoiImageLabel
 from negpy.desktop.view.styles.theme import THEME
@@ -138,6 +138,15 @@ class LiveViewWindow(QDialog):
         bar.addWidget(self.retake_btn, 1)
         layout.addLayout(bar)
 
+        # Capture progress lives here too (not only on the side panel): while scanning a roll
+        # the operator watches this window, and the bar reaching 100% is the "film may be
+        # advanced / next Scan may be pressed" signal.
+        self.progress = QProgressBar()
+        self.progress.setRange(0, 100)
+        self.progress.setFormat("Capturing… %p%")
+        self.progress.setVisible(False)
+        layout.addWidget(self.progress)
+
         self.image = RoiImageLabel()
         self.image.roi_mode = False  # clicks aim the magnifier here, not a calibration ROI
         # Magnifier cursor over the live image → signals "click to magnify here".
@@ -189,6 +198,13 @@ class LiveViewWindow(QDialog):
             QShortcut(QKeySequence(key), self, btn.click)
         self.scan_btn.setToolTip("Scan / Stop  (shortcut: S)")
         self.retake_btn.setToolTip("Re-capture the current frame without advancing the counter  (shortcut: R)")
+
+    def set_progress(self, frac: float) -> None:
+        self.progress.setVisible(True)
+        self.progress.setValue(int(frac * 100))
+
+    def clear_progress(self) -> None:
+        self.progress.setVisible(False)
 
     def set_scanning(self, active: bool) -> None:
         """Mirror the panel's Scan/Stop toggle on the pop-up button."""

--- a/negpy/desktop/view/sidebar/scanlight.py
+++ b/negpy/desktop/view/sidebar/scanlight.py
@@ -72,9 +72,10 @@ _MANUAL_PRESET = "\x00create-manual"
 
 
 # LED settle before each exposure. Narrowband PWM LEDs reach full brightness in <10 ms
-# and the serial set_color round-trip is ~5-20 ms, so 150 ms is a safe margin (the old
-# 400 ms was conservative). A fixed tuning constant, not a user/persisted setting.
-_LED_SETTLE_S = 0.15
+# and set_color is a fire-and-forget serial write (~1 ms on the wire at 115200 baud plus
+# CDC scheduling), so 50 ms still carries an order-of-magnitude margin (150/400 ms before
+# were conservatism). A fixed tuning constant, not a user/persisted setting.
+_LED_SETTLE_S = 0.05
 
 
 class _NoWheel(QObject):

--- a/negpy/desktop/view/sidebar/scanlight.py
+++ b/negpy/desktop/view/sidebar/scanlight.py
@@ -406,6 +406,7 @@ class ScanlightSidebar(QWidget):
         self.controller.capture_calibration_exposure.connect(self._on_calibration_exposure)
         self.controller.connection_polled.connect(self._on_poll_status)
         self.controller.light_temp_polled.connect(self._on_light_temp)
+        self.controller.batch_started.connect(self._keep_scan_windows_on_top)
         # Pop-up toolbar mirrors the panel actions (scan a roll without tab-switching).
         self.lv_window.scanRequested.connect(self._on_scan)
         self.lv_window.retakeRequested.connect(self._on_retake)
@@ -897,6 +898,15 @@ class ScanlightSidebar(QWidget):
             self.lv_btn.setChecked(False)  # stops live view via _on_live_view_toggled(False)
         self._maybe_release_camera_session(closing=self.lv_window)
 
+    def _keep_scan_windows_on_top(self, _title: str, _abortable: bool) -> None:
+        """The batch progress popup shows itself with raise_() on every batch — including the
+        per-frame "Hashing files"/"Generating thumbnails" imports after a capture — which puts
+        it over the live-view pop-up and reads as "wait here" mid-roll. Re-raise the operator's
+        open scan windows one event-loop turn later (the popup's own raise_() runs first)."""
+        for window in (self.lv_window, self.calib_window):
+            if window.isVisible():
+                QTimer.singleShot(0, window.raise_)
+
     def _refresh_live_view(self) -> None:
         if not self._lv_jpeg_path:
             return
@@ -1234,17 +1244,24 @@ class ScanlightSidebar(QWidget):
             aperture=s.aperture if rgb and not s.white_mode else "",
         )
         self.set_scanning(True)
+        if rgb and not req.white_mode:
+            # Triplet progress arrives only after each channel (~1.4 s apart); show the bar
+            # at 0% right away so the click has immediate feedback. White/normal captures
+            # emit no progress events, so a bar would just sit at 0% — skip it there.
+            self.lv_window.set_progress(0.0)
         self.controller.start_capture(req)
 
     @pyqtSlot(float)
     def _on_progress(self, progress: float) -> None:
         self.progress_bar.setVisible(True)
         self.progress_bar.setValue(int(progress * 100))
+        self.lv_window.set_progress(progress)
 
     @pyqtSlot(list)
     def _on_finished(self, paths: list) -> None:
         self.set_scanning(False)
         self.progress_bar.setVisible(False)
+        self.lv_window.clear_progress()
         frame = paths[0].split("_Frame")[-1][:3] if paths else ""
         self._set_status(f"Captured frame {frame} — inverting in NegPy…")
         self._after_capture_live_view()  # re-light the still-running preview
@@ -1253,6 +1270,7 @@ class ScanlightSidebar(QWidget):
     def _on_cancelled(self) -> None:
         self.set_scanning(False)
         self.progress_bar.setVisible(False)
+        self.lv_window.clear_progress()
         if self._calibrating_preset:
             self._finish_calibration_terminal("Calibration cancelled.")
             self._set_status("Calibration cancelled.")
@@ -1275,6 +1293,7 @@ class ScanlightSidebar(QWidget):
     def _on_error(self, msg: str) -> None:
         self.set_scanning(False)
         self.progress_bar.setVisible(False)
+        self.lv_window.clear_progress()
         if self._calibrating_preset:
             # New-preset calibration failed: report in the pop-up, drop back to the scan target.
             self._finish_calibration_terminal(f"Calibration failed: {msg}")

--- a/negpy/desktop/view/sidebar/scanlight.py
+++ b/negpy/desktop/view/sidebar/scanlight.py
@@ -397,6 +397,7 @@ class ScanlightSidebar(QWidget):
 
         self.controller.capture_light_set.connect(self._on_light_set)
         self.controller.capture_progress.connect(self._on_progress)
+        self.controller.capture_channel.connect(self._on_channel)
         self.controller.capture_finished.connect(self._on_finished)
         self.controller.capture_cancelled.connect(self._on_cancelled)
         self.controller.capture_error.connect(self._on_error)
@@ -1258,12 +1259,16 @@ class ScanlightSidebar(QWidget):
         self.progress_bar.setValue(int(progress * 100))
         self.lv_window.set_progress(progress)
 
+    @pyqtSlot(str)
+    def _on_channel(self, letter: str) -> None:
+        self.lv_window.set_channel(letter)
+
     @pyqtSlot(list)
     def _on_finished(self, paths: list) -> None:
         self.set_scanning(False)
         self.progress_bar.setVisible(False)
-        self.lv_window.clear_progress()
         frame = paths[0].split("_Frame")[-1][:3] if paths else ""
+        self.lv_window.flash_captured(frame)
         self._set_status(f"Captured frame {frame} — inverting in NegPy…")
         self._after_capture_live_view()  # re-light the still-running preview
 

--- a/negpy/desktop/workers/capture_worker.py
+++ b/negpy/desktop/workers/capture_worker.py
@@ -73,6 +73,7 @@ class CaptureWorker(QObject):
 
     light_set = pyqtSignal(int, int, int, int)  # r, g, b, w actually applied
     progress = pyqtSignal(float)  # 0.0..1.0
+    channel = pyqtSignal(str)  # "R"/"G"/"B" as each triplet channel starts
     finished = pyqtSignal(list)  # [red_path, green_path, blue_path]
     cancelled = pyqtSignal()
     error = pyqtSignal(str)
@@ -236,11 +237,16 @@ class CaptureWorker(QObject):
             )
             self.status.emit("Capturing R / G / B…")
             _names = {"R": "red", "G": "green", "B": "blue"}
+
+            def _on_channel(letter: str) -> None:
+                self.channel.emit(letter)
+                self.status.emit(f"Capturing {_names.get(letter, letter)} channel…")
+
             result = service.capture_triplet(
                 settings,
                 progress=self.progress.emit,
                 cancel=self._cancel,
-                on_channel=lambda letter: self.status.emit(f"Capturing {_names.get(letter, letter)} channel…"),
+                on_channel=_on_channel,
             )
 
             self.finished.emit(result.paths)

--- a/negpy/infrastructure/capture/gphoto.py
+++ b/negpy/infrastructure/capture/gphoto.py
@@ -12,7 +12,8 @@ Four behaviours of the library shape this module; each is guarded below:
 * Property writes are asynchronous. The body needs ~1-2 s before it reports a new value
   back, so a write is confirmed by polling, never assumed. See `_set_verified`.
 * After a still, the event queue must be drained or the *next* capture fails with a bare
-  `[-1] unspecified error`. See `_drain_events`.
+  `[-1] unspecified error`. See `_drain_events`; after a successful still it runs on a
+  small worker so the wait overlaps the next channel's LED settle (`_finish_shot_async`).
 * Choice strings are run through gettext, so on a German desktop `focusmode` reads
   'Manuell'. The message locale is pinned before the library loads. See `_pin_locale`.
 
@@ -225,6 +226,8 @@ class GphotoCamera:
         # Raised while a still is in flight, so the preview thread doesn't queue another
         # ~40 ms frame grab ahead of the next channel of a triplet.
         self._busy = threading.Event()
+        # The post-shot event drain of the last successful still (see _finish_shot_async).
+        self._post_shot: Optional[threading.Thread] = None
         self._reset_body_state()
 
     def _reset_body_state(self) -> None:
@@ -279,6 +282,9 @@ class GphotoCamera:
 
     def close(self) -> None:
         self.stop()
+        prev = self._post_shot
+        if prev is not None and prev.is_alive():
+            prev.join(timeout=3.0)  # let a post-shot drain finish before the handle goes away
         with self._lock:
             self._alive = False
             if self._camera is not None:
@@ -549,10 +555,15 @@ class GphotoCamera:
         (a scan re-asserts them so a drifted setting can't falsify it); `_set_verified` skips the
         write when the body is already there, so it costs a read unless something actually moved.
         """
+        prev = self._post_shot
+        if prev is not None and prev.is_alive():
+            prev.join()  # the previous shot's drain normally finished during the caller's LED settle
         self._busy.set()
+        drained_async = False
         try:
             with self._lock:
                 camera = self._require()
+                t0 = time.perf_counter()
                 if shutter:
                     name = self._property("shutter")
                     if name is None or not self._set_verified(name, shutter):
@@ -564,20 +575,30 @@ class GphotoCamera:
                         name = self._property(prop)
                         if name is None or not self._set_verified(name, value):
                             logger.warning("gphoto2: could not lock %s to %r for the scan; using the current setting", prop, value)
+                t_assert = time.perf_counter()
                 try:
                     path = camera.capture(self._gp.GP_CAPTURE_IMAGE)
+                    t_shot = time.perf_counter()
                     suffix = os.path.splitext(path.name)[1]
                     if suffix.lower() not in _CAMERA_RAW_EXTENSIONS:
                         shown = suffix or "(no extension)"
                         raise GphotoError(f"camera returned {shown}, not a RAW file; set the camera to RAW-only image quality and retry")
                     camera_file = camera.file_get(path.folder, path.name, self._gp.GP_FILE_TYPE_NORMAL)
                     data = bytes(memoryview(camera_file.get_data_and_size()))
-                except self._gp.GPhoto2Error as exc:
-                    raise GphotoError(f"capture failed: {exc}") from exc
-                finally:
+                    t_download = time.perf_counter()
+                except BaseException:
+                    # A failed shot drains inline, still under the lock: the error must leave a
+                    # clean queue behind before the preview or a retry can touch the session.
                     self._drain_events()
+                    raise
+        except self._gp.GPhoto2Error as exc:
+            raise GphotoError(f"capture failed: {exc}") from exc
+        else:
+            self._finish_shot_async()
+            drained_async = True
         finally:
-            self._busy.clear()
+            if not drained_async:
+                self._busy.clear()
 
         suffix = os.path.splitext(path.name)[1]
         if suffix:
@@ -587,8 +608,43 @@ class GphotoCamera:
         with open(tmp, "wb") as handle:
             handle.write(data)
         os.replace(tmp, out_path)
-        logger.info("gphoto2 captured %s (%.1f MB)", os.path.basename(out_path), len(data) / 1e6)
+        logger.info(
+            "gphoto2 captured %s (%.1f MB): assert %.0f ms, shot %.0f ms, download %.0f ms (%.0f MB/s)",
+            os.path.basename(out_path),
+            len(data) / 1e6,
+            (t_assert - t0) * 1000,
+            (t_shot - t_assert) * 1000,
+            (t_download - t_shot) * 1000,
+            len(data) / 1e6 / max(t_download - t_shot, 1e-9),
+        )
         return out_path
+
+    def _finish_shot_async(self) -> None:
+        """Drain the shot's leftover events off the caller's thread.
+
+        The ~150 ms of wait_for_event after every still would otherwise sit between two
+        channels of a triplet; on a worker it runs while the service is already switching
+        the light and sleeping its LED settle. Vendor-neutral by construction — the order
+        on the wire stays exactly sequential (shot → download → drain → next operation),
+        because `_busy` keeps the preview parked until the queue is clean and the next
+        `capture()` joins this thread before claiming the body.
+        """
+
+        def _run() -> None:
+            start = time.perf_counter()
+            try:
+                with self._lock:
+                    if self._camera is not None and self._alive:
+                        self._drain_events()
+                logger.info("gphoto2 post-shot drain %.0f ms (overlapped)", (time.perf_counter() - start) * 1000)
+            except Exception as exc:  # noqa: BLE001 — a teardown race must not kill the worker
+                logger.warning("gphoto2 post-shot drain: %s", exc)
+            finally:
+                self._busy.clear()
+
+        thread = threading.Thread(target=_run, name="gphoto-drain", daemon=True)
+        self._post_shot = thread
+        thread.start()
 
     # ----- live view -------------------------------------------------------------
 

--- a/tests/test_capture_gphoto.py
+++ b/tests/test_capture_gphoto.py
@@ -261,6 +261,7 @@ def test_capture_writes_the_raw_and_drains_events(cam, fake, tmp_path):
     out = tmp_path / "Roll1_Frame001_R.ARW"
     assert cam.capture(str(out)) == str(out)
     assert out.read_bytes() == b"RAWDATA" * 3
+    cam._post_shot.join()  # a successful shot drains on a worker; wait before asserting
     assert not fake.undrained  # a leftover event makes the *next* capture fail
 
 


### PR DESCRIPTION
Speeds up the R/G/B triplet loop and makes roll scanning calmer to operate. Measured on an a7C II over USB, a triplet drops from about 4.3 s to about 3.8 s.

## Speed

- LED settle before each exposure goes from 150 ms to 50 ms. set_color is a fire and forget serial write (about 1 ms on the wire), so 50 ms keeps an order of magnitude margin. Verified at the rig by rescanning the same frame at both values: every cross channel ratio shift stays below 0.3 percent, so no light bleed from the previous channel.
- The post-shot event drain (the wait_for_event loop that prevents the bare [-1] on the next capture) moves off the capture path onto a small worker, so it runs while the service is already switching the light and sleeping the next channel's settle. The order on the wire is unchanged for every vendor: shot, download, drain, next operation. The session lock plus the busy flag keep the preview parked until the queue is clean, and the next capture joins the worker before claiming the body. On errors the drain stays inline as before.
- The capture timing log now splits assert / shot / download (with MB/s), and the overlapped drain logs separately. This is what located the bottleneck: the download turns out to be nearly free (the transfer hides inside the shot wait), the camera's own processing dominates.

## Scan window feedback

- The batch progress dialogs (Hashing files, Generating thumbnails) raise themselves over every window after each scanned frame, which covered the live view and read as "wait here" even though scanning may continue. The scan pop-ups now re-raise themselves above the dialog.
- The capture progress bar is mirrored into the live view window, below the view like the calibration window's bar, and appears at 0 percent right on Scan.
- Because the capture now holds the camera without gaps, the live view freezes during a triplet and no longer shows the R/G/B light switch. The bar carries that instead: it is tinted with the channel being exposed and names it in the bar text.
- When the frame is done the bar fills green with a short "Frame captured" confirmation before hiding, as the signal that the film may be advanced.

make all is green, and the test suite passes both with and without the optional camera group.