### PR TITLE
Sensor-crosstalk calibration for single-shot narrowband scans

### DIFF
--- a/docs/CAMERA_SCANNING.md
+++ b/docs/CAMERA_SCANNING.md
@@ -104,6 +104,28 @@ panel (next to **Linear RAW**) corrects this by applying the bundled RGBScan inp
 profile to the preview and every export. An explicit **Input ICC** chosen in Export
 settings takes precedence while set.
 
+### Sensor calibration
+
+Single-shot scans under a narrowband RGB source can come out with hues that no slider
+fixes — yellows drifting orange is the classic sign. The cause is **sensor crosstalk**:
+the camera's colour-filter passbands overlap the source's bands (the green pixel sees
+the blue LED and some red), so every channel carries a share of its neighbours. It is a
+fixed property of your sensor + light pair, independent of the film.
+
+To correct it, photograph the bare light — no film in the holder — three times: red-only,
+green-only, blue-only, at the same settings you scan with, exposed just below clipping.
+Then in the Process panel open **Sensor Calibration**, press the calibrate button, pick
+the three captures, name the profile and save. Selecting the profile un-mixes every scan
+with a 3×3 matrix in the linear domain, before inversion. Profiles are TOML files in the
+`NegPy/sensor` folder. Re-run **Batch Analysis** after changing the profile.
+
+When *not* to use it: RGB-triplet (trichrome) scans are crosstalk-free by construction —
+each channel comes from its own single-light exposure — and NegPy skips the correction
+automatically for triplet assets. Dedicated film scanners (a Coolscan's mono CCD reads
+one LED at a time) have no sensor crosstalk either; their residual colour error is
+film-dye crosstalk, which the density-domain **Crosstalk** matrix handles (see
+[CROSSTALK.md](CROSSTALK.md)).
+
 ---
 
 ## Troubleshooting

--- a/negpy/desktop/main.py
+++ b/negpy/desktop/main.py
@@ -91,6 +91,7 @@ def _bootstrap_environment() -> None:
         APP_CONFIG.cache_dir,
         APP_CONFIG.user_icc_dir,
         APP_CONFIG.crosstalk_dir,
+        APP_CONFIG.sensor_dir,
         APP_CONFIG.gear_dir,
         APP_CONFIG.contact_sheet_templates_dir,
         APP_CONFIG.default_export_dir,

--- a/negpy/desktop/session.py
+++ b/negpy/desktop/session.py
@@ -554,6 +554,8 @@ class DesktopSessionManager(QObject):
         sticky_crosstalk_strength = self.repo.get_global_setting("last_crosstalk_strength")
         sticky_crosstalk_matrix = self.repo.get_global_setting("last_crosstalk_matrix")
         sticky_crosstalk_profile = self.repo.get_global_setting("last_crosstalk_profile")
+        sticky_sensor_matrix = self.repo.get_global_setting("last_sensor_matrix")
+        sticky_sensor_profile = self.repo.get_global_setting("last_sensor_profile")
 
         new_process = config.process
         if sticky_mode:
@@ -570,6 +572,10 @@ class DesktopSessionManager(QObject):
             new_process = replace(new_process, crosstalk_matrix=tuple(sticky_crosstalk_matrix))
         if sticky_crosstalk_profile:
             new_process = replace(new_process, crosstalk_profile=str(sticky_crosstalk_profile))
+        if sticky_sensor_matrix:
+            new_process = replace(new_process, sensor_matrix=tuple(sticky_sensor_matrix))
+        if sticky_sensor_profile:
+            new_process = replace(new_process, sensor_profile=str(sticky_sensor_profile))
         config = replace(config, process=new_process)
 
         sticky_ratio = self.repo.get_global_setting("last_aspect_ratio")
@@ -657,6 +663,8 @@ class DesktopSessionManager(QObject):
                 "last_crosstalk_strength": config.process.crosstalk_strength,
                 "last_crosstalk_matrix": config.process.crosstalk_matrix,
                 "last_crosstalk_profile": config.process.crosstalk_profile,
+                "last_sensor_matrix": config.process.sensor_matrix,
+                "last_sensor_profile": config.process.sensor_profile,
                 "last_density": config.exposure.density,
                 "last_grade": config.exposure.grade,
                 "last_wb_cyan": config.exposure.wb_cyan,

--- a/negpy/desktop/settings_catalog.py
+++ b/negpy/desktop/settings_catalog.py
@@ -79,6 +79,7 @@ CATALOG: list[tuple[str, tuple[SettingRow, ...]]] = [
         # Strength + profile + baked matrix copy atomically: strength alone would
         # leave the target on a stale/None matrix.
         _row("Crosstalk", "process", "crosstalk_strength", "crosstalk_profile", "crosstalk_matrix", fmt=lambda v: _fmt_scalar(v[0])),
+        _row("Sensor Calibration", "process", "sensor_profile", "sensor_matrix", fmt=lambda v: _fmt_scalar(v[0])),
     )),
     ("Crop", (
         _row("Auto Crop", "geometry", "auto_crop_enabled"),

--- a/negpy/desktop/view/sidebar/controls_panel.py
+++ b/negpy/desktop/view/sidebar/controls_panel.py
@@ -22,6 +22,7 @@ from negpy.desktop.view.sidebar.presets import PresetsSidebar
 from negpy.desktop.view.sidebar.flatfield import FlatFieldSidebar
 from negpy.desktop.view.sidebar.process import ProcessSidebar
 from negpy.desktop.view.sidebar.roll import RollAnalysisSidebar
+from negpy.desktop.view.sidebar.sensor import SensorSidebar
 from negpy.desktop.view.sidebar.colour import ColourSidebar
 from negpy.desktop.view.sidebar.tone import ToneSidebar
 from negpy.desktop.view.sidebar.geometry import GeometrySidebar
@@ -147,6 +148,14 @@ class ControlsPanel(QWidget):
             icon=qta.icon("fa5s.cogs", color=icon_color),
         )
 
+        self.sensor_sidebar = SensorSidebar(self.controller)
+        self.sensor_section = self._make_section(
+            "Sensor Calibration",
+            "sensor",
+            self.sensor_sidebar,
+            icon=qta.icon("fa5s.vials", color=icon_color),
+        )
+
         self.roll_sidebar = RollAnalysisSidebar(self.controller)
         self.roll_section = self._make_section(
             "Roll Analysis",
@@ -222,9 +231,9 @@ class ControlsPanel(QWidget):
             (
                 "setup",
                 "fa5s.cogs",
-                "Setup — Presets, Process, Roll Analysis",
-                [self.presets_section, self.process_section, self.roll_section],
-                ["process_section", "roll_section"],
+                "Setup — Presets, Sensor Calibration, Process, Roll Analysis",
+                [self.presets_section, self.sensor_section, self.process_section, self.roll_section],
+                ["sensor_section", "process_section", "roll_section"],
             ),
             (
                 "geometry",
@@ -668,6 +677,7 @@ class ControlsPanel(QWidget):
         self.finish_sidebar.sync_ui()
         self.presets_sidebar.sync_ui()
         self.flatfield_sidebar.sync_ui()
+        self.sensor_sidebar.sync_ui()
         self._sync_modified_dots()
 
     def _update_histogram(self) -> None:

--- a/negpy/desktop/view/sidebar/sensor.py
+++ b/negpy/desktop/view/sidebar/sensor.py
@@ -1,0 +1,78 @@
+from PyQt6.QtWidgets import QComboBox, QHBoxLayout
+
+from negpy.desktop.view.sidebar.base import BaseSidebar
+from negpy.desktop.view.styles.templates import field_label
+from negpy.features.process.models import invalidate_local_bounds
+from negpy.services.assets.sensor import SensorProfiles
+
+
+class SensorSidebar(BaseSidebar):
+    """
+    Panel for sensor-crosstalk calibration (single-shot narrowband scans).
+    """
+
+    def _init_ui(self) -> None:
+        conf = self.state.config.process
+
+        row = QHBoxLayout()
+        self.sensor_label = field_label("Profile")
+        self.sensor_combo = QComboBox()
+        self.sensor_combo.addItems(SensorProfiles.list_profiles())
+        self.sensor_combo.setCurrentText(conf.sensor_profile)
+        self.sensor_combo.setToolTip(
+            "<table width='280'><tr><td>"
+            "Sensor crosstalk correction for single-shot narrowband scans: un-mixes the camera's "
+            "cross-channel response in the LINEAR capture, before inversion — a fixed property of "
+            "your sensor + light, independent of film. Calibrate it from three bare-light R/G/B "
+            "exposures; custom .toml matrices live in the NegPy/sensor folder. Skipped automatically "
+            "for RGB-triplet assets. Re-run Batch Analysis after changing this."
+            "</td></tr></table>"
+        )
+        self.calibrate_sensor_btn = self._icon_action("fa5s.vials", "Calibrate the sensor from three bare-light R/G/B exposures", width=32)
+        row.addWidget(self.sensor_label)
+        row.addWidget(self.sensor_combo, 1)
+        row.addWidget(self.calibrate_sensor_btn)
+        self.layout.addLayout(row)
+
+    def _connect_signals(self) -> None:
+        self.sensor_combo.currentTextChanged.connect(self._on_sensor_profile_changed)
+        self.calibrate_sensor_btn.clicked.connect(self._open_sensor_calibration)
+
+    def _on_sensor_profile_changed(self, name: str) -> None:
+        # Bake the matrix like crosstalk does; the per-frame bounds were analyzed
+        # under the previous mix, so clear them.
+        matrix = SensorProfiles.get_matrix(name)
+        self.update_config_section(
+            "process",
+            persist=True,
+            render=True,
+            sensor_profile=name,
+            sensor_matrix=tuple(matrix) if matrix is not None else None,
+            **invalidate_local_bounds(self.state.config.process),
+        )
+
+    def _open_sensor_calibration(self) -> None:
+        from negpy.desktop.view.widgets.sensor_calibration_dialog import SensorCalibrationDialog
+
+        dlg = SensorCalibrationDialog(parent=self)
+        dlg.profile_saved.connect(self._on_sensor_profile_saved)
+        dlg.exec()
+
+    def _on_sensor_profile_saved(self, name: str) -> None:
+        self._on_sensor_profile_changed(name)
+        self.sync_ui()  # rebuild the combo (now includes the new profile) and select it
+
+    def sync_ui(self) -> None:
+        conf = self.state.config.process
+        self.block_signals(True)
+        try:
+            profiles = SensorProfiles.list_profiles()
+            if profiles != [self.sensor_combo.itemText(i) for i in range(self.sensor_combo.count())]:
+                self.sensor_combo.clear()
+                self.sensor_combo.addItems(profiles)
+            self.sensor_combo.setCurrentText(conf.sensor_profile)
+        finally:
+            self.block_signals(False)
+
+    def block_signals(self, blocked: bool) -> None:
+        self.sensor_combo.blockSignals(blocked)

--- a/negpy/desktop/view/widgets/sensor_calibration_dialog.py
+++ b/negpy/desktop/view/widgets/sensor_calibration_dialog.py
@@ -1,0 +1,156 @@
+"""Calibrate the sensor-crosstalk matrix from three bare-light exposures.
+
+Red-only / green-only / blue-only captures (no film in the holder, same light
+and camera settings as scanning) measure the sensor's response to each band;
+the inverted mix is saved as a named sensor profile the Process panel selects.
+"""
+
+import numpy as np
+from PyQt6.QtCore import Qt, pyqtSignal
+from PyQt6.QtGui import QGuiApplication
+from PyQt6.QtWidgets import (
+    QDialog,
+    QFileDialog,
+    QGridLayout,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QPushButton,
+    QVBoxLayout,
+)
+
+from negpy.desktop.view.styles.templates import hint_label
+from negpy.desktop.view.styles.theme import THEME
+from negpy.features.process.sensor import build_sensor_matrix, measure_capture
+from negpy.infrastructure.loaders.helpers import get_supported_raw_wildcards
+from negpy.services.assets.sensor import SensorProfiles
+
+_BANDS = (("R", "Red exposure"), ("G", "Green exposure"), ("B", "Blue exposure"))
+_CLIP_LEVEL = 0.98
+_CLIP_FRACTION = 0.02
+
+
+class SensorCalibrationDialog(QDialog):
+    """Pick three bare-light exposures, compute the unmix matrix, save a profile."""
+
+    profile_saved = pyqtSignal(str)
+
+    def __init__(self, parent=None) -> None:
+        super().__init__(parent)
+        self._paths = {"R": "", "G": "", "B": ""}
+        self.setWindowTitle("Calibrate Sensor")
+        self.resize(560, 320)
+        self._init_ui()
+
+    def _init_ui(self) -> None:
+        root = QVBoxLayout(self)
+        root.setSpacing(10)
+        intro = QLabel(
+            "Pick three <b>bare-light</b> exposures — red-only, green-only and blue-only, with no film in the "
+            "holder and the same light and camera settings you scan with. NegPy measures the sensor's response "
+            "to each band and builds the correction. Expose just below clipping."
+        )
+        intro.setWordWrap(True)
+        intro.setStyleSheet(f"color: {THEME.text_secondary};")
+        root.addWidget(intro)
+
+        grid = QGridLayout()
+        self._path_edits = {}
+        for i, (band, label) in enumerate(_BANDS):
+            grid.addWidget(QLabel(label), i, 0)
+            edit = QLineEdit()
+            edit.setReadOnly(True)
+            edit.setPlaceholderText("Choose a capture…")
+            browse = QPushButton("Browse…")
+            browse.clicked.connect(lambda _c=False, b=band: self._browse(b))
+            grid.addWidget(edit, i, 1)
+            grid.addWidget(browse, i, 2)
+            self._path_edits[band] = edit
+        grid.setColumnStretch(1, 1)
+        root.addLayout(grid)
+
+        name_row = QHBoxLayout()
+        name_row.addWidget(QLabel("Name"))
+        self.name_edit = QLineEdit()
+        self.name_edit.setPlaceholderText("e.g. X-T30 + Scanlight v4")
+        self.name_edit.textChanged.connect(self._refresh)
+        name_row.addWidget(self.name_edit, 1)
+        root.addLayout(name_row)
+
+        self.result_label = hint_label()
+        self.result_label.setWordWrap(True)
+        self.result_label.setVisible(False)
+        root.addWidget(self.result_label)
+        root.addStretch()
+
+        btn_row = QHBoxLayout()
+        btn_row.addStretch()
+        close = QPushButton("Close")
+        close.clicked.connect(self.reject)
+        self.compute_btn = QPushButton("Compute and Save")
+        self.compute_btn.setDefault(True)
+        self.compute_btn.clicked.connect(self._compute_and_save)
+        btn_row.addWidget(close)
+        btn_row.addWidget(self.compute_btn)
+        root.addLayout(btn_row)
+        self._refresh()
+
+    def _browse(self, band: str) -> None:
+        path, _ = QFileDialog.getOpenFileName(
+            self, f"Select the {band} bare-light exposure", "", f"Supported Images ({get_supported_raw_wildcards()})"
+        )
+        if path:
+            self._paths[band] = path
+            self._path_edits[band].setText(path)
+            self._refresh()
+
+    def _refresh(self) -> None:
+        name = self.name_edit.text().strip()
+        self.compute_btn.setEnabled(all(self._paths.values()) and bool(name) and not SensorProfiles.is_bundled(name))
+
+    def _decode(self, path: str) -> np.ndarray:
+        # Sensor-native linear decode (neutral WB), same as the flat-field reference —
+        # per-capture exposure scale cancels in build_sensor_matrix's normalization.
+        from negpy.services.rendering.preview_manager import PreviewManager
+
+        buf, _, _ = PreviewManager().load_linear_preview(path, use_camera_wb=False, full_resolution=False)
+        return buf
+
+    def _compute_and_save(self) -> None:
+        name = self.name_edit.text().strip()
+        if not name or not all(self._paths.values()):
+            return
+        QGuiApplication.setOverrideCursor(Qt.CursorShape.WaitCursor)
+        try:
+            measured = {}
+            clipped = []
+            for band in ("R", "G", "B"):
+                img = self._decode(self._paths[band])
+                measured[band] = measure_capture(img)
+                if float(np.mean(np.any(np.asarray(img[:, :, :3]) >= _CLIP_LEVEL, axis=2))) > _CLIP_FRACTION:
+                    clipped.append(band)
+            matrix = build_sensor_matrix(measured["R"], measured["G"], measured["B"])
+        except Exception as exc:
+            self._show_result(f"Could not build the matrix: {exc}")
+            return
+        finally:
+            QGuiApplication.restoreOverrideCursor()
+
+        SensorProfiles.save(name, list(matrix))
+        self._show_result(self._summary(name, measured, clipped))
+        self.profile_saved.emit(name)
+
+    def _summary(self, name: str, measured: dict, clipped: list) -> str:
+        s = np.column_stack([measured["R"], measured["G"], measured["B"]])
+        s_norm = s / np.diag(s)
+        gb, bg = s_norm[2, 1], s_norm[1, 2]  # green->blue / blue->green, the usual dominant leaks
+        lines = [
+            f"<b>Saved “{name}”</b> — measured green↔blue leakage {gb * 100:.0f}% / {bg * 100:.0f}%.",
+        ]
+        if clipped:
+            lines.append(f"⚠ {'/'.join(clipped)} exposure(s) look clipped — reshoot dimmer for an accurate matrix.")
+        return "<br>".join(lines)
+
+    def _show_result(self, text: str) -> None:
+        self.result_label.setText(text)
+        self.result_label.setVisible(True)

--- a/negpy/desktop/workers/export.py
+++ b/negpy/desktop/workers/export.py
@@ -43,6 +43,7 @@ def _same_decode_source(a: ExportTask, b: ExportTask) -> bool:
     return (
         a.file_info["path"] == b.file_info["path"]
         and a.params.process.linear_raw == b.params.process.linear_raw
+        and a.params.process.sensor_matrix == b.params.process.sensor_matrix
         and a.params.rgbscan == b.params.rgbscan
         and a.params.flatfield == b.params.flatfield
     )

--- a/negpy/desktop/workers/render.py
+++ b/negpy/desktop/workers/render.py
@@ -11,6 +11,8 @@ from negpy.domain.models import WorkspaceConfig
 from negpy.features.exposure.analysis import output_histogram
 from negpy.features.flatfield.logic import apply_flatfield
 from negpy.features.geometry.batch_autocrop import detect_crop_candidate, resolve_roll_crops
+from negpy.features.process.sensor import apply_sensor_correction
+from negpy.features.rgbscan.models import is_rgb_triplet
 from negpy.features.geometry.processor import GeometryProcessor
 from negpy.infrastructure.display.color_spaces import WORKING_COLOR_SPACE
 from negpy.infrastructure.gpu.resources import GPUTexture
@@ -830,6 +832,10 @@ class NormalizationWorker(QObject):
                         base_hash(f_info.get("hash")),  # halves share one decode
                     )
                     raw = slice_for_asset(raw, f_info)
+                    # Bounds must be measured on the same channel mix the render path
+                    # normalizes (triplet composites are never sensor-corrected there).
+                    if params is not None and params.process.sensor_matrix is not None and not is_rgb_triplet(params.rgbscan):
+                        raw = await asyncio.to_thread(apply_sensor_correction, raw, params.process.sensor_matrix)
 
                     ctx = PipelineContext(
                         original_size=(raw.shape[1], raw.shape[0]),

--- a/negpy/domain/types.py
+++ b/negpy/domain/types.py
@@ -35,6 +35,7 @@ class AppConfig:
     cache_dir: str
     user_icc_dir: str
     crosstalk_dir: str
+    sensor_dir: str
     gear_dir: str
     contact_sheet_templates_dir: str
     default_export_dir: str

--- a/negpy/features/process/models.py
+++ b/negpy/features/process/models.py
@@ -68,6 +68,13 @@ class ProcessConfig:
     crosstalk_matrix: Optional[tuple] = None
     crosstalk_profile: str = "Default"
 
+    # Sensor (CFA) crosstalk unmix on the LINEAR capture, before inversion —
+    # a per-setup property calibrated from three bare-light R/G/B exposures
+    # (features/process/sensor.py). 9 floats row-major, baked from a sensor
+    # profile; None = off (no built-in default).
+    sensor_matrix: Optional[tuple] = None
+    sensor_profile: str = "None"
+
     lock_bounds: bool = False
 
     roll_name: Optional[str] = None
@@ -82,6 +89,8 @@ class ProcessConfig:
         object.__setattr__(self, "local_ceils", tuple(self.local_ceils))
         if self.crosstalk_matrix is not None:
             object.__setattr__(self, "crosstalk_matrix", tuple(self.crosstalk_matrix))
+        if self.sensor_matrix is not None:
+            object.__setattr__(self, "sensor_matrix", tuple(self.sensor_matrix))
         if self.analysis_rect is not None:
             object.__setattr__(self, "analysis_rect", tuple(self.analysis_rect))
 

--- a/negpy/features/process/sensor.py
+++ b/negpy/features/process/sensor.py
@@ -1,0 +1,64 @@
+"""Sensor (CFA) crosstalk calibration for single-shot narrowband scans.
+
+The camera's colour-filter passbands overlap the narrowband source's bands, so a
+pure red/green/blue exposure leaks into the other channels — a fixed property of
+the sensor+light pair, independent of film. Calibrated once from three bare-light
+exposures and corrected with a 3x3 unmix in the LINEAR domain, before the
+log/inversion where the film-dye crosstalk (Density Mixer) lives.
+"""
+
+from typing import Optional
+
+import numpy as np
+
+from negpy.domain.types import ImageBuffer
+from negpy.features.exposure.normalization import get_analysis_crop
+from negpy.features.process.models import ProcessConfig
+
+_EPS = 1e-4
+
+
+def measure_capture(img: ImageBuffer, center: float = 0.5) -> tuple[float, float, float]:
+    """Mean linear RGB over the central ``center`` fraction (dodges vignetting)."""
+    region = get_analysis_crop(np.asarray(img[:, :, :3], dtype=np.float64), (1.0 - center) / 2.0)
+    m = region.reshape(-1, 3).mean(axis=0)
+    return (float(m[0]), float(m[1]), float(m[2]))
+
+
+def build_sensor_matrix(
+    rgb_red: tuple[float, float, float],
+    rgb_green: tuple[float, float, float],
+    rgb_blue: tuple[float, float, float],
+) -> tuple[float, ...]:
+    """Correction matrix (9 floats, row-major) from three bare-light capture means.
+
+    Columns of S are each band's sensor response; each column is divided by its
+    own-channel value (unit diagonal — per-capture exposure cancels, white balance
+    stays with downstream normalization), then inverted to un-mix.
+    """
+    s = np.column_stack([rgb_red, rgb_green, rgb_blue]).astype(np.float64)
+    diag = np.diag(s).copy()
+    if np.any(diag <= _EPS * s.max(axis=0)):
+        raise ValueError("a capture has no signal in its own channel — check the R/G/B assignment")
+    s_norm = s / diag
+    try:
+        correction = np.linalg.inv(s_norm)
+    except np.linalg.LinAlgError:
+        raise ValueError("captures are not independent — three distinct single-band exposures are required") from None
+    return tuple(float(x) for x in correction.reshape(-1))
+
+
+def apply_sensor_correction(img: ImageBuffer, matrix: Optional[tuple]) -> ImageBuffer:
+    """Un-mix a linear (H, W, 3) capture with the baked 3x3; identity when None."""
+    if matrix is None:
+        return img
+    m = np.asarray(matrix, dtype=np.float32).reshape(3, 3)
+    out = np.einsum("ck,hwk->hwc", m, img[:, :, :3].astype(np.float32, copy=False))
+    return np.clip(out, 0.0, None)
+
+
+def sensor_token(process: ProcessConfig) -> str:
+    """Identity of the baked sensor matrix, folded into the render source hash."""
+    if process.sensor_matrix is None:
+        return ""
+    return "|sn:" + ",".join(f"{v:.6g}" for v in process.sensor_matrix)

--- a/negpy/features/rgbscan/logic.py
+++ b/negpy/features/rgbscan/logic.py
@@ -5,7 +5,7 @@ from typing import Callable, List, Sequence, Tuple
 import cv2
 import numpy as np
 
-from negpy.features.rgbscan.models import RgbScanConfig
+from negpy.features.rgbscan.models import RgbScanConfig, is_rgb_triplet
 
 # Channel indices, matching the demosaiced RGB axis order.
 RED, GREEN, BLUE = 0, 1, 2
@@ -132,7 +132,7 @@ def merge_rgb_triplet(
 
 def rgbscan_token(config: RgbScanConfig) -> str:
     """Identity of the active triplet, folded into the render source hash. Empty when inactive."""
-    if not config.enabled or not config.green_path or not config.blue_path:
+    if not is_rgb_triplet(config):
         return ""
     try:
         g_mtime = os.path.getmtime(config.green_path)

--- a/negpy/features/rgbscan/models.py
+++ b/negpy/features/rgbscan/models.py
@@ -13,3 +13,8 @@ class RgbScanConfig:
     green_path: str = ""
     blue_path: str = ""
     align: bool = True  # sub-pixel registration of green/blue to the red exposure
+
+
+def is_rgb_triplet(config: RgbScanConfig) -> bool:
+    """The predicate the decode paths use to decide to merge a triplet."""
+    return bool(config.enabled and config.green_path and config.blue_path)

--- a/negpy/kernel/system/config.py
+++ b/negpy/kernel/system/config.py
@@ -33,6 +33,7 @@ APP_CONFIG = AppConfig(
     cache_dir=os.path.join(BASE_USER_DIR, "cache"),
     user_icc_dir=os.path.join(BASE_USER_DIR, "icc"),
     crosstalk_dir=os.path.join(BASE_USER_DIR, "crosstalk"),
+    sensor_dir=os.path.join(BASE_USER_DIR, "sensor"),
     gear_dir=os.path.join(BASE_USER_DIR, "gear"),
     contact_sheet_templates_dir=os.path.join(BASE_USER_DIR, "contact_sheets"),
     default_export_dir=os.path.join(BASE_USER_DIR, "export"),

--- a/negpy/services/assets/naming.py
+++ b/negpy/services/assets/naming.py
@@ -1,0 +1,11 @@
+import re
+
+
+def slugify(name: str, fallback: str) -> str:
+    slug = re.sub(r"[^\w\s-]", "", name.lower())
+    slug = re.sub(r"[-\s]+", "_", slug).strip("_")
+    return slug or fallback
+
+
+def escape_toml_string(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')

--- a/negpy/services/assets/sensor.py
+++ b/negpy/services/assets/sensor.py
@@ -3,56 +3,41 @@ import tomllib
 from typing import List, Optional
 
 from negpy.kernel.system.config import APP_CONFIG
-from negpy.kernel.system.paths import get_resource_path
 from negpy.services.assets.naming import escape_toml_string, slugify
 
-DEFAULT_NAME = "Default"
+NONE_NAME = "None"
 
 
-class CrosstalkProfiles:
+class SensorProfiles:
     """
-    TOML I/O for user spectral-crosstalk matrices.
+    TOML I/O for user sensor-crosstalk matrices (features/process/sensor.py).
 
-    Files live in APP_CONFIG.crosstalk_dir. The built-in hardcoded matrix is
-    exposed as the "Default" profile. Disk I/O only happens on dropdown build
-    and on selection -- never per render (matrices are baked into ProcessConfig).
+    Files live in APP_CONFIG.sensor_dir. "None" means no correction — there is
+    no built-in matrix, a sensor matrix only exists once the user calibrates
+    their setup. Disk I/O only happens on dropdown build and on selection --
+    never per render (matrices are baked into ProcessConfig).
     """
 
-    DEFAULT_NAME = DEFAULT_NAME
+    NONE_NAME = NONE_NAME
 
     @staticmethod
-    def _scan_dir(directory: str) -> dict:
-        """Maps display-name -> flat 9-float matrix for valid .toml files in a directory."""
+    def _scan() -> dict:
+        """Maps display-name -> flat 9-float matrix for valid .toml files."""
         result: dict = {}
+        directory = APP_CONFIG.sensor_dir
         if not os.path.isdir(directory):
             return result
         for fname in os.listdir(directory):
             if not fname.endswith(".toml"):
                 continue
-            path = os.path.join(directory, fname)
-            parsed = CrosstalkProfiles._parse_file(path)
+            parsed = SensorProfiles._parse_file(os.path.join(directory, fname))
             if parsed is None:
                 continue
             name, matrix = parsed
             name = name or fname[:-5]
-            if name != DEFAULT_NAME:
+            if name != NONE_NAME:
                 result[name] = matrix
         return result
-
-    @staticmethod
-    def scan_bundled() -> dict:
-        """Read-only matrices shipped with the app, keyed by display name."""
-        return CrosstalkProfiles._scan_dir(get_resource_path("crosstalk"))
-
-    @staticmethod
-    def scan_user() -> dict:
-        """User-editable matrices in the docs folder, keyed by display name."""
-        return CrosstalkProfiles._scan_dir(APP_CONFIG.crosstalk_dir)
-
-    @staticmethod
-    def _scan() -> dict:
-        """Bundled ∪ user custom matrices, keyed by display name; bundled wins."""
-        return {**CrosstalkProfiles.scan_user(), **CrosstalkProfiles.scan_bundled()}
 
     @staticmethod
     def _parse_file(path: str) -> Optional[tuple]:
@@ -79,36 +64,33 @@ class CrosstalkProfiles:
 
     @staticmethod
     def list_profiles() -> List[str]:
-        """["Default", *sorted custom display-names]."""
-        return [DEFAULT_NAME, *sorted(CrosstalkProfiles._scan().keys())]
+        """["None", *sorted custom display-names]."""
+        return [NONE_NAME, *sorted(SensorProfiles._scan().keys())]
 
     @staticmethod
     def get_matrix(name: str) -> Optional[List[float]]:
-        """
-        Flat 9-float list for a profile, or None for the built-in / missing /
-        invalid profiles. None means the render path uses process.models.DEFAULT_CROSSTALK_MATRIX.
-        """
-        if name == DEFAULT_NAME:
+        """Flat 9-float list, or None for "None" / missing / invalid (= no correction)."""
+        if name == NONE_NAME:
             return None
-        return CrosstalkProfiles._scan().get(name)
+        return SensorProfiles._scan().get(name)
 
     @staticmethod
     def is_bundled(name: str) -> bool:
-        """True for read-only profiles: the built-in Default or any bundled matrix."""
-        return name == DEFAULT_NAME or name in CrosstalkProfiles.scan_bundled()
+        """True for the read-only "None" entry."""
+        return name == NONE_NAME
 
     @staticmethod
     def path_for_name(name: str) -> str:
         """Filesystem path a user profile with this display name would use."""
-        return os.path.join(APP_CONFIG.crosstalk_dir, f"{slugify(name, 'crosstalk')}.toml")
+        return os.path.join(APP_CONFIG.sensor_dir, f"{slugify(name, 'sensor')}.toml")
 
     @staticmethod
     def save(name: str, matrix: List[float]) -> str:
         """Write a user profile TOML (row-major 3×3) and return its path."""
-        os.makedirs(APP_CONFIG.crosstalk_dir, exist_ok=True)
+        os.makedirs(APP_CONFIG.sensor_dir, exist_ok=True)
         rows = "\n".join("  [{:.6g}, {:.6g}, {:.6g}],".format(*matrix[i * 3 : i * 3 + 3]) for i in range(3))
         content = f'name = "{escape_toml_string(name)}"\nmatrix = [\n{rows}\n]\n'
-        path = CrosstalkProfiles.path_for_name(name)
+        path = SensorProfiles.path_for_name(name)
         with open(path, "w", encoding="utf-8") as f:
             f.write(content)
         return path
@@ -116,22 +98,17 @@ class CrosstalkProfiles:
     @staticmethod
     def delete(name: str) -> None:
         """Remove the user profile file whose display name matches (no-op if absent)."""
-        directory = APP_CONFIG.crosstalk_dir
+        directory = APP_CONFIG.sensor_dir
         if not os.path.isdir(directory):
             return
         for fname in os.listdir(directory):
             if not fname.endswith(".toml"):
                 continue
             path = os.path.join(directory, fname)
-            parsed = CrosstalkProfiles._parse_file(path)
+            parsed = SensorProfiles._parse_file(path)
             if parsed is None:
                 continue
             parsed_name = parsed[0] or fname[:-5]
             if parsed_name == name:
                 os.remove(path)
                 return
-
-    @staticmethod
-    def ensure_user_dir() -> None:
-        """Make sure the user's crosstalk directory exists; no seeding."""
-        os.makedirs(APP_CONFIG.crosstalk_dir, exist_ok=True)

--- a/negpy/services/export/contact_sheet_templates.py
+++ b/negpy/services/export/contact_sheet_templates.py
@@ -1,10 +1,10 @@
 import os
-import re
 import tomllib
 from dataclasses import dataclass
 from typing import Dict, Optional
 
 from negpy.kernel.system.config import APP_CONFIG
+from negpy.services.assets.naming import escape_toml_string, slugify
 from negpy.services.export.contact_sheet import CELL_PX, GAP, MARGIN, MAX_TILES_PER_SHEET
 
 DEFAULT_NAME = "Default"
@@ -24,16 +24,6 @@ class ContactSheetLayout:
     show_labels: bool = True
     background_color: str = "#000000"
     label_color: str = "#ffffff"
-
-
-def _slugify(name: str) -> str:
-    slug = re.sub(r"[^\w\s-]", "", name.lower())
-    slug = re.sub(r"[-\s]+", "_", slug).strip("_")
-    return slug or "template"
-
-
-def _escape_toml_string(value: str) -> str:
-    return value.replace("\\", "\\\\").replace('"', '\\"')
 
 
 def _clamp_int(value: object, lo: int, hi: int, default: int) -> int:
@@ -189,7 +179,7 @@ class ContactSheetTemplates:
     @staticmethod
     def path_for_name(name: str) -> str:
         """Filesystem path a template with this display name would use."""
-        return os.path.join(ContactSheetTemplates._templates_dir(), f"{_slugify(name)}.toml")
+        return os.path.join(ContactSheetTemplates._templates_dir(), f"{slugify(name, 'template')}.toml")
 
     @staticmethod
     def template_exists(name: str) -> bool:
@@ -224,15 +214,15 @@ class ContactSheetTemplates:
         os.makedirs(templates_dir, exist_ok=True)
         path = ContactSheetTemplates.path_for_name(name)
         content = (
-            f'name = "{_escape_toml_string(name)}"\n\n'
+            f'name = "{escape_toml_string(name)}"\n\n'
             "[layout]\n"
             f"cell_px = {layout.cell_px}\n"
             f"gap = {layout.gap}\n"
             f"margin = {layout.margin}\n"
             f"max_tiles = {layout.max_tiles}\n"
             f"show_labels = {'true' if layout.show_labels else 'false'}\n"
-            f'background_color = "{_escape_toml_string(layout.background_color)}"\n'
-            f'label_color = "{_escape_toml_string(layout.label_color)}"\n'
+            f'background_color = "{escape_toml_string(layout.background_color)}"\n'
+            f'label_color = "{escape_toml_string(layout.label_color)}"\n'
         )
         with open(path, "w", encoding="utf-8") as f:
             f.write(content)

--- a/negpy/services/rendering/image_processor.py
+++ b/negpy/services/rendering/image_processor.py
@@ -19,6 +19,7 @@ from negpy.domain.models import (
 )
 from negpy.features.process.models import ProcessMode
 from negpy.features.process.logic import linear_raw_token
+from negpy.features.process.sensor import apply_sensor_correction, sensor_token
 from negpy.features.exposure.models import RenderIntent
 from negpy.features.flatfield.logic import apply_flatfield, flatfield_token
 from negpy.features.retouch.logic import (
@@ -36,6 +37,7 @@ from negpy.features.retouch.logic import (
     route_ir_defects,
 )
 from negpy.features.rgbscan.logic import merge_rgb_triplet, rgbscan_token
+from negpy.features.rgbscan.models import is_rgb_triplet
 from negpy.features.stitch.logic import stitch_composite
 from negpy.features.stitch.models import stitch_token
 from negpy.domain.interfaces import PipelineContext
@@ -302,6 +304,12 @@ class ImageProcessor:
         # canvas as one frame would stretch the gain map across the seam.
         if not skip_flatfield and not settings.stitch.stitch_enabled:
             img = apply_flatfield(img, settings.flatfield)
+        # Sensor unmix is a source pre-correction like flat-field. skip_flatfield buffers
+        # come from _load_source_f32, which already applied it; triplet composites take
+        # each channel from its own single-band exposure, so unmixing them would inject
+        # crosstalk that was never captured.
+        if not skip_flatfield and not is_rgb_triplet(settings.rgbscan):
+            img = apply_sensor_correction(img, settings.process.sensor_matrix)
         h_orig, w_cols = img.shape[:2]
         # Fold the buffer resolution into source_hash: toggling HQ re-decodes the same
         # file at full resolution with unchanged settings, so without this the engine
@@ -313,6 +321,7 @@ class ImageProcessor:
             + rgbscan_token(settings.rgbscan)
             + stitch_token(settings.stitch)
             + linear_raw_token(settings.process)
+            + sensor_token(settings.process)
             + ir_bake_token(settings.retouch, ir_buffer is not None)
         )
 
@@ -449,8 +458,7 @@ class ImageProcessor:
 
         Returns (f32_buffer, ir_buffer, source_color_space).
         """
-        rgbcfg = params.rgbscan
-        is_triplet = bool(rgbcfg.enabled and rgbcfg.green_path and rgbcfg.blue_path)
+        is_triplet = is_rgb_triplet(params.rgbscan)
         # Narrowband triplet channels don't survive half_size CFA binning.
         fast_decode = fast_decode and not is_triplet
 
@@ -465,6 +473,7 @@ class ImageProcessor:
             rgbscan_token(params.rgbscan),
             stitch_token(params.stitch),
             flatfield_token(params.flatfield),
+            sensor_token(params.process),
             fast_decode,
         )
         if cache_key == self._source_cache_key and self._source_cache_value is not None:
@@ -498,7 +507,7 @@ class ImageProcessor:
         """
         linear_raw = params.process.linear_raw
         rgbcfg = params.rgbscan
-        is_triplet = bool(rgbcfg.enabled and rgbcfg.green_path and rgbcfg.blue_path)
+        is_triplet = is_rgb_triplet(rgbcfg)
 
         rgb, metadata = self._decode_sensor_rgb(file_path, linear_raw, fast=fast_decode)
         # No embedded profile (scanner-raw linear, sensor-native RAW) → the buffer is
@@ -532,6 +541,8 @@ class ImageProcessor:
         orientation = metadata.get("orientation", 1)
         f32_buffer = apply_exif_orientation(f32_buffer, orientation)
         f32_buffer = apply_flatfield(f32_buffer, params.flatfield)
+        if not is_triplet:
+            f32_buffer = apply_sensor_correction(f32_buffer, params.process.sensor_matrix)
         if ir_full is not None:
             ir_full = apply_exif_orientation(ir_full, orientation)
         return f32_buffer, ir_full, source_cs
@@ -582,6 +593,7 @@ class ImageProcessor:
                 + rgbscan_token(params.rgbscan)
                 + stitch_token(params.stitch)
                 + linear_raw_token(params.process)
+                + sensor_token(params.process)
                 + ir_bake_token(params.retouch, ir_full is not None)
             )
             f32_buffer, _, _, ir_routed = self._ir_bake(f32_buffer, ir_full, params, detect_key)
@@ -828,6 +840,7 @@ class ImageProcessor:
                 + rgbscan_token(params.rgbscan)
                 + stitch_token(params.stitch)
                 + linear_raw_token(params.process)
+                + sensor_token(params.process)
                 + ir_bake_token(params.retouch, ir_full is not None)
             )
             f32_buffer, _, _, ir_routed = self._ir_bake(f32_buffer, ir_full, params, detect_key)

--- a/tests/test_override_config.py
+++ b/tests/test_override_config.py
@@ -29,6 +29,7 @@ def _make_app_config(**kwargs) -> AppConfig:
         cache_dir="/tmp/cache",
         user_icc_dir="/tmp/icc",
         crosstalk_dir="/tmp/crosstalk",
+        sensor_dir="/tmp/sensor",
         gear_dir="/tmp/gear",
         contact_sheet_templates_dir="/tmp/contact_sheets",
         default_export_dir="/tmp/export",

--- a/tests/test_parallel_dispatch.py
+++ b/tests/test_parallel_dispatch.py
@@ -127,6 +127,7 @@ def test_override_parsing_and_apply():
         cache_dir="",
         user_icc_dir="",
         crosstalk_dir="",
+        sensor_dir="",
         gear_dir="",
         contact_sheet_templates_dir="",
         default_export_dir="",

--- a/tests/test_sensor_calibration.py
+++ b/tests/test_sensor_calibration.py
@@ -1,0 +1,131 @@
+from dataclasses import replace
+
+import numpy as np
+import pytest
+
+from negpy.domain.models import WorkspaceConfig
+from negpy.features.process.sensor import (
+    apply_sensor_correction,
+    build_sensor_matrix,
+    measure_capture,
+    sensor_token,
+)
+from negpy.features.rgbscan.models import RgbScanConfig, is_rgb_triplet
+from negpy.kernel.system.config import APP_CONFIG
+
+_RGB_R = (0.9, 0.1, 0.03)
+_RGB_G = (0.05, 0.5, 0.15)  # green leaks 30% into blue after own-channel normalization
+_RGB_B = (0.04, 0.3, 1.0)
+
+
+def _s_norm():
+    s = np.column_stack([_RGB_R, _RGB_G, _RGB_B])
+    return s / np.diag(s)
+
+
+def test_pure_captures_give_identity():
+    m = np.array(build_sensor_matrix((1, 0, 0), (0, 1, 0), (0, 0, 1))).reshape(3, 3)
+    assert np.allclose(m, np.eye(3), atol=1e-12)
+
+
+def test_matrix_inverts_normalized_mixing():
+    m = np.array(build_sensor_matrix(_RGB_R, _RGB_G, _RGB_B)).reshape(3, 3)
+    assert np.allclose(m @ _s_norm(), np.eye(3), atol=1e-9)
+
+
+def test_matrix_invariant_to_per_capture_exposure():
+    scaled = build_sensor_matrix(tuple(v * 3.7 for v in _RGB_R), tuple(v * 0.4 for v in _RGB_G), tuple(v * 1.9 for v in _RGB_B))
+    assert np.allclose(scaled, build_sensor_matrix(_RGB_R, _RGB_G, _RGB_B), atol=1e-9)
+
+
+def test_rejects_zero_own_channel_and_singular():
+    with pytest.raises(ValueError):
+        build_sensor_matrix((0.0, 0.1, 0.03), _RGB_G, _RGB_B)
+    with pytest.raises(ValueError):
+        build_sensor_matrix((1, 1, 1), (1, 1, 1), (1, 1, 1))
+
+
+def test_apply_none_is_same_object():
+    img = np.random.default_rng(0).random((8, 8, 3)).astype(np.float32)
+    assert apply_sensor_correction(img, None) is img
+
+
+def test_apply_unmixes_clips_and_keeps_float32():
+    clean = np.array([[[0.6, 0.2, 0.1]]], dtype=np.float32)
+    mixed = np.einsum("ck,hwk->hwc", _s_norm().astype(np.float32), clean)
+    out = apply_sensor_correction(mixed, build_sensor_matrix(_RGB_R, _RGB_G, _RGB_B))
+    assert np.allclose(out[0, 0], clean[0, 0], atol=1e-5)
+    assert out.dtype == np.float32
+    assert np.all(out >= 0.0)
+
+
+def test_measure_capture_reads_central_crop_only():
+    img = np.zeros((100, 100, 3), dtype=np.float32)
+    img[:, :] = (0.8, 0.3, 0.05)
+    img[:10, :, :] = 5.0  # poisoned border a centre crop must ignore
+    img[:, -10:, :] = 5.0
+    assert measure_capture(img) == pytest.approx((0.8, 0.3, 0.05), abs=1e-5)
+
+
+def test_sensor_token_tracks_matrix():
+    off = WorkspaceConfig().process
+    on = replace(off, sensor_matrix=(1, 0, 0, 0, 1, 0, 0, 0, 1))
+    on2 = replace(off, sensor_matrix=(1, -0.1, 0, 0, 1, 0, 0, 0, 1))
+    assert sensor_token(off) == ""
+    assert sensor_token(on) != sensor_token(on2) != ""
+
+
+def test_is_rgb_triplet_truth_table():
+    assert not is_rgb_triplet(RgbScanConfig())
+    assert not is_rgb_triplet(RgbScanConfig(enabled=True))
+    assert not is_rgb_triplet(RgbScanConfig(enabled=True, green_path="g"))
+    assert not is_rgb_triplet(RgbScanConfig(enabled=False, green_path="g", blue_path="b"))
+    assert is_rgb_triplet(RgbScanConfig(enabled=True, green_path="g", blue_path="b"))
+
+
+def test_config_roundtrips_sensor_fields():
+    matrix = (1.0, -0.09, -0.01, 0.05, 1.12, -0.33, 0.11, -0.34, 1.1)
+    cfg = WorkspaceConfig()
+    cfg = replace(cfg, process=replace(cfg.process, sensor_matrix=matrix, sensor_profile="My Sensor"))
+    restored = WorkspaceConfig.from_flat_dict(cfg.to_dict())
+    assert restored.process.sensor_matrix == matrix
+    assert restored.process.sensor_profile == "My Sensor"
+    # JSON round-trip delivers lists; __post_init__ must coerce back to tuple.
+    from_list = WorkspaceConfig.from_flat_dict({**cfg.to_dict(), "sensor_matrix": list(matrix)})
+    assert from_list.process.sensor_matrix == matrix
+
+
+def test_run_pipeline_gates_triplets(monkeypatch):
+    from negpy.services.rendering import image_processor as ip_mod
+
+    calls = []
+
+    def _recorder(img, matrix):
+        calls.append(matrix)
+        return img
+
+    monkeypatch.setattr(ip_mod, "apply_sensor_correction", _recorder)
+    ip = ip_mod.ImageProcessor.__new__(ip_mod.ImageProcessor)
+    ip.engine_gpu = None
+    ip.engine_cpu = __import__("unittest.mock", fromlist=["MagicMock"]).MagicMock()
+    ip.engine_cpu.process.return_value = np.zeros((8, 8, 3), dtype=np.float32)
+    ip._augment_retouch = lambda settings, img, key: (settings, None, [])
+    ip._ir_bake = lambda img, ir, settings, key: (img, None, None, None)
+    ip._is_flat = lambda settings: False
+
+    img = np.full((8, 8, 3), 0.5, dtype=np.float32)
+    matrix = (1.0, -0.1, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0)
+    cfg = WorkspaceConfig()
+    cfg = replace(cfg, process=replace(cfg.process, sensor_matrix=matrix))
+
+    ip.run_pipeline(img, cfg, "h", render_size_ref=float(APP_CONFIG.preview_render_size), prefer_gpu=False)
+    assert calls == [matrix]
+
+    calls.clear()
+    triplet_cfg = replace(cfg, rgbscan=RgbScanConfig(enabled=True, green_path="g", blue_path="b"))
+    ip.run_pipeline(img, triplet_cfg, "h", render_size_ref=float(APP_CONFIG.preview_render_size), prefer_gpu=False)
+    assert calls == []
+
+    calls.clear()
+    ip.run_pipeline(img, cfg, "h", render_size_ref=float(APP_CONFIG.preview_render_size), prefer_gpu=False, skip_flatfield=True)
+    assert calls == []  # skip_flatfield buffers were corrected at decode already

--- a/tests/test_sensor_profiles.py
+++ b/tests/test_sensor_profiles.py
@@ -1,0 +1,163 @@
+import os
+
+import numpy as np
+import pytest
+
+from negpy.kernel.system.config import APP_CONFIG
+from negpy.services.assets.sensor import SensorProfiles
+
+
+def _write(path, content):
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(content)
+
+
+@pytest.fixture(autouse=True)
+def _isolate(tmp_path, monkeypatch):
+    monkeypatch.setattr(APP_CONFIG, "sensor_dir", str(tmp_path))
+
+
+def test_list_get_and_none(tmp_path):
+    _write(
+        os.path.join(tmp_path, "my_sensor.toml"),
+        'name = "My Sensor"\nmatrix = [[1.0, -0.1, 0.0], [0.0, 1.1, -0.3], [0.0, -0.3, 1.1]]\n',
+    )
+    assert SensorProfiles.list_profiles() == ["None", "My Sensor"]
+    assert SensorProfiles.get_matrix("My Sensor") == [1.0, -0.1, 0.0, 0.0, 1.1, -0.3, 0.0, -0.3, 1.1]
+    assert SensorProfiles.get_matrix("None") is None
+    assert SensorProfiles.get_matrix("missing") is None
+    assert SensorProfiles.is_bundled("None")
+    assert not SensorProfiles.is_bundled("My Sensor")
+
+
+def test_name_falls_back_to_stem(tmp_path):
+    _write(os.path.join(tmp_path, "rig_a.toml"), "matrix = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]\n")
+    assert "rig_a" in SensorProfiles.list_profiles()
+
+
+def test_save_round_trips_and_delete(tmp_path):
+    matrix = [1.004, -0.02, 0.001, -0.118, 1.01, -0.04, -0.042, -0.149, 1.006]
+    path = SensorProfiles.save("Setup A", matrix)
+    assert os.path.isfile(path)
+    assert path.startswith(str(tmp_path))
+    assert SensorProfiles.get_matrix("Setup A") == matrix
+    SensorProfiles.delete("Setup A")
+    assert SensorProfiles.get_matrix("Setup A") is None
+    SensorProfiles.delete("Nonexistent")  # no-op, no raise
+
+
+def test_malformed_skipped(tmp_path):
+    _write(os.path.join(tmp_path, "bad_shape.toml"), "matrix = [[1.0, 0.0], [0.0, 1.0]]\n")
+    _write(os.path.join(tmp_path, "bad_toml.toml"), "matrix = [[[not valid\n")
+    _write(os.path.join(tmp_path, "no_matrix.toml"), 'name = "x"\n')
+    assert SensorProfiles.list_profiles() == ["None"]
+
+
+def _fake_decode(monkeypatch, captures):
+    def fake(self, path):
+        return np.tile(np.array(captures[path], dtype=np.float32), (16, 16, 1))
+
+    monkeypatch.setattr("negpy.desktop.view.widgets.sensor_calibration_dialog.SensorCalibrationDialog._decode", fake)
+
+
+def test_dialog_compute_and_save(tmp_path, monkeypatch, qapp):
+    from negpy.desktop.view.widgets.sensor_calibration_dialog import SensorCalibrationDialog
+
+    _fake_decode(monkeypatch, {"R": (0.9, 0.1, 0.03), "G": (0.05, 0.5, 0.15), "B": (0.04, 0.3, 0.95)})
+    saved = []
+    dlg = SensorCalibrationDialog()
+    dlg.profile_saved.connect(saved.append)
+    dlg._paths = {"R": "R", "G": "G", "B": "B"}
+    dlg.name_edit.setText("Test Sensor")
+    dlg._compute_and_save()
+
+    assert saved == ["Test Sensor"]
+    m = np.array(SensorProfiles.get_matrix("Test Sensor")).reshape(3, 3)
+    # Inverse of the normalized leakage: green/blue off-diagonals go negative.
+    assert m[1, 2] < 0 and m[2, 1] < 0
+    assert not dlg.result_label.isHidden()
+    assert "clipped" not in dlg.result_label.text()
+
+
+def test_dialog_warns_on_clipped_capture(monkeypatch, qapp):
+    from negpy.desktop.view.widgets.sensor_calibration_dialog import SensorCalibrationDialog
+
+    _fake_decode(monkeypatch, {"R": (0.99, 0.1, 0.03), "G": (0.05, 0.5, 0.15), "B": (0.04, 0.3, 1.0)})
+    dlg = SensorCalibrationDialog()
+    dlg._paths = {"R": "R", "G": "G", "B": "B"}
+    dlg.name_edit.setText("Hot")
+    dlg._compute_and_save()
+    assert "clipped" in dlg.result_label.text()
+    assert SensorProfiles.get_matrix("Hot") is not None  # warned, still saved
+
+
+def test_dialog_reports_error_and_saves_nothing(monkeypatch, qapp):
+    from negpy.desktop.view.widgets.sensor_calibration_dialog import SensorCalibrationDialog
+
+    _fake_decode(monkeypatch, {"R": (0.0, 0.1, 0.03), "G": (0.05, 0.5, 0.15), "B": (0.04, 0.3, 1.0)})
+    saved = []
+    dlg = SensorCalibrationDialog()
+    dlg.profile_saved.connect(saved.append)
+    dlg._paths = {"R": "R", "G": "G", "B": "B"}
+    dlg.name_edit.setText("Bad")
+    dlg._compute_and_save()
+    assert saved == []
+    assert "Could not build" in dlg.result_label.text()
+    assert SensorProfiles.list_profiles() == ["None"]
+
+
+def test_dialog_blocks_reserved_name(qapp):
+    from negpy.desktop.view.widgets.sensor_calibration_dialog import SensorCalibrationDialog
+
+    dlg = SensorCalibrationDialog()
+    dlg._paths = {"R": "R", "G": "G", "B": "B"}
+    dlg.name_edit.setText("None")
+    assert not dlg.compute_btn.isEnabled()
+
+
+def _sensor_sidebar():
+    from unittest.mock import MagicMock
+
+    from negpy.desktop.session import AppState
+    from negpy.desktop.view.sidebar.sensor import SensorSidebar
+
+    controller = MagicMock()
+    controller.state = AppState()
+    return controller, SensorSidebar(controller)
+
+
+def test_sidebar_lists_profiles(qapp, tmp_path):
+    SensorProfiles.save("Rig", [1, 0, 0, 0, 1, 0, 0, 0, 1])
+    controller, sidebar = _sensor_sidebar()
+    assert [sidebar.sensor_combo.itemText(i) for i in range(sidebar.sensor_combo.count())] == ["None", "Rig"]
+
+
+def test_sidebar_profile_change_bakes_matrix_and_clears_bounds(qapp, tmp_path):
+    from dataclasses import replace
+
+    matrix = [1.0, -0.1, 0.0, 0.0, 1.1, -0.3, 0.0, -0.3, 1.1]
+    SensorProfiles.save("Rig", matrix)
+
+    controller, sidebar = _sensor_sidebar()
+    controller.state.config = replace(
+        controller.state.config,
+        process=replace(controller.state.config.process, local_floors=(0.1, 0.1, 0.1)),
+    )
+    sidebar._on_sensor_profile_changed("Rig")
+
+    cfg = controller.session.update_config.call_args.args[0]
+    assert cfg.process.sensor_profile == "Rig"
+    assert cfg.process.sensor_matrix == tuple(matrix)
+    assert cfg.process.local_floors == (0.0, 0.0, 0.0)
+
+    sidebar._on_sensor_profile_changed("None")
+    cfg = controller.session.update_config.call_args.args[0]
+    assert cfg.process.sensor_matrix is None
+
+
+def test_sidebar_sync_rebuilds_combo_after_save(qapp, tmp_path):
+    controller, sidebar = _sensor_sidebar()
+    assert sidebar.sensor_combo.count() == 1
+    SensorProfiles.save("New Rig", [1, 0, 0, 0, 1, 0, 0, 0, 1])
+    sidebar.sync_ui()
+    assert [sidebar.sensor_combo.itemText(i) for i in range(sidebar.sensor_combo.count())] == ["None", "New Rig"]


### PR DESCRIPTION
## Summary

Implements the sensor-calibration idea from #561 (thanks @seanharding for the proof of concept and @jackw01 for the analysis): single-shot narrowband scans mix channels through the camera CFA's passband overlap — a fixed property of the sensor + light pair, independent of film — so hues drift (yellow→orange) in a way the density-domain Density Mixer can't correct. This adds a per-setup **sensor profile**: a 3×3 unmix calibrated from three bare-light R/G/B exposures, applied to the linear capture before inversion.

## How it works

- **Calibrate once**: Process page → *Sensor Calibration* → pick three bare-light captures (red-only / green-only / blue-only, no film, scan settings). NegPy measures the centre-weighted mean of each, column-stacks the responses, normalizes each column to its own channel (per-capture exposure cancels; white balance stays with normalization) and inverts. Saved as a TOML profile in `NegPy/sensor`, selectable from the new top-level collapsible above Process.
- **Applied** on the linear buffer right after flat-field, before either engine — both preview and the direct-GPU export/display paths (the PoC's `run_pipeline`-only placement missed GPU exports). Folded into the source/decode/dust-detection cache keys, batch analysis, and the export decode-reuse check. Sticky across newly loaded files, like the crosstalk profile.
- **Gated off for RGB-triplet composites**: `assemble_rgb` takes each channel from its own single-band exposure, so triplet frames are crosstalk-free by construction — unmixing them would *inject* inverse crosstalk. New `is_rgb_triplet` helper replaces the three inline predicates and gates every application site.
- Film scanners (Coolscan-style mono CCD + sequential LEDs) have no sensor crosstalk either; their residual colour error is dye crosstalk → Density Mixer. Documented in CAMERA_SCANNING.md.

Internal naming is **sensor** (not the PoC's "scanner") to avoid colliding with the SANE film-scanner subsystem.

## Testing

- `make all` green; full suite 2469 passed
- New unit tests: matrix math (identity / recovery / exposure-invariance / singular), profile TOML IO, config flat-dict roundtrip + tuple coercion, cache-token behaviour, `run_pipeline` triplet/skip-flatfield gating, calibration dialog (compute/save, clip warning, error path), sensor sidebar (bake + bounds invalidation, combo rebuild)
- Headless E2E against the real app: section renders top-level above Process (collapsed by default); selecting a strong test profile changes the render (mean |Δ| 0.27); on an RGB-triplet asset the same profile leaves the render bit-identical (mean |Δ| 0.0)

Closes #561