### PR TITLE
fix: rotate icons, carrier_enabled migration, analysis-region dot

### DIFF
--- a/negpy/desktop/view/canvas/toolbar.py
+++ b/negpy/desktop/view/canvas/toolbar.py
@@ -89,7 +89,7 @@ class ActionToolbar(QWidget):
         self.btn_next.setToolTip("Next")
 
         # Undo / Redo live in the main toolbar (mdi arrows, distinct from the
-        # circular rotate icons which reuse fa5s.undo/redo).
+        # rotate icons' file-with-arrow glyphs below).
         self.btn_undo = QToolButton()
         self.btn_undo.setIcon(qta.icon("mdi.undo", color=icon_color))
         self.btn_undo.setToolTip(tooltip_with_shortcut("Undo", "undo"))
@@ -105,10 +105,10 @@ class ActionToolbar(QWidget):
 
         # 2. Geometry
         self.btn_rot_l = QToolButton()
-        self.btn_rot_l.setIcon(qta.icon("fa5s.undo", color=icon_color))
+        self.btn_rot_l.setIcon(qta.icon("mdi6.file-rotate-left", color=icon_color))
         self.btn_rot_l.setToolTip(tooltip_with_shortcut("Rotate CCW", "rotate_ccw"))
         self.btn_rot_r = QToolButton()
-        self.btn_rot_r.setIcon(qta.icon("fa5s.redo", color=icon_color))
+        self.btn_rot_r.setIcon(qta.icon("mdi6.file-rotate-right", color=icon_color))
         self.btn_rot_r.setToolTip(tooltip_with_shortcut("Rotate CW", "rotate_cw"))
         self.btn_flip_h = QToolButton()
         self.btn_flip_h.setCheckable(True)
@@ -214,8 +214,8 @@ class ActionToolbar(QWidget):
         self._ov_redo_action = overflow_menu.addAction(qta.icon("mdi.redo", color=icon_color), "Redo")
 
         overflow_menu.addSeparator()
-        self._ov_rot_l_action = overflow_menu.addAction(qta.icon("fa5s.undo", color=icon_color), "Rotate CCW")
-        self._ov_rot_r_action = overflow_menu.addAction(qta.icon("fa5s.redo", color=icon_color), "Rotate CW")
+        self._ov_rot_l_action = overflow_menu.addAction(qta.icon("mdi6.file-rotate-left", color=icon_color), "Rotate CCW")
+        self._ov_rot_r_action = overflow_menu.addAction(qta.icon("mdi6.file-rotate-right", color=icon_color), "Rotate CW")
         self._ov_flip_h_action = overflow_menu.addAction(qta.icon("fa5s.arrows-alt-h", color=icon_color), "Flip Horizontal")
         self._ov_flip_h_action.setCheckable(True)
         self._ov_flip_v_action = overflow_menu.addAction(qta.icon("fa5s.arrows-alt-v", color=icon_color), "Flip Vertical")
@@ -271,8 +271,6 @@ class ActionToolbar(QWidget):
             self.btn_toggle_right,
             self.btn_prev,
             self.btn_next,
-            self.btn_rot_l,
-            self.btn_rot_r,
             self.btn_flip_h,
             self.btn_flip_v,
             self.btn_undo,
@@ -285,6 +283,15 @@ class ActionToolbar(QWidget):
         ]
         for btn in standard_buttons:
             btn.setIconSize(icon_size)
+            btn.setFixedHeight(btn_height)
+            btn.setCursor(Qt.CursorShape.PointingHandCursor)
+
+        # The file-rotate glyphs (page + arrow) read as a blob at the standard 16px
+        # icon size; a touch larger keeps the page and arrow individually legible
+        # without changing the button's own footprint (btn_height still applies).
+        rotate_icon_size = QSize(20, 20)
+        for btn in (self.btn_rot_l, self.btn_rot_r):
+            btn.setIconSize(rotate_icon_size)
             btn.setFixedHeight(btn_height)
             btn.setCursor(Qt.CursorShape.PointingHandCursor)
 

--- a/negpy/desktop/view/sidebar/process.py
+++ b/negpy/desktop/view/sidebar/process.py
@@ -12,7 +12,7 @@ from PyQt6.QtWidgets import (
 from negpy.desktop.session import ToolMode
 from negpy.desktop.view.sidebar.base import BaseSidebar
 from negpy.desktop.view.sidebar.tone import _CH_COLORS, _CH_LABEL, _CH_SUFFIX
-from negpy.desktop.view.styles.templates import field_label, section_subheader
+from negpy.desktop.view.styles.templates import EditedDot, field_label, section_subheader
 from negpy.desktop.view.styles.theme import THEME
 from negpy.desktop.view.widgets.sliders import CompactSlider
 from negpy.features.exposure.models import EXPOSURE_CONSTANTS
@@ -114,6 +114,9 @@ class ProcessSidebar(BaseSidebar):
             "(overrides the Analysis Buffer). Double-click inside it to confirm.",
         )
         self.analysis_region_btn.setFixedWidth(32)
+        # Confirming a region closes the tool (unchecking the toggle), so the dot is
+        # the only cue left that it's still overriding the Analysis Buffer slider.
+        self.analysis_region_btn.edited_dot = EditedDot(self.analysis_region_btn)
         self.clear_analysis_region_btn = self._icon_action(
             "fa5s.times", "Clear the freehand analysis region (fall back to the Analysis Buffer)", width=32
         )
@@ -456,6 +459,7 @@ class ProcessSidebar(BaseSidebar):
 
             has_region = conf.analysis_rect is not None
             self.analysis_region_btn.setChecked(self.state.active_tool == ToolMode.ANALYSIS_DRAW)
+            self.analysis_region_btn.edited_dot.set_active(has_region)
             self.clear_analysis_region_btn.setEnabled(has_region)
 
             locked = conf.lock_bounds

--- a/negpy/domain/models.py
+++ b/negpy/domain/models.py
@@ -426,6 +426,14 @@ class WorkspaceConfig:
         # Auto cast removal became always-on; drop the old toggle key.
         data.pop("auto_cast_removal", None)
 
+        # Filed carrier's separate on/off toggle was folded into carrier_width itself
+        # (0 = off) in #542. A pre-#542 save always serialized both keys together, so
+        # if the toggle was off, force width to 0 too — otherwise the leftover numeric
+        # width (2.0 by the old default) reads as "on" under the new width>0 gating,
+        # silently re-enabling a carrier the user had switched off.
+        if "carrier_enabled" in data and not data.pop("carrier_enabled"):
+            data["carrier_width"] = 0.0
+
         if "use_original_res" in data and "export_resolution_mode" not in data:
             data["export_resolution_mode"] = (
                 ExportResolutionMode.ORIGINAL.value if data.pop("use_original_res") else ExportResolutionMode.PRINT.value

--- a/tests/test_config_deserialization.py
+++ b/tests/test_config_deserialization.py
@@ -244,6 +244,21 @@ class TestConfigDeserialization(unittest.TestCase):
         with self.assertNoLogs("negpy.domain.models", level=logging.WARNING):
             WorkspaceConfig.from_flat_dict({"vignette_strength": 0.2})
 
+    def test_legacy_carrier_enabled_false_zeros_width(self):
+        # Pre-#542 saves always serialize both keys together; the old default
+        # width (2.0) must not read as "on" under the new width>0 gating just
+        # because the separate enabled toggle is gone.
+        config = WorkspaceConfig.from_flat_dict({"carrier_enabled": False, "carrier_width": 2.0})
+        self.assertEqual(config.finish.carrier_width, 0.0)
+
+    def test_legacy_carrier_enabled_true_keeps_width(self):
+        config = WorkspaceConfig.from_flat_dict({"carrier_enabled": True, "carrier_width": 3.0})
+        self.assertEqual(config.finish.carrier_width, 3.0)
+
+    def test_legacy_carrier_enabled_does_not_warn(self):
+        with self.assertNoLogs("negpy.domain.models", level=logging.WARNING):
+            WorkspaceConfig.from_flat_dict({"carrier_enabled": False, "carrier_width": 2.0})
+
     def test_autocrop_mode_defaults_to_image_for_legacy_dicts(self):
         config = WorkspaceConfig.from_flat_dict({"process_mode": ProcessMode.C41})
         self.assertEqual(config.geometry.autocrop_mode, "image")

--- a/tests/test_process_sidebar.py
+++ b/tests/test_process_sidebar.py
@@ -70,3 +70,25 @@ def test_lock_bounds_disables_wp_bp_and_selector(qapp):
     sidebar.sync_ui()
     for w in (sidebar.white_point_slider, sidebar.black_point_slider, sidebar.ch_global_btn, sidebar.ch_r_btn):
         assert not w.isEnabled()
+
+
+def test_analysis_region_dot_reflects_committed_region_not_just_tool_state(qapp):
+    """Confirming a freehand region closes the draw tool (button unchecks), so the
+    dot is the only remaining cue that a region is active and overriding the
+    Analysis Buffer slider — it must track analysis_rect, not active_tool."""
+    controller, sidebar = _sidebar()
+
+    sidebar.sync_ui()
+    assert not sidebar.analysis_region_btn.edited_dot.isVisibleTo(sidebar.analysis_region_btn)
+
+    cfg = controller.state.config
+    controller.state.config = replace(cfg, process=replace(cfg.process, analysis_rect=(0.1, 0.1, 0.9, 0.9)))
+    sidebar.sync_ui()
+
+    assert sidebar.analysis_region_btn.edited_dot.isVisibleTo(sidebar.analysis_region_btn)
+    assert not sidebar.analysis_region_btn.isChecked()  # tool itself is closed
+    assert not sidebar.analysis_buffer_slider.isEnabled()
+
+    controller.state.config = replace(cfg, process=replace(cfg.process, analysis_rect=None))
+    sidebar.sync_ui()
+    assert not sidebar.analysis_region_btn.edited_dot.isVisibleTo(sidebar.analysis_region_btn)


### PR DESCRIPTION
## Summary

Three independent small fixes:

**1. Distinct, larger icons for Rotate CCW/CW.** They reused `fa5s.undo`/`fa5s.redo` — the same plain circular-arrow glyphs as the adjacent Undo/Redo buttons, easy to confuse at a glance. Switched to `mdi6.file-rotate-left`/`file-rotate-right` (a small page/box with a rotation arrow) and sized them a touch larger (20px vs the toolbar's standard 16px) so the page and arrow read clearly instead of blobbing together.

**2. `carrier_enabled` migration could silently re-enable a disabled carrier.** Loading any file/edit-history saved before #542 warned `Dropping unknown config keys: ['carrier_enabled']` on every load. That part is cosmetic, but the real issue: #542 folded the separate on/off toggle into `carrier_width` itself (0 = off), and the old default was `carrier_enabled=False` with `carrier_width=2.0` already set. A naive drop-the-key migration would read any old "off" save as "on" under the new `width>0` gating. `from_flat_dict` now zeroes `carrier_width` too when `carrier_enabled` was `False`, so state carries over correctly.

**3. Freedraw Analysis Region button now shows an active-state dot.** Confirming a region closes the draw tool (button unchecks), so the only remaining sign a custom region was overriding the Analysis Buffer slider was the slider going gray. Reuses the existing `EditedDot` pattern (same as Crop, sliders, channel tabs) — a corner dot tracking `analysis_rect is not None`, independent of whether the tool is currently open.

## Test plan
- [x] **Rotate icons**: verified visually via headless screenshot — clearly distinct from Undo/Redo
- [x] **Carrier migration**: new tests mirroring the existing migration-test pattern (width zeroed when disabled, kept when enabled, no warning either way); confirmed both fail without the fix
- [x] **Analysis dot**: verified against the real app with before/after screenshots — dot appears on confirm, clears when region is removed; new regression test confirms it tracks `analysis_rect` not `active_tool`, and fails without the fix
- [x] Full suite: 1987 passed. Two failures are pre-existing, unrelated Windows path-separator issues (`test_effective_input_icc`, `test_output_dir_subfolder_of_source`) that reproduce on a clean `main`
- [x] `ruff check` / `ruff format --check` clean