### PR TITLE
fix(ir): match IR sidecars case-insensitively

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ## 0.42.0
 
-- Fix: **Tool clicks no longer offset by the print border** — heal spots, dodge & burn masks and white-balance picks land where clicked when a border or paper size pads the preview; the crop tool's preview is no longer padded either.
+- New: **Selectable scanner backend** — a Backend dropdown in the Film Scanner panel picks the scan transport; SANE is the only one today, and more slot in through a registry.
 - Change: **Presets UX pass** — presets now live in a visible list (tooltips show contents), and Save, Edit and Apply all use the per-setting picker from copy/paste: a preset stores exactly the settings you tick, and applying shows them again with a choice of current frame, selection or whole roll, laid over existing edits or replacing the look. Per-frame crop, rotation, metadata, dust and masks are never touched; existing preset files keep working.
+- Fix: **Tool clicks no longer offset by the print border** — heal spots, dodge & burn masks and white-balance picks land where clicked when a border or paper size pads the preview; the crop tool's preview is no longer padded either.
+- Fix: **IR sidecars matched case-insensitively** — infrared files named `_ir.tiff` (not just `_IR.tif`) are now detected, so IR dust removal works on scans from more tools.
 
 ## 0.41.0
 

--- a/negpy/infrastructure/loaders/tiff_loader.py
+++ b/negpy/infrastructure/loaders/tiff_loader.py
@@ -23,44 +23,57 @@ def _normalize_ir_to_float32(ir: np.ndarray) -> np.ndarray:
     return np.clip(ir.astype(np.float32), 0.0, 1.0)
 
 
+def _find_sidecar(dirname: str, entries: list[str], stem_lower: str, suffixes: tuple[str, ...]) -> Optional[str]:
+    """First dir entry whose lowercased name == stem_lower + one of `suffixes` (suffixes already lowercase)."""
+    for name in entries:
+        if name.lower() in tuple(stem_lower + s for s in suffixes):
+            return os.path.join(dirname, name)
+    return None
+
+
 def _read_sidecar_ir(file_path: str) -> Tuple[Optional[np.ndarray], Optional[np.ndarray]]:
-    """Read an IR sidecar and its optional validity mask fail-closed."""
+    """Read an IR sidecar and its optional validity mask fail-closed. Case-insensitive on the
+    _ir token and the .tif/.tiff extension so scanner tools that emit lowercase names are picked up."""
     base, _ = os.path.splitext(file_path)
-    for ext in ("_IR.tif", "_IR.tiff"):
-        candidate = base + ext
-        if os.path.exists(candidate):
-            try:
-                arr = tifffile.imread(candidate)
-                ir = _normalize_ir_to_float32(np.asarray(arr))
-            except Exception as e:
-                logger.warning(f"Failed to read IR sidecar {candidate}: {e}")
-                continue
-            mask_candidate = next(
-                (base + mask_ext for mask_ext in ("_IR_VALID.tif", "_IR_VALID.tiff") if os.path.exists(base + mask_ext)),
-                None,
-            )
-            if mask_candidate is None:
-                return ir, None
-            try:
-                valid = np.asarray(tifffile.imread(mask_candidate))
-                if valid.shape != ir.shape:
-                    raise ValueError(f"mask shape {valid.shape} does not match IR shape {ir.shape}")
-                if valid.dtype not in (np.dtype(np.bool_), np.dtype(np.uint8)):
-                    raise ValueError(f"mask dtype {valid.dtype} is not bool or uint8")
-                if valid.dtype == np.uint8:
-                    rows_per_chunk = max(1, (1 << 20) // max(1, valid.shape[1]))
-                    for start in range(0, valid.shape[0], rows_per_chunk):
-                        chunk = valid[start : start + rows_per_chunk]
-                        if not np.all((chunk == 0) | (chunk == 1) | (chunk == 255)):
-                            raise ValueError("uint8 mask values must be 0, 1, or 255")
-                valid = valid.astype(np.bool_, copy=False)
-                ir = ir.copy()
-                ir[~valid] = 1.0
-                return ir, valid
-            except Exception as e:
-                logger.warning(f"Failed to read IR validity mask {mask_candidate}; ignoring IR sidecar {candidate}: {e}")
-                return None, None
-    return None, None
+    dirname = os.path.dirname(file_path) or "."
+    stem_lower = os.path.basename(base).lower()
+    try:
+        entries = os.listdir(dirname)
+    except OSError:
+        return None, None
+
+    candidate = _find_sidecar(dirname, entries, stem_lower, ("_ir.tif", "_ir.tiff"))
+    if candidate is None:
+        return None, None
+    try:
+        arr = tifffile.imread(candidate)
+        ir = _normalize_ir_to_float32(np.asarray(arr))
+    except Exception as e:
+        logger.warning(f"Failed to read IR sidecar {candidate}: {e}")
+        return None, None
+
+    mask_candidate = _find_sidecar(dirname, entries, stem_lower, ("_ir_valid.tif", "_ir_valid.tiff"))
+    if mask_candidate is None:
+        return ir, None
+    try:
+        valid = np.asarray(tifffile.imread(mask_candidate))
+        if valid.shape != ir.shape:
+            raise ValueError(f"mask shape {valid.shape} does not match IR shape {ir.shape}")
+        if valid.dtype not in (np.dtype(np.bool_), np.dtype(np.uint8)):
+            raise ValueError(f"mask dtype {valid.dtype} is not bool or uint8")
+        if valid.dtype == np.uint8:
+            rows_per_chunk = max(1, (1 << 20) // max(1, valid.shape[1]))
+            for start in range(0, valid.shape[0], rows_per_chunk):
+                chunk = valid[start : start + rows_per_chunk]
+                if not np.all((chunk == 0) | (chunk == 1) | (chunk == 255)):
+                    raise ValueError("uint8 mask values must be 0, 1, or 255")
+        valid = valid.astype(np.bool_, copy=False)
+        ir = ir.copy()
+        ir[~valid] = 1.0
+        return ir, valid
+    except Exception as e:
+        logger.warning(f"Failed to read IR validity mask {mask_candidate}; ignoring IR sidecar {candidate}: {e}")
+        return None, None
 
 
 def _read_ir_from_extra_page(file_path: str, main_h: int, main_w: int) -> Optional[np.ndarray]:

--- a/tests/test_tiff_loader_ir_validity.py
+++ b/tests/test_tiff_loader_ir_validity.py
@@ -52,6 +52,39 @@ def test_ir_sidecar_without_validity_mask_preserves_existing_behavior(tmp_path) 
     assert metadata["ir"][0, 0] == np.float32(50000.0 / 65535.0)
 
 
+def test_lowercase_ir_sidecar_is_detected(tmp_path) -> None:
+    """Scanner tools (nkscan) emit lowercase `_ir.tiff`; the loader must still pair it."""
+    ir = np.full((5, 7), 50000, dtype=np.uint16)
+    ir[1, 2] = 0
+    rgb_path = tmp_path / "frame.tif"
+    tifffile.imwrite(rgb_path, np.full((*ir.shape, 3), 30000, dtype=np.uint16), photometric="rgb")
+    tifffile.imwrite(tmp_path / "frame_ir.tiff", ir, photometric="minisblack")
+
+    _context, metadata = TiffLoader().load(str(rgb_path))
+
+    assert metadata["ir"] is not None
+    assert metadata["ir_valid_mask"] is None
+    assert metadata["ir"][1, 2] == 0.0
+    assert metadata["ir"][0, 0] == np.float32(50000.0 / 65535.0)
+
+
+def test_lowercase_ir_valid_mask_pairs_with_lowercase_sidecar(tmp_path) -> None:
+    ir = np.full((6, 8), 32768, dtype=np.uint16)
+    ir[2, 3] = 0
+    valid = np.ones(ir.shape, dtype=np.uint8) * 255
+    valid[2, 3] = 0
+    rgb_path = tmp_path / "frame.tif"
+    tifffile.imwrite(rgb_path, np.full((*ir.shape, 3), 30000, dtype=np.uint16), photometric="rgb")
+    tifffile.imwrite(tmp_path / "frame_ir.tiff", ir, photometric="minisblack")
+    tifffile.imwrite(tmp_path / "frame_ir_valid.tiff", valid, photometric="minisblack")
+
+    _context, metadata = TiffLoader().load(str(rgb_path))
+
+    assert metadata["ir_valid_mask"].dtype == np.bool_
+    np.testing.assert_array_equal(metadata["ir_valid_mask"], valid.astype(bool))
+    assert metadata["ir"][2, 3] == 1.0
+
+
 @pytest.mark.parametrize("failure", ("mismatched", "malformed"))
 def test_invalid_validity_mask_ignores_ir_sidecar_fail_closed(
     tmp_path,


### PR DESCRIPTION
## What

The TIFF loader matched IR sidecars only as uppercase `_IR.tif` / `_IR.tiff` via case-sensitive `os.path.exists`. External scan tools (e.g. `nkscan`) write lowercase `_ir.tiff`, so those sidecars were **silently dropped** — `metadata["ir"]` stayed `None`, `has_ir` was `False`, and the **IR Removal** toggle stayed greyed out with no log or error.

## Change

`_read_sidecar_ir` (`negpy/infrastructure/loaders/tiff_loader.py`) now lists the directory once and matches the IR sidecar and its `_IR_VALID` mask by lowercased name, so `_ir`/`_IR` and `.tif`/`.tiff`/`.TIF` all pair. Fail-closed mask validation is unchanged.

## Tests

Added two regression tests to `tests/test_tiff_loader_ir_validity.py` (lowercase `_ir.tiff` detected; lowercase `_ir_valid.tiff` pairs). Existing uppercase tests stay green. `make all` passes.

Changelog entry added under 0.42.0.