### PR TITLE
feat(retouch): score-weighted IR dust reconstruction

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,5 @@
+The IR dust reconstruction in negpy/features/retouch/logic.py ports algorithm
+concepts (continuous defect score, score-weighted multiscale reconstruction,
+original-floor writer rule, interior-radius routing with feathered compositing)
+from digital-fauxice, Copyright (c) 2026 Rohan Pandula, MIT License.
+https://github.com/rohanpandula/digital-fauxice

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -129,7 +129,19 @@ The control lives in the Lab sidebar (`lab.clahe_strength`), but the stage runs 
 ## 5. Retouching
 **Code**: `negpy.features.retouch`
 
-This stage removes physical artifacts like dust, hairs, and scratches from the negative. We use two complementary approaches:
+This stage removes physical artifacts like dust, hairs, and scratches from the negative. Three complementary approaches:
+
+*   **Infrared (IR) Dust Removal** (scans carrying an IR channel — Coolscan, SilverFast iSRD, VueScan DNG):
+    Dust and scratches block infrared light while the film's dyes pass it, so the IR plane is a defect map independent of the photograph. This path runs on the **linear source before normalization**, so every meter reads the cleaned film. Algorithm concepts are ported from digital-fauxice (see `NOTICE.md`), a validated recreation of Digital ICE.
+
+    1.  **Normalized ratio**: the IR plane is divided by its own local clean base — $r = IR / \text{blur}(\text{dilate}(IR))$ — reading ~$1.0$ on clean film and dipping under defects, independent of illumination. A crosstalk fit divides out the visible image's IR ghost first.
+    2.  **Division tier**: semi-transparent dust *attenuates* rather than blocks, so the image beneath is recovered directly: $RGB / r^{\gamma}$ with per-channel γ fitted per frame. The gain never lifts a pixel past its local clean base (defect-excluded mean $- \sigma$) — the guard that used to be a grain-biased local max and printed dark rings around specks.
+    3.  **Score-weighted fill**: the ratio maps to a continuous defect score $s \in [0.02, 1]$ ($1$ = clean; the IR Threshold slider moves the ramp — nothing is ever thresholded, so there is no abort and no mask edge). Opaque cores and hairs are rebuilt as a multiscale score-weighted average over nested supports:
+        $$\text{fill} = \frac{\sum I \cdot s \cdot w}{\sum s \cdot w}$$
+        Defective neighbours self-exclude, edges continue through defects (the finest support with clean data wins). Written under the **original-floor rule**: dust is dark in negative transmittance, so a repair may only lighten — a dark halo cannot be produced.
+    4.  **Routed inpaint**: only defects with an interior the fill can't see across (chebyshev radius ≥ 5 at detection scale) go to structure-following inpaint, composited with an alpha feather. A 2% frame budget bounds this heavy path; the fill itself always runs.
+
+    B&W silver and Kodachrome block IR like dust does; such frames are auto-detected (the IR plane mirrors the image) and skipped.
 
 *   **Automatic Dust Removal**:
     A resolution-invariant impulse detector and patching engine.
@@ -166,11 +178,11 @@ This mimics what lab scanners like Frontier or Noritsu do automatically. For max
 
 2.  **Vibrance**: Selectively boosts the saturation of muted colors using a chroma mask. The mask is strongest at zero chroma and fades to zero for already vibrant colors, preventing over-saturation of sensitive areas like skin tones.
 3.  **Global Saturation**: A linear boost applied to all colors via the HSV saturation channel. Before applying, the factor is multiplied by a grade-coupled chroma damping term $(k_{min}/k_g)^{strength}$ ("Dye Mute", default 0.5), where $k_g$ is the green print-curve slope and $k_{min}$ the softest printable slope. Per-channel H&D curves inflate chroma as contrast rises; the damping counters it, mimicking paper dyes' unwanted absorptions. Strength 0 disables. (The default was tuned against the old ProPhoto working gamut — it may run strong now that the working space is Adobe RGB.)
-4.  **Sharpening**: A **Method** selector picks Unsharp Mask or Deconvolution; both share the Amount/Radius/Masking controls and the same $\text{radius}\cdot\text{scale\_factor}$ Gaussian taps from `gaussian_kernel_1d` (uploaded to the `sharpen_k` storage buffer, convolved identically on CPU `cv2.sepFilter2D` and the separable WGSL passes), so CPU and GPU match bit-for-bit.
+4.  **Sharpening**: A **Method** selector picks Unsharp Mask or Deconvolution; both share the Amount/Radius/Masking controls and the same $\text{radius} \cdot \text{scale factor}$ Gaussian taps from `gaussian_kernel_1d` (uploaded to the `sharpen_k` storage buffer, convolved identically on CPU `cv2.sepFilter2D` and the separable WGSL passes), so CPU and GPU match bit-for-bit.
 
     **Unsharp Mask** — on the Lightness channel ($L$) in LAB space, with halo suppression (`lab_sharpen_h/v.wgsl`):
 
-    $$L_{diff} = L - \text{blur}(L, \sigma), \qquad \sigma = \text{radius} \cdot \text{scale\_factor}$$
+    $$L_{diff} = L - \text{blur}(L, \sigma), \qquad \sigma = \text{radius} \cdot \text{scale factor}$$
     $$\text{gain} = \text{amount} \cdot 2.5 \cdot \text{smoothstep}(1.5, 2.0, |L_{diff}|) \cdot m$$
     $$L_{final} = \text{clamp}\big(L + L_{diff}\cdot\text{gain},\; L_{min}-2,\; L_{max}+1\big)$$
     *   **Radius** (px): blur $\sigma$, scaled to the render size so preview and export match.

--- a/negpy/desktop/view/canvas/overlay.py
+++ b/negpy/desktop/view/canvas/overlay.py
@@ -675,13 +675,12 @@ class CanvasOverlay(QWidget):
 
         with self.state.metrics_lock:
             luma = self.state.last_metrics.get("detected_dust_luma")
-            ir = self.state.last_metrics.get("detected_dust_ir")
             uv_grid = self.state.last_metrics.get("uv_grid")
         if uv_grid is None:
             return
-        # Green = auto-luma, magenta = IR; absent lists (detection off) draw nothing.
+        # Green = auto-luma; an absent list (detection off) draws nothing. IR defects
+        # emit no capsules — the wash above is their overlay cue.
         self._draw_detection_strokes(painter, luma, uv_grid, _DUST_MARK_LUMA)
-        self._draw_detection_strokes(painter, ir, uv_grid, _DUST_MARK_IR)
 
     def _draw_detection_strokes(self, painter: QPainter, strokes, uv_grid: np.ndarray, color: QColor) -> None:
         """Neon outlines of detected dust strokes (mirrors _draw_placed_heals)."""
@@ -735,8 +734,8 @@ class CanvasOverlay(QWidget):
         return img
 
     def _corrected_masks(self) -> List[np.ndarray]:
-        """Auto-corrected-region masks to wash: IR division + inpainted hairs
-        (both emit no stroke capsules, so the wash is their only overlay cue)."""
+        """Auto-corrected-region masks to wash: IR corrections (division + fill)
+        and inpainted defects — none emit capsules, the wash is their overlay cue."""
         with self.state.metrics_lock:
             masks = []
             corr = self.state.last_metrics.get("ir_corrected_mask")

--- a/negpy/desktop/view/sidebar/retouch.py
+++ b/negpy/desktop/view/sidebar/retouch.py
@@ -8,7 +8,8 @@ from negpy.desktop.view.styles.theme import THEME
 
 _IR_REMOVAL_TIP = (
     "Use the scanner's infrared channel to remove dust and scratches (invisible to the colour dyes): faint "
-    "semi-transparent specks are divided back out to recover the image underneath, and only opaque cores are cloned."
+    "semi-transparent specks are divided back out to recover the image underneath, opaque cores and hairs are "
+    "rebuilt from clean neighbouring film, and only defects too wide to see across are inpainted."
 )
 _IR_THRESH_TIP = "Lower catches more dust, higher is conservative. Smooth response, no cliff."
 _OPTICAL_TIP = (

--- a/negpy/domain/models.py
+++ b/negpy/domain/models.py
@@ -427,6 +427,8 @@ class WorkspaceConfig:
         data.pop("vignette_strength", None)
         # Flare (veiling-glare floor) was removed; drop the key from old edits silently.
         data.pop("flare", None)
+        # IR stroke synthesis was replaced by the score-weighted fill; its pad radius is gone.
+        data.pop("ir_inpaint_radius", None)
         # Auto cast removal became always-on; drop the old toggle key.
         data.pop("auto_cast_removal", None)
 

--- a/negpy/features/retouch/logic.py
+++ b/negpy/features/retouch/logic.py
@@ -36,7 +36,7 @@ _DETECT_PAD_PX = 2.5
 # a ring on the defect's PSF skirt biases every boundary diff bright and the whole
 # clone renders as a soft ghost. The blend footprint stays at the blend radius.
 _MEMBRANE_RIM_PX = 2.0
-# Rim feather fraction of the blend radius (1.5px floor). Ungated auto/IR regions
+# Rim feather fraction of the blend radius (1.5px floor). Ungated auto-luma regions
 # widen it via the gate lane. Mirrored in retouch.wgsl.
 _RIM_FEATHER_FRAC = 0.25
 _RIM_FEATHER_UNGATED = 0.15
@@ -44,8 +44,6 @@ _RIM_FEATHER_UNGATED = 0.15
 # IR ratio-normalization base window (px at detection scale, pinned like HEAL_SIZE_REF).
 # Defects wider than ~half of it depress their own base (max-area/Scratch territory).
 _IR_BASE_WIN = 25
-_IR_COVERAGE_ABORT = 0.01  # cutoff marking >this fraction → unusable IR, return nothing
-_IR_GROW_FRAC = 0.3  # hysteresis: grow seeded defects this far across the gap to clean film
 _IR_GAIN_IDENTITY = 0.97  # gain is identity at/above this ratio
 _IR_GAIN_CLAMP = 2.0  # caps misregistration halos
 # Per-channel refraction γ, fitted per frame (patent 1.03–1.10 under-correct file IR).
@@ -60,7 +58,7 @@ _IR_DEAD_FLOOR = 0.05
 _IR_XTALK_MAX = 0.8  # per-channel exponent cap; ≥0 only — density can only block IR
 _IR_XTALK_MIN = 0.02  # |b| sum below this is a noise-level fit → exact no-op
 _IR_DEGENERATE_GHOST = 0.5  # fitted exponent sum above this: IR mirrors the image (B&W/Kodachrome)
-_IR_XTALK_TRIM = 5.0  # fit drops this bottom-ratio percentile (the dust minority); 5x the coverage abort
+_IR_XTALK_TRIM = 5.0  # fit drops this bottom-ratio percentile (the dust minority)
 # γ fit sample: keep this flattest fraction of the band by visible Laplacian, dropping the
 # restriction below _IR_FIT_MIN_PX rather than fitting a handful of pixels. See _fit_refraction_gammas.
 _IR_FIT_FLAT_PCT = 40
@@ -70,11 +68,36 @@ _IR_FIT_MIN_PX = 200
 # downsample_ir is min-preserving while the visible arrives area-averaged, so at detection scale
 # the ratio's dip runs deeper and ~1 px wider than the defect the visible carries (0.816 against
 # 0.892); uncapped, that skirt lifts clean film and every speck and hair renders with a dark
-# outline. Reaches ±4 px, past _DETECT_PAD_PX's skirt: wider re-admits the rim (25 px leaves 3x
-# the residual), narrower sits inside the skirt and caps real correction away.
+# outline. Reaches ±4 px, past _DETECT_PAD_PX's skirt. Base = defect-excluded local mean −
+# _IR_CAP_SIGMA·σ, not blur(dilate): the dilate is a local max, ~2σ of grain high, and re-admits
+# the ring on grainy film (#563). Under _IR_CAP_MIN_SUPPORT clean pixels in the window → the max
+# estimate returns (deep inside wide defects, where _IR_GAIN_CLAMP binds first).
 _IR_CAP_WIN = 9
+_IR_CAP_SIGMA = 1.0
+_IR_CAP_MIN_SUPPORT = 0.1  # fraction of the window (~8 px at 9×9)
 
-# Strong hairs/scratches (auto/IR) route to structure-following inpaint instead of
+# IR reconstruction: concepts ported from digital-fauxice (MIT, © 2026 Rohan
+# Pandula, see NOTICE.md) — continuous score, score-weighted fill, original-floor rule.
+# Score: 1 = clean (ratio ≥ _IR_GAIN_IDENTITY), floor at/below the slider's cutoff.
+# Never thresholded — no mask edge to halo, no coverage fraction to abort on.
+_IR_SCORE_FLOOR = 0.02
+# Fill supports (detection-scale px, × the buffer's upsample factor). Candidate per
+# support: Σ(rgb·score·win)/Σ(score·win) — low-score neighbours self-exclude. A finer
+# support wins once its clean fraction reaches _IR_FILL_TAU (edges continue through).
+_IR_FILL_SCALES = (9, 5, 3)
+_IR_FILL_TAU = 0.15
+# Write ramp: untouched above HI (grain survives), full fill at/below LO.
+_IR_WRITE_HI = 0.85
+_IR_WRITE_LO = 0.40
+# Route to inpaint only components with a core the fill can't see across (chebyshev
+# radius ≥ 5 ⇔ solid 9×9 interior). Thin hairs stay with the fill: every pixel is
+# within reach of clean film, and NS inpaint would smear structure the fill keeps.
+# The budget bounds only this heavy path; the fill always runs.
+_IR_ROUTE_RADIUS = 5
+_IR_ROUTE_DILATE = 2
+_IR_ROUTE_BUDGET = 0.02  # fraction of the frame
+
+# Strong hairs/scratches (auto-luma) route to structure-following inpaint instead of
 # the membrane clone: a long twist crosses varied background, and one clone-source
 # offset can't match it. Bar sits above the mild-elongation capsule test so ordinary
 # dust clusters stay on the membrane. Detection-scale px. See _is_hair.
@@ -496,23 +519,18 @@ def _mask_to_strokes(
     mask: np.ndarray,
     pad_px: float,
     max_n: int,
-    min_area: int = 1,
-    max_area: Optional[int] = None,
 ) -> Tuple[List[Tuple[np.ndarray, float, float]], Optional[np.ndarray]]:
     """Connected defect components → ``(compact_comps, hair_mask)``. Compact specks
     become ``(chain_px, radius_px, area)`` tuples (largest first, truncated to
     ``max_n``); mildly elongated ones a ≤8-point membrane capsule. Strongly
     elongated defects (long twisted hairs/scratches) are painted into ``hair_mask``
     instead — they route to structure-following inpaint, which a single-offset
-    membrane clone can't track. ``min_area``/``max_area`` drop noise specks and
-    oversized blobs (IR path); the luma path leaves them at the defaults."""
+    membrane clone can't track."""
     n_lbl, labels, stats, centroids = cv2.connectedComponentsWithStats(np.ascontiguousarray(mask, dtype=np.uint8), connectivity=8)
     comps = []
     hair_mask: Optional[np.ndarray] = None
     for i in range(1, n_lbl):
         area = int(stats[i, cv2.CC_STAT_AREA])
-        if area < min_area or (max_area is not None and area > max_area):
-            continue
         x0 = int(stats[i, cv2.CC_STAT_LEFT])
         y0 = int(stats[i, cv2.CC_STAT_TOP])
         bw = int(stats[i, cv2.CC_STAT_WIDTH])
@@ -778,19 +796,6 @@ def normalize_ir(plane: np.ndarray) -> np.ndarray:
     return plane / np.maximum(base, 1e-4)
 
 
-def _hysteresis(ratio: np.ndarray, strong: np.ndarray, cutoff: float) -> np.ndarray:
-    """Grow each seeded defect through ``_IR_GROW_FRAC`` of the gap to clean film, keeping
-    only components holding a strong pixel (Canny's rule).
-
-    ``_ir_decontaminate`` divides by ``Π vis^b`` and a defect blocks visible light too, so
-    it lifts the defect's own ratio (a hair core 0.252 → 0.362). Cores still clear the
-    cutoff by a mile; thin sections don't, so a hair would arrive shattered into specks."""
-    grow = cutoff + (1.0 - cutoff) * _IR_GROW_FRAC
-    _n, labels = cv2.connectedComponents((ratio < grow).astype(np.uint8), connectivity=8)
-    keep = np.unique(labels[strong])
-    return np.isin(labels, keep[keep > 0]).astype(np.uint8)
-
-
 def ir_detect_cutoff(slider: float, attenuation: bool) -> float:
     """UI IR sensitivity (higher = conservative) → ratio cutoff; lower slider catches
     more. Attenuation-on band sits lower (division handles the rest, only cores need cloning)."""
@@ -798,37 +803,89 @@ def ir_detect_cutoff(slider: float, attenuation: bool) -> float:
     return (0.85 - 0.40 * s) if attenuation else (0.95 - 0.20 * s)
 
 
-def detect_ir_regions(
-    ratio: np.ndarray,
-    cutoff: float,
-    pad_px: float = 3.0,
-    max_n: int = 512,
-    guide: Optional[np.ndarray] = None,
-    min_area: int = 2,
-    max_area: int = 2000,
-) -> Tuple[List[Tuple], Optional[np.ndarray]]:
-    """Normalized-IR defects → ``(strokes, hair_mask)``: compact cores become
-    ungated membrane strokes, strong hairs a detection-scale mask for inpaint
-    (``ratio`` from normalize_ir, ``cutoff`` from ir_detect_cutoff). Coverage abort
-    guards a misregistered IR plane. ``guide`` (RGB proxy) scores clone sources; else the ratio."""
-    ratio = np.ascontiguousarray(ratio, dtype=np.float32)
-    strong = ratio < cutoff
-    # Coverage guards a misregistered IR plane, so it reads the *seed*: hysteresis only
-    # completes defects the strict cutoff already accepted, it never finds new ones.
-    cov = float(strong.mean())
-    if cov <= 0.0:
-        return [], None
-    if cov > _IR_COVERAGE_ABORT:
-        logger.warning("IR dust: cutoff %.3f marks %.1f%% of the frame — skipping (raise IR threshold)", cutoff, cov * 100.0)
-        return [], None
-    mask = _hysteresis(ratio, strong, cutoff)
-    if guide is None or guide.shape[:2] != ratio.shape[:2]:
-        guide = ratio
-    comps, hair_mask = _mask_to_strokes(mask, pad_px, max_n, min_area=min_area, max_area=max_area)
-    if not comps:
-        return [], hair_mask
-    offsets = _pick_source_offsets(mask, comps, guide)
-    return _finalize_strokes(comps, offsets, mask.shape, gate=0.0), hair_mask
+def ir_defect_score(ratio: np.ndarray, cutoff: float) -> np.ndarray:
+    """Continuous defect score in ``[_IR_SCORE_FLOOR, 1]``: 1 = clean film, floor
+    at/below ``cutoff`` (from ir_detect_cutoff). The 3×3 erode bleeds a defect's score
+    one pixel outward, covering sub-pixel hairs and the min-pool skirt."""
+    span = max(_IR_GAIN_IDENTITY - cutoff, 1e-4)
+    t = (np.ascontiguousarray(ratio, dtype=np.float32) - cutoff) / span
+    score = np.clip(t * (1.0 - _IR_SCORE_FLOOR) + _IR_SCORE_FLOOR, _IR_SCORE_FLOOR, 1.0)
+    return cv2.erode(score, np.ones((3, 3), np.uint8))
+
+
+def score_weighted_fill(img: np.ndarray, score: np.ndarray, scales: Tuple[int, ...] = _IR_FILL_SCALES) -> np.ndarray:
+    """Multiscale score-normalized average, blended coarse→fine by clean fraction.
+    Where no support holds clean film the quotient tends to zero and the original-floor
+    rule in apply_ir_reconstruction keeps the source pixel."""
+    s3 = score[..., None]
+    weighted = img * s3
+    fill: Optional[np.ndarray] = None
+    for i, k in enumerate(scales):
+        if i == len(scales) - 1:
+            num = cv2.GaussianBlur(weighted, (k, k), 0)
+            den = cv2.GaussianBlur(score, (k, k), 0)
+        else:
+            num = cv2.boxFilter(weighted, -1, (k, k))
+            den = cv2.boxFilter(score, -1, (k, k))
+        cand = num / np.maximum(den, 1e-6)[..., None]
+        if fill is None:
+            fill = cand
+        else:
+            conf = np.clip(den / _IR_FILL_TAU, 0.0, 1.0)[..., None]
+            fill = fill * (1.0 - conf) + cand * conf
+    assert fill is not None  # scales is never empty
+    return fill
+
+
+def apply_ir_reconstruction(img: ImageBuffer, score_det: np.ndarray) -> ImageBuffer:
+    """Bake the score-weighted fill into the linear source (new array). The detection-scale
+    score is upsampled; the fill convolutions rerun at the buffer's own resolution with
+    rescaled supports — filled pixels are never upsampled."""
+    h, w = img.shape[:2]
+    src = np.ascontiguousarray(img, dtype=np.float32)
+    if score_det.shape[:2] == (h, w):
+        score, factor = np.ascontiguousarray(score_det, dtype=np.float32), 1.0
+    else:
+        factor = max(h / score_det.shape[0], w / score_det.shape[1])
+        score = cv2.resize(score_det, (w, h), interpolation=cv2.INTER_LINEAR)
+    scales = tuple(int(round(k * factor)) | 1 for k in _IR_FILL_SCALES)
+    fill = score_weighted_fill(src, score, scales)
+    a = np.clip((_IR_WRITE_HI - score) / (_IR_WRITE_HI - _IR_WRITE_LO), 0.0, 1.0)
+    a = (a * a * (3.0 - 2.0 * a))[..., None]
+    out = src * (1.0 - a) + fill * a
+    # Original-floor rule: dust is dark in negative transmittance — repairs only lighten.
+    np.maximum(out, src, out=out)
+    return ensure_image(out)
+
+
+def route_ir_defects(score: np.ndarray) -> Optional[np.ndarray]:
+    """Detection-scale mask of at-floor components past the fill's reach, for
+    apply_hair_inpaint. Over budget (misregistered/garbage IR) → None + warning."""
+    at_floor = (score <= _IR_SCORE_FLOOR + 1e-6).astype(np.uint8)
+    if not at_floor.any():
+        return None
+    n_lbl, labels, stats, _ = cv2.connectedComponentsWithStats(at_floor, connectivity=8)
+    routed = np.zeros_like(at_floor)
+    side = 2 * _IR_ROUTE_RADIUS - 1
+    hit = False
+    for i in range(1, n_lbl):
+        bw, bh = int(stats[i, cv2.CC_STAT_WIDTH]), int(stats[i, cv2.CC_STAT_HEIGHT])
+        if min(bw, bh) < side:  # can't contain a side² solid → radius under the bar
+            continue
+        x0, y0 = int(stats[i, cv2.CC_STAT_LEFT]), int(stats[i, cv2.CC_STAT_TOP])
+        sub = np.pad((labels[y0 : y0 + bh, x0 : x0 + bw] == i).astype(np.uint8), 1)
+        if float(cv2.distanceTransform(sub, cv2.DIST_C, 3).max()) >= _IR_ROUTE_RADIUS:
+            routed[labels == i] = 1
+            hit = True
+    if not hit:
+        return None
+    k = cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (2 * _IR_ROUTE_DILATE + 1,) * 2)
+    routed = cv2.dilate(routed, k)
+    frac = float(routed.mean())
+    if frac > _IR_ROUTE_BUDGET:
+        logger.warning("IR dust: routed defects cover %.1f%% of the frame — inpaint skipped, fill only", frac * 100.0)
+        return None
+    return routed
 
 
 def _ir_decontaminate(ratio: np.ndarray, vis_log: np.ndarray) -> Tuple[np.ndarray, float]:
@@ -880,15 +937,29 @@ def _fit_refraction_gammas(ratio: np.ndarray, vis_log: np.ndarray, img_det: np.n
     return tuple(float(np.clip(np.median(vis_log[:, :, c][fit] / xb), _IR_GAMMA_LO, _IR_GAMMA_HI)) for c in range(3))
 
 
+def _ir_clean_base(img_det: np.ndarray, ratio: np.ndarray) -> np.ndarray:
+    """Local clean-film level per channel over ``_IR_CAP_WIN``: mean of the pixels the
+    IR ratio calls clean, minus ``_IR_CAP_SIGMA`` of their σ (see the constants block)."""
+    win = (_IR_CAP_WIN, _IR_CAP_WIN)
+    w_clean = (ratio >= _IR_GAIN_IDENTITY).astype(np.float32)
+    den = np.maximum(cv2.blur(w_clean, win), 1e-6)[..., None]
+    mean = cv2.blur(img_det * w_clean[..., None], win) / den
+    var = cv2.blur(img_det * img_det * w_clean[..., None], win) / den - mean * mean
+    base = mean - _IR_CAP_SIGMA * np.sqrt(np.clip(var, 0.0, None))
+    kernel = cv2.getStructuringElement(cv2.MORPH_RECT, (_IR_CAP_WIN, _IR_CAP_WIN))
+    dil = cv2.blur(cv2.dilate(img_det, kernel), win)
+    return np.where(den > _IR_CAP_MIN_SUPPORT, base, dil)
+
+
 def ir_ratio_and_gain(ir_det: np.ndarray, img_det: np.ndarray) -> Tuple[np.ndarray, np.ndarray, bool, Tuple[float, ...]]:
     """Detection-scale ``(ratio, gain HxWx3, degenerate, gammas)`` for IR-division
     attenuation: semi-transparent dust recovered by ``RGB / ratio^γ``, γ per channel from
     ``_fit_refraction_gammas``. ``degenerate`` = IR carrying image content
-    (B&W/Kodachrome) → caller skips bake and strokes."""
+    (B&W/Kodachrome) → caller skips the whole IR bake."""
     plane = ir_det[:, :, 0] if ir_det.ndim == 3 else ir_det
     ratio = normalize_ir(plane)
-    # No film under the head is not a defect; left as a dip the holder margin alone trips
-    # the coverage abort at every threshold.
+    # No film under the head is not a defect; left as a dip the holder margin would score
+    # as one giant routed component and swamp the routing budget.
     ratio[plane < _IR_DEAD_FLOOR] = 1.0
     img_det = np.ascontiguousarray(img_det, dtype=np.float32)
     if img_det.shape[:2] != ratio.shape[:2]:
@@ -907,8 +978,7 @@ def ir_ratio_and_gain(ir_det: np.ndarray, img_det: np.ndarray) -> Tuple[np.ndarr
         gain[:, :, c] = np.minimum(_IR_GAIN_CLAMP, base ** (-gammas[c]))
     # Never lift a pixel past its own local clean base (see _IR_CAP_WIN); floored at 1 so the
     # cap only ever holds the bake back, never darkens a pixel itself.
-    kernel = cv2.getStructuringElement(cv2.MORPH_RECT, (_IR_CAP_WIN, _IR_CAP_WIN))
-    clean = cv2.blur(cv2.dilate(img_det, kernel), (_IR_CAP_WIN, _IR_CAP_WIN))
+    clean = _ir_clean_base(img_det, ratio)
     np.minimum(gain, np.maximum(clean / np.maximum(img_det, 1e-5), 1.0), out=gain)
     return ratio, gain, degenerate, gammas
 
@@ -924,8 +994,10 @@ def apply_ir_attenuation(img: ImageBuffer, gain_det: np.ndarray) -> ImageBuffer:
 
 def ir_bake_token(retouch, has_ir: bool) -> str:
     """Config-identity token for the IR bake (mirrors ``flatfield_token``); folded into
-    source_hash so toggling it invalidates the engine cache."""
-    return "|irdiv1" if (retouch.ir_dust_remove and retouch.ir_attenuation and has_ir) else ""
+    source_hash so a toggle or threshold drag invalidates the engine cache."""
+    if not (retouch.ir_dust_remove and has_ir):
+        return ""
+    return f"|ir{int(retouch.ir_attenuation)}r{round(float(retouch.ir_threshold), 3)}"
 
 
 def apply_hair_inpaint(
@@ -943,10 +1015,11 @@ def apply_hair_inpaint(
     masks = [hm for hm in hair_masks if hm is not None]
     if not masks:
         return img
+    factor = max(1.0, h / masks[0].shape[0], w / masks[0].shape[1])
     if dilate_px is None:
         # A detection-scale mask knows its boundary only to within the upsample factor,
         # so the dilate tracks it; at 1:1 that's _HAIR_DILATE_PX, the PSF skirt alone.
-        dilate_px = max(_HAIR_DILATE_PX, round(max(h / masks[0].shape[0], w / masks[0].shape[1])))
+        dilate_px = max(_HAIR_DILATE_PX, round(factor))
     m = np.zeros((h, w), dtype=np.uint8)
     for hm in masks:
         r = hm if hm.shape[:2] == (h, w) else cv2.resize(hm.astype(np.float32), (w, h), interpolation=cv2.INTER_LINEAR)
@@ -968,13 +1041,23 @@ def apply_hair_inpaint(
         # Mask the whole crop, not just this component: a neighbour reaching into the
         # bbox must stay unknown or it becomes clone source and its dust is filled back in.
         sub_m = np.ascontiguousarray(m[y0:y1, x0:x1])
-        enc = np.clip(src[y0:y1, x0:x1], 0.0, 1.0) ** (1.0 / _HAIR_INPAINT_GAMMA)
+        crop = src[y0:y1, x0:x1]
+        # Encode against the crop's clean range — clip(0,1) posterizes fills in dark regions.
+        ctx = crop[sub_m == 0]
+        lo = float(np.percentile(ctx, 0.5)) if ctx.size else 0.0
+        hi = float(np.percentile(ctx, 99.5)) if ctx.size else 1.0
+        span = max(hi - lo, 1e-4)
+        enc = np.clip((crop - lo) / span, 0.0, 1.0) ** (1.0 / _HAIR_INPAINT_GAMMA)
         filled = cv2.inpaint((enc * 255.0 + 0.5).astype(np.uint8), sub_m, radius, cv2.INPAINT_NS)
-        dec = (filled.astype(np.float32) / 255.0) ** _HAIR_INPAINT_GAMMA
-        # ...but only keep this component: a neighbour clipped by the bbox fills badly here,
-        # and gets its own correctly-padded crop anyway.
+        dec = ((filled.astype(np.float32) / 255.0) ** _HAIR_INPAINT_GAMMA) * span + lo
+        # ...but only keep this component (a neighbour clipped by the bbox fills badly here,
+        # and gets its own correctly-padded crop anyway), alpha-feathered across the dilate
+        # band: full fill on the detected defect, ramp over the skirt. dilate_px=0 → no feather.
         mb = labels[y0:y1, x0:x1] == i
-        out[y0:y1, x0:x1][mb] = dec[mb]
+        d = cv2.distanceTransform(mb.astype(np.uint8), cv2.DIST_C, 3)
+        a = np.minimum(d / float(dilate_px + 1), 1.0)[..., None]
+        blended = crop * (1.0 - a) + dec * a
+        out[y0:y1, x0:x1][mb] = blended[mb]
     return out
 
 

--- a/negpy/features/retouch/models.py
+++ b/negpy/features/retouch/models.py
@@ -20,9 +20,8 @@ class RetouchConfig:
     manual_dust_size: int = 6
     ir_dust_remove: bool = False
     # Sensitivity on the normalized IR ratio (higher = conservative). Default 0.66 →
-    # cutoff 0.59 with attenuation on: division fixes shallow dust, detection heals cores.
+    # cutoff 0.59 with attenuation on: division fixes shallow dust, the fill rebuilds cores.
     ir_threshold: float = 0.66
-    ir_inpaint_radius: int = 3
     # IR-division tier: recover the image under semi-transparent dust (no cloning).
     # Tracks ir_dust_remove from the single "IR Removal" control; B&W/Kodachrome
     # frames are auto-skipped by the degenerate guard, not this flag.

--- a/negpy/services/rendering/image_processor.py
+++ b/negpy/services/rendering/image_processor.py
@@ -24,14 +24,16 @@ from negpy.features.flatfield.logic import apply_flatfield, flatfield_token
 from negpy.features.retouch.logic import (
     apply_hair_inpaint,
     apply_ir_attenuation,
+    apply_ir_reconstruction,
     compute_dust_stats,
-    detect_ir_regions,
     detect_luma_regions,
     downsample_ir,
     hair_bake_token,
     ir_bake_token,
+    ir_defect_score,
     ir_detect_cutoff,
     ir_ratio_and_gain,
+    route_ir_defects,
 )
 from negpy.features.rgbscan.logic import merge_rgb_triplet, rgbscan_token
 from negpy.domain.interfaces import PipelineContext
@@ -115,6 +117,10 @@ class ImageProcessor:
         # so creative-slider drags reuse it instead of re-inpainting every frame.
         self._hair_key: Optional[tuple] = None
         self._hair_value: Optional[np.ndarray] = None
+        # IR-baked source (division + score-weighted fill) and its routed mask, keyed
+        # like _hair so creative-slider drags reuse the baked buffer.
+        self._ir_recon_key: Optional[tuple] = None
+        self._ir_recon_value: Optional[tuple] = None
 
         if APP_CONFIG.use_gpu:
             gpu = GPUDevice.get()
@@ -161,19 +167,29 @@ class ImageProcessor:
         ir_buffer: Optional[np.ndarray],
         settings: WorkspaceConfig,
         source_key: str,
-    ) -> Tuple[np.ndarray, Optional[np.ndarray], bool]:
-        """IR-division attenuation, baked in source transmittance space before the
-        engine (mirrors apply_flatfield; the GPU re-uploads source each frame, so the
-        bake reaches it parity-free). Returns (corrected_img, corrected_mask_or_None, degenerate)."""
+    ) -> Tuple[np.ndarray, Optional[np.ndarray], bool, Optional[np.ndarray]]:
+        """IR correction baked in source transmittance space before the engine (mirrors
+        apply_flatfield; the GPU re-uploads source each frame, so the bake reaches it
+        parity-free): division attenuation for semi-transparent dust, score-weighted
+        fill for opaque cores. Returns (corrected_img, corrected_mask_or_None, degenerate,
+        routed_mask_or_None) — the routed mask goes to _hair_inpaint."""
         ret = settings.retouch
         if self._is_flat(settings) or ir_buffer is None or not ret.ir_dust_remove:
-            return img, None, False
+            return img, None, False, None
         ratio_det, gain_det, degenerate, _ = self._ir_ratio_gain(ir_buffer, img, source_key)
         if degenerate:
-            return img, None, True
-        if not ret.ir_attenuation:
-            return img, None, False
-        return apply_ir_attenuation(img, gain_det), (ratio_det < 0.97), False
+            return img, None, True, None
+        key = (source_key, round(float(ret.ir_threshold), 6), bool(ret.ir_attenuation), img.shape)
+        if key == self._ir_recon_key and self._ir_recon_value is not None:
+            out, routed = self._ir_recon_value
+        else:
+            score_det = ir_defect_score(ratio_det, ir_detect_cutoff(ret.ir_threshold, ret.ir_attenuation))
+            out = apply_ir_attenuation(img, gain_det) if ret.ir_attenuation else img
+            out = apply_ir_reconstruction(out, score_det)
+            routed = route_ir_defects(score_det)
+            self._ir_recon_key = key
+            self._ir_recon_value = (out, routed)
+        return out, (ratio_det < 0.97), False, routed
 
     def _hair_inpaint(self, img: np.ndarray, hair_masks: List[np.ndarray], cache_key: str) -> np.ndarray:
         """Structure-following inpaint of detected hairs, baked into the source before
@@ -191,30 +207,22 @@ class ImageProcessor:
         self,
         settings: WorkspaceConfig,
         img: np.ndarray,
-        ir_buffer: Optional[np.ndarray],
         source_key: str,
     ) -> Tuple[WorkspaceConfig, Optional[Dict[str, list]], List[np.ndarray]]:
-        """Source-space dust detection → synthesized heal strokes on a
+        """Source-space luma dust detection → synthesized heal strokes on a
         render-local config (auto flags cleared — the engines only see strokes).
         The caller's config is untouched, so synthesized strokes never reach
-        sidecars, presets or the DB. Also returns the detected strokes split by
-        source ({"luma", "ir"}) for the display overlay (or None when detection
-        is off), and the detection-scale hair masks for structure-following inpaint."""
+        sidecars, presets or the DB. Also returns the detected strokes for the
+        display overlay (None when detection is off) and the detection-scale hair
+        masks for inpaint. IR defects never become strokes — _ir_bake repairs them."""
         ret = settings.retouch
-        do_luma = ret.dust_remove
-        do_ir = ret.ir_dust_remove and ir_buffer is not None
-        if self._is_flat(settings) or not (do_luma or do_ir):
+        if self._is_flat(settings) or not ret.dust_remove:
             return settings, None, []
 
         key = (
             source_key,
-            do_luma,
             round(float(ret.dust_threshold), 6),
             int(ret.dust_size),
-            do_ir,
-            round(float(ret.ir_threshold), 6),
-            bool(ret.ir_attenuation),
-            int(ret.ir_inpaint_radius),
             settings.process.process_mode,
         )
         if key == self._retouch_detect_key and self._retouch_detect_value is not None:
@@ -227,35 +235,21 @@ class ImageProcessor:
                 stats = compute_dust_stats(_detection_downsample(img), ret.dust_size)
                 self._dust_stats_key = stats_key
                 self._dust_stats_value = stats
-            synth_ir, hair_ir = [], None
-            if do_ir and ir_buffer is not None:
-                ratio_det, _gain, degenerate, _g = self._ir_ratio_gain(ir_buffer, img, source_key)
-                if not degenerate:
-                    synth_ir, hair_ir = detect_ir_regions(
-                        ratio_det,
-                        ir_detect_cutoff(ret.ir_threshold, ret.ir_attenuation),
-                        pad_px=float(ret.ir_inpaint_radius),
-                        guide=stats[4],
-                    )
-            synth_luma, hair_luma = [], None
-            if do_luma:
-                # Ungated like IR: the detector already confirmed the defect, and
-                # the bright-only gate leaves half-healed fringe rings (halos)
-                # around soft-edged specks (also, E6 dust is dark — gate would
-                # veto it entirely).
-                synth_luma, hair_luma = detect_luma_regions(
-                    _detection_downsample(img), ret.dust_threshold, ret.dust_size, gate=0.0, stats=stats
-                )
-            detected = {"ir": synth_ir, "luma": synth_luma}
-            hair_masks = [m for m in (hair_ir, hair_luma) if m is not None]
+            # Ungated: the detector already confirmed the defect, and the
+            # bright-only gate leaves half-healed fringe rings (halos) around
+            # soft-edged specks (also, E6 dust is dark — gate would veto it).
+            synth_luma, hair_luma = detect_luma_regions(
+                _detection_downsample(img), ret.dust_threshold, ret.dust_size, gate=0.0, stats=stats
+            )
+            detected = {"luma": synth_luma}
+            hair_masks = [hair_luma] if hair_luma is not None else []
             self._retouch_detect_key = key
             self._retouch_detect_value = (detected, hair_masks)
 
-        synth = list(detected["ir"]) + list(detected["luma"])
+        synth = list(detected["luma"])
         budget = max(0, 512 - len(ret.manual_heal_strokes) - len(ret.manual_dust_spots))
         if len(synth) > budget:
             logger.warning("Retouch: healing %d of %d detected defects (region cap)", budget, len(synth))
-            # Keep the largest across ir+luma (IR used to head-truncate luma wholesale).
             synth = sorted(synth, key=lambda s: -s[1])[:budget]
         return (
             dc_replace(
@@ -307,12 +301,14 @@ class ImageProcessor:
             + ir_bake_token(settings.retouch, ir_buffer is not None)
         )
 
-        # Bake IR attenuation before detection so meters/stats see the corrected buffer.
+        # Bake the IR correction before detection so meters/stats see the corrected buffer.
         want_ir = settings.retouch.ir_dust_remove and ir_buffer is not None and not self._is_flat(settings)
-        img, ir_corrected_mask, ir_degenerate = self._ir_bake(img, ir_buffer, settings, base_hash)
+        img, ir_corrected_mask, ir_degenerate, ir_routed = self._ir_bake(img, ir_buffer, settings, base_hash)
 
         orig_ret = settings.retouch
-        settings, detected_dust, hair_masks = self._augment_retouch(settings, img, ir_buffer, base_hash)
+        settings, detected_dust, hair_masks = self._augment_retouch(settings, img, base_hash)
+        if ir_routed is not None:
+            hair_masks = hair_masks + [ir_routed]  # never mutate the cached list
         # Inpaint long/twisted hairs into the source (both engines see it — the token
         # invalidates the base stage when detection params change; empty otherwise).
         hair_token = hair_bake_token(orig_ret) if hair_masks else ""
@@ -336,11 +332,10 @@ class ImageProcessor:
         # source. Absent when detection is off (so the overlay draws nothing).
         if detected_dust is not None:
             context.metrics["detected_dust_luma"] = detected_dust["luma"]
-            context.metrics["detected_dust_ir"] = detected_dust["ir"]
         # Overlay wash over the inpainted hairs (they emit no stroke capsules).
         if hair_masks:
             context.metrics["hair_inpaint_masks"] = hair_masks
-        # Overlay data for the division-corrected regions + the B&W/Kodachrome guard.
+        # Overlay data for the IR-corrected regions (division + fill) + the B&W/Kodachrome guard.
         if want_ir:
             context.metrics["ir_degenerate"] = ir_degenerate
             if ir_corrected_mask is not None:
@@ -536,9 +531,11 @@ class ImageProcessor:
                 + linear_raw_token(params.process)
                 + ir_bake_token(params.retouch, ir_full is not None)
             )
-            f32_buffer, _, _ = self._ir_bake(f32_buffer, ir_full, params, detect_key)
+            f32_buffer, _, _, ir_routed = self._ir_bake(f32_buffer, ir_full, params, detect_key)
             orig_ret = params.retouch
-            params, _, hair_masks = self._augment_retouch(params, f32_buffer, ir_full, detect_key)
+            params, _, hair_masks = self._augment_retouch(params, f32_buffer, detect_key)
+            if ir_routed is not None:
+                hair_masks = hair_masks + [ir_routed]
             if hair_masks:
                 f32_buffer = self._hair_inpaint(f32_buffer, hair_masks, detect_key + hair_bake_token(orig_ret))
 
@@ -757,9 +754,11 @@ class ImageProcessor:
                 + linear_raw_token(params.process)
                 + ir_bake_token(params.retouch, ir_full is not None)
             )
-            f32_buffer, _, _ = self._ir_bake(f32_buffer, ir_full, params, detect_key)
+            f32_buffer, _, _, ir_routed = self._ir_bake(f32_buffer, ir_full, params, detect_key)
             orig_ret = params.retouch
-            params, _, hair_masks = self._augment_retouch(params, f32_buffer, ir_full, detect_key)
+            params, _, hair_masks = self._augment_retouch(params, f32_buffer, detect_key)
+            if ir_routed is not None:
+                hair_masks = hair_masks + [ir_routed]
             if hair_masks:
                 f32_buffer = self._hair_inpaint(f32_buffer, hair_masks, detect_key + hair_bake_token(orig_ret))
 

--- a/tests/test_dust_overlay.py
+++ b/tests/test_dust_overlay.py
@@ -17,39 +17,42 @@ def _speck_image():
     return img
 
 
-def test_augment_retouch_returns_split_lists():
+def test_augment_retouch_returns_luma_strokes():
     service = ImageProcessor()
     cfg = replace(WorkspaceConfig(), retouch=RetouchConfig(dust_remove=True, dust_threshold=0.5, dust_size=4))
-    settings, detected, _ = service._augment_retouch(cfg, _speck_image(), None, "s")
+    settings, detected, _ = service._augment_retouch(cfg, _speck_image(), "s")
 
-    assert detected is not None and set(detected) == {"luma", "ir"}
+    assert detected is not None and set(detected) == {"luma"}
     assert len(detected["luma"]) >= 1
-    assert detected["ir"] == []
     # The merged strokes still reach the render-local config (auto flag cleared).
     assert settings.retouch.dust_remove is False
     assert len(settings.retouch.manual_heal_strokes) >= 1
 
 
-def test_augment_retouch_ir_populates_ir_list():
+def test_ir_bake_repairs_defects_in_place():
+    """IR defects never become strokes — _ir_bake rebuilds them in the source buffer."""
     h, w = 80, 80
     rng = np.random.default_rng(17)
-    img = (np.full((h, w, 3), 0.5) + rng.normal(0, 0.01, (h, w, 3))).astype(np.float32)
+    img = np.clip(np.full((h, w, 3), 0.5) + rng.normal(0, 0.01, (h, w, 3)), 0, 1).astype(np.float32)
+    img[39:42, 39:42] = 0.05
     ir = np.full((h, w), 0.9, dtype=np.float32)
     ir[39:42, 39:42] = 0.05
 
     service = ImageProcessor()
     cfg = replace(WorkspaceConfig(), retouch=RetouchConfig(ir_dust_remove=True, ir_threshold=0.5))
-    _, detected, _ = service._augment_retouch(cfg, img, ir, "s")
+    baked, corrected_mask, degenerate, routed = service._ir_bake(img, ir, cfg, "s")
+    assert not degenerate and routed is None
+    assert corrected_mask is not None and corrected_mask[40, 40]
+    assert float(np.asarray(baked)[40, 40].min()) > 0.4, "the speck is rebuilt in the bake"
 
-    assert detected is not None
-    assert len(detected["ir"]) >= 1
-    assert detected["luma"] == []
+    _, detected, _ = service._augment_retouch(cfg, baked, "s")
+    assert detected is None, "IR-only config synthesizes no strokes"
 
 
 def test_augment_retouch_returns_none_when_detection_off():
     service = ImageProcessor()
     cfg = replace(WorkspaceConfig(), retouch=RetouchConfig(dust_remove=False, ir_dust_remove=False))
-    settings, detected, hair = service._augment_retouch(cfg, _speck_image(), None, "s")
+    settings, detected, hair = service._augment_retouch(cfg, _speck_image(), "s")
     assert detected is None and hair == []
     assert settings is cfg  # untouched
 
@@ -61,7 +64,6 @@ def test_run_pipeline_surfaces_detected_dust_to_metrics(monkeypatch):
     cfg = replace(WorkspaceConfig(), retouch=RetouchConfig(dust_remove=True, dust_threshold=0.5, dust_size=4))
     _, metrics = service.run_pipeline(_speck_image(), cfg, "h", render_size_ref=512, prefer_gpu=False, readback_metrics=False)
     assert len(metrics["detected_dust_luma"]) >= 1
-    assert metrics["detected_dust_ir"] == []
 
     cfg_off = replace(WorkspaceConfig(), retouch=RetouchConfig(dust_remove=False))
     _, metrics_off = service.run_pipeline(_speck_image(), cfg_off, "h2", render_size_ref=512, prefer_gpu=False, readback_metrics=False)

--- a/tests/test_image_processor.py
+++ b/tests/test_image_processor.py
@@ -155,11 +155,11 @@ def test_augment_retouch_reuses_stats_across_threshold_changes(monkeypatch) -> N
     service = ImageProcessor()
     for thr in (0.5, 0.6, 0.7):
         cfg = replace(WorkspaceConfig(), retouch=RetouchConfig(dust_remove=True, dust_threshold=thr, dust_size=4))
-        service._augment_retouch(cfg, img, None, "same-source")
+        service._augment_retouch(cfg, img, "same-source")
     assert len(calls) == 1, "stat maps must survive threshold-only changes"
 
     cfg = replace(WorkspaceConfig(), retouch=RetouchConfig(dust_remove=True, dust_threshold=0.7, dust_size=6))
-    service._augment_retouch(cfg, img, None, "same-source")
+    service._augment_retouch(cfg, img, "same-source")
     assert len(calls) == 2, "dust_size changes the blur windows and must recompute"
 
 
@@ -190,9 +190,9 @@ def test_ir_ratio_gain_downsamples_once_per_source(monkeypatch) -> None:
     assert len(calls) == 2, "a new source must still recompute"
 
 
-def test_ir_two_tier_bake_and_detection() -> None:
-    """Semi-transparent dust is fixed by division (no stroke); an opaque core still
-    detects into a spatial-fill stroke."""
+def test_ir_two_tier_bake() -> None:
+    """Semi-transparent dust is fixed by division, the opaque core by the
+    score-weighted fill — both inside the same bake, no strokes anywhere."""
     from dataclasses import replace
 
     from negpy.features.retouch.models import RetouchConfig
@@ -208,80 +208,60 @@ def test_ir_two_tier_bake_and_detection() -> None:
     service = ImageProcessor()
     cfg = replace(WorkspaceConfig(), retouch=RetouchConfig(ir_dust_remove=True, ir_attenuation=True))
 
-    baked, corr_mask, degenerate = service._ir_bake(img, ir, cfg, "s")
-    assert not degenerate
+    baked, corr_mask, degenerate, routed = service._ir_bake(img, ir, cfg, "s")
+    assert not degenerate and routed is None
     assert corr_mask is not None
     assert baked[41, 41].mean() > img[41, 41].mean(), "semi-transparent speck not lifted by division"
+    assert float(np.asarray(baked)[151, 151].min()) > 0.4, "opaque core not rebuilt by the fill"
 
-    _, detected, _ = service._augment_retouch(cfg, baked, ir, "s")
-    assert detected is not None
-    assert len(detected["ir"]) == 1, "only the opaque core should become a stroke"
+    _, detected, _ = service._augment_retouch(cfg, baked, "s")
+    assert detected is None, "no strokes for an IR-only config"
 
 
-def test_ir_bake_noop_when_attenuation_off() -> None:
+def test_ir_bake_fill_runs_without_attenuation() -> None:
+    """ir_attenuation off is no longer a full escape hatch: the division gain is
+    skipped, but the score-weighted fill still repairs opaque defects."""
     from dataclasses import replace
 
     from negpy.features.retouch.models import RetouchConfig
 
     ir = np.full((80, 80), 0.9, dtype=np.float32)
-    ir[40:44, 40:44] = 0.2
+    ir[40:44, 40:44] = 0.1
     img = np.full((80, 80, 3), 0.5, dtype=np.float32)
+    img[40:44, 40:44] = 0.06
     service = ImageProcessor()
     cfg = replace(WorkspaceConfig(), retouch=RetouchConfig(ir_dust_remove=True, ir_attenuation=False))
-    baked, corr_mask, _ = service._ir_bake(img, ir, cfg, "s")
-    assert baked is img and corr_mask is None  # escape hatch: no correction
+    baked, corr_mask, _, _ = service._ir_bake(img, ir, cfg, "s")
+    assert corr_mask is not None and corr_mask[41, 41]
+    assert float(np.asarray(baked)[41, 41].min()) > 0.4, "the fill must run even without division"
+    off = np.ones((80, 80), dtype=bool)
+    off[36:48, 36:48] = False
+    assert np.array_equal(np.asarray(baked)[off], img[off]), "clean film untouched without the gain"
 
 
-def _ir_hair_and_core():
-    """Source + IR with a long diagonal hair (→ inpaint) and a compact core (→ stroke)."""
-    h = w = 200
-    ir = np.full((h, w), 0.9, dtype=np.float32)
-    img = np.full((h, w, 3), 0.5, dtype=np.float32)
-    for t in range(90):
-        y, x = 60 + t // 2, 40 + t
-        ir[y : y + 2, x : x + 2] = 0.1
-        img[y : y + 2, x : x + 2] = 0.95
-    ir[150:154, 150:154] = 0.1
-    img[150:154, 150:154] = 0.9
-    return img, ir
-
-
-def test_augment_retouch_routes_hair_to_inpaint_mask() -> None:
-    from dataclasses import replace
-
-    from negpy.features.retouch.models import RetouchConfig
-
-    img, ir = _ir_hair_and_core()
-    service = ImageProcessor()
-    cfg = replace(WorkspaceConfig(), retouch=RetouchConfig(ir_dust_remove=True, ir_attenuation=False, ir_threshold=0.35))
-
-    settings, detected, hair_masks = service._augment_retouch(cfg, img, ir, "s")
-    assert hair_masks, "long hair must produce an inpaint mask"
-    assert len(detected["ir"]) == 1, "the compact core should still become one membrane stroke"
-
-    # Idempotent: the render-local config (flags cleared) yields no second bake.
-    _, _, hair_again = service._augment_retouch(settings, img, ir, "s2")
-    assert hair_again == []
-
-
-def test_run_pipeline_inpaints_hair_and_surfaces_mask(monkeypatch) -> None:
+def test_run_pipeline_routes_wide_ir_blob_to_inpaint(monkeypatch) -> None:
+    """A blob wider than the fill's reach is routed to the structure-following inpaint
+    inside the pipeline, and its mask surfaces for the overlay wash."""
     from dataclasses import replace
 
     from negpy.features.retouch.models import RetouchConfig
 
     service = ImageProcessor()
     monkeypatch.setattr(service.engine_cpu, "process", lambda img, s, sh, ctx: img)  # identity → inspect the baked source
-    img, ir = _ir_hair_and_core()
+    h = w = 200
+    ir = np.full((h, w), 0.9, dtype=np.float32)
+    img = np.full((h, w, 3), 0.5, dtype=np.float32)
+    ir[60:76, 60:76] = 0.1  # 16×16: interior radius ≥ the routing bar
+    img[60:76, 60:76] = 0.06
     cfg = replace(WorkspaceConfig(), retouch=RetouchConfig(ir_dust_remove=True, ir_attenuation=False, ir_threshold=0.35))
 
     out, metrics = service.run_pipeline(img, cfg, "h", render_size_ref=512, prefer_gpu=False, readback_metrics=False, ir_buffer=ir)
     assert "hair_inpaint_masks" in metrics
-    assert float(out[72, 65, 0]) < 0.7, "hair not inpainted out of the source"
+    assert float(out[68, 68, 0]) > 0.4, "blob interior not inpainted out of the source"
 
 
 def test_augment_retouch_cap_keeps_largest(monkeypatch) -> None:
-    """Over budget, the largest regions survive across ir+luma (IR used to
-    head-truncate the whole luma list)."""
+    """Over budget, the largest detected regions survive."""
     from dataclasses import replace
 
     import negpy.services.rendering.image_processor as ip
@@ -289,17 +269,15 @@ def test_augment_retouch_cap_keeps_largest(monkeypatch) -> None:
 
     big = ([[0.5, 0.5]], 40.0, 0.1, 0.0, 0.0)
     small = ([[0.4, 0.4]], 5.0, 0.1, 0.0, 0.0)
-    monkeypatch.setattr(ip, "detect_ir_regions", lambda *a, **k: ([small, small, small], None))
-    monkeypatch.setattr(ip, "detect_luma_regions", lambda *a, **k: ([big, big, big], None))
+    monkeypatch.setattr(ip, "detect_luma_regions", lambda *a, **k: ([small, big, small, big, big], None))
 
     img = np.full((160, 160, 3), 0.5, dtype=np.float32)
-    ir = np.full((160, 160), 0.9, dtype=np.float32)
     manual = [([[0.1, 0.1]], 3.0, 0.0, 0.0)] * 510  # budget = 512 − 510 = 2
-    cfg = replace(WorkspaceConfig(), retouch=RetouchConfig(dust_remove=True, ir_dust_remove=True, manual_heal_strokes=manual))
+    cfg = replace(WorkspaceConfig(), retouch=RetouchConfig(dust_remove=True, manual_heal_strokes=manual))
 
-    settings, _, _ = ImageProcessor()._augment_retouch(cfg, img, ir, "s")
+    settings, _, _ = ImageProcessor()._augment_retouch(cfg, img, "s")
     survivors = settings.retouch.manual_heal_strokes[:2]
-    assert all(s[1] == 40.0 for s in survivors), "cap dropped the largest instead of the IR-first smalls"
+    assert all(s[1] == 40.0 for s in survivors), "cap dropped the largest instead of the head of the list"
 
 
 def test_run_pipeline_skip_flatfield(monkeypatch) -> None:

--- a/tests/test_ir_dust.py
+++ b/tests/test_ir_dust.py
@@ -7,22 +7,23 @@ import tifffile
 
 from negpy.domain.models import WorkspaceConfig
 from negpy.features.retouch.logic import (
-    _HAIR_INPAINT_GAMMA,
-    _HAIR_INPAINT_RADIUS,
     _IR_GAMMA_FALLBACK,
     _IR_GAMMA_HI,
+    _IR_SCORE_FLOOR,
+    _IR_WRITE_HI,
+    _IR_WRITE_LO,
     _fit_refraction_gammas,
     _mask_to_strokes,
     apply_hair_inpaint,
     apply_ir_attenuation,
-    apply_manual_heals,
-    build_heal_regions,
-    detect_ir_regions,
+    apply_ir_reconstruction,
     downsample_ir,
     ir_bake_token,
+    ir_defect_score,
     ir_detect_cutoff,
     ir_ratio_and_gain,
     normalize_ir,
+    route_ir_defects,
 )
 from negpy.features.retouch.models import RetouchConfig
 from negpy.infrastructure.loaders.factory import LoaderFactory
@@ -32,7 +33,6 @@ def test_retouch_config_defaults_include_ir_fields():
     cfg = RetouchConfig()
     assert cfg.ir_dust_remove is False
     assert 0.05 < cfg.ir_threshold < 0.95
-    assert cfg.ir_inpaint_radius >= 1
 
 
 def test_workspace_config_backcompat_for_ir_fields():
@@ -43,7 +43,7 @@ def test_workspace_config_backcompat_for_ir_fields():
 
 def test_workspace_config_roundtrip_ir_fields():
     cfg = WorkspaceConfig(
-        retouch=RetouchConfig(ir_dust_remove=True, ir_threshold=0.4, ir_inpaint_radius=5),
+        retouch=RetouchConfig(ir_dust_remove=True, ir_threshold=0.4),
     )
     flat = cfg.to_dict()
     assert flat["ir_dust_remove"] is True
@@ -53,29 +53,34 @@ def test_workspace_config_roundtrip_ir_fields():
     assert restored.retouch.ir_dust_remove is True
     assert restored.retouch.ir_threshold == 0.4
 
+    # Old sidecars carrying the retired stroke-pad key must still load.
+    old = dict(flat, ir_inpaint_radius=5)
+    assert WorkspaceConfig.from_flat_dict(old).retouch.ir_threshold == 0.4
 
-def test_detect_ir_regions_heals_defect_end_to_end():
-    """IR speck → synthesized ungated stroke → membrane clone removes it."""
+
+def test_ir_reconstruction_heals_defect_end_to_end():
+    """IR speck → continuous score → score-weighted fill rebuilds it from clean
+    neighbours, and never darkens anything (the original-floor rule)."""
     h, w = 80, 80
     rng = np.random.default_rng(17)
-    img = (np.full((h, w, 3), 0.5) + rng.normal(0, 0.01, (h, w, 3))).astype(np.float32)
-    img[39:42, 39:42] = 0.95
+    img = np.clip(np.full((h, w, 3), 0.5) + rng.normal(0, 0.01, (h, w, 3)), 0, 1).astype(np.float32)
+    img[39:42, 39:42] = 0.05  # dust is dark in negative transmittance
     ir = np.full((h, w), 0.9, dtype=np.float32)
     ir[39:42, 39:42] = 0.05
 
-    strokes, _ = detect_ir_regions(normalize_ir(ir), 0.5, pad_px=3.0)
-    assert len(strokes) == 1
-    assert strokes[0][4] == 0.0  # IR regions are ungated
-
-    regions = build_heal_regions(strokes, [], (h, w), 0, 0.0, False, False, 0.0, (w, h))
-    out = apply_manual_heals(img, *regions)
-    assert out[40, 40, 0] < 0.7
+    score = ir_defect_score(normalize_ir(ir), 0.5)
+    assert abs(float(score[40, 40]) - _IR_SCORE_FLOOR) < 1e-6
+    out = np.asarray(apply_ir_reconstruction(img, score))
+    assert float(out[40, 40].min()) > 0.4, "the speck is rebuilt to the surround level"
+    assert (out >= np.asarray(img) - 1e-6).all(), "a repair may only lighten"
 
 
-def test_detect_ir_regions_no_defect_is_empty():
+def test_ir_reconstruction_is_identity_on_clean_film():
     ir = np.full((40, 40), 0.9, dtype=np.float32)
-    strokes, hair = detect_ir_regions(normalize_ir(ir), 0.5)
-    assert strokes == [] and hair is None
+    img = np.clip(np.random.default_rng(2).normal(0.5, 0.1, (40, 40, 3)), 0, 1).astype(np.float32)
+    score = ir_defect_score(normalize_ir(ir), 0.5)
+    assert np.array_equal(np.asarray(apply_ir_reconstruction(img, score)), img)
+    assert route_ir_defects(score) is None
 
 
 def test_ir_detect_cutoff_mapping_and_direction():
@@ -96,14 +101,30 @@ def test_normalize_ir_flat_plane_is_unity():
 
     grad = np.linspace(0.7, 0.85, 120, dtype=np.float32)[:, None].repeat(120, axis=1)
     grad[60:63, 60:63] = grad[60:63, 60:63] * 0.4  # dust dip on the gradient
-    strokes, _ = detect_ir_regions(normalize_ir(grad), ir_detect_cutoff(0.35, True))
-    assert len(strokes) == 1
+    score = ir_defect_score(normalize_ir(grad), ir_detect_cutoff(0.35, True))
+    assert abs(float(score[61, 61]) - _IR_SCORE_FLOOR) < 1e-6
+    off = np.ones(score.shape, dtype=bool)
+    off[55:68, 55:68] = False
+    assert float(score[off].min()) > _IR_WRITE_HI, "clean film keeps its grain untouched"
 
 
-def test_detect_ir_regions_coverage_abort():
-    """A cutoff that marks the whole frame returns nothing (never smears the preview)."""
-    ratio = np.full((80, 80), 0.5, dtype=np.float32)  # 100% below any sane cutoff
-    assert detect_ir_regions(ratio, 0.8)[0] == []
+def test_ir_reconstruction_survives_dusty_frames():
+    """The #563 regression: ~5% dust coverage used to trip a hard abort and silently
+    disable the whole IR path at every threshold. The fill is unconditional now."""
+    h = w = 200
+    rng = np.random.default_rng(9)
+    img = np.clip(0.5 + rng.normal(0, 0.01, (h, w, 3)), 0, 1).astype(np.float32)
+    ir = np.full((h, w), 0.9, dtype=np.float32)
+    centers = [(y, x) for y in range(10, 190, 18) for x in range(10, 190, 18)]  # ~4.9% coverage
+    for y, x in centers:
+        ir[y : y + 4, x : x + 4] = 0.1
+        img[y : y + 4, x : x + 4] = 0.06
+
+    score = ir_defect_score(normalize_ir(ir), ir_detect_cutoff(0.66, True))
+    assert float((score <= _IR_SCORE_FLOOR + 1e-6).mean()) > 0.04, "fixture really is a dusty frame"
+    out = np.asarray(apply_ir_reconstruction(img, score))
+    for y, x in centers:
+        assert float(out[y + 1, x + 1].min()) > 0.35, f"speck at {(y, x)} left unhealed"
 
 
 def test_tiff_loader_reads_ir_from_extrasamples():
@@ -203,10 +224,15 @@ def test_ir_attenuation_field_invalidates_retouch_hash():
 
 def test_ir_bake_token_active_and_empty():
     on = RetouchConfig(ir_dust_remove=True, ir_attenuation=True)
-    assert ir_bake_token(on, has_ir=True) == "|irdiv1"
+    assert ir_bake_token(on, has_ir=True) != ""
     assert ir_bake_token(on, has_ir=False) == ""  # no IR plane → nothing to bake
-    assert ir_bake_token(RetouchConfig(ir_dust_remove=True, ir_attenuation=False), True) == ""
     assert ir_bake_token(RetouchConfig(ir_dust_remove=False, ir_attenuation=True), True) == ""
+    # The fill bakes even without attenuation, and it is threshold-dependent — every
+    # distinct (attenuation, threshold) pair must produce a distinct engine-cache token.
+    att_off = ir_bake_token(RetouchConfig(ir_dust_remove=True, ir_attenuation=False), True)
+    assert att_off != "" and att_off != ir_bake_token(on, True)
+    moved = ir_bake_token(RetouchConfig(ir_dust_remove=True, ir_threshold=0.31), True)
+    assert moved != ir_bake_token(on, True)
 
 
 def test_ir_ratio_and_gain_properties():
@@ -263,8 +289,10 @@ def test_ir_dead_margins_do_not_mask_the_frame():
     assert not degenerate
     assert float(ratio[:, :20].min()) > 0.99  # dead margin reads as clean film
     assert float(gain[:, :20].max()) < 1.01  # ...and is never "corrected"
-    strokes, _ = detect_ir_regions(ratio, ir_detect_cutoff(0.66, True), pad_px=3.0)
-    assert len(strokes) >= 1
+    score = ir_defect_score(ratio, ir_detect_cutoff(0.66, True))
+    # :19, not :20 — the erode legitimately bleeds the in-frame gate transition 1 px in.
+    assert float(score[:, :19].min()) > _IR_WRITE_HI, "the margin is never rebuilt"
+    assert float(score[speck].min()) < _IR_WRITE_LO, "the real speck still is"
 
 
 def test_ir_noisy_clean_film_is_not_degenerate():
@@ -312,8 +340,8 @@ def test_ir_decontaminate_removes_ghost():
     assert abs(float(np.median(clean[off])) - 1.0) < 0.02
 
     assert float(clean[speck].min()) < 0.75  # the defect survives unmixing
-    strokes, _ = detect_ir_regions(clean, ir_detect_cutoff(0.66, True), pad_px=3.0)
-    assert len(strokes) >= 1
+    score = ir_defect_score(clean, ir_detect_cutoff(0.66, True))
+    assert float(score[speck].min()) < _IR_WRITE_LO  # ...deep enough to take the full fill
 
 
 def test_ir_decontaminate_noop_on_clean_ir():
@@ -410,6 +438,113 @@ def test_ir_gain_never_lifts_a_pixel_past_its_local_clean_base():
     # asserted in test_ir_ratio_and_gain_properties.
 
 
+def test_ir_cap_does_not_halo_grainy_film():
+    """Issue #563: the cap's old blur(dilate) clean-base estimate is a local max, sitting
+    ~2σ of grain above the true level — on grainy film it licensed the bake to lift the
+    ratio-dip skirt around every speck ~16% mean, a dark ring after inversion. The
+    noise-free test above can't see it (dilate bias is zero without grain)."""
+    h = w = 300
+    rng = np.random.default_rng(5)
+    ir = np.clip(0.9 + rng.normal(0, 0.005, (h, w)), 0.0, 1.0).astype(np.float32)
+    img = np.clip(0.30 + rng.normal(0, 0.02, (h, w, 3)), 1e-3, 1.0).astype(np.float32)
+    ir_dip = np.zeros((h, w), dtype=bool)
+    vis_dip = np.zeros((h, w), dtype=bool)
+    for _ in range(40):
+        y, x = int(rng.integers(12, h - 14)), int(rng.integers(12, w - 14))
+        ir[y - 3 : y + 6, x - 3 : x + 6] *= 0.5  # strongly IR-opaque: not unmixable as ghost
+        img[y : y + 3, x : x + 3] *= 0.82
+        ir_dip[y - 3 : y + 6, x - 3 : x + 6] = True
+        vis_dip[y : y + 3, x : x + 3] = True
+
+    _, gain, degenerate, _ = ir_ratio_and_gain(ir, img)
+    assert not degenerate
+
+    out = np.asarray(apply_ir_attenuation(img, gain))
+    skirt = ir_dip & ~vis_dip
+    lift = out[skirt] / img[skirt] - 1.0  # what the bake lifted each skirt pixel by
+    assert float(lift.mean()) < 0.02, f"mean skirt lift {lift.mean():.3f} — dark ring after inversion"
+    assert float(np.percentile(lift, 95)) < 0.08
+    # The speck itself must still be corrected — the cap may not swallow the recovery.
+    assert float(gain[vis_dip].mean()) > 1.05
+
+
+def test_ir_fill_leaves_clean_pixels_byte_identical():
+    """The other half of the #563 halo fix: everything scoring clean (≥ _IR_WRITE_HI)
+    is not merely 'close' — it is untouched, grain and all."""
+    h = w = 120
+    rng = np.random.default_rng(21)
+    img = np.clip(0.4 + rng.normal(0, 0.03, (h, w, 3)), 0, 1).astype(np.float32)
+    img[58:62, 58:62] = 0.05
+    ir = np.clip(0.9 + rng.normal(0, 0.004, (h, w)), 0, 1).astype(np.float32)
+    ir[58:62, 58:62] = 0.1
+
+    score = ir_defect_score(normalize_ir(ir), ir_detect_cutoff(0.66, True))
+    out = np.asarray(apply_ir_reconstruction(img, score))
+    untouched = score >= _IR_WRITE_HI
+    assert untouched.sum() > 0.9 * untouched.size
+    assert np.array_equal(out[untouched], np.asarray(img)[untouched])
+    assert (out >= np.asarray(img) - 1e-6).all()
+    assert float(out[60, 60].min()) > 0.3, "the core is still rebuilt"
+
+
+def test_ir_fill_follows_an_edge_through_the_defect():
+    """Multiscale: a speck straddling a two-tone edge fills each side toward its own
+    tone — the finest support with clean data wins, so edges continue through defects."""
+    h = w = 80
+    img = np.full((h, w, 3), 0.2, dtype=np.float32)
+    img[:, 40:] = 0.7
+    ir = np.full((h, w), 0.9, dtype=np.float32)
+    img[38:42, 36:44] = 0.05
+    ir[38:42, 36:44] = 0.1
+
+    score = ir_defect_score(normalize_ir(ir), ir_detect_cutoff(0.66, True))
+    out = np.asarray(apply_ir_reconstruction(img, score))
+    assert float(out[40, 37].max()) < 0.45, "left of the edge rebuilds toward the dark tone"
+    assert float(out[40, 43].min()) > 0.45, "right of the edge toward the light tone"
+
+
+def test_ir_reconstruction_wysiwyg_across_scales():
+    """Export runs the same detection-scale score against the full-res buffer with
+    rescaled supports; the healed result must agree with the preview once downsampled."""
+    hd = wd = 100
+    rng = np.random.default_rng(13)
+    img_det = np.clip(0.5 + rng.normal(0, 0.01, (hd, wd, 3)), 0, 1).astype(np.float32)
+    ir = np.full((hd, wd), 0.9, dtype=np.float32)
+    img_det[48:52, 48:52] = 0.05
+    ir[48:52, 48:52] = 0.1
+    score = ir_defect_score(normalize_ir(ir), ir_detect_cutoff(0.66, True))
+
+    out_det = np.asarray(apply_ir_reconstruction(img_det, score))
+    img_full = cv2.resize(img_det, (wd * 3, hd * 3), interpolation=cv2.INTER_NEAREST)
+    out_full = np.asarray(apply_ir_reconstruction(img_full, score))
+    down = cv2.resize(out_full, (wd, hd), interpolation=cv2.INTER_AREA)
+    speck = np.zeros((hd, wd), dtype=bool)
+    speck[46:54, 46:54] = True
+    assert abs(float(down[speck].mean()) - float(out_det[speck].mean())) < 0.05
+    assert float(down[50, 50].min()) > 0.35 and float(out_det[50, 50].min()) > 0.35
+
+
+def test_route_ir_defects_by_interior_radius_and_budget():
+    """Only at-floor components with a core the fill's 9×9 support can't see across
+    (chebyshev radius ≥ _IR_ROUTE_RADIUS) route to the heavy inpaint; a long thin hair
+    stays with the fill. The over-budget guard skips routing (never the fill)."""
+    score = np.ones((200, 200), dtype=np.float32)
+    score[10:12, 10:12] = _IR_SCORE_FLOOR  # 4 px speck: the fill's job
+    score[100:103, 20:180] = _IR_SCORE_FLOOR  # 480 px hair — big, but thin: fill's job too
+    assert route_ir_defects(score) is None
+
+    score[40:52, 40:52] = _IR_SCORE_FLOOR  # 12×12 blob: radius 6, past the fill's reach
+    routed = route_ir_defects(score)
+    assert routed is not None
+    assert routed[46, 46] == 1 and routed[39, 46] == 1, "routed, dilated past the skirt"
+    assert routed[10, 10] == 0, "the small speck stays with the fill"
+    assert routed[101, 100] == 0, "the hair stays with the fill"
+
+    score = np.ones((200, 200), dtype=np.float32)
+    score[40:70, 40:74] = _IR_SCORE_FLOOR  # ~2.5% of the frame once dilated
+    assert route_ir_defects(score) is None, "over budget: inpaint skipped, fill still runs"
+
+
 def test_gamma_fit_falls_back_when_the_band_is_too_small():
     """A frame with almost no semi-transparent dust has nothing to fit — the gain is ~1
     regardless of γ, so the fallback stands rather than fitting noise."""
@@ -420,25 +555,29 @@ def test_gamma_fit_falls_back_when_the_band_is_too_small():
     assert _fit_refraction_gammas(ratio, vis_log, img) == (_IR_GAMMA_FALLBACK,) * 3
 
 
-def test_hysteresis_grows_from_cores_but_admits_no_new_defects():
-    """Both halves of Canny's rule: a shallow dip touching a strong core is pulled in
-    whole, while an equally shallow dip with no core stays out."""
+def test_ir_defect_score_is_continuous_and_bleeds_one_pixel():
+    """The score replaces hysteresis: a shallow dip gets a proportional partial score
+    (no cliff to grow across), and the erode bleeds a defect's score one pixel outward
+    so sub-pixel hairs and the min-pool skirt take the correction too."""
     ratio = np.ones((80, 200), dtype=np.float32)
-    ratio[40, 20:60] = 0.40  # core, below the cutoff
-    ratio[40, 60:100] = 0.65  # its shallow continuation — above the cutoff
-    ratio[40, 140:180] = 0.65  # same depth, but no core anywhere near it
+    ratio[40, 20:60] = 0.40  # deep core, below the cutoff
+    ratio[40, 60:100] = 0.65  # shallow continuation
 
-    strokes, hair = detect_ir_regions(ratio, 0.586, pad_px=1.0, min_area=1)
-    covered = np.zeros((80, 200), dtype=bool)
-    for pts, size, _sdx, _sdy, _g in strokes:
-        for px, py in np.atleast_2d(pts):
-            covered[int(round(py * 80)), int(round(px * 200))] = True
-    if hair is not None:
-        covered |= hair.astype(bool)
+    cutoff = 0.586
+    score = ir_defect_score(ratio, cutoff)
+    assert abs(float(score[40, 30]) - _IR_SCORE_FLOOR) < 1e-6
+    assert _IR_SCORE_FLOOR < float(score[40, 80]) < _IR_WRITE_LO, "shallow dip: partial, proportional"
+    assert abs(float(score[39, 30]) - _IR_SCORE_FLOOR) < 1e-6, "erode bleeds the core one pixel outward"
+    assert float(score[38, 30]) > _IR_WRITE_HI, "...exactly one pixel"
+    assert float(score[:20].min()) == 1.0
 
-    assert covered[40, 20:60].all(), "the core itself"
-    assert covered[40, 60:100].any(), "its above-cutoff continuation is pulled in by the core"
-    assert not covered[40, 140:180].any(), "an identical dip with no core must stay rejected"
+    # Monotone in the slider, in both attenuation modes: a lower slider catches more
+    # (higher cutoff), so a fixed dip scores lower — more correction, no cliff anywhere.
+    dip = np.full((16, 16), 0.75, dtype=np.float32)
+    for att in (True, False):
+        scores = [float(ir_defect_score(dip, ir_detect_cutoff(s, att))[8, 8]) for s in (0.1, 0.5, 0.9)]
+        assert scores[0] <= scores[1] <= scores[2] + 1e-6
+        assert all(_IR_SCORE_FLOOR - 1e-6 <= s <= 1.0 for s in scores)
 
 
 def _curled_hair_mask(size: int = 120) -> np.ndarray:
@@ -517,35 +656,22 @@ def _noisy_frame(h: int, w: int, seed: int = 0) -> np.ndarray:
     return np.clip(rng.normal(0.5, 0.15, (h, w, 3)), 0, 1).astype(np.float32)
 
 
-def _inpaint_whole_frame(img: np.ndarray, mask: np.ndarray) -> np.ndarray:
-    """The pre-optimisation implementation, kept as the oracle: gamma-encode the entire
-    buffer, inpaint, decode, keep the masked pixels. apply_hair_inpaint now does this per
-    connected component's bbox, which must be bit-exact, not merely close."""
-    enc = np.clip(np.ascontiguousarray(img, dtype=np.float32), 0.0, 1.0) ** (1.0 / _HAIR_INPAINT_GAMMA)
-    filled = cv2.inpaint((enc * 255.0 + 0.5).astype(np.uint8), mask, _HAIR_INPAINT_RADIUS, cv2.INPAINT_NS)
-    dec = (filled.astype(np.float32) / 255.0) ** _HAIR_INPAINT_GAMMA
-    out = np.ascontiguousarray(img, dtype=np.float32).copy()
-    mb = mask.astype(bool)
-    out[mb] = dec[mb]
-    return out
-
-
-def test_hair_inpaint_per_component_matches_whole_frame():
-    """cv2.inpaint only propagates outward from the mask boundary, so filling each defect
-    inside its own bbox is exactly the whole-frame result — without gamma-encoding 34MP to
-    serve a hairline (1.7s -> 0.3s on a full scan)."""
+def test_hair_inpaint_fills_and_leaves_clean_pixels():
+    """Per-component bbox fill: the hair is rebuilt to the surrounding level, everything
+    outside the mask stays byte-identical (the feather blends only inside the mask)."""
     img = _noisy_frame(300, 400)
     m = np.zeros((300, 400), dtype=np.uint8)
     cv2.line(m, (60, 80), (200, 190), 1, 2)
     mb = m.astype(bool)
+    img[mb] = 0.02  # a real defect, far darker than the 0.5 surround
 
     out = apply_hair_inpaint(img, [m], dilate_px=0)
-    assert np.array_equal(out, _inpaint_whole_frame(img, m))
     assert not np.array_equal(out[mb], img[mb]), "the hair must actually be filled"
     assert np.array_equal(out[~mb], img[~mb]), "clean pixels stay byte-identical"
+    assert float(np.abs(out[mb].mean() - 0.5)) < 0.15, "filled toward the surround level"
 
 
-def test_hair_inpaint_matches_for_scattered_hairs():
+def test_hair_inpaint_fills_scattered_hairs():
     """Hairs in opposite corners — their union bbox is the whole frame, which is why the
     crop is per-component and not one bbox over the union."""
     img = _noisy_frame(300, 400, seed=1)
@@ -553,19 +679,65 @@ def test_hair_inpaint_matches_for_scattered_hairs():
     cv2.line(m, (20, 20), (70, 60), 1, 2)
     cv2.line(m, (330, 240), (380, 280), 1, 2)
     assert cv2.connectedComponentsWithStats(m, connectivity=8)[0] - 1 == 2, "fixture must be two components"
-    assert np.array_equal(apply_hair_inpaint(img, [m], dilate_px=0), _inpaint_whole_frame(img, m))
+    mb = m.astype(bool)
+    img[mb] = 0.02
+    out = apply_hair_inpaint(img, [m], dilate_px=0)
+    for comp_label in (1, 2):
+        labels = cv2.connectedComponents(m, connectivity=8)[1]
+        sel = labels == comp_label
+        assert float(np.abs(out[sel].mean() - 0.5)) < 0.15, f"component {comp_label} filled"
+    assert np.array_equal(out[~mb], img[~mb])
 
 
 def test_hair_inpaint_neighbour_in_bbox_is_not_cloned_as_source():
-    """Two hairs closer than the bbox pad: each one's crop contains the other. The neighbour
-    has to stay masked inside that crop — mask only the component being filled and its dust
-    becomes clone source, filling the defect straight back in."""
+    """Two hairs closer than the bbox pad: each one's crop contains the other. The
+    neighbour has to stay masked inside that crop — mask only the component being filled
+    and its dust becomes fill source, pulling the defect value straight back in."""
     img = _noisy_frame(200, 200, seed=2)
     m = np.zeros((200, 200), dtype=np.uint8)
     cv2.line(m, (80, 40), (80, 160), 1, 2)
     cv2.line(m, (86, 40), (86, 160), 1, 2)  # 6 px away — well inside _HAIR_INPAINT_PAD
     assert cv2.connectedComponentsWithStats(m, connectivity=8)[0] - 1 == 2, "fixture must be two components"
-    assert np.array_equal(apply_hair_inpaint(img, [m], dilate_px=0), _inpaint_whole_frame(img, m))
+    mb = m.astype(bool)
+    img[mb] = 0.98  # both hairs blown far above the 0.5 surround
+    out = apply_hair_inpaint(img, [m], dilate_px=0)
+    assert float(out[mb].mean()) < 0.7, "a neighbour used as source would keep the fill near 0.98"
+    assert np.array_equal(out[~mb], img[~mb])
+
+
+def test_hair_inpaint_feathers_the_dilate_band():
+    """The detected defect takes the full fill; the dilate band around it (real scans:
+    the PSF skirt) ramps in by distance, so a partially-darkened skirt is lifted
+    partially instead of stamped — no hard seam at the patch boundary."""
+    img = np.full((120, 120, 3), 0.6, dtype=np.float32)
+    core = np.zeros((120, 120), dtype=np.uint8)
+    cv2.circle(core, (60, 60), 8, 1, -1)
+    skirt = cv2.dilate(core, cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (7, 7))).astype(bool) & ~core.astype(bool)
+    img[core.astype(bool)] = 0.1
+    img[skirt] = 0.35  # the soft penumbra the detection mask never covers
+
+    out = apply_hair_inpaint(img, [core], dilate_px=3)
+    assert float(out[60, 60].mean()) > 0.5, "the core takes the full fill"
+    inner = float(out[60, 51].mean())  # skirt px adjacent to the core (deep in the band)
+    outer = float(out[60, 49].mean())  # skirt px at the band's outer edge
+    assert inner > outer > 0.35 - 1e-6, "the band ramps: deeper in, more fill"
+    band = cv2.dilate(core, cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (7, 7))).astype(bool)
+    assert np.array_equal(out[~band], img[~band]), "outside the dilated mask: byte-identical"
+
+
+def test_hair_inpaint_context_range_survives_dark_regions():
+    """The 8-bit encode normalizes to the crop's own clean range: a defect deep in the
+    shadows otherwise lands on a handful of codes and fills as a posterized flat patch."""
+    rng = np.random.default_rng(8)
+    img = np.clip(rng.normal(0.003, 0.001, (200, 200, 3)), 0.0005, 1).astype(np.float32)
+    m = np.zeros((200, 200), dtype=np.uint8)
+    cv2.line(m, (60, 60), (140, 140), 1, 3)
+    mb = m.astype(bool)
+    img[mb] = 0.0006
+
+    out = apply_hair_inpaint(img, [m], dilate_px=0)
+    assert float(np.abs(out[mb].mean() - 0.003)) < 0.002, "filled toward the shadow level"
+    assert np.unique(out[mb]).size > 10, "posterized fill: the encode collapsed the range"
 
 
 def test_ir_attenuation_is_the_upsampled_gain_product():

--- a/tests/test_retouch_logic.py
+++ b/tests/test_retouch_logic.py
@@ -8,12 +8,14 @@ from negpy.features.retouch.logic import (
     _mask_to_strokes,
     _pick_source_offsets,
     apply_hair_inpaint,
+    apply_ir_reconstruction,
     apply_manual_heals,
     build_heal_regions,
-    detect_ir_regions,
     detect_luma_regions,
     hair_bake_token,
+    ir_defect_score,
     normalize_ir,
+    route_ir_defects,
     select_source_offset,
 )
 from negpy.features.retouch.models import HEAL_SIZE_REF, RetouchConfig
@@ -407,37 +409,29 @@ def test_detect_luma_regions_clean_frame_is_empty():
     assert detect_luma_regions(img, 0.66, 4)[0] == []
 
 
-def test_detect_ir_regions_speck_ungated():
-    ir = np.full((120, 120), 0.9, dtype=np.float32)
-    ir[60:63, 60:63] = 0.1
-    strokes, _ = detect_ir_regions(normalize_ir(ir), 0.5)
-    assert len(strokes) == 1
-    pts, size, sdx, sdy, gate = strokes[0]
-    assert gate == 0.0
-    assert abs(pts[0][0] - 61.5 / 120) < 0.02
-    json.dumps(strokes)
-
-
-def test_detect_ir_long_scratch_routes_to_hair_mask():
-    """A long twisted scratch no longer becomes a membrane capsule — it goes to the
-    structure-following inpaint mask (a single clone offset can't track a long twist)."""
+def test_ir_long_scratch_is_healed_by_the_fill():
+    """A long thin scratch stays with the score-weighted fill (every pixel sits within
+    reach of clean film) and is actually rebuilt — the #563 'cloned blobs' came from
+    handing this class to a single-offset membrane clone."""
     ir = np.full((200, 200), 0.9, dtype=np.float32)
+    img = np.clip(np.random.default_rng(4).normal(0.5, 0.01, (200, 200, 3)), 0, 1).astype(np.float32)
     for t in range(80):
         x, y = 40 + t, 60 + t // 2
         ir[y : y + 2, x : x + 2] = 0.1
-    strokes, hair = detect_ir_regions(normalize_ir(ir), 0.5)
-    assert strokes == [], "a long hair must not synthesize a clone stroke"
-    assert hair is not None and int(hair.sum()) > 0
+        img[y : y + 2, x : x + 2] = 0.06
+    score = ir_defect_score(normalize_ir(ir), 0.5)
+    assert route_ir_defects(score) is None, "thin: the fill's job, not the inpaint's"
+    out = np.asarray(apply_ir_reconstruction(img, score))
+    scratch = img[:, :, 0] < 0.1
+    assert float(out[scratch].min()) > 0.35, "the scratch is rebuilt from its flanks"
 
 
-def test_detect_ir_mild_elongation_still_capsule():
-    """Mildly elongated dust (below the hair bar) keeps its grain-preserving membrane
-    capsule — only strong hairs route to inpaint."""
+def test_ir_mild_speck_stays_with_the_fill():
+    """Small defects stay with the score-weighted fill — routing is reserved for
+    components the fill's support can't see across."""
     ir = np.full((120, 120), 0.9, dtype=np.float32)
-    ir[60:62, 55:66] = 0.1  # ~11px long, ~1px wide: mild elongation
-    strokes, hair = detect_ir_regions(normalize_ir(ir), 0.5)
-    assert hair is None
-    assert len(strokes) == 1 and len(strokes[0][0]) >= 2, "mild scratch should be a polyline capsule"
+    ir[60:62, 55:66] = 0.1  # ~11px long, ~1px wide: well inside the fill's reach
+    assert route_ir_defects(ir_defect_score(normalize_ir(ir), 0.5)) is None
 
 
 def test_pick_source_offsets_footprint_is_mask_free():


### PR DESCRIPTION
Closes #563.

## Problem

- Dust specks got a dark halo and stayed visible at any IR threshold.
- Scans with >1% dust coverage silently disabled the whole IR path (`_IR_COVERAGE_ABORT`), swallowing the entire slider range.
- Raising the abort limit exposed the next failure: hairs merged by hysteresis defeated the thinness test and rendered as big single-offset membrane-clone blobs.

## Root causes

1. **Halo**: the IR-division bake's clean-base cap estimated clean film as `blur(dilate(img))` — a local max, ~2σ of grain above the true level on real film — licensing the bake to lift every speck's ratio-dip skirt ~16% mean (dark ring after inversion). The existing cap test used a noise-free fixture, where dilate bias is zero.
2. **Abort**: a dusty-but-fine frame exceeds 1% seed coverage at every usable cutoff.
3. **Blobs**: merged hair+speck components fell through `_is_hair` into giant membrane capsules.

## Change

Ports algorithm concepts from [digital-fauxice](https://github.com/rohanpandula/digital-fauxice) (MIT, attribution in `NOTICE.md`) — a validated bit-exact Digital ICE recreation. Three-tier IR cascade, all pre-engine on the linear source (CPU bake reaches both engines parity-free):

| Tier | Defects | Mechanism |
|---|---|---|
| 1 | Semi-transparent dust | γ-fitted IR-division gain (kept; cap estimator fixed to defect-excluded mean − σ) |
| 2 | Opaque cores, hairs | **new** continuous score + score-weighted multiscale fill (9/5/3 px supports, defective neighbours self-exclude), written under the original-floor rule — repairs only lighten, dark halos impossible |
| 3 | Wide blobs (chebyshev radius ≥ 5) | routed cv2.inpaint with dilate-band alpha feather + context-range 8-bit encode; 2% budget bounds only this path |

Deleted: `detect_ir_regions`, `_hysteresis`, `_IR_COVERAGE_ABORT`, IR membrane-stroke synthesis, dead `ir_inpaint_radius` config (with `from_flat_dict` migration). The IR Threshold slider keeps its name/range/direction — it now moves the ramp of a never-thresholded score. No config schema changes otherwise; old sidecars/presets load unchanged. Membrane clone remains for manual + optical-auto heals.

## Verification

- `make all` green (2337 tests); new grainy-fixture cap test fails on the old estimator (mean skirt lift 0.165 → 0.008).
- Fill property tests: floor rule (`out >= img` everywhere), clean pixels byte-identical, edge continuation through defects, preview/export WYSIWYG within tolerance, routing by interior radius, over-budget fail-open.
- Headless E2E on the SilverFast IR sample: curled hair on sky fully rebuilt (before/after captured via the headless driver), ring around healed dust within 0.008 luma, slider monotone with no dead zone.
- Perf: ~100 ms per threshold step at preview (cached across creative drags), ~1.5 s added at 24 MP export.

| Before | After |
|---|---|
| curled hair + halo on sky | hair gone, sky texture continuous |

`docs/PIPELINE.md` §5 gains the IR subsection.
