### PR TITLE
Camera scanning: dim the framing light for stored RGB presets (fixes #573)

### DIFF
--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -217,6 +217,7 @@ class AppController(QObject):
     capture_light_set = pyqtSignal(int, int, int, int)
     capture_progress = pyqtSignal(float)
     capture_channel = pyqtSignal(str)  # "R"/"G"/"B" as each triplet channel starts
+    capture_camera_setting_applied = pyqtSignal(str)  # a set_camera_setting call ran to completion
     capture_finished = pyqtSignal(list)
     capture_cancelled = pyqtSignal()
     capture_error = pyqtSignal(str)
@@ -497,6 +498,7 @@ class AppController(QObject):
         self.capture_worker.light_set.connect(self.capture_light_set.emit)
         self.capture_worker.progress.connect(self.capture_progress.emit)
         self.capture_worker.channel.connect(self.capture_channel.emit)
+        self.capture_worker.camera_setting_applied.connect(self.capture_camera_setting_applied.emit)
         self.capture_worker.finished.connect(self._on_capture_finished)
         self.capture_worker.cancelled.connect(self.capture_cancelled.emit)
         self.capture_worker.error.connect(self.capture_error.emit)
@@ -2121,6 +2123,9 @@ class AppController(QObject):
         self.live_view_focus_magnifier_pos_requested.emit(x, y)
 
     def set_camera_setting(self, which: str, raw: int) -> None:
+        # Ensure the worker thread runs: the sidebar counts these writes and gates Scan until
+        # each one reports back, so a write queued to a never-started thread would gate forever.
+        self._ensure_capture_thread()
         self.live_view_camera_setting_requested.emit(which, raw)
 
     def start_calibration(self, req: CalibrationRequest) -> None:

--- a/negpy/desktop/view/sidebar/scanlight.py
+++ b/negpy/desktop/view/sidebar/scanlight.py
@@ -37,7 +37,7 @@ from negpy.desktop.view.styles.theme import THEME
 from negpy.infrastructure.capture.gphoto import default_settings_path
 from negpy.infrastructure.capture.settings import ScanlightSettings
 from negpy.services.capture.calibration import REFERENCE_LEVELS, SHUTTER_CANDIDATES, normalize_start_point, shutter_seconds, usable_ladder
-from negpy.services.capture.presets import PresetStore, ScanlightPreset
+from negpy.services.capture.presets import PresetStore, ScanlightPreset, framing_levels
 
 _CHANNEL_COLORS = {"R": "#E24B4A", "G": "#639922", "B": "#378ADD", "W": "#B4B2A9"}
 
@@ -108,6 +108,9 @@ class ScanlightSidebar(QWidget):
         self._slider_rows: dict = {}  # slider → its row widget, so the W row can be hidden on an RGB-only Scanlight
         self._light_has_white = True  # does the connected Scanlight have a white LED? (False = v1-v3, RGB-only)
         self._suppress_camera_release = False  # true only mid hand-off between lv_window/calib_window
+        # Preset-exposure writes (shutter/ISO/aperture) still in flight on the worker; Scan stays
+        # gated until each is confirmed, so a capture can't race the body's async programming.
+        self._pending_exposure_writes = 0
         self._no_wheel = _NoWheel(self)
 
         self.lv_window = LiveViewWindow(self)
@@ -398,6 +401,7 @@ class ScanlightSidebar(QWidget):
         self.controller.capture_light_set.connect(self._on_light_set)
         self.controller.capture_progress.connect(self._on_progress)
         self.controller.capture_channel.connect(self._on_channel)
+        self.controller.capture_camera_setting_applied.connect(self._on_camera_setting_applied)
         self.controller.capture_finished.connect(self._on_finished)
         self.controller.capture_cancelled.connect(self._on_cancelled)
         self.controller.capture_error.connect(self._on_error)
@@ -452,10 +456,16 @@ class ScanlightSidebar(QWidget):
             self.controller.set_scanlight_color(0, 0, 0, self.w_slider.value(), self._settings.port)
         else:
             # Any RGB state — a selected preset, manual building, or framing/focusing in live view —
-            # lights the R/G/B mix from the sliders. The preset's own values are the framing light too
-            # (one light for scanning and focusing), so it works on every Scanlight and never assumes a
+            # lights the R/G/B mix from the sliders, so it works on every Scanlight and never assumes a
             # white LED an RGB-only body lacks. White stays off: the Scanlight can't mix white with RGB.
-            self.controller.set_scanlight_color(self.r_slider.value(), self.g_slider.value(), self.b_slider.value(), 0, self._settings.port)
+            r, g, b = self.r_slider.value(), self.g_slider.value(), self.b_slider.value()
+            if not self._manual_mode and self._preset_selected():
+                # A stored RGB preset frames by its own mix, but dimmed (issue #573): all three
+                # channels burn at once against a single-channel scan exposure, so full levels
+                # blow the live view out. The scan never reads this — capture levels come from
+                # the preset; manual building keeps full levels (the operator is dialling them).
+                r, g, b = framing_levels(r, g, b)
+            self.controller.set_scanlight_color(r, g, b, 0, self._settings.port)
         self._update_settings_from_ui()
 
     def _on_light_off(self) -> None:
@@ -706,8 +716,9 @@ class ScanlightSidebar(QWidget):
         return ""
 
     def _apply_active_preset_camera_settings(self) -> None:
-        """Push the active RGB preset's baked ISO/aperture to the body (no-op for white/built-in
-        presets or no selection). Used when the scan live view comes up after a preset was picked."""
+        """Push the active RGB preset's baked exposure (shutter/ISO/aperture) to the body (no-op for
+        white/built-in presets or no selection). Used when the scan live view comes up after a preset
+        was picked."""
         name = self.preset_combo.currentData()
         if not name or name in _BUILTIN_WHITE_PRESETS:
             return
@@ -716,11 +727,15 @@ class ScanlightSidebar(QWidget):
             self._apply_preset_camera_settings(preset)
 
     def _apply_preset_camera_settings(self, preset) -> None:
-        """Set the body's ISO + aperture to the values baked into the RGB preset, so the scan
-        matches the calibration. Labels are resolved against the live options (a no-op if the value
-        is absent, the body lacks the option, or no camera session is open to receive the write)."""
+        """Set the body's shutter + ISO + aperture to the values baked into the RGB preset, so the
+        scan matches the calibration and the framing brightness is deterministic: the dimmed framing
+        light (see framing_levels) is sized against the preset's shutter, so a body left on some
+        other speed would frame too dark or too bright. Shutter first — it dominates that brightness.
+        Labels are resolved against the live options (a no-op if the value is absent, the body lacks
+        the option, or no camera session is open to receive the write)."""
         data = self._settings_json()
-        for key, label in (("iso", preset.iso), ("aperture", preset.aperture)):
+        issued = 0
+        for key, label in (("shutter", preset.shutter_r), ("iso", preset.iso), ("aperture", preset.aperture)):
             if not label:
                 continue
             info = data.get(key)
@@ -729,7 +744,19 @@ class ScanlightSidebar(QWidget):
             for o in info.get("options", []):
                 if str(o.get("label", "")) == label:
                     self.controller.set_camera_setting(key, int(o["raw"]))
+                    issued += 1
                     break
+        if issued:
+            self._pending_exposure_writes += issued
+            self._apply_gating()  # Scan greys out until the worker confirms every write
+
+    @pyqtSlot(str)
+    def _on_camera_setting_applied(self, _which: str) -> None:
+        if self._pending_exposure_writes == 0:
+            return  # a stepper write from manual/white mode, not one of the gated preset writes
+        self._pending_exposure_writes -= 1
+        if self._pending_exposure_writes == 0:
+            self._apply_gating()
 
     def _available_shutters(self) -> tuple[str, ...]:
         """The camera's writable shutter labels (from the live-view settings JSON), fastest-first,
@@ -1419,6 +1446,8 @@ class ScanlightSidebar(QWidget):
         # queue — and then fire with the exposure the calibration was about to replace.
         if self._calibrating_preset:
             m.append("wait for the calibration to finish")
+        if self._pending_exposure_writes:
+            m.append("wait for the preset exposure to reach the camera")
         if not self._camera_verified:
             m.append("connect the camera")
         if self._rgb_mode:

--- a/negpy/desktop/workers/capture_worker.py
+++ b/negpy/desktop/workers/capture_worker.py
@@ -74,6 +74,9 @@ class CaptureWorker(QObject):
     light_set = pyqtSignal(int, int, int, int)  # r, g, b, w actually applied
     progress = pyqtSignal(float)  # 0.0..1.0
     channel = pyqtSignal(str)  # "R"/"G"/"B" as each triplet channel starts
+    #: One set_camera_setting call ran to completion — verified, rejected, or skipped without a
+    #: session. Always fires, so the sidebar's pending-write gate on Scan can never stick.
+    camera_setting_applied = pyqtSignal(str)
     finished = pyqtSignal(list)  # [red_path, green_path, blue_path]
     cancelled = pyqtSignal()
     error = pyqtSignal(str)
@@ -427,16 +430,17 @@ class CaptureWorker(QObject):
     def set_camera_setting(self, which: str, raw: int) -> None:
         """Change a live camera setting (iso/shutter/wb/aperture); `raw` is a choice index."""
         try:
-            if not self._holds_camera():
-                return
-            cam = self._camera
-            {
-                "iso": cam.set_iso,
-                "shutter": cam.set_shutter,
-                "aperture": cam.set_aperture,
-            }.get(which, lambda _r: None)(raw)
+            if self._holds_camera():
+                cam = self._camera
+                {
+                    "iso": cam.set_iso,
+                    "shutter": cam.set_shutter,
+                    "aperture": cam.set_aperture,
+                }.get(which, lambda _r: None)(raw)
         except Exception as exc:  # noqa: BLE001 — exceptions cannot cross a Qt slot
             self._camera_control_failed("set_camera_setting", exc)
+        finally:
+            self.camera_setting_applied.emit(which)
 
     # ----- calibration -----
 

--- a/negpy/services/capture/presets.py
+++ b/negpy/services/capture/presets.py
@@ -9,6 +9,25 @@ from __future__ import annotations
 from dataclasses import asdict, dataclass
 
 
+#: Framing runs all three channels at once against a single-channel scan exposure, so the
+#: live view blows out at full levels (issue #573). 3 stops ≈ the 3× light plus headroom.
+FRAMING_DIM_STOPS = 3
+
+
+def framing_levels(r: int, g: int, b: int, stops: int = FRAMING_DIM_STOPS) -> tuple[int, int, int]:
+    """The framing-light mix for a scan-level RGB recipe: the same colour, `stops` dimmer.
+
+    Dimming the light rather than speeding the shutter keeps the scan start free of the
+    1-2 s a verified shutter write costs, and works on bodies whose shutter NegPy cannot
+    drive. A lit channel never dims to 0, so the mix keeps its hue at single-digit levels.
+    """
+
+    def dim(level: int) -> int:
+        return max(1, level >> stops) if level > 0 else 0
+
+    return dim(r), dim(g), dim(b)
+
+
 @dataclass(frozen=True)
 class ScanlightPreset:
     """One film stock's capture recipe."""

--- a/tests/test_capture_presets.py
+++ b/tests/test_capture_presets.py
@@ -1,6 +1,6 @@
 """Film-stock preset store unit tests (fake repo)."""
 
-from negpy.services.capture.presets import PresetStore, ScanlightPreset
+from negpy.services.capture.presets import PresetStore, ScanlightPreset, framing_levels
 
 
 class FakeRepo:
@@ -56,3 +56,11 @@ def test_legacy_preset_without_exposure_defaults_blank():
     repo.save_global_setting("scanlight_presets", {"Old": {"r_level": 200, "shutter_r": "1/5"}})
     p = PresetStore(repo).get("Old")
     assert p is not None and p.iso == "" and p.aperture == ""
+
+
+def test_framing_levels_dim_three_stops():
+    assert framing_levels(210, 95, 80) == (26, 11, 10)  # the reference start point, 2^3 dimmer
+
+
+def test_framing_levels_keep_lit_channels_lit_and_dark_channels_dark():
+    assert framing_levels(255, 4, 0) == (31, 1, 0)  # a lit channel never dims to 0; off stays off


### PR DESCRIPTION
Fixes #573.

Between shots the Scanlight frames with all three channels lit at once while the body sits on the preset's single-channel scan exposure, so the live view blows out and reframing is guesswork (as reported in the issue with a 1/8 preset).

What this does:

- A stored RGB preset now frames with its own mix dimmed by 3 stops (framing_levels in services/capture/presets.py, one constant). The scan is untouched: capture levels come from the preset, manual preset building keeps full levels (the operator is dialling them in), and the calibration window keeps its full probe light (the crosshair must sit under the light the probe starts from).
- Dimming the light instead of speeding up the shutter was deliberate: a verified shutter write costs 1 to 2 s on the body, which would slow every scan start, and it would not work on bodies whose shutter NegPy cannot drive. The light write is a few ms of serial and vendor neutral.
- Opening the scan window now also asserts the preset's shutter along with ISO and aperture (shutter first, it dominates the framing brightness), so the framing exposure is deterministic no matter what the body was left on.
- While those writes are in flight, Scan and Retake stay greyed out ("wait for the preset exposure to reach the camera"): the worker confirms each write, including rejected or session-less ones, so the gate always releases, and the capture path still re-asserts the exposure per channel as the final safety.

Tested at the rig on an a7C II: framing is comfortable at 3 stops down, scans are unchanged, and the gate releases in about 1 to 2 s after the window opens. make all is green with and without the optional camera group.