### PR TITLE
feat: DB management dialog to view and clear stored data

### DIFF
--- a/negpy/desktop/view/canvas/toolbar.py
+++ b/negpy/desktop/view/canvas/toolbar.py
@@ -262,6 +262,9 @@ class ActionToolbar(QWidget):
         )
         overflow_menu.addSeparator()
 
+        overflow_menu.addAction(qta.icon("fa5s.database", color=icon_color), "Manage Database…", self._show_database_dialog)
+        overflow_menu.addSeparator()
+
         overflow_menu.addAction(qta.icon("fa5s.map-signs", color=icon_color), "Take the tour", self._show_tour)
         overflow_menu.addAction(qta.icon("fa5s.keyboard", color=icon_color), "Keyboard Shortcuts  ?", self._show_shortcuts)
         self.btn_overflow.setMenu(overflow_menu)
@@ -530,6 +533,11 @@ class ActionToolbar(QWidget):
 
         dlg = ShortcutsOverlay(self.window().shortcut_manager, self.window())
         dlg.exec()
+
+    def _show_database_dialog(self) -> None:
+        from negpy.desktop.view.widgets.database_dialog import DatabaseDialog
+
+        DatabaseDialog(self.session.repo, self.window()).exec()
 
     def _update_ui_state(self) -> None:
         state = self.session.state

--- a/negpy/desktop/view/widgets/database_dialog.py
+++ b/negpy/desktop/view/widgets/database_dialog.py
@@ -1,0 +1,208 @@
+from typing import Optional
+
+from PyQt6.QtCore import Qt
+from PyQt6.QtWidgets import (
+    QDialog,
+    QFrame,
+    QGridLayout,
+    QHBoxLayout,
+    QLabel,
+    QMessageBox,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from negpy.desktop.view.styles.theme import THEME
+
+# (stat key, display label). Order = display order; a separator sits between the
+# per-image group and the reusable-tooling group.
+_EDIT_ROWS = (
+    ("file_settings", "Saved edits (images)"),
+    ("edit_history", "Undo-history steps"),
+    ("file_marks", "Keep / reject marks"),
+)
+_TOOLING_ROWS = (
+    ("normalization_rolls", "Normalization rolls"),
+    ("flatfield_profiles", "Flat-field profiles"),
+    ("export_presets", "Export presets"),
+    ("app_preferences", "App preferences"),
+)
+
+
+def _human_bytes(n: int) -> str:
+    size = float(n)
+    for unit in ("B", "KB", "MB", "GB"):
+        if size < 1024 or unit == "GB":
+            return f"{size:.0f} {unit}" if unit == "B" else f"{size:.1f} {unit}"
+        size /= 1024
+    return f"{size:.1f} GB"
+
+
+class DatabaseDialog(QDialog):
+    """View what the app has stored in SQLite and clear it.
+
+    Two clear actions: 'Clear Saved Edits' drops per-image looks/history/marks so a
+    reloaded image starts from defaults; 'Reset Everything' wipes both databases
+    (also presets, rig profiles, preferences). Both confirm first; the counts and
+    sizes refresh in place after a clear.
+    """
+
+    def __init__(self, repo, parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent)
+        self.repo = repo
+        self.setWindowTitle("Manage Database")
+        self.setMinimumWidth(420)
+        self.setStyleSheet(f"QDialog {{ background: {THEME.bg_dark}; }}")
+
+        root = QVBoxLayout(self)
+        root.setContentsMargins(THEME.space_2xl, THEME.space_2xl, THEME.space_2xl, THEME.space_2xl)
+        root.setSpacing(THEME.space_xl)
+
+        header = QLabel("Stored data")
+        header.setStyleSheet(f"color: {THEME.text_primary}; font-size: {THEME.font_size_header}px; font-weight: {THEME.weight_semibold};")
+        root.addWidget(header)
+
+        self._grid = QGridLayout()
+        self._grid.setColumnStretch(0, 1)
+        self._grid.setHorizontalSpacing(THEME.space_2xl)
+        self._grid.setVerticalSpacing(THEME.space_sm)
+        self._value_labels: dict[str, QLabel] = {}
+        root.addLayout(self._grid)
+
+        self._size_label = QLabel("")
+        self._size_label.setStyleSheet(f"color: {THEME.text_muted}; font-size: {THEME.font_size_xs}px;")
+        root.addWidget(self._size_label)
+
+        note = QLabel(
+            "Clearing only affects this app's database. Source files are never touched. "
+            "If you export .negpy sidecars, those still exist next to your images and can "
+            "restore an edit when that image is reloaded."
+        )
+        note.setWordWrap(True)
+        note.setStyleSheet(f"color: {THEME.text_muted}; font-size: {THEME.font_size_xs}px;")
+        root.addWidget(note)
+
+        root.addLayout(self._build_footer())
+        self._populate()
+
+    def _build_footer(self) -> QHBoxLayout:
+        row = QHBoxLayout()
+        row.setSpacing(THEME.space_lg)
+
+        self.clear_edits_btn = QPushButton("Clear Saved Edits")
+        self.clear_edits_btn.setToolTip("Drop saved per-image edits, undo history and keep/reject marks. Keeps presets and rig profiles.")
+        self.clear_edits_btn.clicked.connect(self._on_clear_edits)
+
+        self.reset_all_btn = QPushButton("Reset Everything")
+        self.reset_all_btn.setToolTip(
+            "Wipe the entire database: edits, history, marks, rig profiles, export presets and all app preferences."
+        )
+        self.reset_all_btn.setStyleSheet(
+            f"QPushButton {{ background: {THEME.accent_primary}; color: #FFFFFF; border: none; "
+            f"border-radius: {THEME.radius_sm}px; padding: {THEME.space_md}px {THEME.space_xl}px; }}"
+            f"QPushButton:hover {{ background: {THEME.accent_secondary}; }}"
+        )
+        self.reset_all_btn.clicked.connect(self._on_reset_all)
+
+        close_btn = QPushButton("Close")
+        close_btn.clicked.connect(self.accept)
+
+        row.addWidget(self.clear_edits_btn)
+        row.addWidget(self.reset_all_btn)
+        row.addStretch(1)
+        row.addWidget(close_btn)
+        return row
+
+    def _add_separator(self, grid_row: int) -> None:
+        # A plain QFrame HLine draws from the palette and barely shows on the dark
+        # background; a 1px background-filled frame renders reliably.
+        line = QFrame()
+        line.setFixedHeight(1)
+        line.setStyleSheet(f"background: {THEME.border_color};")
+        self._grid.addWidget(line, grid_row, 0, 1, 2)
+
+    def _stat_row(self, grid_row: int, key: str, label: str) -> None:
+        name = QLabel(label)
+        name.setStyleSheet(f"color: {THEME.text_secondary}; font-size: {THEME.font_size_base}px;")
+        value = QLabel("0")
+        value.setAlignment(Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter)
+        value.setStyleSheet(f"color: {THEME.text_primary}; font-size: {THEME.font_size_base}px; font-weight: {THEME.weight_medium};")
+        self._grid.addWidget(name, grid_row, 0)
+        self._grid.addWidget(value, grid_row, 1)
+        self._value_labels[key] = value
+
+    def _populate(self) -> None:
+        # Build the grid once; refreshes only update the value labels.
+        if not self._value_labels:
+            r = 0
+            for key, label in _EDIT_ROWS:
+                self._stat_row(r, key, label)
+                r += 1
+            self._add_separator(r)
+            r += 1
+            for key, label in _TOOLING_ROWS:
+                self._stat_row(r, key, label)
+                r += 1
+        self._refresh()
+
+    def _refresh(self) -> None:
+        try:
+            stats = self.repo.database_stats()
+        except Exception:
+            for lbl in self._value_labels.values():
+                lbl.setText("—")
+            self._size_label.setText("Could not read the database.")
+            return
+        for key, lbl in self._value_labels.items():
+            lbl.setText(f"{stats.get(key, 0):,}")
+        total = stats.get("edits_db_bytes", 0) + stats.get("settings_db_bytes", 0)
+        self._size_label.setText(f"On disk: {_human_bytes(total)}")
+        self._update_enabled(stats)
+
+    def _update_enabled(self, stats: dict) -> None:
+        edits = stats.get("file_settings", 0) + stats.get("edit_history", 0) + stats.get("file_marks", 0)
+        total = edits + sum(stats.get(k, 0) for k in ("normalization_rolls", "flatfield_profiles", "export_presets", "app_preferences"))
+        self.clear_edits_btn.setEnabled(edits > 0)
+        self.reset_all_btn.setEnabled(total > 0)
+
+    def _confirm(self, title: str, text: str, ok_label: str) -> bool:
+        box = QMessageBox(self)
+        box.setIcon(QMessageBox.Icon.Warning)
+        box.setWindowTitle(title)
+        box.setText(text)
+        box.setInformativeText("This cannot be undone.")
+        ok = box.addButton(ok_label, QMessageBox.ButtonRole.DestructiveRole)
+        box.addButton("Cancel", QMessageBox.ButtonRole.RejectRole)
+        box.setDefaultButton(box.buttons()[-1])  # default to Cancel
+        box.exec()
+        return box.clickedButton() is ok
+
+    def _on_clear_edits(self) -> None:
+        if not self._confirm(
+            "Clear Saved Edits",
+            "Delete all saved per-image edits, their undo history, and keep/reject marks?\n\n"
+            "Reloading an image will start from defaults. Export presets and rig profiles are kept.",
+            "Clear Saved Edits",
+        ):
+            return
+        try:
+            self.repo.clear_saved_edits()
+        except Exception as exc:
+            QMessageBox.critical(self, "Clear failed", f"Could not clear the database:\n{exc}")
+        self._refresh()
+
+    def _on_reset_all(self) -> None:
+        if not self._confirm(
+            "Reset Everything",
+            "Wipe the entire database — every saved edit, undo history, keep/reject mark, "
+            "normalization roll, flat-field profile, export preset, and all app preferences?\n\n"
+            "The app returns to a first-run state.",
+            "Reset Everything",
+        ):
+            return
+        try:
+            self.repo.reset_everything()
+        except Exception as exc:
+            QMessageBox.critical(self, "Reset failed", f"Could not reset the database:\n{exc}")
+        self._refresh()

--- a/negpy/infrastructure/storage/repository.py
+++ b/negpy/infrastructure/storage/repository.py
@@ -352,3 +352,91 @@ class StorageRepository(IRepository):
             except Exception:
                 pass
         return result
+
+    # ------------------------------------------------------------------
+    # Database management (view / clear) — backs the DB Management dialog.
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _count(conn: sqlite3.Connection, table: str) -> int:
+        try:
+            return int(conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0])
+        except sqlite3.OperationalError:
+            return 0  # table not created yet
+
+    @staticmethod
+    def _db_size_bytes(path: str) -> int:
+        """On-disk footprint including the WAL/SHM sidecars (uncheckpointed writes
+        live in -wal, so the bare .db size understates real usage)."""
+        total = 0
+        for suffix in ("", "-wal", "-shm"):
+            try:
+                total += os.path.getsize(path + suffix)
+            except OSError:
+                pass
+        return total
+
+    def database_stats(self) -> dict[str, int]:
+        """Row counts per category plus on-disk sizes, for the management dialog.
+
+        ``export_presets`` is one JSON row inside global_settings, so it's counted
+        from that list and excluded from ``app_preferences`` to avoid double-counting.
+        """
+        with self._connect(self.edits_db_path) as conn:
+            file_settings = self._count(conn, "file_settings")
+            edit_history = self._count(conn, "edit_history")
+            file_marks = self._count(conn, "file_marks")
+            normalization_rolls = self._count(conn, "normalization_rolls")
+            flatfield_profiles = self._count(conn, "flatfield_profiles")
+
+        with self._connect(self.settings_db_path) as conn:
+            global_settings = self._count(conn, "global_settings")
+
+        raw_presets = self.get_global_setting("export_presets", default=None)
+        export_presets = len(raw_presets) if isinstance(raw_presets, list) else 0
+        has_presets_row = raw_presets is not None
+
+        return {
+            "file_settings": file_settings,
+            "edit_history": edit_history,
+            "file_marks": file_marks,
+            "normalization_rolls": normalization_rolls,
+            "flatfield_profiles": flatfield_profiles,
+            "export_presets": export_presets,
+            # global_settings rows minus the single export_presets row (if present).
+            "app_preferences": max(0, global_settings - (1 if has_presets_row else 0)),
+            "edits_db_bytes": self._db_size_bytes(self.edits_db_path),
+            "settings_db_bytes": self._db_size_bytes(self.settings_db_path),
+        }
+
+    def _wipe(self, path: str, tables: list[str]) -> None:
+        """Empty the given tables, then checkpoint + VACUUM so the disk footprint
+        actually shrinks (WAL retains freed pages until checkpointed; VACUUM
+        rebuilds the file). VACUUM must run outside a transaction — a fresh
+        connection with no prior DML has none open."""
+        with self._connect(path) as conn:
+            for table in tables:
+                try:
+                    conn.execute(f"DELETE FROM {table}")
+                except sqlite3.OperationalError:
+                    pass  # table absent — nothing to clear
+        with self._connect(path) as conn:
+            conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+            conn.execute("VACUUM")
+
+    def clear_saved_edits(self) -> None:
+        """Drop per-image looks: saved edits, their undo history, and keep/reject
+        marks. Rig calibration (normalization rolls, flat-field profiles), export
+        presets, and app preferences are left intact — so a reloaded image starts
+        from defaults without losing the user's tooling."""
+        self._wipe(self.edits_db_path, ["file_settings", "edit_history", "file_marks"])
+
+    def reset_everything(self) -> None:
+        """Full clean slate: every table in both databases. Export presets, rig
+        profiles, and all app preferences go too. Schema is preserved (rows only),
+        so the app keeps working against the emptied databases without re-init."""
+        self._wipe(
+            self.edits_db_path,
+            ["file_settings", "edit_history", "file_marks", "normalization_rolls", "flatfield_profiles"],
+        )
+        self._wipe(self.settings_db_path, ["global_settings"])

--- a/tests/test_database_management.py
+++ b/tests/test_database_management.py
@@ -1,0 +1,130 @@
+from dataclasses import replace
+
+from negpy.domain.models import ExportPreset, WorkspaceConfig
+from negpy.infrastructure.storage.repository import StorageRepository
+
+
+def _repo(tmp_path):
+    repo = StorageRepository(str(tmp_path / "edits.db"), str(tmp_path / "settings.db"))
+    repo.initialize()
+    return repo
+
+
+def _seed(repo):
+    """Populate every category the stats/clear methods touch."""
+    cfg = WorkspaceConfig()
+    repo.save_file_settings("hash-a", cfg, file_path="/photos/a.raw")
+    repo.save_file_settings("hash-b", cfg, file_path="/photos/b.raw")
+    repo.save_history_step("hash-a", 0, cfg)
+    repo.save_history_step("hash-a", 1, replace(cfg))
+    repo.save_file_mark("hash-a", "keeper")
+    repo.save_normalization_roll("roll-1", (0.1, 0.1, 0.1), (0.9, 0.9, 0.9))
+    repo.save_flatfield_profile("rig-1", "/refs/flat.dng", k1=-0.05)
+    repo.save_export_presets([ExportPreset(name="mine")])
+    repo.save_global_setting("window_geometry", [0, 0, 800, 600])
+    repo.save_global_setting("last_open_folder", "/photos")
+
+
+def test_database_stats_counts_each_category(tmp_path):
+    repo = _repo(tmp_path)
+    _seed(repo)
+    stats = repo.database_stats()
+
+    assert stats["file_settings"] == 2
+    assert stats["edit_history"] == 2
+    assert stats["file_marks"] == 1
+    assert stats["normalization_rolls"] == 1
+    assert stats["flatfield_profiles"] == 1
+    assert stats["export_presets"] == 1
+    # export_presets is one row inside global_settings; it must not inflate the
+    # preferences count, which here is the two real settings we saved.
+    assert stats["app_preferences"] == 2
+    assert stats["edits_db_bytes"] > 0
+    assert stats["settings_db_bytes"] > 0
+
+
+def test_stats_on_empty_db_are_all_zero(tmp_path):
+    repo = _repo(tmp_path)
+    stats = repo.database_stats()
+    for key in (
+        "file_settings",
+        "edit_history",
+        "file_marks",
+        "normalization_rolls",
+        "flatfield_profiles",
+        "export_presets",
+        "app_preferences",
+    ):
+        assert stats[key] == 0
+
+
+def test_clear_saved_edits_drops_only_per_image_data(tmp_path):
+    repo = _repo(tmp_path)
+    _seed(repo)
+
+    repo.clear_saved_edits()
+    stats = repo.database_stats()
+
+    # Per-image data gone.
+    assert stats["file_settings"] == 0
+    assert stats["edit_history"] == 0
+    assert stats["file_marks"] == 0
+    # Tooling kept.
+    assert stats["normalization_rolls"] == 1
+    assert stats["flatfield_profiles"] == 1
+    assert stats["export_presets"] == 1
+    assert stats["app_preferences"] == 2
+
+
+def test_clear_saved_edits_makes_reloaded_image_start_fresh(tmp_path):
+    """The user's actual goal: after clearing, loading the same hash returns nothing,
+    so hydration falls back to defaults instead of the previous look."""
+    repo = _repo(tmp_path)
+    edited = replace(WorkspaceConfig(), process=replace(WorkspaceConfig().process, narrowband_scan=True))
+    repo.save_file_settings("hash-x", edited, file_path="/photos/x.raw")
+    assert repo.load_file_settings("hash-x") is not None
+
+    repo.clear_saved_edits()
+
+    assert repo.load_file_settings("hash-x") is None
+    # Path-based fallback must not resurrect it either.
+    assert repo.load_file_settings_by_path("/photos/x.raw") is None
+
+
+def test_reset_everything_wipes_both_databases(tmp_path):
+    repo = _repo(tmp_path)
+    _seed(repo)
+
+    repo.reset_everything()
+    stats = repo.database_stats()
+
+    for key in (
+        "file_settings",
+        "edit_history",
+        "file_marks",
+        "normalization_rolls",
+        "flatfield_profiles",
+        "export_presets",
+        "app_preferences",
+    ):
+        assert stats[key] == 0
+    # A global setting written before the reset is gone.
+    assert repo.get_global_setting("window_geometry") is None
+
+
+def test_repository_still_usable_after_reset(tmp_path):
+    """Reset empties rows but preserves schema — the app must keep working."""
+    repo = _repo(tmp_path)
+    _seed(repo)
+    repo.reset_everything()
+
+    repo.save_file_settings("hash-new", WorkspaceConfig(), file_path="/photos/new.raw")
+    assert repo.load_file_settings("hash-new") is not None
+    assert repo.database_stats()["file_settings"] == 1
+
+
+def test_clear_on_empty_db_is_a_noop(tmp_path):
+    repo = _repo(tmp_path)
+    repo.clear_saved_edits()  # must not raise
+    repo.reset_everything()  # must not raise
+    assert repo.database_stats()["file_settings"] == 0


### PR DESCRIPTION
## Summary

There was no in-app way to inspect or wipe the SQLite databases, so a reloaded image always restored its previously saved edits with no way to opt out short of hand-deleting the `.db` files.

Adds a **"Manage Database…"** entry to the More Actions (⋯) menu that opens a dialog:

- **View** everything stored, grouped as *per-image* (saved edits, undo history, keep/reject marks) and *tooling* (normalization rolls, flat-field profiles, export presets, app preferences), plus total on-disk size including the WAL/SHM sidecars.
- **Clear Saved Edits** — drops the per-image looks + history + marks so a reloaded image starts from defaults; export presets and rig profiles survive.
- **Reset Everything** (destructive/red) — wipes both databases to a first-run state.

Both clears sit behind a warning dialog that defaults to Cancel and says "This cannot be undone". Counts refresh in place afterward and buttons disable when there's nothing left to clear.

## Implementation notes

- Repository gains `database_stats()`, `clear_saved_edits()`, `reset_everything()`.
- Clears run `PRAGMA wal_checkpoint(TRUNCATE)` + `VACUUM` so the on-disk footprint actually shrinks, and delete **rows only** (schema preserved) so the app keeps working against the emptied databases without a re-init or restart.
- `export_presets` is one JSON row inside `global_settings`, so it's counted from that list and excluded from the "app preferences" count to avoid double-counting.
- Clearing is **DB-only** — it never touches source files or the thumbnail cache. The dialog notes that if `.negpy` sidecars are enabled, those still sit next to source images and can restore an edit on reload (sidecars are off by default).

## Test plan
- [x] Verified end-to-end against the real desktop app: menu entry present; seeded 142 edits / 40 history steps / 38 marks / presets / profiles / prefs and confirmed the dialog counts; ran both clears through the real dialog and confirmed the correct categories were dropped/kept; repo still writable after a full reset (screenshots captured)
- [x] 7 new unit tests: per-category stats, the export-presets-vs-preferences split, targeted vs full clear, the reloaded-image-starts-fresh goal (`load_file_settings` returns `None` after clear, path fallback doesn't resurrect it), post-reset usability, and empty-DB no-op — each confirmed to fail against a sabotaged no-op clear
- [x] Full suite: 2352 passed. The 3 failures are pre-existing, unrelated Windows path-separator issues that reproduce on a clean `main`
- [x] `ruff check` / `ruff format --check` clean