### PR TITLE
Add contact sheet labels and background/label color customization with persistent templates

### DIFF
--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -2764,6 +2764,9 @@ class AppController(QObject):
             Q_ARG(int, cs.contact_sheet_gap),
             Q_ARG(int, cs.contact_sheet_margin),
             Q_ARG(int, cs.contact_sheet_max_tiles),
+            Q_ARG(bool, cs.contact_sheet_show_labels),
+            Q_ARG(str, cs.contact_sheet_background_color),
+            Q_ARG(str, cs.contact_sheet_label_color),
         )
 
     def _write_edit_sidecars(self, files: list[dict]) -> int:

--- a/negpy/desktop/view/sidebar/export.py
+++ b/negpy/desktop/view/sidebar/export.py
@@ -21,6 +21,7 @@ from PyQt6.QtWidgets import (
 )
 
 from negpy.desktop.view.sidebar.base import BaseSidebar
+from negpy.desktop.view.widgets.contact_sheet_colors_dialog import ContactSheetColorsDialog
 from negpy.desktop.view.styles.templates import (
     default_button_height,
     field_label,
@@ -187,6 +188,8 @@ class ExportSidebar(BaseSidebar):
         content_layout.addWidget(self.cs_save_template_btn)
 
         initial_layout = self._contact_sheet_layout_for_config(conf)
+        self._cs_background_color = initial_layout.background_color
+        self._cs_label_color = initial_layout.label_color
 
         def _labeled_spinbox(label: str, value: int, lo: int, hi: int) -> QSpinBox:
             row = QHBoxLayout()
@@ -203,6 +206,23 @@ class ExportSidebar(BaseSidebar):
         self.cs_gap_input = _labeled_spinbox("Gap px", initial_layout.gap, 0, 200)
         self.cs_margin_input = _labeled_spinbox("Margin px", initial_layout.margin, 0, 500)
         self.cs_max_tiles_input = _labeled_spinbox("Max tiles", initial_layout.max_tiles, 1, 200)
+
+        self.cs_show_labels_checkbox = QCheckBox("Show filenames")
+        self.cs_show_labels_checkbox.setChecked(initial_layout.show_labels)
+        self.cs_show_labels_checkbox.setToolTip("Print each frame's original filename below its thumbnail")
+        self.cs_show_labels_checkbox.stateChanged.connect(self._on_contact_sheet_settings_changed)
+        content_layout.addWidget(self.cs_show_labels_checkbox)
+
+        colors_row = QHBoxLayout()
+        colors_label = field_label("Colours")
+        colors_label.setFixedWidth(90)
+        colors_row.addWidget(colors_label)
+        self.cs_colors_btn = QPushButton(" Choose…")
+        self.cs_colors_btn.setToolTip("Background and label colours")
+        self._update_cs_colors_btn_tooltip()
+        self.cs_colors_btn.clicked.connect(self._on_cs_colors_clicked)
+        colors_row.addWidget(self.cs_colors_btn, 1)
+        content_layout.addLayout(colors_row)
 
         self._refresh_contact_sheet_templates()
         saved_template = conf.contact_sheet_template.strip()
@@ -254,6 +274,25 @@ class ExportSidebar(BaseSidebar):
         if path:
             self.cs_output_path_edit.setText(path)
 
+    def _update_cs_colors_btn_tooltip(self) -> None:
+        self.cs_colors_btn.setToolTip(
+            f"Background {self._cs_background_color}, labels {self._cs_label_color}"
+        )
+
+    def _on_cs_colors_clicked(self) -> None:
+        try:
+            dlg = ContactSheetColorsDialog(self._cs_background_color, self._cs_label_color, self)
+            if not dlg.exec():
+                return
+            bg, label = dlg.colors()
+        except Exception as exc:
+            QMessageBox.critical(self, "Contact Sheet Colours", f"Could not open colour picker:\n{exc}")
+            return
+        self._cs_background_color = bg
+        self._cs_label_color = label
+        self._update_cs_colors_btn_tooltip()
+        self._on_contact_sheet_settings_changed()
+
     def _contact_sheet_layout_for_config(self, conf) -> ContactSheetLayout:
         saved_template = conf.contact_sheet_template.strip()
         if saved_template and saved_template in ContactSheetTemplates.list_templates():
@@ -279,6 +318,9 @@ class ExportSidebar(BaseSidebar):
             gap=self.cs_gap_input.value(),
             margin=self.cs_margin_input.value(),
             max_tiles=self.cs_max_tiles_input.value(),
+            show_labels=self.cs_show_labels_checkbox.isChecked(),
+            background_color=self._cs_background_color,
+            label_color=self._cs_label_color,
         )
 
     def _apply_contact_sheet_layout(self, layout: ContactSheetLayout) -> None:
@@ -288,6 +330,10 @@ class ExportSidebar(BaseSidebar):
             self.cs_gap_input.setValue(layout.gap)
             self.cs_margin_input.setValue(layout.margin)
             self.cs_max_tiles_input.setValue(layout.max_tiles)
+            self.cs_show_labels_checkbox.setChecked(layout.show_labels)
+            self._cs_background_color = layout.background_color
+            self._cs_label_color = layout.label_color
+            self._update_cs_colors_btn_tooltip()
         finally:
             self._cs_syncing = False
 
@@ -298,6 +344,9 @@ class ExportSidebar(BaseSidebar):
         return name
 
     def _on_contact_sheet_layout_changed(self, _value: int) -> None:
+        self._on_contact_sheet_settings_changed()
+
+    def _on_contact_sheet_settings_changed(self) -> None:
         if self._cs_syncing:
             return
         self.update_timer.start()
@@ -917,6 +966,10 @@ class ExportSidebar(BaseSidebar):
             self.cs_gap_input.setValue(layout.gap)
             self.cs_margin_input.setValue(layout.margin)
             self.cs_max_tiles_input.setValue(layout.max_tiles)
+            self.cs_show_labels_checkbox.setChecked(layout.show_labels)
+            self._cs_background_color = layout.background_color
+            self._cs_label_color = layout.label_color
+            self._update_cs_colors_btn_tooltip()
             self.cs_output_path_edit.setText(conf.contact_sheet_output_path)
             self.sidecars_enabled_btn.setChecked(conf.export_sidecars_enabled)
             self._refresh_contact_sheet_templates()
@@ -949,6 +1002,8 @@ class ExportSidebar(BaseSidebar):
             self.cs_gap_input,
             self.cs_margin_input,
             self.cs_max_tiles_input,
+            self.cs_show_labels_checkbox,
+            self.cs_colors_btn,
             self.cs_output_path_edit,
             self.cs_template_combo,
             self.sidecars_enabled_btn,

--- a/negpy/desktop/view/widgets/contact_sheet_colors_dialog.py
+++ b/negpy/desktop/view/widgets/contact_sheet_colors_dialog.py
@@ -3,7 +3,7 @@ import colorsys
 import numpy as np
 from PyQt6.QtCore import QPointF, Qt, QRectF, pyqtSignal
 from PyQt6.QtGui import QColor, QFont, QImage, QMouseEvent, QPainter, QPainterPath, QPen, QPixmap
-from PyQt6.QtWidgets import QDialog, QHBoxLayout, QLabel, QPushButton, QVBoxLayout, QWidget
+from PyQt6.QtWidgets import QDialog, QHBoxLayout, QPushButton, QVBoxLayout, QWidget
 
 from negpy.desktop.view.styles.theme import THEME
 

--- a/negpy/desktop/view/widgets/contact_sheet_colors_dialog.py
+++ b/negpy/desktop/view/widgets/contact_sheet_colors_dialog.py
@@ -1,0 +1,462 @@
+import colorsys
+
+import numpy as np
+from PyQt6.QtCore import QPointF, Qt, QRectF, pyqtSignal
+from PyQt6.QtGui import QColor, QFont, QImage, QMouseEvent, QPainter, QPainterPath, QPen, QPixmap
+from PyQt6.QtWidgets import QDialog, QHBoxLayout, QLabel, QPushButton, QVBoxLayout, QWidget
+
+from negpy.desktop.view.styles.theme import THEME
+
+
+def _hex_to_rgb(hex_color: str) -> tuple[int, int, int]:
+    h = hex_color.lstrip("#")
+    if len(h) != 6:
+        return (0, 0, 0)
+    try:
+        return (int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16))
+    except ValueError:
+        return (0, 0, 0)
+
+
+def _rgb_to_hex(r: int, g: int, b: int) -> str:
+    return f"#{r:02x}{g:02x}{b:02x}"
+
+
+def _hex_to_hsv(hex_color: str) -> tuple[float, float, float]:
+    r, g, b = _hex_to_rgb(hex_color)
+    h, s, v = colorsys.rgb_to_hsv(r / 255.0, g / 255.0, b / 255.0)
+    return h * 360.0, s, v
+
+
+def _hsv_to_hex(h: float, s: float, v: float) -> str:
+    r, g, b = colorsys.hsv_to_rgb(h / 360.0, s, v)
+    return _rgb_to_hex(int(round(r * 255)), int(round(g * 255)), int(round(b * 255)))
+
+
+def _sv_pixmap(hue: float, width: int, height: int) -> QPixmap:
+    s = np.linspace(0.0, 1.0, width, dtype=np.float32)
+    v = np.linspace(1.0, 0.0, height, dtype=np.float32)
+    ss, vv = np.meshgrid(s, v)
+    hh = np.full_like(ss, hue / 360.0)
+    i = (hh * 6.0).astype(np.int32)
+    f = hh * 6.0 - i
+    i = i % 6
+    p = vv * (1.0 - ss)
+    q = vv * (1.0 - f * ss)
+    t = vv * (1.0 - (1.0 - f) * ss)
+    r = np.choose(i, [vv, q, p, p, t, vv])
+    g = np.choose(i, [t, vv, vv, q, p, p])
+    b = np.choose(i, [p, p, t, vv, vv, q])
+    buf = np.ascontiguousarray(np.clip(np.stack((r, g, b), axis=-1) * 255.0, 0, 255).astype(np.uint8))
+    img = QImage(buf.data, width, height, width * 3, QImage.Format.Format_RGB888)
+    return QPixmap.fromImage(img.copy())
+
+
+def _hue_pixmap(width: int, height: int) -> QPixmap:
+    hues = np.linspace(0.0, 1.0, width, dtype=np.float32)
+    rgb_row = np.empty((width, 3), dtype=np.uint8)
+    for x, h in enumerate(hues):
+        r, g, b = colorsys.hsv_to_rgb(float(h), 1.0, 1.0)
+        rgb_row[x] = (int(r * 255), int(g * 255), int(b * 255))
+    strip = np.broadcast_to(rgb_row[np.newaxis, :, :], (height, width, 3))
+    buf = np.ascontiguousarray(strip)
+    img = QImage(buf.data, width, height, width * 3, QImage.Format.Format_RGB888)
+    return QPixmap.fromImage(img.copy())
+
+
+class _SvField(QWidget):
+    changed = pyqtSignal()
+
+    _W = 280
+    _H = 168
+    _R = 6.0
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._hue = 0.0
+        self._sat = 0.0
+        self._val = 1.0
+        self._dragging = False
+        self._pixmap = QPixmap()
+        self.setFixedSize(self._W, self._H)
+        self.setCursor(Qt.CursorShape.CrossCursor)
+        self._rebuild_pixmap()
+
+    def set_hsv(self, hue: float, sat: float, val: float) -> None:
+        hue = max(0.0, min(360.0, hue))
+        sat = max(0.0, min(1.0, sat))
+        val = max(0.0, min(1.0, val))
+        if abs(hue - self._hue) > 0.01 or self._pixmap.isNull():
+            self._hue = hue
+            self._rebuild_pixmap()
+        else:
+            self._hue = hue
+        self._sat = sat
+        self._val = val
+        self.update()
+
+    def hex_color(self) -> str:
+        return _hsv_to_hex(self._hue, self._sat, self._val)
+
+    def hsv(self) -> tuple[float, float, float]:
+        return self._hue, self._sat, self._val
+
+    def _rebuild_pixmap(self) -> None:
+        self._pixmap = _sv_pixmap(self._hue, self._W, self._H)
+
+    def paintEvent(self, _event) -> None:
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+        path = QPainterPath()
+        path.addRoundedRect(QRectF(0.5, 0.5, self._W - 1, self._H - 1), self._R, self._R)
+        painter.setClipPath(path)
+        if self._pixmap.isNull():
+            painter.fillRect(self.rect(), QColor(THEME.bg_header))
+        else:
+            painter.drawPixmap(0, 0, self._pixmap)
+        painter.setClipping(False)
+        painter.setPen(QPen(QColor(THEME.border_primary), 1))
+        painter.setBrush(Qt.BrushStyle.NoBrush)
+        painter.drawPath(path)
+
+        x = int(round(self._sat * (self._W - 1)))
+        y = int(round((1.0 - self._val) * (self._H - 1)))
+        # Dual ring so the cursor stays readable on any hue.
+        for color, width, radius in ((QColor("#000000"), 3, 7), (QColor("#ffffff"), 1.5, 7)):
+            painter.setPen(QPen(color, width))
+            painter.drawEllipse(QPointF(x, y), radius, radius)
+
+    def _pick(self, pos) -> None:
+        x = max(0, min(self._W - 1, pos.x()))
+        y = max(0, min(self._H - 1, pos.y()))
+        self._sat = x / max(1, self._W - 1)
+        self._val = 1.0 - y / max(1, self._H - 1)
+        self.update()
+        self.changed.emit()
+
+    def mousePressEvent(self, event: QMouseEvent) -> None:
+        if event.button() == Qt.MouseButton.LeftButton:
+            self._dragging = True
+            self._pick(event.position().toPoint())
+
+    def mouseMoveEvent(self, event: QMouseEvent) -> None:
+        if self._dragging:
+            self._pick(event.position().toPoint())
+
+    def mouseReleaseEvent(self, event: QMouseEvent) -> None:
+        if event.button() == Qt.MouseButton.LeftButton:
+            self._dragging = False
+
+
+class _HueBar(QWidget):
+    changed = pyqtSignal(float)
+
+    _W = 280
+    _H = 14
+    _R = 7.0
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._hue = 0.0
+        self._dragging = False
+        self._pixmap = _hue_pixmap(self._W, self._H)
+        self.setFixedSize(self._W, self._H + 8)
+        self.setCursor(Qt.CursorShape.PointingHandCursor)
+
+    def set_hue(self, hue: float) -> None:
+        self._hue = max(0.0, min(360.0, hue))
+        self.update()
+
+    def hue(self) -> float:
+        return self._hue
+
+    def paintEvent(self, _event) -> None:
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+        y0 = 4.0
+        path = QPainterPath()
+        path.addRoundedRect(QRectF(0.5, y0, self._W - 1, self._H - 1), self._R, self._R)
+        painter.setClipPath(path)
+        if not self._pixmap.isNull():
+            painter.drawPixmap(0, int(y0), self._pixmap)
+        painter.setClipping(False)
+
+        x = self._hue / 360.0 * (self._W - 1)
+        # Soft white thumb.
+        painter.setPen(QPen(QColor(0, 0, 0, 140), 1))
+        painter.setBrush(QColor("#ffffff"))
+        painter.drawRoundedRect(QRectF(x - 3, 1, 6, self._H + 6), 2, 2)
+
+    def _pick(self, pos) -> None:
+        x = max(0, min(self._W - 1, pos.x()))
+        self._hue = x / max(1, self._W - 1) * 360.0
+        self.update()
+        self.changed.emit(self._hue)
+
+    def mousePressEvent(self, event: QMouseEvent) -> None:
+        if event.button() == Qt.MouseButton.LeftButton:
+            self._dragging = True
+            self._pick(event.position().toPoint())
+
+    def mouseMoveEvent(self, event: QMouseEvent) -> None:
+        if self._dragging:
+            self._pick(event.position().toPoint())
+
+    def mouseReleaseEvent(self, event: QMouseEvent) -> None:
+        if event.button() == Qt.MouseButton.LeftButton:
+            self._dragging = False
+
+
+class _TargetRow(QWidget):
+    """Selectable row: swatch + name + hex readout. Click selects the edit target."""
+
+    clicked = pyqtSignal()
+
+    _H = 42
+
+    def __init__(self, title: str, parent=None):
+        super().__init__(parent)
+        self._title = title
+        self._hex = "#000000"
+        self._selected = False
+        self.setFixedHeight(self._H)
+        self.setMinimumWidth(132)
+        self.setCursor(Qt.CursorShape.PointingHandCursor)
+
+    def set_color(self, hex_color: str) -> None:
+        self._hex = hex_color
+        self.update()
+
+    def set_selected(self, selected: bool) -> None:
+        self._selected = selected
+        self.update()
+
+    def paintEvent(self, _event) -> None:
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+        rect = QRectF(0.5, 0.5, self.width() - 1, self.height() - 1)
+
+        # Row background: subtle lift when selected, accent border to mark focus.
+        painter.setBrush(QColor(THEME.bg_header if self._selected else THEME.bg_dark))
+        painter.setPen(QPen(QColor(THEME.accent_primary if self._selected else THEME.border_primary), 2 if self._selected else 1))
+        painter.drawRoundedRect(rect, THEME.radius_md, THEME.radius_md)
+
+        # Swatch square
+        sw = 22.0
+        sx = 11.0
+        sy = (self.height() - sw) / 2
+        swatch = QRectF(sx, sy, sw, sw)
+        painter.setBrush(QColor(self._hex))
+        painter.setPen(QPen(QColor(THEME.border_color), 1))
+        painter.drawRoundedRect(swatch, THEME.radius_sm, THEME.radius_sm)
+
+        # Title
+        painter.setPen(QColor(THEME.text_primary))
+        title_font = QFont(painter.font())
+        title_font.setPixelSize(THEME.font_size_small)
+        title_font.setWeight(THEME.weight_medium if self._selected else THEME.weight_regular)
+        painter.setFont(title_font)
+        painter.drawText(QRectF(42, 0, self.width() - 46, self.height()), int(Qt.AlignmentFlag.AlignVCenter), self._title)
+
+        # Hex readout (right-aligned, read-only)
+        painter.setPen(QColor(THEME.text_secondary))
+        hex_font = QFont("Consolas, Menlo, monospace")
+        hex_font.setPixelSize(THEME.font_size_xs)
+        painter.setFont(hex_font)
+        painter.drawText(
+            QRectF(0, 0, self.width() - 12, self.height()),
+            int(Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter),
+            self._hex.upper(),
+        )
+
+    def mousePressEvent(self, event: QMouseEvent) -> None:
+        if event.button() == Qt.MouseButton.LeftButton:
+            self.clicked.emit()
+
+
+class _MiniSheetPreview(QWidget):
+    """Contact-sheet mock so both colours read in context."""
+
+    _W = 280
+    _H = 96
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._bg = "#000000"
+        self._fg = "#ffffff"
+        self.setFixedSize(self._W, self._H)
+
+    def set_colors(self, background: str, label_color: str) -> None:
+        self._bg = background
+        self._fg = label_color
+        self.update()
+
+    def paintEvent(self, _event) -> None:
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+        painter.setRenderHint(QPainter.RenderHint.TextAntialiasing)
+
+        outer = QPainterPath()
+        outer.addRoundedRect(QRectF(0.5, 0.5, self._W - 1, self._H - 1), 6, 6)
+        painter.setClipPath(outer)
+        painter.fillRect(self.rect(), QColor(self._bg))
+        painter.setClipping(False)
+        painter.setPen(QPen(QColor(THEME.border_primary), 1))
+        painter.setBrush(Qt.BrushStyle.NoBrush)
+        painter.drawPath(outer)
+
+        cell_w, cell_h = 108, 46
+        band_h = 15
+        gap = 16
+        margin_x = (self._W - (2 * cell_w + gap)) / 2
+        margin_y = 10
+        font = QFont(painter.font())
+        font.setPixelSize(9)
+        painter.setFont(font)
+
+        # Caption band tint mirrors the export: bg blended 15% toward label colour.
+        bg = QColor(self._bg)
+        fg = QColor(self._fg)
+        band = QColor(
+            round(0.85 * bg.red() + 0.15 * fg.red()),
+            round(0.85 * bg.green() + 0.15 * fg.green()),
+            round(0.85 * bg.blue() + 0.15 * fg.blue()),
+        )
+
+        for i in range(2):
+            x = margin_x + i * (cell_w + gap)
+            y = margin_y
+            # Soft photo placeholder with a subtle gradient feel (two fills).
+            painter.setPen(Qt.PenStyle.NoPen)
+            painter.setBrush(QColor("#4a4a4a"))
+            painter.drawRect(QRectF(x, y, cell_w, cell_h))
+            painter.setBrush(QColor("#3a3a3a"))
+            painter.drawRect(QRectF(x, y + cell_h * 0.55, cell_w, cell_h * 0.45))
+            painter.setBrush(QColor(255, 255, 255, 18))
+            painter.drawEllipse(QRectF(x + cell_w * 0.15, y + 5, cell_w * 0.35, cell_h * 0.35))
+
+            # Caption band hugging the photo (card feel), then filename.
+            band_y = y + cell_h + 3
+            painter.setBrush(band)
+            painter.drawRoundedRect(QRectF(x, band_y, cell_w, band_h), 2, 2)
+            painter.setPen(QColor(self._fg))
+            painter.drawText(
+                QRectF(x, band_y, cell_w, band_h),
+                int(Qt.AlignmentFlag.AlignHCenter | Qt.AlignmentFlag.AlignVCenter),
+                f"IMG_{1001 + i}.NEF",
+            )
+
+
+class ContactSheetColorsDialog(QDialog):
+    """Background + label colours — visual HSV picker, no typed values."""
+
+    def __init__(self, background: str, label_color: str, parent=None):
+        super().__init__(parent)
+        self._background = (background or "#000000").lower()
+        self._label_color = (label_color or "#ffffff").lower()
+        self._editing_background = True
+        self._syncing = False
+
+        self.setWindowTitle("Contact Sheet Colours")
+        self.setStyleSheet(f"QDialog {{ background: {THEME.bg_dark}; }}")
+        self.setFixedWidth(328)
+
+        root = QVBoxLayout(self)
+        root.setContentsMargins(24, 20, 24, 20)
+        root.setSpacing(16)
+
+        self._mini = _MiniSheetPreview(self)
+        root.addWidget(self._mini, alignment=Qt.AlignmentFlag.AlignHCenter)
+
+        targets = QVBoxLayout()
+        targets.setSpacing(6)
+        self._bg_row = _TargetRow("Background", self)
+        self._label_row = _TargetRow("Labels", self)
+        self._bg_row.clicked.connect(lambda: self._select_target(True))
+        self._label_row.clicked.connect(lambda: self._select_target(False))
+        targets.addWidget(self._bg_row)
+        targets.addWidget(self._label_row)
+        root.addLayout(targets)
+
+        self._sv = _SvField(self)
+        root.addWidget(self._sv, alignment=Qt.AlignmentFlag.AlignHCenter)
+
+        self._hue = _HueBar(self)
+        root.addWidget(self._hue, alignment=Qt.AlignmentFlag.AlignHCenter)
+
+        btn_row = QHBoxLayout()
+        btn_row.setSpacing(8)
+        btn_row.addStretch()
+        cancel = QPushButton("Cancel")
+        cancel.clicked.connect(self.reject)
+        ok = QPushButton("OK")
+        ok.setProperty("primary", True)
+        ok.setDefault(True)
+        ok.clicked.connect(self.accept)
+        ok.style().polish(ok)
+        btn_row.addWidget(cancel)
+        btn_row.addWidget(ok)
+        root.addLayout(btn_row)
+
+        self._sv.changed.connect(self._on_picker_changed)
+        self._hue.changed.connect(self._on_hue_changed)
+
+        self._refresh_targets()
+        self._mini.set_colors(self._background, self._label_color)
+        self._select_target(True)
+
+    def _select_target(self, background: bool) -> None:
+        self._editing_background = background
+        self._bg_row.set_selected(background)
+        self._label_row.set_selected(not background)
+        self._load_active_into_picker()
+
+    def _active_hex(self) -> str:
+        return self._background if self._editing_background else self._label_color
+
+    def _set_active_hex(self, hex_color: str) -> None:
+        if self._editing_background:
+            self._background = hex_color
+        else:
+            self._label_color = hex_color
+
+    def _refresh_targets(self) -> None:
+        self._bg_row.set_color(self._background)
+        self._label_row.set_color(self._label_color)
+
+    def _load_active_into_picker(self) -> None:
+        self._syncing = True
+        try:
+            h, s, v = _hex_to_hsv(self._active_hex())
+            if s < 1e-6:
+                h = self._hue.hue()
+            self._hue.set_hue(h)
+            self._sv.set_hsv(h, s, v)
+        finally:
+            self._syncing = False
+
+    def _on_hue_changed(self, hue: float) -> None:
+        if self._syncing:
+            return
+        self._syncing = True
+        try:
+            _, s, v = self._sv.hsv()
+            self._sv.set_hsv(hue, s, v)
+        finally:
+            self._syncing = False
+        self._commit_picker()
+
+    def _on_picker_changed(self) -> None:
+        if self._syncing:
+            return
+        h, _, _ = self._sv.hsv()
+        self._hue.set_hue(h)
+        self._commit_picker()
+
+    def _commit_picker(self) -> None:
+        self._set_active_hex(self._sv.hex_color())
+        self._refresh_targets()
+        self._mini.set_colors(self._background, self._label_color)
+
+    def colors(self) -> tuple[str, str]:
+        return self._background, self._label_color

--- a/negpy/desktop/workers/export.py
+++ b/negpy/desktop/workers/export.py
@@ -193,13 +193,25 @@ class ExportWorker(QObject):
         finally:
             gc.collect()
 
-    @pyqtSlot(list, str, int, int, int, int)
-    def run_contact_sheet(self, tasks: List[ExportTask], out_dir: str, cell_px: int, gap: int, margin: int, max_tiles: int) -> None:
-        """Renders each task small and composites darkroom contact sheet(s) on black."""
+    @pyqtSlot(list, str, int, int, int, int, bool, str, str)
+    def run_contact_sheet(
+        self,
+        tasks: List[ExportTask],
+        out_dir: str,
+        cell_px: int,
+        gap: int,
+        margin: int,
+        max_tiles: int,
+        show_labels: bool,
+        background_color: str,
+        label_color: str,
+    ) -> None:
+        """Renders each task small and composites contact sheet(s)."""
         self._cancel.clear()
         total = len(tasks)
         try:
             tiles = []
+            labels: list[str] = []
             for i, task in enumerate(tasks):
                 if self._cancel.is_set():
                     self.cancelled.emit()
@@ -221,8 +233,19 @@ class ExportWorker(QObject):
                 )
                 if tile is not None:
                     tiles.append(tile)
+                    labels.append(task.file_info["name"])
 
-            sheets = ContactSheetService.build_sheets(tiles, max_tiles=max_tiles, cell_px=cell_px, gap=gap, margin=margin)
+            sheets = ContactSheetService.build_sheets(
+                tiles,
+                labels=labels if show_labels else None,
+                show_labels=show_labels,
+                background_color=background_color,
+                label_color=label_color,
+                max_tiles=max_tiles,
+                cell_px=cell_px,
+                gap=gap,
+                margin=margin,
+            )
             os.makedirs(out_dir, exist_ok=True)
 
             for idx, sheet in enumerate(sheets):

--- a/negpy/domain/models.py
+++ b/negpy/domain/models.py
@@ -228,12 +228,18 @@ class ExportConfig:
     contact_sheet_gap: int = 16
     contact_sheet_margin: int = 32
     contact_sheet_max_tiles: int = 38
+    contact_sheet_show_labels: bool = True
+    contact_sheet_background_color: str = "#000000"
+    contact_sheet_label_color: str = "#ffffff"
     contact_sheet_output_path: str = ""  # empty = follow export destination rules
     contact_sheet_template: str = ""  # empty = Default template active
     contact_sheet_default_cell_px: int = 600
     contact_sheet_default_gap: int = 16
     contact_sheet_default_margin: int = 32
     contact_sheet_default_max_tiles: int = 38
+    contact_sheet_default_show_labels: bool = True
+    contact_sheet_default_background_color: str = "#000000"
+    contact_sheet_default_label_color: str = "#ffffff"
 
     export_sidecars_enabled: bool = False
 

--- a/negpy/features/lab/shaders/lab_color.wgsl
+++ b/negpy/features/lab/shaders/lab_color.wgsl
@@ -1,0 +1,183 @@
+// Chroma denoise, vibrance, saturation — mirrors CPU lab stage order before CLAHE.
+// Decodes the encoded retouch buffer to scene-linear ProPhoto RGB.
+struct LabUniforms {
+    sharpen: f32,
+    chroma_denoise: f32,
+    saturation: f32,
+    vibrance: f32,
+    glow_amount: f32,
+    halation_strength: f32,
+    scale_factor: f32,
+    _pad1: f32,
+};
+
+@group(0) @binding(0) var input_tex: texture_2d<f32>;
+@group(0) @binding(1) var output_tex: texture_storage_2d<rgba32float, write>;
+@group(0) @binding(2) var<uniform> params: LabUniforms;
+
+const FIBONACCI_64 = array<vec2<f32>, 64>(
+    vec2<f32>(0.088388, 0.000000),
+    vec2<f32>(-0.112886, 0.103413),
+    vec2<f32>(0.017279, -0.196886),
+    vec2<f32>(0.142286, 0.185586),
+    vec2<f32>(-0.261112, -0.046187),
+    vec2<f32>(0.247348, -0.157342),
+    vec2<f32>(-0.082733, 0.307763),
+    vec2<f32>(-0.157781, -0.303797),
+    vec2<f32>(0.342321, 0.125015),
+    vec2<f32>(-0.356128, 0.147004),
+    vec2<f32>(0.171677, -0.366864),
+    vec2<f32>(0.126865, 0.404466),
+    vec2<f32>(-0.382373, -0.221593),
+    vec2<f32>(0.448567, -0.098616),
+    vec2<f32>(-0.273753, 0.389386),
+    vec2<f32>(-0.063243, -0.488045),
+    vec2<f32>(0.388252, 0.327220),
+    vec2<f32>(-0.522466, 0.021606),
+    vec2<f32>(0.381099, -0.379244),
+    vec2<f32>(-0.025497, 0.551396),
+    vec2<f32>(-0.362617, -0.434536),
+    vec2<f32>(0.574425, 0.077288),
+    vec2<f32>(-0.486709, 0.338640),
+    vec2<f32>(0.132997, -0.591185),
+    vec2<f32>(0.307615, 0.536829),
+    vec2<f32>(-0.601358, -0.191850),
+    vec2<f32>(0.584143, -0.269889),
+    vec2<f32>(-0.253065, 0.604686),
+    vec2<f32>(-0.225855, -0.627935),
+    vec2<f32>(0.600976, 0.315856),
+    vec2<f32>(-0.667533, 0.175960),
+    vec2<f32>(0.379431, -0.590102),
+    vec2<f32>(0.120699, 0.702313),
+    vec2<f32>(-0.572008, -0.442995),
+    vec2<f32>(0.731702, -0.060620),
+    vec2<f32>(-0.505760, 0.546712),
+    vec2<f32>(0.003684, -0.755181),
+    vec2<f32>(0.514305, 0.566946),
+    vec2<f32>(-0.772295, -0.071576),
+    vec2<f32>(0.625787, -0.474950),
+    vec2<f32>(-0.142381, 0.782650),
+    vec2<f32>(-0.428884, -0.681539),
+    vec2<f32>(0.785920, 0.215388),
+    vec2<f32>(-0.733486, 0.376413),
+    vec2<f32>(0.289862, -0.781852),
+    vec2<f32>(0.317911, 0.780942),
+    vec2<f32>(-0.770264, -0.365042),
+    vec2<f32>(0.823263, -0.253821),
+    vec2<f32>(-0.440157, 0.751049),
+    vec2<f32>(-0.184643, -0.859851),
+    vec2<f32>(0.724177, 0.514422),
+    vec2<f32>(-0.890157, 0.110939),
+    vec2<f32>(0.587054, -0.689695),
+    vec2<f32>(0.033320, 0.913689),
+    vec2<f32>(-0.647727, -0.657276),
+    vec2<f32>(0.930014, 0.047552),
+    vec2<f32>(-0.724323, 0.598472),
+    vec2<f32>(0.130975, -0.938767),
+    vec2<f32>(0.542205, 0.787449),
+    vec2<f32>(-0.939649, -0.216211),
+    vec2<f32>(0.845937, -0.479274),
+    vec2<f32>(-0.302492, 0.932436),
+    vec2<f32>(-0.410097, -0.899101),
+    vec2<f32>(0.916976, 0.389028)
+);
+const BLOOM_GAUSS_SUM = 27.668145;
+
+fn oetf_decode(c: vec3<f32>) -> vec3<f32> {
+    let e = max(c, vec3<f32>(0.0));
+    return select(pow(e, vec3<f32>(1.8)), e / 16.0, e < vec3<f32>(0.03125));
+}
+
+fn load_lin(coords: vec2<i32>) -> vec3<f32> {
+    return oetf_decode(textureLoad(input_tex, coords, 0).rgb);
+}
+
+fn rgb_to_lab(rgb: vec3<f32>) -> vec3<f32> {
+    let r = max(rgb.r, 0.0);
+    let g = max(rgb.g, 0.0);
+    let b = max(rgb.b, 0.0);
+
+    var x = r * 0.7976749 + g * 0.1351917 + b * 0.0313534;
+    var y = r * 0.2880402 + g * 0.7118741 + b * 0.0000857;
+    var z = r * 0.0000000 + g * 0.0000000 + b * 0.8252100;
+
+    x = x / 0.96422;
+    y = y / 1.00000;
+    z = z / 0.82521;
+
+    if (x > 0.008856) { x = pow(x, 1.0/3.0); } else { x = (7.787 * x) + (16.0 / 116.0); }
+    if (y > 0.008856) { y = pow(y, 1.0/3.0); } else { y = (7.787 * y) + (16.0 / 116.0); }
+    if (z > 0.008856) { z = pow(z, 1.0/3.0); } else { z = (7.787 * z) + (16.0 / 116.0); }
+
+    let l = (116.0 * y) - 16.0;
+    let a = 500.0 * (x - y);
+    let b_lab = 200.0 * (y - z);
+
+    return vec3<f32>(l, a, b_lab);
+}
+
+fn lab_to_rgb(lab: vec3<f32>) -> vec3<f32> {
+    var y = (lab.x + 16.0) / 116.0;
+    var x = lab.y / 500.0 + y;
+    var z = y - lab.z / 200.0;
+
+    if (pow(x, 3.0) > 0.008856) { x = pow(x, 3.0); } else { x = (x - 16.0 / 116.0) / 7.787; }
+    if (pow(y, 3.0) > 0.008856) { y = pow(y, 3.0); } else { y = (y - 16.0 / 116.0) / 7.787; }
+    if (pow(z, 3.0) > 0.008856) { z = pow(z, 3.0); } else { z = (z - 16.0 / 116.0) / 7.787; }
+
+    x = x * 0.96422;
+    y = y * 1.00000;
+    z = z * 0.82521;
+
+    let r = x * 1.3459433 + y * -0.2556075 + z * -0.0511118;
+    let g = x * -0.5445989 + y * 1.5081673 + z * 0.0205351;
+    let b = x * 0.0000000 + y * 0.0000000 + z * 1.2118128;
+
+    return max(vec3<f32>(r, g, b), vec3<f32>(0.0));
+}
+
+@compute @workgroup_size(8, 8)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let dims = textureDimensions(input_tex);
+    if (gid.x >= dims.x || gid.y >= dims.y) { return; }
+
+    let coords = vec2<i32>(i32(gid.x), i32(gid.y));
+    var color = load_lin(coords);
+
+    if (params.chroma_denoise > 0.0) {
+        let radius = 2.0 * params.chroma_denoise * params.scale_factor;
+        if (radius >= 0.5) {
+            let current_lab = rgb_to_lab(color);
+            var blur_ab = vec2<f32>(0.0);
+            for (var tap = 0; tap < 64; tap++) {
+                let offset = FIBONACCI_64[tap];
+                let s_coord = clamp(coords + vec2<i32>(offset * radius), vec2<i32>(0), vec2<i32>(dims) - 1);
+                let s_lab = rgb_to_lab(load_lin(s_coord));
+                let r = length(offset);
+                let w = exp(-r * r * 2.0);
+                blur_ab += s_lab.yz * w;
+            }
+            blur_ab = blur_ab / BLOOM_GAUSS_SUM;
+            color = lab_to_rgb(vec3<f32>(current_lab.x, blur_ab.x, blur_ab.y));
+        }
+    }
+
+    if (params.vibrance != 1.0) {
+        var lab = rgb_to_lab(color);
+        let chroma = length(lab.yz);
+        let muted_mask = clamp(1.0 - (chroma / 60.0), 0.0, 1.0);
+        let boost = (params.vibrance - 1.0) * muted_mask;
+        lab.y = lab.y * (1.0 + boost);
+        lab.z = lab.z * (1.0 + boost);
+        color = lab_to_rgb(lab);
+    }
+
+    if (params.saturation != 1.0) {
+        var lab = rgb_to_lab(color);
+        lab.y = lab.y * params.saturation;
+        lab.z = lab.z * params.saturation;
+        color = lab_to_rgb(lab);
+    }
+
+    textureStore(output_tex, coords, vec4<f32>(clamp(color, vec3<f32>(0.0), vec3<f32>(1.0)), 1.0));
+}

--- a/negpy/services/export/contact_sheet.py
+++ b/negpy/services/export/contact_sheet.py
@@ -22,7 +22,7 @@ def _hex_to_rgb(hex_color: str) -> tuple[int, int, int]:
 
 
 @lru_cache(maxsize=8)
-def _load_font(size: int) -> ImageFont.FreeTypeFont:
+def _load_font(size: int) -> ImageFont.FreeTypeFont | ImageFont.ImageFont:
     """Anti-aliased TrueType, trying common faces before PIL's default."""
     for name in ("DejaVuSans.ttf", "arial.ttf", "Arial.ttf", "Helvetica.ttc"):
         try:
@@ -179,7 +179,9 @@ class ContactSheetService:
             draw.text((x, y), display, font=font, fill=fg, anchor="lm")
 
     @staticmethod
-    def _truncate(draw: ImageDraw.ImageDraw, text: str, font: ImageFont.FreeTypeFont, max_w: int) -> str:
+    def _truncate(
+        draw: ImageDraw.ImageDraw, text: str, font: ImageFont.FreeTypeFont | ImageFont.ImageFont, max_w: int
+    ) -> str:
         if draw.textlength(text, font=font) <= max_w:
             return text
         ellipsis = "..."

--- a/negpy/services/export/contact_sheet.py
+++ b/negpy/services/export/contact_sheet.py
@@ -1,15 +1,44 @@
 import math
-from typing import List, Tuple
+from functools import lru_cache
+from typing import List, Optional, Tuple
 
 import cv2
 import numpy as np
-from PIL import Image
+from PIL import Image, ImageDraw, ImageFont
 
 MAX_TILES_PER_SHEET = 38
 
 CELL_PX = 600  # long-edge of a single cell
 GAP = 16  # gap between cells
-MARGIN = 32  # black border around the grid
+MARGIN = 32  # border around the grid
+CAPTION_GAP = 6  # space between a photo and its caption band
+
+
+def _hex_to_rgb(hex_color: str) -> tuple[int, int, int]:
+    h = hex_color.lstrip("#")
+    if len(h) != 6:
+        return (0, 0, 0)
+    return (int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16))
+
+
+@lru_cache(maxsize=8)
+def _load_font(size: int) -> ImageFont.FreeTypeFont:
+    """Anti-aliased TrueType, trying common faces before PIL's default."""
+    for name in ("DejaVuSans.ttf", "arial.ttf", "Arial.ttf", "Helvetica.ttc"):
+        try:
+            return ImageFont.truetype(name, size)
+        except OSError:
+            continue
+    return ImageFont.load_default()
+
+
+def _caption_font_size(cell_px: int) -> int:
+    return max(13, min(40, round(cell_px * 0.05)))
+
+
+def _caption_height(cell_px: int) -> int:
+    # Band tall enough for the glyphs plus even vertical padding.
+    return _caption_font_size(cell_px) + 12
 
 
 class ContactSheetService:
@@ -26,43 +55,135 @@ class ContactSheetService:
     def build_sheets(
         tiles: List[np.ndarray],
         *,
+        labels: Optional[List[str]] = None,
+        show_labels: bool = True,
+        background_color: str = "#000000",
+        label_color: str = "#ffffff",
         max_tiles: int = MAX_TILES_PER_SHEET,
         cell_px: int = CELL_PX,
         gap: int = GAP,
         margin: int = MARGIN,
     ) -> List[Image.Image]:
-        """Paginate tiles (<=max_tiles per sheet) into grids on a black background."""
+        """Paginate tiles (<=max_tiles per sheet) into grids on a solid background."""
+        if labels is not None and len(labels) != len(tiles):
+            raise ValueError("labels length must match tiles")
         sheets: List[Image.Image] = []
+        bg = _hex_to_rgb(background_color)
+        fg = _hex_to_rgb(label_color)
         for start in range(0, len(tiles), max_tiles):
             chunk = tiles[start : start + max_tiles]
-            sheets.append(ContactSheetService._compose_sheet(chunk, cell_px, gap, margin))
+            chunk_labels = labels[start : start + max_tiles] if labels else None
+            sheets.append(
+                ContactSheetService._compose_sheet(
+                    chunk,
+                    chunk_labels,
+                    show_labels,
+                    bg,
+                    fg,
+                    cell_px,
+                    gap,
+                    margin,
+                )
+            )
         return sheets
 
     @staticmethod
-    def _compose_sheet(tiles: List[np.ndarray], cell_px: int, gap: int, margin: int) -> Image.Image:
+    def _slot_height(cell_px: int, show_labels: bool) -> int:
+        if not show_labels:
+            return cell_px
+        return cell_px + CAPTION_GAP + _caption_height(cell_px)
+
+    @staticmethod
+    def _compose_sheet(
+        tiles: List[np.ndarray],
+        labels: Optional[List[str]],
+        show_labels: bool,
+        bg: tuple[int, int, int],
+        fg: tuple[int, int, int],
+        cell_px: int,
+        gap: int,
+        margin: int,
+    ) -> Image.Image:
         cols, rows = ContactSheetService.grid_dims(len(tiles))
+        slot_h = ContactSheetService._slot_height(cell_px, show_labels)
+        draw_labels = show_labels and labels is not None
 
         sheet_w = margin * 2 + cols * cell_px + (cols - 1) * gap
-        sheet_h = margin * 2 + rows * cell_px + (rows - 1) * gap
-        canvas = np.zeros((sheet_h, sheet_w, 3), dtype=np.uint8)
+        sheet_h = margin * 2 + rows * slot_h + (rows - 1) * gap
+        canvas = np.empty((sheet_h, sheet_w, 3), dtype=np.uint8)
+        canvas[:] = bg
+
+        caption_h = _caption_height(cell_px)
+        band_rgb = tuple(int(round(0.85 * b + 0.15 * f)) for b, f in zip(bg, fg))
+        # Each photo + caption is a card, vertically centered in its slot so the
+        # caption always hugs its own image rather than floating in the cell.
+        captions: list[tuple[int, int, int, str]] = []  # (band_x, band_y, band_w, text)
 
         for idx, tile in enumerate(tiles):
             row, col = divmod(idx, cols)
             cell_x = margin + col * (cell_px + gap)
-            cell_y = margin + row * (cell_px + gap)
-            ContactSheetService._paste_centered(canvas, tile, cell_x, cell_y, cell_px)
+            cell_y = margin + row * (slot_h + gap)
 
-        return Image.fromarray(canvas)
+            th_scaled, tw_scaled = ContactSheetService._fit_dims(tile, cell_px)
+            if draw_labels:
+                card_h = th_scaled + CAPTION_GAP + caption_h
+                photo_top = cell_y + (slot_h - card_h) // 2
+            else:
+                photo_top = cell_y + (cell_px - th_scaled) // 2
+            photo_x = cell_x + (cell_px - tw_scaled) // 2
+
+            ContactSheetService._paste_resized(canvas, tile, photo_x, photo_top, tw_scaled, th_scaled)
+
+            if draw_labels:
+                band_y = photo_top + th_scaled + CAPTION_GAP
+                band_rgb_arr = np.array(band_rgb, dtype=np.uint8)
+                canvas[band_y : band_y + caption_h, photo_x : photo_x + tw_scaled] = band_rgb_arr
+                captions.append((photo_x, band_y, tw_scaled, labels[idx]))
+
+        image = Image.fromarray(canvas)
+        if captions:
+            ContactSheetService._draw_captions(image, captions, caption_h, cell_px, fg)
+        return image
 
     @staticmethod
-    def _paste_centered(canvas: np.ndarray, tile: np.ndarray, cell_x: int, cell_y: int, cell_px: int) -> None:
-        """Resize tile to fit a cell_px square (keep aspect) and center it in the cell."""
+    def _fit_dims(tile: np.ndarray, cell_px: int) -> tuple[int, int]:
+        """Scaled (height, width) fitting a cell_px square while keeping aspect."""
         h, w = tile.shape[:2]
         scale = cell_px / max(h, w)
         tw = max(1, int(round(w * scale)))
         th = max(1, int(round(h * scale)))
-        resized = cv2.resize(tile, (tw, th), interpolation=cv2.INTER_AREA)
+        return th, tw
 
-        off_x = cell_x + (cell_px - tw) // 2
-        off_y = cell_y + (cell_px - th) // 2
-        canvas[off_y : off_y + th, off_x : off_x + tw] = resized
+    @staticmethod
+    def _paste_resized(canvas: np.ndarray, tile: np.ndarray, x: int, y: int, tw: int, th: int) -> None:
+        resized = cv2.resize(tile, (tw, th), interpolation=cv2.INTER_AREA)
+        canvas[y : y + th, x : x + tw] = resized
+
+    @staticmethod
+    def _draw_captions(
+        image: Image.Image,
+        captions: list[tuple[int, int, int, str]],
+        caption_h: int,
+        cell_px: int,
+        fg: tuple[int, int, int],
+    ) -> None:
+        draw = ImageDraw.Draw(image)
+        font = _load_font(_caption_font_size(cell_px))
+        for band_x, band_y, band_w, text in captions:
+            if not text:
+                continue
+            display = ContactSheetService._truncate(draw, text, font, band_w - 8)
+            tw = int(round(draw.textlength(display, font=font)))
+            x = band_x + max(4, (band_w - tw) // 2)
+            y = band_y + caption_h // 2
+            draw.text((x, y), display, font=font, fill=fg, anchor="lm")
+
+    @staticmethod
+    def _truncate(draw: ImageDraw.ImageDraw, text: str, font: ImageFont.FreeTypeFont, max_w: int) -> str:
+        if draw.textlength(text, font=font) <= max_w:
+            return text
+        ellipsis = "..."
+        display = text
+        while display and draw.textlength(display + ellipsis, font=font) > max_w:
+            display = display[:-1]
+        return (display + ellipsis) if display else text[:1]

--- a/negpy/services/export/contact_sheet_templates.py
+++ b/negpy/services/export/contact_sheet_templates.py
@@ -21,6 +21,9 @@ class ContactSheetLayout:
     gap: int = GAP
     margin: int = MARGIN
     max_tiles: int = MAX_TILES_PER_SHEET
+    show_labels: bool = True
+    background_color: str = "#000000"
+    label_color: str = "#ffffff"
 
 
 def _slugify(name: str) -> str:
@@ -37,6 +40,21 @@ def _clamp_int(value: object, lo: int, hi: int, default: int) -> int:
     if not isinstance(value, int) or isinstance(value, bool):
         return default
     return max(lo, min(hi, value))
+
+
+def _parse_hex_color(value: object, default: str) -> str:
+    if not isinstance(value, str):
+        return default
+    h = value.strip()
+    if len(h) == 7 and h[0] == "#" and all(c in "0123456789abcdefABCDEF" for c in h[1:]):
+        return h.lower()
+    return default
+
+
+def _parse_bool(value: object, default: bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    return default
 
 
 class ContactSheetTemplates:
@@ -85,6 +103,9 @@ class ContactSheetTemplates:
                 gap=_clamp_int(layout_data.get("gap"), *_GAP_RANGE, GAP),
                 margin=_clamp_int(layout_data.get("margin"), *_MARGIN_RANGE, MARGIN),
                 max_tiles=_clamp_int(layout_data.get("max_tiles"), *_MAX_TILES_RANGE, MAX_TILES_PER_SHEET),
+                show_labels=_parse_bool(layout_data.get("show_labels"), True),
+                background_color=_parse_hex_color(layout_data.get("background_color"), "#000000"),
+                label_color=_parse_hex_color(layout_data.get("label_color"), "#ffffff"),
             )
             raw_name = data.get("name")
             if isinstance(raw_name, str) and raw_name.strip():
@@ -114,6 +135,9 @@ class ContactSheetTemplates:
             gap=export.contact_sheet_default_gap,
             margin=export.contact_sheet_default_margin,
             max_tiles=export.contact_sheet_default_max_tiles,
+            show_labels=export.contact_sheet_default_show_labels,
+            background_color=export.contact_sheet_default_background_color,
+            label_color=export.contact_sheet_default_label_color,
         )
         if stored != factory:
             return stored
@@ -123,27 +147,36 @@ class ContactSheetTemplates:
                 gap=export.contact_sheet_gap,
                 margin=export.contact_sheet_margin,
                 max_tiles=export.contact_sheet_max_tiles,
+                show_labels=export.contact_sheet_show_labels,
+                background_color=export.contact_sheet_background_color,
+                label_color=export.contact_sheet_label_color,
             )
             if active != factory:
                 return active
         return factory
 
     @staticmethod
-    def default_layout_field_updates(layout: ContactSheetLayout) -> dict[str, int]:
+    def default_layout_field_updates(layout: ContactSheetLayout) -> dict:
         return {
             "contact_sheet_default_cell_px": layout.cell_px,
             "contact_sheet_default_gap": layout.gap,
             "contact_sheet_default_margin": layout.margin,
             "contact_sheet_default_max_tiles": layout.max_tiles,
+            "contact_sheet_default_show_labels": layout.show_labels,
+            "contact_sheet_default_background_color": layout.background_color,
+            "contact_sheet_default_label_color": layout.label_color,
         }
 
     @staticmethod
-    def active_layout_field_updates(layout: ContactSheetLayout) -> dict[str, int]:
+    def active_layout_field_updates(layout: ContactSheetLayout) -> dict:
         return {
             "contact_sheet_cell_px": layout.cell_px,
             "contact_sheet_gap": layout.gap,
             "contact_sheet_margin": layout.margin,
             "contact_sheet_max_tiles": layout.max_tiles,
+            "contact_sheet_show_labels": layout.show_labels,
+            "contact_sheet_background_color": layout.background_color,
+            "contact_sheet_label_color": layout.label_color,
         }
 
     @staticmethod
@@ -197,6 +230,9 @@ class ContactSheetTemplates:
             f"gap = {layout.gap}\n"
             f"margin = {layout.margin}\n"
             f"max_tiles = {layout.max_tiles}\n"
+            f"show_labels = {'true' if layout.show_labels else 'false'}\n"
+            f'background_color = "{_escape_toml_string(layout.background_color)}"\n'
+            f'label_color = "{_escape_toml_string(layout.label_color)}"\n'
         )
         with open(path, "w", encoding="utf-8") as f:
             f.write(content)

--- a/tests/test_contact_sheet.py
+++ b/tests/test_contact_sheet.py
@@ -66,13 +66,47 @@ class TestContactSheetService(unittest.TestCase):
 
     def test_custom_layout_dimensions(self):
         # 4 tiles -> 2x2 grid; sheet size derives from cell_px/gap/margin.
-        sheets = ContactSheetService.build_sheets([_tile(200, 200) for _ in range(4)], cell_px=200, gap=4, margin=8)
+        sheets = ContactSheetService.build_sheets(
+            [_tile(200, 200) for _ in range(4)],
+            show_labels=False,
+            cell_px=200,
+            gap=4,
+            margin=8,
+        )
         arr = np.asarray(sheets[0])
         cols = rows = 2
         expected_w = 8 * 2 + cols * 200 + (cols - 1) * 4
         expected_h = 8 * 2 + rows * 200 + (rows - 1) * 4
         self.assertEqual(arr.shape[1], expected_w)
         self.assertEqual(arr.shape[0], expected_h)
+
+    def test_custom_background_color(self):
+        sheets = ContactSheetService.build_sheets([_tile(100, 150)], background_color="#ff0000")
+        arr = np.asarray(sheets[0])
+        self.assertTrue(np.all(arr[0, 0] == [255, 0, 0]))
+
+    def test_labels_increase_sheet_height(self):
+        tiles = [_tile(100, 150) for _ in range(4)]
+        labels = ["a.jpg", "b.jpg", "c.jpg", "d.jpg"]
+        without = ContactSheetService.build_sheets(tiles, show_labels=False, cell_px=100, gap=4, margin=8)
+        with_labels = ContactSheetService.build_sheets(
+            tiles, labels=labels, show_labels=True, cell_px=100, gap=4, margin=8
+        )
+        self.assertGreater(np.asarray(with_labels[0]).shape[0], np.asarray(without[0]).shape[0])
+
+    def test_caption_band_present(self):
+        # Band tint = round(0.85*bg + 0.15*fg); with black bg + green label -> (0,38,0).
+        sheets = ContactSheetService.build_sheets(
+            [_tile(200, 200)],
+            labels=["frame_one.jpg"],
+            show_labels=True,
+            background_color="#000000",
+            label_color="#00ff00",
+            cell_px=200,
+        )
+        arr = np.asarray(sheets[0])
+        band = np.array([0, 38, 0])
+        self.assertTrue(np.any(np.all(arr == band, axis=-1)))
 
 
 if __name__ == "__main__":

--- a/tests/test_contact_sheet_templates.py
+++ b/tests/test_contact_sheet_templates.py
@@ -64,12 +64,33 @@ def test_partial_layout_uses_defaults(tmp_path, monkeypatch):
 
 def test_save_writes_readable_template(tmp_path, monkeypatch):
     monkeypatch.setattr(APP_CONFIG, "contact_sheet_templates_dir", str(tmp_path))
-    layout = ContactSheetLayout(cell_px=450, gap=12, margin=24, max_tiles=40)
+    layout = ContactSheetLayout(
+        cell_px=450,
+        gap=12,
+        margin=24,
+        max_tiles=40,
+        show_labels=False,
+        background_color="#1a1a1a",
+        label_color="#cccccc",
+    )
     path = ContactSheetTemplates.save("My Roll", layout)
     assert path.endswith("my_roll.toml")
     assert os.path.isfile(path)
     assert ContactSheetTemplates.list_templates() == ["Default", "My Roll"]
     assert ContactSheetTemplates.get_layout("My Roll") == layout
+
+
+def test_template_parses_label_and_color_fields(tmp_path, monkeypatch):
+    monkeypatch.setattr(APP_CONFIG, "contact_sheet_templates_dir", str(tmp_path))
+    _write(
+        os.path.join(tmp_path, "labeled.toml"),
+        'name = "Labeled"\n\n[layout]\ncell_px = 400\nshow_labels = false\n'
+        'background_color = "#112233"\nlabel_color = "#aabbcc"\n',
+    )
+    layout = ContactSheetTemplates.get_layout("Labeled")
+    assert layout.show_labels is False
+    assert layout.background_color == "#112233"
+    assert layout.label_color == "#aabbcc"
 
 
 def test_default_layout_matches_service_defaults():


### PR DESCRIPTION
## Summary

Adds filename labels and customizable colours to exported contact sheets. Each frame can now be captioned with its original filename, and the sheet background and label colours are user-configurable via a custom colour picker. All settings persist with the workspace and can be saved into contact sheet templates.

## What's new

- **Filename labels**  a "Show filenames" checkbox (on by default) prints each frame's original filename beneath its thumbnail.
- **Caption-band layout**  each photo and its label render as a single card: an image-width caption band hugs the bottom of each photo so the label is clearly bound to its image, even with mixed portrait/landscape frames.
- **Readable text** labels use an anti-aliased TrueType font, sized proportionally to the cell, with `...` truncation for long names.
- **Colour customization** a "Choose…" button opens a custom HSV colour picker (SV field + hue bar, live preview, hex readout) to set the background and label colours.
- **Persistence** background colour, label colour, and the show-labels flag are stored in `ExportConfig` (saved with the workspace) and written into contact sheet template `.toml` files, so they survive restarts and travel with saved templates.

## Implementation notes

- `ContactSheetService` extended to accept `labels`, `show_labels`, `background_color`, and `label_color`, and to composite the caption bands.
- New `ContactSheetColorsDialog` widget for the picker; wired through the export worker and controller.
- `ContactSheetLayout` and the TOML schema gained the new fields, with backward-compatible parsing/defaults.

## Testing

- Extended `tests/test_contact_sheet.py` and `tests/test_contact_sheet_templates.py` (caption band presence, custom colours, label height, TOML round-trip). All pass.
- Manually verified: mixed-aspect frames, custom background/label colours, template save/load, and dialog interaction.

Fixes #581 