### PR TITLE
Camera scanning: surface a dropped live-view session instead of hanging, and reject an invalid output folder

### DIFF
--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -223,6 +223,7 @@ class AppController(QObject):
     capture_progress = pyqtSignal(float)
     capture_channel = pyqtSignal(str)  # "R"/"G"/"B" as each triplet channel starts
     capture_camera_setting_applied = pyqtSignal(str)  # a set_camera_setting call ran to completion
+    capture_live_view_failed = pyqtSignal(str)  # preview thread died after retries; session dropped
     capture_finished = pyqtSignal(list)
     capture_cancelled = pyqtSignal()
     capture_error = pyqtSignal(str)
@@ -516,6 +517,7 @@ class AppController(QObject):
         self.capture_worker.progress.connect(self.capture_progress.emit)
         self.capture_worker.channel.connect(self.capture_channel.emit)
         self.capture_worker.camera_setting_applied.connect(self.capture_camera_setting_applied.emit)
+        self.capture_worker.live_view_failed.connect(self.capture_live_view_failed.emit)
         self.capture_worker.finished.connect(self._on_capture_finished)
         self.capture_worker.cancelled.connect(self.capture_cancelled.emit)
         self.capture_worker.error.connect(self.capture_error.emit)

--- a/negpy/desktop/view/sidebar/scanlight.py
+++ b/negpy/desktop/view/sidebar/scanlight.py
@@ -395,6 +395,8 @@ class ScanlightSidebar(QWidget):
         self.preset_new_btn.clicked.connect(self._on_preset_new)
         self.preset_save_btn.clicked.connect(self._on_preset_save)
         self.preset_del_btn.clicked.connect(self._on_preset_delete)
+        # Typing an invalid path greys Scan immediately (with the reason), not on the next click.
+        self.folder_edit.editingFinished.connect(self._apply_gating)
         for w in (self.roll_edit, self.folder_edit):
             w.editingFinished.connect(self._update_settings_from_ui)
 
@@ -402,6 +404,7 @@ class ScanlightSidebar(QWidget):
         self.controller.capture_progress.connect(self._on_progress)
         self.controller.capture_channel.connect(self._on_channel)
         self.controller.capture_camera_setting_applied.connect(self._on_camera_setting_applied)
+        self.controller.capture_live_view_failed.connect(self._on_live_view_failed)
         self.controller.capture_finished.connect(self._on_finished)
         self.controller.capture_cancelled.connect(self._on_cancelled)
         self.controller.capture_error.connect(self._on_error)
@@ -975,6 +978,29 @@ class ScanlightSidebar(QWidget):
         if self.lv_btn.isChecked():
             self._push_light()
 
+    @pyqtSlot(str)
+    def _on_live_view_failed(self, reason: str) -> None:
+        """The preview thread died after its retries and the session was dropped (issue #617:
+        the GFX50S II times out with [-110] three times) — without this, whichever pop-up was
+        streaming spins on "loading live view" forever. Covers the scan window and the idle
+        calibration window (which streams for crosshair placement before a run and as the
+        exposure-abort retry surface); a death during a *running* calibration is left to that
+        run's own capture error. Both pop-ups close and the same pinned panel warning names
+        the reason — reopening is the retry."""
+        if self._calibrating_preset:
+            return
+        if self.lv_btn.isChecked():
+            self.lv_btn.setChecked(False)  # full teardown via _on_live_view_toggled(False)
+        elif self.calib_window.isVisible():
+            self.calib_window.close()  # its closed-handler stops the calib stream + routes the session
+        else:
+            return
+        self._set_status(
+            f"⚠ Live view failed — the camera stopped answering ({reason}). "
+            "Reconnect or power-cycle the camera, then start Live View again.",
+            pinned=True,
+        )
+
     def _stop_calibration_live_view(self) -> None:
         """Tear down the live view a calibration captured inside (Step-1-style, no reconnect)
         once it's done or failed — restores the pre-migration state: LV off, re-enable Scan to
@@ -1229,6 +1255,13 @@ class ScanlightSidebar(QWidget):
             output_folder = self.folder_edit.text().strip()
             if not output_folder:
                 return
+        if not (os.path.isabs(output_folder) and os.path.isdir(output_folder)):
+            # Belt for a folder that vanished after gating last ran (ejected drive) or was
+            # typed invalid: without this, makedirs resolves it against the app's working
+            # directory and the scan lands somewhere the operator will never look.
+            self._set_status(f"Output folder does not exist: {output_folder}")
+            self._apply_gating()  # greys Scan and repeats the reason in the gate hint
+            return
 
         roll = self._capture_roll_name()
         if roll is None:
@@ -1455,8 +1488,14 @@ class ScanlightSidebar(QWidget):
                 m.append("connect the Scanlight")
             if not self._preset_selected():
                 m.append("select or create a preset")
-        if not self.folder_edit.text().strip():
+        folder = self.folder_edit.text().strip()
+        if not folder:
             m.append("choose an output folder")
+        elif not (os.path.isabs(folder) and os.path.isdir(folder)):
+            # A typed or stale path (ejected drive, a literal "~", relative text) must not
+            # gate through: the capture's makedirs would silently create it relative to the
+            # app's working directory and the scans would "vanish" with no error shown.
+            m.append("choose a valid output folder (the current one does not exist)")
         return m
 
     def _apply_gating(self) -> None:

--- a/negpy/desktop/workers/capture_worker.py
+++ b/negpy/desktop/workers/capture_worker.py
@@ -82,6 +82,9 @@ class CaptureWorker(QObject):
     error = pyqtSignal(str)
     status = pyqtSignal(str)
     live_view_started = pyqtSignal(str)  # jpeg path being refreshed
+    #: The preview thread died after its retries and the session was dropped (issue #617) —
+    #: carries the last gphoto error, so the UI can stop the spinner and offer a retry.
+    live_view_failed = pyqtSignal(str)
     calibration_progress = pyqtSignal(float, str)
     calibration_finished = pyqtSignal(object)  # CalibrationResult
     calibration_exposure = pyqtSignal(str)  # "over"/"under" — target unreachable, run aborted, no preset
@@ -114,7 +117,9 @@ class CaptureWorker(QObject):
         probe (a probe IS a claim, and would steal the body mid-live-view), so open attempts
         are the verdict's only eyes."""
         if self._camera is None:
-            self._camera = GphotoCamera()
+            # The callback runs on the camera's own preview thread; the signal hop is what
+            # moves the report onto the Qt side.
+            self._camera = GphotoCamera(on_preview_died=self.live_view_failed.emit)
         if not self._camera.is_open():
             try:
                 self._camera.open()

--- a/negpy/infrastructure/capture/gphoto.py
+++ b/negpy/infrastructure/capture/gphoto.py
@@ -31,7 +31,7 @@ import tempfile
 import threading
 import time
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
 from negpy.infrastructure.loaders.constants import (
     SUPPORTED_JPEG_EXTENSIONS,
@@ -211,10 +211,15 @@ class GphotoCamera:
         jpeg_path: Optional[str] = None,
         settings_path: Optional[str] = None,
         gp_module: Optional[Any] = None,
+        on_preview_died: Optional[Callable[[str], None]] = None,
     ) -> None:
         self._gp = gp_module or _gp()
         self._jpeg_path = jpeg_path or default_jpeg_path()
         self._settings_path = settings_path or default_settings_path()
+        # Called (from the preview thread) when the stream dies after retries — NOT on a
+        # normal stop(). Without it a body that stops answering (issue #617: GFX50S II
+        # times out with [-110]) leaves the UI spinning on "loading live view" forever.
+        self._on_preview_died = on_preview_died
         self._camera: Any = None
         self._model = ""
         # Cleared when the body stops answering — unplugging it leaves the handle behind,
@@ -692,6 +697,11 @@ class GphotoCamera:
                     # close() from here, it would join this very thread.
                     logger.warning("gphoto2: camera stopped answering, dropping the session")
                     self._alive = False
+                    if self._on_preview_died is not None:
+                        try:
+                            self._on_preview_died(str(exc))
+                        except Exception:  # noqa: BLE001 — the report must not break teardown
+                            logger.exception("preview-died callback failed")
                     return
                 self._stop.wait(0.5)
                 continue

--- a/tests/test_capture_gphoto.py
+++ b/tests/test_capture_gphoto.py
@@ -545,7 +545,13 @@ def test_unplugged_camera_stops_reporting_itself_open(fake, tmp_path):
     """A handle left behind by a vanished body must not keep claiming to be open."""
     import time
 
-    camera = GphotoCamera(gp_module=fake, jpeg_path=str(tmp_path / "lv.jpg"), settings_path=str(tmp_path / "lv.json"))
+    deaths: list[str] = []
+    camera = GphotoCamera(
+        gp_module=fake,
+        jpeg_path=str(tmp_path / "lv.jpg"),
+        settings_path=str(tmp_path / "lv.json"),
+        on_preview_died=deaths.append,
+    )
     camera.start()
     assert camera.is_open()
 
@@ -557,6 +563,7 @@ def test_unplugged_camera_stops_reporting_itself_open(fake, tmp_path):
     else:
         raise AssertionError("the session still reports itself open")
     assert not camera.is_running()  # the preview thread gave up rather than spinning forever
+    assert len(deaths) == 1  # the death was reported, not swallowed (issue #617's silent hang)
     camera.close()
 
 


### PR DESCRIPTION
Two independent camera-scanning robustness fixes. The first is part of #617 (its Bug 1); the other two bugs in that report are addressed in a comment there rather than here.

## Live view: a dropped session is now visible and retryable (part of #617)

The preview thread already handled a body that stops answering: it retries three times, gives up, and marks the session dead so nothing reuses a stale handle. What was missing was any path back to the UI, so the pop-up kept spinning on "loading live view" with no error and no way out short of restarting the app. On a Fujifilm GFX50S II this reproduces every time, as reported in #617 with three consecutive `[-110] I/O in progress` timeouts.

`GphotoCamera` now takes an `on_preview_died` callback, invoked from the preview thread only when the stream dies after its retries, never on a normal `stop()`. The capture worker passes its own signal emit as that callback, so the report crosses onto the Qt thread as `live_view_failed`. The scanlight sidebar closes whichever pop-up was streaming, the scan window or the calibration window, and pins one panel warning naming the underlying error plus a reconnect hint. Reopening the window is the retry. A death during a running calibration is left alone, since that run's own capture error already reports it.

This does not address why the GFX50S II times out in the first place, which is a libgphoto2-level question I cannot reproduce without the hardware. It turns an unrecoverable hang into a visible, recoverable state. Verified on a Sony a7C II by pulling the USB cable mid-stream, which takes the identical retry-then-drop path, and covered by a unit test on the fake gphoto module.

## Invalid output folder no longer swallows a scan

Typing a path that does not exist (a stale folder, an ejected drive, a literal `~`, or anything relative) passed the gate, and the capture's `makedirs` then created it relative to the application's working directory. The scan succeeded, reported success, and the files landed somewhere the operator would never look.

The gate now requires an absolute, existing directory and says so when it is not, re-checked as soon as the field is edited rather than on the next click. The capture start re-checks it too, which catches a folder that disappeared after the gate last ran, and reports it instead of writing.

`make all` is green with and without the optional camera group.