### PR TITLE
fix: restore saved export destination mode on image open

### DIFF
--- a/negpy/desktop/view/widgets/export_settings_form.py
+++ b/negpy/desktop/view/widgets/export_settings_form.py
@@ -37,6 +37,17 @@ from negpy.infrastructure.display.color_spaces import ColorSpaceRegistry
 _LABEL_WIDTH = 90
 
 
+def _coerce_output_mode(mode: Any) -> ExportPresetOutputMode:
+    """Persisted configs come back from JSON as plain strings. The destination
+    combo holds StrEnum members as item data, and findData() compares across the
+    QVariant boundary — a plain string never matches, so the row must be
+    normalized to the enum before lookup."""
+    try:
+        return ExportPresetOutputMode(mode)
+    except ValueError:
+        return ExportPresetOutputMode.ABSOLUTE
+
+
 def constrain_combo(combo: QComboBox, min_chars: int = 6) -> None:
     """Stop long item text from stretching the panel: size the combo to a small
     minimum and elide overflow, filling its row via the layout's spare space."""
@@ -509,7 +520,7 @@ class ExportSettingsForm(QWidget):
             out_path = v.get("icc_output_path")
             self.icc_output_combo.setCurrentText(os.path.basename(out_path) if out_path else "None")
 
-            mode = v.get("output_mode", ExportPresetOutputMode.ABSOLUTE)
+            mode = _coerce_output_mode(v.get("output_mode"))
             idx = self.output_mode_combo.findData(mode)
             if idx >= 0:
                 self.output_mode_combo.setCurrentIndex(idx)

--- a/tests/test_export_settings_form.py
+++ b/tests/test_export_settings_form.py
@@ -120,6 +120,22 @@ def test_destination_subfields_track_output_mode(qapp):
     assert form._abspath_container.isHidden()
 
 
+def test_destination_mode_restored_from_persisted_plain_string(qapp):
+    """Saved settings come back from JSON as plain strings, not StrEnum members —
+    the combo must still land on the saved destination mode."""
+    form = ExportSettingsForm()
+    for mode in ExportPresetOutputMode:
+        form.load(_values(output_mode=str(mode.value)))
+        assert form.output_mode_combo.currentData() == mode, mode
+        assert form.values()["output_mode"] == mode, mode
+
+
+def test_destination_mode_falls_back_to_absolute_when_unknown(qapp):
+    form = ExportSettingsForm()
+    form.load(_values(output_mode="not_a_mode"))
+    assert form.values()["output_mode"] == ExportPresetOutputMode.ABSOLUTE
+
+
 def test_load_does_not_emit_changed(qapp):
     form = ExportSettingsForm()
     fired = []


### PR DESCRIPTION
Fixes #602

The Folder combo stores `ExportPresetOutputMode` members as item data, but a persisted config round-trips through JSON as a plain string, so `findData()` never matched and the combo fell back to index 0. The panel showed "Subfolder of source" whatever was saved, and the next edit to any export field wrote that wrong mode back over the saved destination.

Normalize the row to the enum before lookup, falling back to `ABSOLUTE` for unknown values.

**Testing**

- Two new cases in `tests/test_export_settings_form.py`: every mode restored from a plain string, and unknown values falling back to `ABSOLUTE`.
- `make all` clean (2383 passed, 5 skipped).
- Verified in the running app: the Export panel and the presets dialog both show the saved destination after opening an image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nm64ZGh8un7ch3EanYv2K6
