### PR TITLE
Stop 'Dropping unknown config keys: stitch_*' warning on load

### DIFF
--- a/negpy/domain/models.py
+++ b/negpy/domain/models.py
@@ -484,6 +484,7 @@ class WorkspaceConfig:
             ExposureConfig,
             FlatFieldConfig,
             RgbScanConfig,
+            StitchConfig,
             GeometryConfig,
             LabConfig,
             RetouchConfig,

--- a/tests/test_config_deserialization.py
+++ b/tests/test_config_deserialization.py
@@ -284,6 +284,34 @@ class TestConfigDeserialization(unittest.TestCase):
         config = WorkspaceConfig.from_flat_dict({"autocrop_mode": "banana"})
         self.assertEqual(config.geometry.autocrop_mode, "image")
 
+    def test_stitch_config_round_trips(self):
+        """Stitch fields must survive to_dict/from_flat_dict (JSON turns tuples into
+        lists), keeping the frozen StitchConfig hashable for the pipeline cache key."""
+        config = replace(
+            WorkspaceConfig(),
+            stitch=replace(
+                WorkspaceConfig().stitch,
+                stitch_enabled=True,
+                stitch_paths=("/scans/b.raw", "/scans/c.raw"),
+                stitch_transforms=((1.0, 0.0, 10.0, 0.0, 1.0, 20.0),),
+                stitch_canvas=(4000, 3000),
+                stitch_sizes=((2000, 3000), (2100, 3000)),
+            ),
+        )
+        reloaded = WorkspaceConfig.from_flat_dict(json.loads(json.dumps(config.to_dict(), default=str)))
+
+        self.assertTrue(reloaded.stitch.stitch_enabled)
+        self.assertEqual(reloaded.stitch.stitch_paths, ("/scans/b.raw", "/scans/c.raw"))
+        self.assertEqual(reloaded.stitch.stitch_canvas, (4000, 3000))
+        self.assertEqual(reloaded.stitch.stitch_sizes, ((2000, 3000), (2100, 3000)))
+        hash(reloaded.stitch)  # must not raise
+
+    def test_stitch_keys_do_not_warn(self):
+        """Regression: StitchConfig was missing from the known-keys set, so every
+        load of a stitched edit warned 'Dropping unknown config keys: [stitch_*]'."""
+        with self.assertNoLogs("negpy.domain.models", level=logging.WARNING):
+            WorkspaceConfig.from_flat_dict(WorkspaceConfig().to_dict())
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Every load of a serialized edit logs:

```
WARNING negpy.domain.models: Dropping unknown config keys: ['stitch_canvas', 'stitch_enabled', 'stitch_paths', 'stitch_sizes', 'stitch_transforms']
```

`WorkspaceConfig.to_dict()` serializes the `StitchConfig` fields (`res.update(asdict(self.stitch))`) and `from_flat_dict()`'s `_build_stitch()` reconstructs them — but `StitchConfig` was missing from the `config_classes` list that builds the known-keys set. So the stitch keys were treated as unknown and warned about on every load, despite being consumed correctly. The stitch config itself round-tripped fine; only the spurious warning was the problem.

Fix: add `StitchConfig` to that known-keys list.

## Test plan
- `tests/test_config_deserialization.py`:
  - `test_stitch_keys_do_not_warn` — asserts no warning when loading a freshly serialized config (fails on `main` with the exact stitch-keys message; passes with the fix).
  - `test_stitch_config_round_trips` — a stitch-enabled config survives to_dict/from_flat_dict with fields intact and stays hashable.
- Full `test_config_deserialization.py` passes (28 tests); `ruff check` + `ruff format` clean.