### PR TITLE
feat(scan): selectable scanner backend

### DIFF
--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -200,6 +200,7 @@ class AppController(QObject):
     densitometer_readout = pyqtSignal(object)  # DensitometerReading or None
     tone_drag_changed = pyqtSignal(str)  # exposure field being slider-dragged; "" = drag ended
     scan_devices_requested = pyqtSignal()
+    scan_backend_requested = pyqtSignal(str)
     scan_requested = pyqtSignal(ScanRequest)
     scan_devices_ready = pyqtSignal(list)
     scan_progress = pyqtSignal(float)
@@ -493,6 +494,7 @@ class AppController(QObject):
         self.preview_load_worker.load_failed.connect(self._on_preview_load_failed)
 
         self.scan_devices_requested.connect(self.scan_worker.list_devices)
+        self.scan_backend_requested.connect(self.scan_worker.set_backend)
         self.scan_worker.devices_ready.connect(self.scan_devices_ready.emit)
         self.scan_worker.progress.connect(self.scan_progress.emit)
         self.scan_worker.finished.connect(self._on_scan_finished)
@@ -2057,6 +2059,10 @@ class AppController(QObject):
     def request_scan_devices(self) -> None:
         """Request device enumeration on the scan worker thread."""
         self.scan_devices_requested.emit()
+
+    def set_scan_backend(self, backend_id: str) -> None:
+        """Route the chosen scanner backend to the worker thread."""
+        self.scan_backend_requested.emit(backend_id)
 
     def start_scan(self, req: ScanRequest) -> None:
         """Start a scan. The UI connects to scan signals for state updates."""

--- a/negpy/desktop/view/sidebar/right_panel.py
+++ b/negpy/desktop/view/sidebar/right_panel.py
@@ -225,7 +225,7 @@ class RightPanel(QWidget):
             section.expanded_changed.connect(lambda checked, k=key: repo.save_global_setting(f"section_expanded_{k}", checked))
             return section
 
-        self.scan_sane_section = make("Scanner (SANE)", "scan_sane", "fa5s.camera-retro", self.scan_sidebar, False)
+        self.scan_sane_section = make("Film Scanner", "scan_sane", "fa5s.camera-retro", self.scan_sidebar, False)
         self.scan_rgb_section = make("Camera Scanning", "scan_rgb", "fa5s.camera", self.scanlight_sidebar, True)
 
         page = QWidget()

--- a/negpy/desktop/view/sidebar/scan.py
+++ b/negpy/desktop/view/sidebar/scan.py
@@ -15,9 +15,10 @@ from PyQt6.QtWidgets import (
     QWidget,
 )
 
-from negpy.desktop.view.styles.templates import hint_label, section_subheader
+from negpy.desktop.view.styles.templates import hint_label
 from negpy.desktop.view.styles.theme import THEME
 from negpy.infrastructure.scanners.base import ScannerCapabilities, ScannerDevice
+from negpy.infrastructure.scanners.registry import DEFAULT_BACKEND_ID, backend_choices
 from negpy.infrastructure.scanners.settings import ScannerSettings
 
 
@@ -67,9 +68,19 @@ class ScanSidebar(QWidget):
         layout.setSpacing(THEME.space_lg)
 
         # ── DEVICE ───────────────────────────────────────────
-        layout.addWidget(section_subheader("DEVICE"))
+        device_form = QFormLayout()
+        device_form.setSpacing(6)
+
+        self.backend_combo = QComboBox()
+        self.backend_combo.setToolTip("Scanner transport backend")
+        for backend_id, backend_label in backend_choices():
+            self.backend_combo.addItem(backend_label, backend_id)
+        idx = self.backend_combo.findData(self._settings.backend)
+        self.backend_combo.setCurrentIndex(idx if idx >= 0 else 0)
+        device_form.addRow("Backend", self.backend_combo)
 
         device_row = QHBoxLayout()
+        device_row.setContentsMargins(0, 0, 0, 0)
         self.device_combo = QComboBox()
         self.device_combo.setToolTip("Select scanner")
         self.device_combo.addItem("Detecting scanners…", None)
@@ -88,7 +99,10 @@ class ScanSidebar(QWidget):
         device_row.addWidget(self.device_combo, 1)
         device_row.addWidget(self.refresh_btn)
         device_row.addWidget(self.eject_btn)
-        layout.addLayout(device_row)
+        device_row_widget = QWidget()
+        device_row_widget.setLayout(device_row)
+        device_form.addRow("Device", device_row_widget)
+        layout.addLayout(device_form)
 
         # ── CAPS INFO ───────────────────────────────────────
         self.frame_label = hint_label("")
@@ -215,6 +229,7 @@ class ScanSidebar(QWidget):
     def _connect_signals(self) -> None:
         self.refresh_btn.clicked.connect(self._on_refresh)
         self.eject_btn.clicked.connect(self._on_eject)
+        self.backend_combo.currentIndexChanged.connect(self._on_backend_changed)
         self.device_combo.currentIndexChanged.connect(self._on_device_changed)
         self.browse_btn.clicked.connect(self._on_browse)
         self.scan_btn.clicked.connect(self._on_scan)
@@ -253,6 +268,7 @@ class ScanSidebar(QWidget):
 
     def _request_devices(self) -> None:
         """Request device list from the scan worker thread."""
+        self.controller.set_scan_backend(self._current_backend_id())
         self.device_combo.clear()
         self.device_combo.addItem("Detecting scanners…", None)
         self.device_combo.setEnabled(False)
@@ -260,6 +276,16 @@ class ScanSidebar(QWidget):
         self.controller.request_scan_devices()
 
     def _on_refresh(self) -> None:
+        self._request_devices()
+
+    def _current_backend_id(self) -> str:
+        return self.backend_combo.currentData() or DEFAULT_BACKEND_ID
+
+    def _on_backend_changed(self, _index: int) -> None:
+        # Device lists are backend-specific → persist the choice, then re-enumerate.
+        # Per-backend UI tweaks that capabilities can't express branch here on
+        # _current_backend_id(); none needed today.
+        self._update_settings_from_ui()
         self._request_devices()
 
     def _on_eject(self) -> None:
@@ -621,6 +647,7 @@ class ScanSidebar(QWidget):
     def set_scanning(self, active: bool) -> None:
         self._scanning = active
         device = self._current_device()
+        self.backend_combo.setEnabled(not active)
         self.eject_btn.setEnabled(bool(device and device.capabilities.can_eject) and not active)
         if active:
             self.scan_btn.setText(" Stop")
@@ -652,6 +679,7 @@ class ScanSidebar(QWidget):
         self.settings = replace(
             self._settings,
             last_device_id=device.id if device else self._settings.last_device_id,
+            backend=self._current_backend_id(),
             dpi=dpi,
             depth=depth,
             capture_ir=self.ir_check.isChecked() and self.ir_check.isEnabled(),

--- a/negpy/desktop/workers/scan_worker.py
+++ b/negpy/desktop/workers/scan_worker.py
@@ -67,6 +67,7 @@ class ScanWorker(QObject):
     def __init__(self) -> None:
         super().__init__()
         self._service: ScannerService | None = None
+        self._backend_id: str | None = None  # None → ScannerService uses the registry default
         self._cancel_event = threading.Event()
         self._state_lock = threading.Lock()
         self._request_prepared = False
@@ -74,8 +75,19 @@ class ScanWorker(QObject):
 
     def _ensure_service(self) -> ScannerService:
         if self._service is None:
-            self._service = ScannerService()
+            self._service = ScannerService(backend_id=self._backend_id)
         return self._service
+
+    @pyqtSlot(str)
+    def set_backend(self, backend_id: str) -> None:
+        """Select the scanner transport. Rebuilds the service lazily on next use.
+
+        Queued onto the worker thread, so it serializes with list_devices/run_scan
+        and can never swap the backend out from under an in-flight scan."""
+        if backend_id == self._backend_id:
+            return
+        self._backend_id = backend_id
+        self._service = None
 
     @pyqtSlot()
     def list_devices(self) -> None:

--- a/negpy/infrastructure/scanners/registry.py
+++ b/negpy/infrastructure/scanners/registry.py
@@ -1,0 +1,31 @@
+from typing import Callable
+
+from negpy.infrastructure.scanners.base import ScannerBackend
+
+
+def _make_sane() -> ScannerBackend:
+    from negpy.infrastructure.scanners.sane_backend import SaneBackend
+
+    return SaneBackend()
+
+
+DEFAULT_BACKEND_ID = "sane"
+
+# id -> (display label, factory). Insertion order drives the sidebar dropdown.
+# Adding a backend is one entry here plus its implementation module.
+BACKENDS: dict[str, tuple[str, Callable[[], ScannerBackend]]] = {
+    "sane": ("SANE", _make_sane),
+}
+
+
+def backend_choices() -> list[tuple[str, str]]:
+    """(id, label) pairs for the dropdown, in registration order."""
+    return [(bid, label) for bid, (label, _factory) in BACKENDS.items()]
+
+
+def create_backend(backend_id: str) -> ScannerBackend:
+    """Instantiate the backend for `backend_id`, falling back to the default for
+    an unknown/removed id — persisted settings may name a backend that no longer
+    ships, and that must not crash a scan."""
+    _label, factory = BACKENDS.get(backend_id) or BACKENDS[DEFAULT_BACKEND_ID]
+    return factory()

--- a/negpy/infrastructure/scanners/settings.py
+++ b/negpy/infrastructure/scanners/settings.py
@@ -8,6 +8,7 @@ class ScannerSettings:
     """Persisted scanner preferences, stored as JSON blob."""
 
     last_device_id: str = ""
+    backend: str = "sane"  # mirrors registry.DEFAULT_BACKEND_ID; keep in sync
     dpi: int = 3600
     depth: int = 16
     capture_ir: bool = False

--- a/negpy/services/scanning/service.py
+++ b/negpy/services/scanning/service.py
@@ -29,14 +29,15 @@ class ScannerService:
     capabilities. See ScannerBackend for what an implementation owes this class.
     """
 
-    def __init__(self, backend: ScannerBackend | None = None) -> None:
+    def __init__(self, backend: ScannerBackend | None = None, backend_id: str | None = None) -> None:
         self._backend = backend
+        self._backend_id = backend_id
 
     def _get_backend(self) -> ScannerBackend:
         if self._backend is None:
-            from negpy.infrastructure.scanners.sane_backend import SaneBackend
+            from negpy.infrastructure.scanners.registry import DEFAULT_BACKEND_ID, create_backend
 
-            self._backend = SaneBackend()
+            self._backend = create_backend(self._backend_id or DEFAULT_BACKEND_ID)
         return self._backend
 
     def list_devices(self) -> list[ScannerDevice]:

--- a/tests/scanners/test_backend_registry.py
+++ b/tests/scanners/test_backend_registry.py
@@ -1,0 +1,14 @@
+from negpy.infrastructure.scanners import registry
+
+
+def test_backend_choices_includes_sane():
+    assert ("sane", "SANE") in registry.backend_choices()
+
+
+def test_create_backend_resolves_and_falls_back(monkeypatch):
+    sentinel = object()
+    monkeypatch.setattr(registry, "BACKENDS", {"sane": ("SANE", lambda: sentinel)})
+
+    assert registry.create_backend("sane") is sentinel
+    # An unknown/removed persisted id must fall back to the default, not crash.
+    assert registry.create_backend("bogus") is sentinel

--- a/tests/scanners/test_scanner_settings.py
+++ b/tests/scanners/test_scanner_settings.py
@@ -16,6 +16,19 @@ def test_scan_window_json_roundtrip_yields_tuple():
     assert isinstance(restored.scan_window, tuple)
 
 
+def test_backend_default_is_sane():
+    assert ScannerSettings.defaults().backend == "sane"
+
+
+def test_backend_survives_json_roundtrip():
+    from dataclasses import replace
+
+    original = replace(ScannerSettings.defaults(), backend="mock")
+    restored = ScannerSettings(**json.loads(json.dumps(asdict(original), default=str)))
+    assert restored.backend == "mock"
+    assert restored == original
+
+
 def test_per_frame_defaults_are_empty():
     d = ScannerSettings.defaults()
     assert d.frame_windows == {}

--- a/tests/scanners/test_service_backend_selection.py
+++ b/tests/scanners/test_service_backend_selection.py
@@ -1,0 +1,37 @@
+from negpy.services.scanning.service import ScannerService
+
+
+def test_injected_backend_wins_over_id():
+    fake = object()
+    svc = ScannerService(backend=fake, backend_id="anything")
+    assert svc._get_backend() is fake
+
+
+def test_backend_id_routes_through_registry(monkeypatch):
+    fake = object()
+    seen: list[str] = []
+
+    def _create(backend_id):
+        seen.append(backend_id)
+        return fake
+
+    # service imports create_backend lazily inside _get_backend, so patch the
+    # registry module attribute it resolves.
+    monkeypatch.setattr("negpy.infrastructure.scanners.registry.create_backend", _create)
+
+    svc = ScannerService(backend_id="fake")
+    assert svc._get_backend() is fake
+    assert seen == ["fake"]
+
+
+def test_default_backend_id_used_when_none(monkeypatch):
+    seen: list[str] = []
+
+    def _create(backend_id):
+        seen.append(backend_id)
+        return object()
+
+    monkeypatch.setattr("negpy.infrastructure.scanners.registry.create_backend", _create)
+
+    ScannerService()._get_backend()
+    assert seen == ["sane"]

--- a/tests/test_scan_sidebar.py
+++ b/tests/test_scan_sidebar.py
@@ -96,10 +96,14 @@ class _FakeController(QObject):
         self.started: list[tuple[str, object]] = []
         self.ejected_ids: list[str] = []
         self.device_requests = 0
+        self.backend_requests: list[str] = []
         self.cancels = 0
 
     def request_scan_devices(self) -> None:
         self.device_requests += 1
+
+    def set_scan_backend(self, backend_id: str) -> None:
+        self.backend_requests.append(backend_id)
 
     def start_scan(self, req) -> None:
         self.started.append(("scan", req))
@@ -238,6 +242,35 @@ def test_ui_edit_preserves_dialog_selection() -> None:
 
     assert sidebar._settings.selected_frames == (1, 2, 4)
     assert sidebar._settings.frame_windows == {4: rect}
+
+
+def test_backend_combo_lists_registry_default() -> None:
+    sidebar, _ = _sidebar()
+    assert sidebar.backend_combo.findData("sane") >= 0
+    assert sidebar._current_backend_id() == "sane"
+
+
+def test_request_devices_routes_the_backend() -> None:
+    sidebar, controller = _sidebar()
+    controller.device_requests = 0
+    sidebar._request_devices()
+    assert controller.backend_requests[-1] == "sane"
+    assert controller.device_requests == 1
+
+
+def test_backend_change_persists_and_re_enumerates(monkeypatch) -> None:
+    from negpy.desktop.view.sidebar import scan as scan_mod
+
+    monkeypatch.setattr(scan_mod, "backend_choices", lambda: [("sane", "SANE"), ("mock", "Mock")])
+    sidebar, controller = _sidebar()
+    before = controller.device_requests
+
+    sidebar.backend_combo.setCurrentIndex(1)  # fires _on_backend_changed
+
+    assert sidebar._current_backend_id() == "mock"
+    assert controller.backend_requests[-1] == "mock"
+    assert controller.device_requests == before + 1
+    assert controller.session.repo.get_global_setting("scanner_settings")["backend"] == "mock"
 
 
 def test_ui_edit_preserves_offset_and_drift() -> None:


### PR DESCRIPTION
## What

Prepares NegPy for scanner backends beyond SANE by making the transport user-selectable.

- **Backend registry** (`negpy/infrastructure/scanners/registry.py`) — `id -> (label, factory)`. Adding a backend is one entry; `create_backend` falls back to the default for an unknown/removed persisted id. The `sane` import stays deferred (only the factory imports it).
- **Routing** — sidebar → `controller.set_scan_backend` → `scan_backend_requested` signal → worker `set_backend` slot → `ScannerService(backend_id=…)`. The slot is queued onto the worker thread, so it serializes with `list_devices`/`run_scan` and can never swap the backend mid-scan. An injected `backend=` still wins (tests untouched).
- **Persistence** — new `ScannerSettings.backend` field; changing the backend re-enumerates (device lists are backend-specific).
- **Sidebar** — a "Backend" dropdown above the scanner combo (labelled "Device"); combo disabled during a scan.
- **Per-backend UI seam** — capability-gating (`_update_device_caps`/`_populate_form`) is the primary seam; `_on_backend_changed` is the id-keyed seam for tweaks capabilities can't express. No empty scaffolding.
- Renamed the Scan section "Scanner (SANE)" → "Film Scanner".

## Tests

- `test_backend_registry.py` — choices include SANE; `create_backend` resolves and falls back.
- `test_service_backend_selection.py` — injected backend wins; `backend_id` routes through the registry; default used when `None`.
- `test_scanner_settings.py` — `backend` default + JSON round-trip.
- `test_scan_sidebar.py` — backend dropdown lists the registry, `_request_devices` routes the backend, backend change persists + re-enumerates.

`make format` / `lint` / `type` clean; full suite **2447 passed, 1 skipped**.

## Not done (deferred)

Dynamic per-backend section title — not worth the cross-boundary wiring for a one-item dropdown; add when a second backend ships.