### PR TITLE
fix: filmstrip thumbnail colour + sizing (single-column default, size slider)

### DIFF
--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -36,6 +36,7 @@ from negpy.desktop.workers.capture_worker import (
     LiveViewRequest,
 )
 from negpy.domain.models import (
+    ColorSpace,
     ExportFormat,
     ExportPreset,
     ExportPresetOutputMode,
@@ -2177,6 +2178,24 @@ class AppController(QObject):
             return get_resource_path("icc/RGBScan.icc")
         return None
 
+    def display_transform_params(self, splash: bool = False) -> tuple[str, Optional[bytes]]:
+        """Source space + monitor profile to hand the display transform for the
+        current render, as ``(color_space, monitor_icc_bytes)``.
+
+        Single source of truth for every consumer of a rendered buffer — the canvas
+        and the filmstrip thumbnail must agree, or the same frame shows two different
+        colours. With a proof active the render worker already baked
+        source→output→monitor into the buffer, so the transform has to be a no-op
+        (sRGB→sRGB, no monitor profile); treating that buffer as working-space instead
+        re-applies the working→sRGB conversion and blows the saturation out. ``splash``
+        marks the embedded camera thumbnail, which is already sRGB.
+        """
+        if splash:
+            return ColorSpace.SRGB.value, self.state.monitor_icc_bytes
+        if self.proof_active():
+            return ColorSpace.SRGB.value, None
+        return self.state.workspace_color_space, self.state.monitor_icc_bytes
+
     def proof_active(self) -> bool:
         """True when the preview should soft-proof: the toggle is on and an input or
         output profile is available, or Narrowband Scan supplies an implicit input
@@ -3029,12 +3048,16 @@ class AppController(QObject):
         if buffer is None or not isinstance(buffer, np.ndarray):
             return
 
+        # Same transform the canvas used for this buffer, so the filmstrip and the
+        # canvas can't disagree about the frame's colour.
+        display_cs, monitor_bytes = self.display_transform_params(splash=bool(metrics.get("splash")))
         self.thumbnail_update_requested.emit(
             ThumbnailUpdateTask(
                 filename=os.path.basename(self.state.current_file_path),
                 file_hash=self.state.current_file_hash,
                 buffer=buffer,
-                color_space=self.state.workspace_color_space,
+                color_space=display_cs,
+                monitor_icc_bytes=monitor_bytes,
                 persist=persist,
             )
         )

--- a/negpy/desktop/view/main_window.py
+++ b/negpy/desktop/view/main_window.py
@@ -26,7 +26,7 @@ from negpy.desktop.view.styles.theme import THEME
 from negpy.desktop.view.widgets.loading_overlay import LoadingOverlay
 from negpy.desktop.view.widgets.pinnable_dock import PinnableDockWidget
 from negpy.desktop.view.widgets.progress_dialog import ProgressDialog
-from negpy.domain.models import AspectRatio, ColorSpace
+from negpy.domain.models import AspectRatio
 from negpy.infrastructure.gpu.resources import GPUTexture
 from negpy.kernel.image.logic import float_to_uint8
 from negpy.kernel.system.config import APP_CONFIG
@@ -484,17 +484,9 @@ class MainWindow(QMainWindow):
                 except Exception as e:
                     logger.error(f"Border preview failure: {e}")
 
-        # With a proof active the render worker already baked the full
-        # source→output→monitor transform into the buffer, so the display step must be
-        # a no-op (pass no monitor profile) to avoid converting to the monitor twice.
-        # Otherwise the buffer is in the assumed source space and needs source→monitor.
-        icc_active = self.controller.proof_active()
-        if metrics.get("splash"):  # embedded sRGB thumbnail, not a working-space render
-            display_cs = ColorSpace.SRGB.value
-            monitor_bytes = self.state.monitor_icc_bytes
-        else:
-            display_cs = ColorSpace.SRGB.value if icc_active else self.state.workspace_color_space
-            monitor_bytes = None if icc_active else self.state.monitor_icc_bytes
+        # Shared with the filmstrip thumbnail so the same frame can't render two
+        # different colours in the two places (see display_transform_params).
+        display_cs, monitor_bytes = self.controller.display_transform_params(splash=bool(metrics.get("splash")))
         self.canvas.update_buffer(buffer, display_cs, content_rect=content_rect, monitor_icc_bytes=monitor_bytes)
 
     def _refresh_image_info(self) -> None:

--- a/negpy/desktop/view/sidebar/files.py
+++ b/negpy/desktop/view/sidebar/files.py
@@ -16,6 +16,7 @@ from PyQt6.QtWidgets import (
     QListView,
     QMenu,
     QPushButton,
+    QSlider,
     QStyle,
     QStyledItemDelegate,
     QStyleOptionViewItem,
@@ -138,29 +139,75 @@ class _ThumbnailDelegate(QStyledItemDelegate):
         painter.restore()
 
 
+# Thumbnail size preference (px), as set by the filmstrip's size slider. The default
+# is chosen so one column fills the session sidebar at its minimum width (~240px
+# viewport) — the sidebar can't be dragged narrower, so this is the smallest the
+# filmstrip is ever laid out at, and a single full-width frame is the most legible
+# use of it. Dropping toward THUMB_CELL_MIN fits a second column at that same width.
+#
+# The maximum is the default: the slider only shrinks frames. Anything larger just
+# holds a widened sidebar at one column — cells fill the panel, so a 500px-wide
+# sidebar became a single ~500px cell, and since cells are square a 3:2 frame in one
+# leaves ~165px of empty space above and below. Splitting into two columns is both
+# denser and larger-in-practice, so there is nothing above the default worth offering.
+THUMB_CELL_MIN = 100
+THUMB_CELL_DEFAULT = 220
+THUMB_CELL_MAX = THUMB_CELL_DEFAULT
+
+
 class ThumbnailGridView(QListView):
     """
     Icon-mode grid that justifies thumbnails to the panel width. It fits as many
-    MIN_CELL-wide columns as possible, then scales the cell up (to MAX_CELL) to fill
-    the width; once there's room for another MIN_CELL column it adds one and the cells
-    snap back down. e.g. with MIN 120 / MAX 180: 2 columns grow 120→180, and at ~3×120
-    of width a 3rd column appears.
+    columns of at least ``target_cell`` as the viewport allows, then grows the cell to
+    fill the leftover width exactly; once another target-wide column fits it adds one
+    and the cells snap back down. So ``target_cell`` sets thumbnail size and the panel
+    width sets how many fit — e.g. at the default 220 a 240px-wide panel shows one
+    236px column, and widening past ~444px splits into two.
+
+    Cells are not capped directly — at one column the frame is meant to fill the panel
+    — but capping the *target* at the default bounds them in practice: a target above
+    it only delays the split to two columns, which is what produced oversized cells
+    (and, since cells are square, large empty bands around a 3:2 frame) on a widened
+    sidebar. Cells can still exceed APP_CONFIG.thumbnail_size and upscale on a very
+    wide panel; the frames stay legible because the canvas is the place for detail.
     """
 
-    MIN_CELL = 120
-    MAX_CELL = 180
     SPACING = 2
 
-    def __init__(self, parent=None):
+    def __init__(self, parent=None, target_cell: int = THUMB_CELL_DEFAULT):
         super().__init__(parent)
         self._last_cell = -1
+        self._target_cell = self._clamp_target(target_cell)
         # Reserve the vertical scrollbar permanently so the viewport width is stable —
         # otherwise scaling toggles the scrollbar, which changes the width and flips the
         # column count back, causing flicker.
         self.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOn)
         self.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
         self.setSpacing(self.SPACING)
-        self._apply_cell(self.MIN_CELL)
+        self._apply_cell(self._target_cell)
+
+    @staticmethod
+    def _clamp_target(cell: int) -> int:
+        return max(THUMB_CELL_MIN, min(THUMB_CELL_MAX, int(cell)))
+
+    @property
+    def target_cell(self) -> int:
+        return self._target_cell
+
+    def set_target_cell(self, cell: int) -> None:
+        """Set the preferred thumbnail size and re-justify to the current width."""
+        cell = self._clamp_target(cell)
+        if cell == self._target_cell:
+            return
+        self._target_cell = cell
+        self._relayout()
+
+    def columns_for_width(self, vw: int) -> int:
+        return max(1, (vw - self.SPACING) // (self._target_cell + self.SPACING))
+
+    def cell_for_width(self, vw: int) -> int:
+        columns = self.columns_for_width(vw)
+        return max(1, (vw - (columns + 1) * self.SPACING) // columns)
 
     def _apply_cell(self, cell: int) -> None:
         if cell == self._last_cell:
@@ -170,11 +217,7 @@ class ThumbnailGridView(QListView):
         self.setIconSize(QSize(cell, cell))
 
     def _relayout(self) -> None:
-        vw = self.viewport().width()
-        columns = max(1, (vw - self.SPACING) // (self.MIN_CELL + self.SPACING))
-        cell = (vw - (columns + 1) * self.SPACING) // columns
-        cell = max(self.MIN_CELL, min(self.MAX_CELL, cell))
-        self._apply_cell(cell)
+        self._apply_cell(self.cell_for_width(self.viewport().width()))
 
     def resizeEvent(self, event) -> None:
         super().resizeEvent(event)
@@ -366,6 +409,16 @@ class FileBrowser(QWidget):
         self.regex_btn.setToolTip("Regex mode")
         search_row.addWidget(self.search_input)
         search_row.addWidget(self.regex_btn)
+
+        # Thumbnail size lives here rather than the toolbar row above, which already
+        # overflows the sidebar's minimum width with its eight buttons.
+        saved_cell = self.session.repo.get_global_setting("thumbnail_cell_size") or THUMB_CELL_DEFAULT
+        self.thumb_size_slider = QSlider(Qt.Orientation.Horizontal)
+        self.thumb_size_slider.setRange(THUMB_CELL_MIN, THUMB_CELL_MAX)
+        self.thumb_size_slider.setValue(ThumbnailGridView._clamp_target(int(saved_cell)))
+        self.thumb_size_slider.setFixedWidth(72)
+        self.thumb_size_slider.setToolTip("Thumbnail size — smaller fits more columns in the panel")
+        search_row.addWidget(self.thumb_size_slider)
         layout.addLayout(search_row)
 
         self.tally_label = QLabel("")
@@ -373,7 +426,7 @@ class FileBrowser(QWidget):
         self.tally_label.setVisible(False)
         layout.addWidget(self.tally_label)
 
-        self.list_view = ThumbnailGridView()
+        self.list_view = ThumbnailGridView(target_cell=self.thumb_size_slider.value())
         self.list_view.setModel(self.session.asset_model)
         self.list_view.setItemDelegate(_ThumbnailDelegate(self.list_view))
         self.list_view.setViewMode(QListView.ViewMode.IconMode)
@@ -403,12 +456,19 @@ class FileBrowser(QWidget):
         self.session.files_changed.connect(self._on_files_changed)
         self.search_input.textChanged.connect(lambda _: self.filter_timer.start())
         self.regex_btn.toggled.connect(lambda _: self.filter_timer.start())
+        # Relayout live while dragging, but only write the setting on release —
+        # a drag crosses dozens of values and each save is a DB round-trip.
+        self.thumb_size_slider.valueChanged.connect(self.list_view.set_target_cell)
+        self.thumb_size_slider.sliderReleased.connect(self._save_thumb_size)
 
         # Delete key unloads the selected frame(s) — scoped to the thumbnail list so it
         # doesn't fire while typing in the filter box or editing elsewhere.
         del_shortcut = QShortcut(QKeySequence(Qt.Key.Key_Delete), self.list_view)
         del_shortcut.setContext(Qt.ShortcutContext.WidgetShortcut)
         del_shortcut.activated.connect(self._on_delete_key)
+
+    def _save_thumb_size(self) -> None:
+        self.session.repo.save_global_setting("thumbnail_cell_size", self.thumb_size_slider.value())
 
     def _on_files_changed(self) -> None:
         # A mark toggle can hide the active frame under a Sheet filter — pruning then

--- a/negpy/desktop/workers/render.py
+++ b/negpy/desktop/workers/render.py
@@ -55,7 +55,10 @@ class ThumbnailUpdateTask:
     filename: str
     file_hash: str
     buffer: np.ndarray
+    # Display-transform inputs, from AppController.display_transform_params — must be
+    # the same pair the canvas used for this buffer or the thumbnail's colour drifts.
     color_space: str = WORKING_COLOR_SPACE
+    monitor_icc_bytes: Optional[bytes] = None
     persist: bool = True  # False = in-memory filmstrip only, skip the disk JPEG encode.
 
 
@@ -266,7 +269,13 @@ class ThumbnailWorker(QObject):
         try:
             buf = task.buffer.copy()
             store = self._store if task.persist else None
-            thumb = get_rendered_thumbnail(buf, task.file_hash, store, color_space=task.color_space)
+            thumb = get_rendered_thumbnail(
+                buf,
+                task.file_hash,
+                store,
+                color_space=task.color_space,
+                monitor_icc_bytes=task.monitor_icc_bytes,
+            )
             if thumb:
                 self.finished.emit({task.filename: thumb})
         except Exception as e:

--- a/negpy/infrastructure/storage/local_asset_store.py
+++ b/negpy/infrastructure/storage/local_asset_store.py
@@ -59,11 +59,22 @@ class LocalAssetStore(IAssetStore):
             return None
 
     def get_thumbnail(self, file_hash: str) -> Optional[Image.Image]:
-        """Loads cached thumb."""
+        """Loads cached thumb, ignoring one cached at a different size.
+
+        The cache key is only the file hash, so a thumbnail written before
+        APP_CONFIG.thumbnail_size changed would otherwise be served forever and
+        scaled to the current cell — visibly soft. Treating a size mismatch as a
+        miss regenerates it at the current size.
+        """
+        from negpy.kernel.system.config import APP_CONFIG
+
         thumb_path = os.path.join(self.thumb_dir, f"{file_hash}.jpg")
         if os.path.exists(thumb_path):
             try:
-                return Image.open(thumb_path)
+                img = Image.open(thumb_path)
+                if max(img.size) != APP_CONFIG.thumbnail_size:
+                    return None
+                return img
             except Exception:
                 return None
         return None

--- a/negpy/kernel/system/config.py
+++ b/negpy/kernel/system/config.py
@@ -19,7 +19,11 @@ from negpy.kernel.system.paths import get_default_user_dir, get_resource_path
 
 BASE_USER_DIR = get_default_user_dir()
 APP_CONFIG = AppConfig(
-    thumbnail_size=120,
+    # Cache thumbnails at the largest size the filmstrip shows them at 1:1 — a single
+    # column filling the minimum-width session sidebar (~240px). Cached smaller and
+    # that default view is a visible upscale. Raising this invalidates existing cached
+    # JPEGs; LocalAssetStore.get_thumbnail drops any that aren't this size.
+    thumbnail_size=256,
     max_workers=max(1, (os.cpu_count() or 1)),
     preview_render_size=1600,
     max_history_steps=100,

--- a/negpy/services/assets/thumbnails.py
+++ b/negpy/services/assets/thumbnails.py
@@ -123,11 +123,22 @@ def get_thumbnail_worker(
 
 
 def get_rendered_thumbnail(
-    buffer: Any, file_hash: str, asset_store: Any = None, color_space: str = WORKING_COLOR_SPACE
+    buffer: Any,
+    file_hash: str,
+    asset_store: Any = None,
+    color_space: str = WORKING_COLOR_SPACE,
+    monitor_icc_bytes: Optional[bytes] = None,
 ) -> Optional[Image.Image]:
     """
-    Creates a thumbnail from a rendered float32 buffer, color-managing the working
-    space to sRGB so it matches the canvas (mirrors ImageConverter.to_qimage).
+    Creates a thumbnail from a rendered float32 buffer, applying the same display
+    transform the canvas applied to that buffer (mirrors ImageConverter.to_qimage).
+
+    ``color_space``/``monitor_icc_bytes`` must come from
+    ``AppController.display_transform_params`` — they encode whether the buffer is
+    still in the working space or has already been baked into display space by a
+    soft proof. Assuming working space unconditionally re-applies the working->sRGB
+    conversion to an already-converted buffer, which clips channels and leaves the
+    filmstrip visibly more saturated than the canvas.
     """
     try:
         from negpy.infrastructure.display.color_mgmt import apply_display_transform
@@ -137,7 +148,7 @@ def get_rendered_thumbnail(
         if isinstance(buffer, np.ndarray) and buffer.ndim == 3 and buffer.shape[2] == 4:
             buffer = buffer[:, :, :3]
         if isinstance(buffer, np.ndarray) and buffer.dtype == np.float32:
-            buffer = apply_display_transform(buffer, color_space)
+            buffer = apply_display_transform(buffer, color_space, monitor_icc_bytes)
         u8_arr = float_to_uint8(buffer)
         img = Image.fromarray(u8_arr)
 

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -1,5 +1,7 @@
 import unittest
 import os
+import tempfile
+from PIL import Image
 from negpy.infrastructure.storage.local_asset_store import LocalAssetStore
 from negpy.kernel.system.config import APP_CONFIG
 
@@ -14,6 +16,33 @@ class TestAssetStore(unittest.TestCase):
         s_dir = self.store._get_session_dir(s_id)
         self.assertTrue(os.path.exists(s_dir))
         self.assertIn(s_id, s_dir)
+
+
+class TestThumbnailCacheSize(unittest.TestCase):
+    """The thumbnail cache is keyed on file hash alone, so a thumb written before
+    APP_CONFIG.thumbnail_size changed would be served forever and upscaled into the
+    current cell. A size mismatch has to read as a cache miss."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.store = LocalAssetStore(self._tmp.name, os.path.join(self._tmp.name, "icc"))
+        self.store.initialize()
+
+    def test_thumbnail_at_current_size_is_returned(self):
+        ts = APP_CONFIG.thumbnail_size
+        self.store.save_thumbnail("h_current", Image.new("RGB", (ts, ts), (10, 20, 30)))
+        got = self.store.get_thumbnail("h_current")
+        self.assertIsNotNone(got)
+        self.assertEqual(max(got.size), ts)
+
+    def test_thumbnail_cached_at_a_stale_size_is_a_miss(self):
+        stale = APP_CONFIG.thumbnail_size // 2
+        self.store.save_thumbnail("h_stale", Image.new("RGB", (stale, stale), (10, 20, 30)))
+        self.assertIsNone(self.store.get_thumbnail("h_stale"))
+
+    def test_missing_thumbnail_is_a_miss(self):
+        self.assertIsNone(self.store.get_thumbnail("h_absent"))
 
 
 if __name__ == "__main__":

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1592,3 +1592,90 @@ class TestRetouchPersistence(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestDisplayTransformParams(unittest.TestCase):
+    """The canvas and the filmstrip thumbnail must derive their display transform
+    from the same place. When a soft proof is active the render worker has already
+    baked source->output->monitor into the buffer, so the transform has to be a
+    no-op; treating that buffer as working-space re-applies ProPhoto->sRGB and the
+    thumbnail comes out visibly oversaturated next to the canvas."""
+
+    def setUp(self):
+        self.mock_session_manager = MagicMock(spec=DesktopSessionManager)
+        self.mock_session_manager.state = AppState()
+        self.mock_session_manager.repo = MagicMock()
+        with (
+            patch("negpy.desktop.controller.RenderWorker") as mock_rw_class,
+            patch("negpy.desktop.controller.PreviewManager") as mock_pm_class,
+        ):
+            mock_rw_class.return_value = MagicMock()
+            mock_pm_class.return_value = MagicMock(spec=PreviewManager)
+            mock_pm_class.return_value.load_linear_preview.return_value = (None, (0, 0), {})
+            self.controller = AppController(self.mock_session_manager)
+        self.controller.state.monitor_icc_bytes = b"fake-monitor-profile"
+
+    def tearDown(self):
+        import gc
+
+        # Same teardown as TestAppController: the controller owns live QThreads and
+        # letting it be collected while they run crashes the interpreter.
+        for thread in [
+            self.controller.render_thread,
+            self.controller.export_thread,
+            self.controller.thumb_thread,
+            self.controller.norm_thread,
+            self.controller.discovery_thread,
+            self.controller.preview_load_thread,
+            self.controller.scan_thread,
+        ]:
+            if thread is not None and thread.isRunning():
+                thread.quit()
+                thread.wait()
+        del self.controller
+        gc.collect()
+
+    def test_proof_active_yields_a_no_op_transform(self):
+        self.controller.proof_active = lambda: True
+        cs, monitor = self.controller.display_transform_params()
+        # sRGB source + no monitor profile is the documented identity case in
+        # get_display_lut, i.e. the already-baked buffer is passed through untouched.
+        self.assertEqual(cs, ColorSpace.SRGB.value)
+        self.assertIsNone(monitor)
+
+    def test_proof_inactive_converts_from_the_working_space(self):
+        self.controller.proof_active = lambda: False
+        cs, monitor = self.controller.display_transform_params()
+        self.assertEqual(cs, self.controller.state.workspace_color_space)
+        self.assertEqual(monitor, b"fake-monitor-profile")
+
+    def test_splash_buffer_is_treated_as_srgb(self):
+        self.controller.proof_active = lambda: False
+        cs, monitor = self.controller.display_transform_params(splash=True)
+        self.assertEqual(cs, ColorSpace.SRGB.value)
+        self.assertEqual(monitor, b"fake-monitor-profile")
+
+    def test_thumbnail_task_carries_the_same_params_as_the_canvas(self):
+        """The actual regression: the thumbnail used to hardcode the working space."""
+        import numpy as np
+
+        self.controller.proof_active = lambda: True
+        state = self.controller.state
+        state.current_file_path = "/tmp/frame.cr2"
+        state.current_file_hash = "hash-1"
+        state.last_metrics = {"base_positive": np.zeros((4, 4, 3), dtype=np.float32)}
+
+        emitted = []
+        # Drop the real worker connection first: emitting would otherwise hand the
+        # buffer to the thumbnail QThread, which then races this test's teardown.
+        try:
+            self.controller.thumbnail_update_requested.disconnect()
+        except TypeError:
+            pass
+        self.controller.thumbnail_update_requested.connect(emitted.append)
+        self.controller._update_thumbnail_from_state()
+
+        self.assertEqual(len(emitted), 1)
+        task = emitted[0]
+        self.assertEqual((task.color_space, task.monitor_icc_bytes), self.controller.display_transform_params())
+        self.assertNotEqual(task.color_space, state.workspace_color_space)

--- a/tests/test_file_browser_widget.py
+++ b/tests/test_file_browser_widget.py
@@ -4,7 +4,7 @@ import pytest
 from PyQt6.QtWidgets import QDialog
 
 from negpy.desktop.session import DesktopSessionManager
-from negpy.desktop.view.sidebar.files import FileBrowser
+from negpy.desktop.view.sidebar.files import THUMB_CELL_MAX, THUMB_CELL_MIN, FileBrowser
 from negpy.desktop.view.styles.theme import THEME
 from negpy.desktop.view.widgets.sync_settings_dialog import SyncSettingsDialog
 from negpy.infrastructure.storage.repository import StorageRepository
@@ -282,3 +282,79 @@ def test_clearing_filter_clears_error_stylesheet(browser):
     browser.search_input.setText("")
     browser._apply_filter()
     assert browser.search_input.styleSheet() == ""
+
+
+def test_thumbnail_grid_defaults_to_one_filling_column_at_min_sidebar_width(browser):
+    """The session sidebar can't be dragged below ~240px, so that viewport width is
+    the smallest the filmstrip ever lays out at. At the default thumbnail size it
+    must show a single column that *fills* it — the previous 180px cell cap left
+    25% of the panel empty at that width."""
+    view = browser.list_view
+    for viewport_w in (214, 240):  # measured: sidebar at minimum, then default width
+        assert view.columns_for_width(viewport_w) == 1
+        assert view.cell_for_width(viewport_w) / viewport_w > 0.95
+
+
+def test_thumbnail_grid_stays_single_column_on_a_slightly_wider_sidebar(browser):
+    """Regression: with the old 120px target the grid flipped to two columns as soon
+    as the panel was nudged past ~260px, which is where users actually sit — the
+    reported "two columns by default"."""
+    view = browser.list_view
+    for viewport_w in (260, 272, 300, 340):
+        assert view.columns_for_width(viewport_w) == 1, f"split into columns at {viewport_w}px"
+
+
+def test_thumbnail_slider_low_end_fits_two_columns(browser):
+    """The point of the slider's low end: trade size for a second column at the
+    same panel width."""
+    view = browser.list_view
+    browser.thumb_size_slider.setValue(THUMB_CELL_MIN)
+    assert view.columns_for_width(240) == 2
+
+
+def test_slider_maximum_never_pins_a_widened_sidebar_to_one_oversized_column(browser):
+    """Regression: the slider's top end used to hold a widened sidebar at a single
+    column, so the cell grew to the full panel width (~500px). Cells are square, so a
+    3:2 frame in one left ~165px of empty space above and below it. Even at the
+    largest setting a wide panel has to split into columns."""
+    view = browser.list_view
+    browser.thumb_size_slider.setValue(browser.thumb_size_slider.maximum())
+    for viewport_w in (450, 500, 600, 700):
+        assert view.columns_for_width(viewport_w) > 1, f"still one column at {viewport_w}px"
+        assert view.cell_for_width(viewport_w) <= 300, f"oversized cell at {viewport_w}px"
+
+
+def test_thumbnail_slider_drives_the_grid_live(browser):
+    view = browser.list_view
+    browser.thumb_size_slider.setValue(THUMB_CELL_MIN)
+    assert view.target_cell == THUMB_CELL_MIN
+    browser.thumb_size_slider.setValue(THUMB_CELL_MAX)
+    assert view.target_cell == THUMB_CELL_MAX
+
+
+def test_thumbnail_size_persists_only_on_release(browser, session):
+    """Dragging crosses dozens of values; each one must not hit the settings DB."""
+    session.repo.save_global_setting.reset_mock()
+    browser.thumb_size_slider.setValue(180)
+    assert not any(c.args and c.args[0] == "thumbnail_cell_size" for c in session.repo.save_global_setting.call_args_list)
+
+    browser.thumb_size_slider.sliderReleased.emit()
+    session.repo.save_global_setting.assert_called_with("thumbnail_cell_size", 180)
+
+
+def test_thumbnail_size_restored_from_settings(session):
+    session.repo.get_global_setting.side_effect = lambda key, default=None: (150 if key == "thumbnail_cell_size" else None)
+    controller = MagicMock()
+    controller.session = session
+    restored = FileBrowser(controller)
+    assert restored.thumb_size_slider.value() == 150
+    assert restored.list_view.target_cell == 150
+
+
+def test_thumbnail_size_out_of_range_setting_is_clamped(session):
+    """A hand-edited or stale setting must not produce an unusable grid."""
+    session.repo.get_global_setting.side_effect = lambda key, default=None: (9999 if key == "thumbnail_cell_size" else None)
+    controller = MagicMock()
+    controller.session = session
+    restored = FileBrowser(controller)
+    assert restored.list_view.target_cell == THUMB_CELL_MAX


### PR DESCRIPTION
## Summary

Two independent fixes to the session sidebar's filmstrip:

**1. Thumbnail colour was oversaturated vs the canvas.** Soft-proofing is on by default, and when active the render worker already bakes source→output→monitor into the displayed buffer — the canvas shows it raw. The thumbnail path didn't know this: it unconditionally assumed the buffer was still in the working space and applied a second working→sRGB conversion on top of the already-converted buffer, clipping channels and inflating saturation (~30-50% depending on working space, measured against both ProPhoto RGB and the now-current Adobe RGB 1998).

Added `AppController.display_transform_params()` as the single place that decides `(color_space, monitor_icc_bytes)` for a rendered buffer, and moved both the canvas and the thumbnail worker onto it so they can't diverge again. `ThumbnailUpdateTask` now carries `monitor_icc_bytes` alongside `color_space`.

**2. Filmstrip defaulted to two cramped columns instead of one filling column.** The session sidebar can't be dragged narrower than ~240px, and the old grid capped cells at 180px — so at minimum width it wasted ~25% of the panel, and past ~260px (where most windows actually sit) it split into two columns instead of one that filled the width.

Replaced the MIN/MAX_CELL model with a target-size model: fit as many columns of at least `target_cell` as the viewport allows, then grow cells to fill the remaining width exactly. Added a persistent size slider (in the filter row) that drives the grid live and saves on release, not per drag step. The slider's top end is capped at the default — above it, a widened sidebar just delayed the column split, growing the (square) cell up to the full panel width and leaving 150-230px of empty vertical space around a 3:2 frame; splitting into columns is both denser and larger in practice.

Also raised the cached thumbnail resolution 120→256px to match the largest size the filmstrip now shows by default (a single column filling the sidebar), and made the disk cache treat a thumbnail cached at a stale size as a miss so existing 120px thumbnails regenerate instead of staying soft.

## Test plan
- [x] **Colour**: real-scan swatch probe confirms canvas/thumbnail are bit-identical in both proof states, against both the old (ProPhoto) and current (Adobe RGB) working space; unit tests pin `display_transform_params`'s proof/no-proof/splash cases and the resulting `ThumbnailUpdateTask` fields — confirmed to fail against the old always-working-space behaviour
- [x] **Sizing**: layout math verified against real measured sidebar widths and against the running app (screenshots at default/min/max slider settings); tests cover single-column-at-minimum-width, no-split-on-slight-widening, the capped maximum not pinning a wide sidebar to one oversized column, slider-drives-grid-live, persist-on-release-not-per-step — each confirmed to fail against the prior behaviour
- [x] **Cache**: tests confirm a stale-size cached thumbnail is treated as a miss and regenerates
- [x] Rebased onto current `main` (26 commits, including the ProPhoto→Adobe RGB working-space change) and re-verified all of the above against it
- [x] Full suite: 2345 passed. The 3 failures are pre-existing Windows path-separator issues that reproduce on a clean `main` without this branch
- [x] `ruff check` / `ruff format --check` clean