### PR TITLE
Fix: make thumbnails render correctly for rgb triplets

### DIFF
--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -64,6 +64,8 @@ from negpy.features.geometry.models import FINE_ROTATION_LIMIT, AutocropMode
 from negpy.features.lab.models import LabConfig
 from negpy.features.local.models import LocalAdjustmentsConfig
 from negpy.features.process.models import ProcessConfig, ProcessMode, invalidate_local_bounds
+from negpy.features.rgbscan.models import is_rgb_triplet
+from negpy.services.assets.thumbnails import thumbnail_cache_key
 from negpy.kernel.system.paths import get_resource_path
 from negpy.features.retouch.logic import fallback_source_offset, select_source_offset
 from negpy.features.retouch.models import HEAL_SIZE_REF, RetouchConfig
@@ -466,6 +468,7 @@ class AppController(QObject):
         self.thumb_worker.progress.connect(self._on_thumbnail_progress)
         self.thumbnail_update_requested.connect(self.thumb_worker.update_rendered)
         self.thumb_worker.finished.connect(self._on_thumbnails_finished)
+        self.thumb_worker.rendered_finished.connect(self._on_rendered_thumbnail)
         self.thumb_worker.error.connect(self._on_render_error)
         self.thumb_worker.error.connect(self._on_thumbnail_batch_error)
 
@@ -559,17 +562,19 @@ class AppController(QObject):
         self.status_progress_requested.emit(current, total)
         self.batch_progress.emit(current, total, name)
 
+    def _set_thumbnail(self, name: str, pil_img: Any) -> None:
+        u8_arr = np.array(pil_img.convert("RGB"))
+        self.state.thumbnails[name] = QIcon(QPixmap.fromImage(ImageConverter.to_qimage(u8_arr)))
+
     def _on_thumbnails_finished(self, new_thumbs: Dict[str, Any]) -> None:
         self.status_progress_requested.emit(0, 0)
         self._end_batch("thumbnails")
         for name, pil_img in new_thumbs.items():
-            if pil_img:
-                u8_arr = np.array(pil_img.convert("RGB"))
-                self.state.thumbnails[name] = QIcon(QPixmap.fromImage(ImageConverter.to_qimage(u8_arr)))
+            # A frame that already rendered on the canvas has the correct (inverted)
+            # thumbnail; don't let this batch overwrite it with the source-decode placeholder.
+            if pil_img and name not in self.state.rendered_thumbnails:
+                self._set_thumbnail(name, pil_img)
 
-        # Consume the request list: update_rendered() re-emits this same signal with
-        # single-file dicts after every settled render, and evaluating those against
-        # a stale batch list would falsely badge every other frame.
         requested = getattr(self, "_thumb_requested", [])
         self._thumb_requested = []
         failed = {n for n in requested if not new_thumbs.get(n)}
@@ -578,6 +583,14 @@ class AppController(QObject):
                 f.setdefault("decode_failed", _THUMB_FAILED_MSG)
             elif f["name"] in new_thumbs and f.get("decode_failed") == _THUMB_FAILED_MSG:
                 del f["decode_failed"]
+        self.session.asset_model.refresh()
+
+    def _on_rendered_thumbnail(self, new_thumbs: Dict[str, Any]) -> None:
+        """A canvas render produced a thumbnail — it supersedes any batch placeholder."""
+        for name, pil_img in new_thumbs.items():
+            if pil_img:
+                self._set_thumbnail(name, pil_img)
+                self.state.rendered_thumbnails.add(name)
         self.session.asset_model.refresh()
 
     # --- Batch progress popup -------------------------------------------------
@@ -806,6 +819,7 @@ class AppController(QObject):
             # Re-run over already-loaded files (e.g. RGB-scan toggle): rebuild the list
             # so dedup-by-hash doesn't drop a regrouped red, then reselect the active frame.
             self.session.state.uploaded_files.clear()
+            self.session.state.rendered_thumbnails.clear()
             self.session.add_files([], validated_info=valid_assets)
             self.generate_missing_thumbnails()
             idx = next(
@@ -2170,6 +2184,7 @@ class AppController(QObject):
         paths = [asset["path"], *parts]
         self.state.uploaded_files.pop(idx)
         self.session.state.thumbnails.pop(asset["name"], None)
+        self.session.state.rendered_thumbnails.discard(asset["name"])
         self.session.asset_model.refresh()
         self._pending_scanned_file = paths[0]
         self.request_asset_discovery(paths)
@@ -3164,6 +3179,15 @@ class AppController(QObject):
     def _update_thumbnail_from_state(self, force_readback: bool = False, persist: bool = True) -> None:
         if not self.state.current_file_path or not self.state.current_file_hash:
             return
+        idx = self.state.selected_file_idx
+        if not (0 <= idx < len(self.state.uploaded_files)):
+            return
+        # The filmstrip keys state.thumbnails by the asset's display name, which for an
+        # RGB-scan triplet is "<base> (RGB)" — NOT basename(current_file_path), which is
+        # the underlying red exposure's filename. Keying by the wrong name silently
+        # orphans every triplet's rendered thumbnail under a key nothing ever reads.
+        asset_name = self.state.uploaded_files[idx]["name"]
+
         with self.state.metrics_lock:
             metrics = dict(self.state.last_metrics)
         buffer = metrics.get("base_positive")
@@ -3174,7 +3198,7 @@ class AppController(QObject):
             logger.info(
                 "thumb-refresh readback %.1fms %s",
                 (time.perf_counter() - t0) * 1000,
-                os.path.basename(self.state.current_file_path),
+                asset_name,
             )
 
         if buffer is not None and not isinstance(buffer, np.ndarray):
@@ -3185,10 +3209,13 @@ class AppController(QObject):
         # Same transform the canvas used for this buffer, so the filmstrip and the
         # canvas can't disagree about the frame's colour.
         display_cs, monitor_bytes = self.display_transform_params(splash=bool(metrics.get("splash")))
+        # Cache under the triplet-namespaced key so the batch (source) path re-serves this
+        # rendered positive instead of the uninverted source merge it decodes itself.
+        cache_key = thumbnail_cache_key(self.state.current_file_hash, is_rgb_triplet(self.state.config.rgbscan))
         self.thumbnail_update_requested.emit(
             ThumbnailUpdateTask(
-                filename=os.path.basename(self.state.current_file_path),
-                file_hash=self.state.current_file_hash,
+                filename=asset_name,
+                file_hash=cache_key,
                 buffer=buffer,
                 color_space=display_cs,
                 monitor_icc_bytes=monitor_bytes,

--- a/negpy/desktop/session.py
+++ b/negpy/desktop/session.py
@@ -3,7 +3,7 @@ import re
 import threading
 from dataclasses import dataclass, field, replace
 from enum import Enum, auto
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Set
 
 from PyQt6.QtCore import QAbstractListModel, QModelIndex, QObject, Qt, pyqtSignal
 
@@ -48,6 +48,9 @@ class AppState:
     wb_pick_region: int = 0
     uploaded_files: List[Dict[str, Any]] = field(default_factory=list)
     thumbnails: Dict[str, Any] = field(default_factory=dict)  # filename -> QIcon/QPixmap
+    # Names whose thumbnail came from a canvas render (correct, inverted); the batch
+    # generator must not overwrite these with its cheaper source-decode placeholder.
+    rendered_thumbnails: Set[str] = field(default_factory=set)
     source_exif: Dict[str, Any] = field(default_factory=dict)  # file_hash -> piexif dict
     selected_file_idx: int = -1
     selected_indices: List[int] = field(default_factory=list)
@@ -1115,6 +1118,7 @@ class DesktopSessionManager(QObject):
                 if same_path_idx is not None:
                     old = self.state.uploaded_files[same_path_idx]
                     self.state.thumbnails.pop(old["name"], None)
+                    self.state.rendered_thumbnails.discard(old["name"])
                     self.state.uploaded_files[same_path_idx] = info
                     continue
                 if any(f["hash"] == info["hash"] for f in self.state.uploaded_files):
@@ -1159,6 +1163,7 @@ class DesktopSessionManager(QObject):
         for i in reversed(valid):
             removed = self.state.uploaded_files.pop(i)
             self.state.thumbnails.pop(removed["name"], None)
+            self.state.rendered_thumbnails.discard(removed["name"])
         marks = self.repo.load_file_marks()
         m = marks.get(composite["hash"])
         composite = {**composite, "keeper": m == "keeper", "excluded": m == "excluded"}
@@ -1212,6 +1217,7 @@ class DesktopSessionManager(QObject):
         """
         self.state.uploaded_files.clear()
         self.state.thumbnails.clear()
+        self.state.rendered_thumbnails.clear()
         self._reset_active_image_state()
 
         self.asset_model.refresh()
@@ -1226,6 +1232,7 @@ class DesktopSessionManager(QObject):
         if 0 <= idx < len(self.state.uploaded_files):
             file_info = self.state.uploaded_files.pop(idx)
             self.state.thumbnails.pop(file_info["name"], None)
+            self.state.rendered_thumbnails.discard(file_info["name"])
 
             if not self.state.uploaded_files:
                 self._reset_active_image_state()
@@ -1249,6 +1256,7 @@ class DesktopSessionManager(QObject):
             if 0 <= idx < len(self.state.uploaded_files):
                 file_info = self.state.uploaded_files.pop(idx)
                 self.state.thumbnails.pop(file_info["name"], None)
+                self.state.rendered_thumbnails.discard(file_info["name"])
 
         if not self.state.uploaded_files:
             self._reset_active_image_state()

--- a/negpy/desktop/workers/render.py
+++ b/negpy/desktop/workers/render.py
@@ -234,6 +234,9 @@ class ThumbnailWorker(QObject):
 
     progress = pyqtSignal(int, int, str)
     finished = pyqtSignal(dict)
+    # Rendered positives use their own signal so the batch's bulk overwrite can't
+    # clobber a frame that already rendered on the canvas.
+    rendered_finished = pyqtSignal(dict)
     error = pyqtSignal(str)
 
     def __init__(self, asset_store) -> None:
@@ -285,7 +288,7 @@ class ThumbnailWorker(QObject):
                 monitor_icc_bytes=task.monitor_icc_bytes,
             )
             if thumb:
-                self.finished.emit({task.filename: thumb})
+                self.rendered_finished.emit({task.filename: thumb})
         except Exception as e:
             logger.error(f"Thumbnail update failure: {e}")
 

--- a/negpy/services/assets/thumbnails.py
+++ b/negpy/services/assets/thumbnails.py
@@ -34,6 +34,8 @@ async def generate_batch_thumbnails(
                 asset_store,
                 int(f_info.get("half") or 0),
                 float(f_info.get("split_x") or 0.5),
+                f_info.get("green_path") or "",
+                f_info.get("blue_path") or "",
             )
             completed += 1
             if progress_callback:
@@ -49,8 +51,54 @@ async def generate_batch_thumbnails(
     return {name: thumb for name, thumb in results if isinstance(thumb, Image.Image)}
 
 
-def decode_source_image(file_path: str) -> Optional[Image.Image]:
-    """Small EXIF-oriented preview of a source file (embedded thumb, else fast decode)."""
+def _fast_demosaic(raw: Any) -> np.ndarray:
+    """Fast half-size linear demosaic used for preview thumbnails."""
+    return ensure_rgb(
+        raw.postprocess(
+            use_camera_wb=True,
+            user_wb=None,
+            half_size=True,
+            no_auto_bright=True,
+            bright=1.0,
+            demosaic_algorithm=rawpy.DemosaicAlgorithm.LINEAR,
+            user_flip=0,
+        )
+    )
+
+
+def _decode_triplet_preview(red_path: str, green_path: str, blue_path: str) -> Optional[Image.Image]:
+    """Merge an RGB-scan triplet's three narrowband exposures into one preview.
+
+    The red file's embedded thumbnail (and a lone decode of it) shows only the red
+    channel, so the filmstrip would disagree with the canvas. Alignment is skipped:
+    it's imperceptible at thumbnail scale and avoids a phase-correlation pass per file."""
+    from negpy.features.rgbscan.logic import assemble_rgb
+
+    def _decode(path: str) -> Tuple[np.ndarray, Dict[str, Any]]:
+        ctx_mgr, metadata = loader_factory.get_loader(path)
+        with ctx_mgr as raw:
+            return _fast_demosaic(raw), metadata
+
+    r, red_meta = _decode(red_path)
+    g, _ = _decode(green_path)
+    b, _ = _decode(blue_path)
+    merged = assemble_rgb(r, g, b, align=False)
+
+    img = Image.fromarray(merged)
+    orientation = red_meta.get("orientation", 1)
+    if orientation and orientation != 1:
+        img = Image.fromarray(apply_exif_orientation(np.asarray(img), orientation))
+    return img
+
+
+def decode_source_image(file_path: str, green_path: str = "", blue_path: str = "") -> Optional[Image.Image]:
+    """Small EXIF-oriented preview of a source file (embedded thumb, else fast decode).
+
+    An RGB-scan triplet (green_path/blue_path given) is merged from its three
+    exposures so the thumbnail matches the canvas rather than showing red only."""
+    if green_path and blue_path:
+        return _decode_triplet_preview(file_path, green_path, blue_path)
+
     ctx_mgr, metadata = loader_factory.get_loader(file_path)
     with ctx_mgr as raw:
         img: Optional[Image.Image] = None
@@ -68,19 +116,7 @@ def decode_source_image(file_path: str) -> Optional[Image.Image]:
                 pass
 
         if img is None:
-            algo = rawpy.DemosaicAlgorithm.LINEAR
-
-            rgb = raw.postprocess(
-                use_camera_wb=True,
-                user_wb=None,
-                half_size=True,
-                no_auto_bright=True,
-                bright=1.0,
-                demosaic_algorithm=algo,
-                user_flip=0,
-            )
-            rgb = ensure_rgb(rgb)
-            img = Image.fromarray(rgb)
+            img = Image.fromarray(_fast_demosaic(raw))
 
         orientation = metadata.get("orientation", 1)
         if orientation and orientation != 1:
@@ -90,19 +126,29 @@ def decode_source_image(file_path: str) -> Optional[Image.Image]:
 
 
 def get_thumbnail_worker(
-    file_path: str, file_hash: str, asset_store: Any = None, half: int = 0, split_x: float = 0.5
+    file_path: str,
+    file_hash: str,
+    asset_store: Any = None,
+    half: int = 0,
+    split_x: float = 0.5,
+    green_path: str = "",
+    blue_path: str = "",
 ) -> Optional[Image.Image]:
     """
     Checks cache -> extracts/renders -> resize.
     """
     try:
+        # A triplet's red exposure shares its hash with the same file scanned plain,
+        # so namespace the merged thumbnail's cache key — otherwise a red-only entry
+        # cached before this fix would be served forever.
+        cache_key = f"{file_hash}-rgb" if green_path and blue_path else file_hash
         if asset_store:
-            cached = asset_store.get_thumbnail(file_hash)
+            cached = asset_store.get_thumbnail(cache_key)
             if isinstance(cached, Image.Image):
                 return cached
 
         ts = APP_CONFIG.thumbnail_size
-        img = decode_source_image(file_path)
+        img = decode_source_image(file_path, green_path, blue_path)
         if img is None:
             return None
 
@@ -114,7 +160,7 @@ def get_thumbnail_worker(
         square_img: Image.Image = prepare_thumbnail(img, ts)
 
         if asset_store:
-            asset_store.save_thumbnail(file_hash, square_img)
+            asset_store.save_thumbnail(cache_key, square_img)
 
         return square_img
     except Exception as e:

--- a/negpy/services/assets/thumbnails.py
+++ b/negpy/services/assets/thumbnails.py
@@ -51,6 +51,16 @@ async def generate_batch_thumbnails(
     return {name: thumb for name, thumb in results if isinstance(thumb, Image.Image)}
 
 
+def thumbnail_cache_key(file_hash: str, is_triplet: bool) -> str:
+    """Disk cache key for a frame's thumbnail.
+
+    A triplet caches under a distinct key so (a) a red-only thumbnail cached before
+    merge support can't shadow the corrected one, and (b) the batch (source) path and
+    the rendered-positive path agree on where the triplet's thumbnail lives — the
+    rendered positive is what makes the filmstrip match the canvas."""
+    return f"{file_hash}-rgb" if is_triplet else file_hash
+
+
 def _fast_demosaic(raw: Any) -> np.ndarray:
     """Fast half-size linear demosaic used for preview thumbnails."""
     return ensure_rgb(
@@ -138,10 +148,7 @@ def get_thumbnail_worker(
     Checks cache -> extracts/renders -> resize.
     """
     try:
-        # A triplet's red exposure shares its hash with the same file scanned plain,
-        # so namespace the merged thumbnail's cache key — otherwise a red-only entry
-        # cached before this fix would be served forever.
-        cache_key = f"{file_hash}-rgb" if green_path and blue_path else file_hash
+        cache_key = thumbnail_cache_key(file_hash, bool(green_path and blue_path))
         if asset_store:
             cached = asset_store.get_thumbnail(cache_key)
             if isinstance(cached, Image.Image):

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -122,10 +122,59 @@ class TestAppController(unittest.TestCase):
         self.controller._on_thumbnails_finished({"a.dng": img, "b.dng": img})
         self.assertNotIn("decode_failed", state.uploaded_files[0])
 
-        # update_rendered() re-emits finished with a single-file dict after every
-        # settled render — it must not badge the frames absent from that dict.
+        # A second, narrower batch result must not badge frames absent from it.
         self.controller._on_thumbnails_finished({"a.dng": img})
         self.assertNotIn("decode_failed", state.uploaded_files[1])
+
+    def test_batch_thumbnail_does_not_clobber_rendered(self):
+        """A frame that already rendered on the canvas keeps its (correct, inverted)
+        thumbnail even if the slower batch decode finishes afterward."""
+        from PIL import Image
+
+        self.mock_session_manager.asset_model = MagicMock()
+        state = self.mock_session_manager.state
+        state.uploaded_files = [{"name": "a.dng", "path": "/tmp/a.dng", "hash": "h1"}]
+        self.controller._thumb_requested = ["a.dng"]
+
+        rendered = Image.new("RGB", (4, 4), (255, 0, 0))
+        placeholder = Image.new("RGB", (4, 4), (0, 255, 0))
+        self.controller._on_rendered_thumbnail({"a.dng": rendered})
+        self.controller._on_thumbnails_finished({"a.dng": placeholder})
+
+        self.assertEqual(state.thumbnails["a.dng"].pixmap(4, 4).toImage().pixelColor(0, 0).red(), 255)
+
+    def test_rendered_thumbnail_keys_by_asset_name_not_file_basename(self):
+        """An RGB-scan triplet's asset name ("<base> (RGB)") differs from the underlying
+        red exposure's filename — the rendered-thumbnail task must key by the former,
+        since that's what the filmstrip (AssetListModel) looks up. Keying by the raw
+        basename orphans the thumbnail under a name nothing ever reads (issue #575)."""
+        import numpy as np
+        from negpy.features.rgbscan.models import RgbScanConfig
+        from dataclasses import replace as dc_replace
+
+        state = self.mock_session_manager.state
+        state.uploaded_files = [
+            {
+                "name": "_DSC1316 (RGB)",
+                "path": "/tmp/_DSC1316.NEF",
+                "hash": "h1",
+                "green_path": "/tmp/_DSC1317.NEF",
+                "blue_path": "/tmp/_DSC1318.NEF",
+            }
+        ]
+        state.selected_file_idx = 0
+        state.current_file_path = "/tmp/_DSC1316.NEF"
+        state.current_file_hash = "h1"
+        state.config = dc_replace(
+            state.config, rgbscan=RgbScanConfig(enabled=True, green_path="/tmp/_DSC1317.NEF", blue_path="/tmp/_DSC1318.NEF")
+        )
+        state.last_metrics = {"base_positive": np.zeros((2, 2, 3), dtype=np.float32)}
+
+        captured = {}
+        self.controller.thumbnail_update_requested.connect(lambda task: captured.setdefault("task", task))
+        self.controller._update_thumbnail_from_state(persist=False)
+
+        self.assertEqual(captured["task"].filename, "_DSC1316 (RGB)")
 
     def test_capture_worker_cancelled_is_forwarded(self):
         cancelled = MagicMock()
@@ -1663,6 +1712,8 @@ class TestDisplayTransformParams(unittest.TestCase):
 
         self.controller.proof_active = lambda: True
         state = self.controller.state
+        state.uploaded_files = [{"name": "frame.cr2", "path": "/tmp/frame.cr2", "hash": "hash-1"}]
+        state.selected_file_idx = 0
         state.current_file_path = "/tmp/frame.cr2"
         state.current_file_hash = "hash-1"
         state.last_metrics = {"base_positive": np.zeros((4, 4, 3), dtype=np.float32)}

--- a/tests/test_rgbscan.py
+++ b/tests/test_rgbscan.py
@@ -231,3 +231,65 @@ def test_resolve_asset_rgbscan_resets_when_not_triplet():
     leaked = replace(WorkspaceConfig(), rgbscan=RgbScanConfig(enabled=True, green_path="/g", blue_path="/b"))
     out = resolve_asset_rgbscan(leaked, {"path": "/r"})
     assert out.rgbscan == RgbScanConfig()
+
+
+def test_thumbnail_decode_routes_triplet_to_merge(monkeypatch):
+    """With green/blue paths, the thumbnail must merge the triplet, not decode red alone."""
+    from negpy.services.assets import thumbnails
+
+    calls = {}
+    monkeypatch.setattr(thumbnails, "_decode_triplet_preview", lambda r, g, b: calls.setdefault("args", (r, g, b)))
+    thumbnails.decode_source_image("r", "g", "b")
+    assert calls["args"] == ("r", "g", "b")
+
+
+def test_thumbnail_worker_namespaces_triplet_cache(monkeypatch):
+    """A triplet caches under a distinct key so it never collides with the red file scanned plain."""
+    from PIL import Image
+
+    from negpy.services.assets import thumbnails
+
+    saved: dict = {}
+
+    class Store:
+        def get_thumbnail(self, key):
+            return saved.get(key)
+
+        def save_thumbnail(self, key, img):
+            saved[key] = img
+
+    img = Image.new("RGB", (4, 4))
+    monkeypatch.setattr(thumbnails, "decode_source_image", lambda *a, **k: img)
+    monkeypatch.setattr(thumbnails, "prepare_thumbnail", lambda i, ts: i)
+
+    store = Store()
+    thumbnails.get_thumbnail_worker("r", "hash", store, 0, 0.5, "g", "b")
+    assert "hash-rgb" in saved and "hash" not in saved
+
+    thumbnails.get_thumbnail_worker("r2", "hash2", store)
+    assert "hash2" in saved
+
+
+def test_triplet_ignores_stale_plain_hash_cache(monkeypatch):
+    """A red-only thumb cached under the plain hash (pre-fix) must not be served for a triplet."""
+    from PIL import Image
+
+    from negpy.services.assets import thumbnails
+
+    stale = Image.new("RGB", (4, 4))
+    merged = Image.new("RGB", (4, 4))
+    saved: dict = {"hash": stale}
+
+    class Store:
+        def get_thumbnail(self, key):
+            return saved.get(key)
+
+        def save_thumbnail(self, key, img):
+            saved[key] = img
+
+    monkeypatch.setattr(thumbnails, "decode_source_image", lambda *a, **k: merged)
+    monkeypatch.setattr(thumbnails, "prepare_thumbnail", lambda i, ts: i)
+
+    out = thumbnails.get_thumbnail_worker("r", "hash", Store(), 0, 0.5, "g", "b")
+    assert out is merged
+    assert saved["hash-rgb"] is merged

--- a/tests/test_rgbscan.py
+++ b/tests/test_rgbscan.py
@@ -233,6 +233,14 @@ def test_resolve_asset_rgbscan_resets_when_not_triplet():
     assert out.rgbscan == RgbScanConfig()
 
 
+def test_thumbnail_cache_key_namespaces_triplets():
+    """Batch and rendered paths must derive the same triplet key so they share a cache slot."""
+    from negpy.services.assets.thumbnails import thumbnail_cache_key
+
+    assert thumbnail_cache_key("h", False) == "h"
+    assert thumbnail_cache_key("h", True) == "h-rgb"
+
+
 def test_thumbnail_decode_routes_triplet_to_merge(monkeypatch):
     """With green/blue paths, the thumbnail must merge the triplet, not decode red alone."""
     from negpy.services.assets import thumbnails


### PR DESCRIPTION
Fixes #575

## Summary
Filmstrip thumbnails for RGB-scan triplets showed the raw red exposure instead of the converted positive shown on the canvas. Two separate bugs:

1. **Batch thumbnail decode never merged the triplet.** It only decoded the primary (red) file, so the placeholder was red-only.
2. **Rendered (correct) thumbnails were being written under the wrong key.** The update path keyed by the underlying file's basename, but the filmstrip looks up thumbnails by the asset's *display* name — which diverges from the basename for any composite asset (RGB triplets, half-frame splits, stitched composites). The correct, inverted thumbnail was silently written somewhere nothing ever read, so it was permanently stuck on the placeholder.

Fixing #2 means the batch and rendered paths can now race for the same key, so the batch generator's signal is split from the rendered-positive one, with a small guard so a slower batch decode can't clobber a thumbnail that already came from a canvas render.

## Test plan
- [x] `make all` (lint, type check, full test suite) passes
- [x] New unit tests cover the triplet merge, the shared cache key, the asset-name keying fix, and the no-clobber guard
- [x] Manually verified in-app: importing an RGB-scan triplet now shows the correct inverted positive in the filmstrip, matching the canvas. Tested non-triplet images, and behavior remains correct.