### PR TITLE
Fix macOS release builds for Intel + ARM runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Install System Dependencies (macOS)
         if: startsWith(matrix.os, 'macos-')
-        run: brew install sane-backends
+        run: brew install sane-backends llvm@20
 
       - name: Install Packaging Tools (Windows)
         if: matrix.os == 'windows-latest'
@@ -82,6 +82,15 @@ jobs:
       - name: Install Dependencies (Linux)
         if: matrix.os == 'ubuntu-latest'
         run: uv sync --all-groups
+
+      - name: Configure LLVM for llvmlite (macOS x86_64)
+        if: matrix.arch == 'x86_64'
+        shell: bash
+        run: |
+          LLVM20="$(brew --prefix llvm@20)"
+          echo "PATH=/usr/local/bin:${LLVM20}/bin:${PATH}" >> "$GITHUB_ENV"
+          echo "LLVM_CONFIG=${LLVM20}/bin/llvm-config" >> "$GITHUB_ENV"
+          echo "CMAKE_ARGS=-DLLVM_DIR=${LLVM20}/lib/cmake/llvm -DCMAKE_PREFIX_PATH=${LLVM20}" >> "$GITHUB_ENV"
 
       - name: Install Dependencies (macOS)
         if: startsWith(matrix.os, 'macos-')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,13 +27,13 @@ jobs:
       - id: set-matrix
         run: |
           if [ "${{ github.event.inputs.platform }}" == "all" ]; then
-            echo 'matrix=[{"os":"ubuntu-latest"},{"os":"windows-latest"},{"os":"macos-14","arch":"arm64"},{"os":"macos-13","arch":"x86_64"}]' >> $GITHUB_OUTPUT
+            echo 'matrix=[{"os":"ubuntu-latest"},{"os":"windows-latest"},{"os":"macos-14","arch":"arm64"},{"os":"macos-15-intel","arch":"x86_64"}]' >> $GITHUB_OUTPUT
           elif [ "${{ github.event.inputs.platform }}" == "windows" ]; then
             echo 'matrix=[{"os":"windows-latest"}]' >> $GITHUB_OUTPUT
           elif [ "${{ github.event.inputs.platform }}" == "linux" ]; then
             echo 'matrix=[{"os":"ubuntu-latest"}]' >> $GITHUB_OUTPUT
           elif [ "${{ github.event.inputs.platform }}" == "macos" ]; then
-            echo 'matrix=[{"os":"macos-14","arch":"arm64"},{"os":"macos-13","arch":"x86_64"}]' >> $GITHUB_OUTPUT
+            echo 'matrix=[{"os":"macos-14","arch":"arm64"},{"os":"macos-15-intel","arch":"x86_64"}]' >> $GITHUB_OUTPUT
           fi
 
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,13 +27,13 @@ jobs:
       - id: set-matrix
         run: |
           if [ "${{ github.event.inputs.platform }}" == "all" ]; then
-            echo 'matrix=[{"os":"ubuntu-latest"},{"os":"windows-latest"},{"os":"macos-latest","arch":"arm64"},{"os":"macos-latest","arch":"x86_64"}]' >> $GITHUB_OUTPUT
+            echo 'matrix=[{"os":"ubuntu-latest"},{"os":"windows-latest"},{"os":"macos-14","arch":"arm64"},{"os":"macos-13","arch":"x86_64"}]' >> $GITHUB_OUTPUT
           elif [ "${{ github.event.inputs.platform }}" == "windows" ]; then
             echo 'matrix=[{"os":"windows-latest"}]' >> $GITHUB_OUTPUT
           elif [ "${{ github.event.inputs.platform }}" == "linux" ]; then
             echo 'matrix=[{"os":"ubuntu-latest"}]' >> $GITHUB_OUTPUT
           elif [ "${{ github.event.inputs.platform }}" == "macos" ]; then
-            echo 'matrix=[{"os":"macos-latest","arch":"arm64"},{"os":"macos-latest","arch":"x86_64"}]' >> $GITHUB_OUTPUT
+            echo 'matrix=[{"os":"macos-14","arch":"arm64"},{"os":"macos-13","arch":"x86_64"}]' >> $GITHUB_OUTPUT
           fi
 
   build:
@@ -65,7 +65,7 @@ jobs:
           chmod +x appimagetool-x86_64.AppImage
 
       - name: Install System Dependencies (macOS)
-        if: matrix.os == 'macos-latest'
+        if: startsWith(matrix.os, 'macos-')
         run: brew install sane-backends
 
       - name: Install Packaging Tools (Windows)
@@ -84,7 +84,7 @@ jobs:
         run: uv sync --all-groups
 
       - name: Install Dependencies (macOS)
-        if: matrix.os == 'macos-latest'
+        if: startsWith(matrix.os, 'macos-')
         run: CFLAGS="-I$(brew --prefix)/include" LDFLAGS="-L$(brew --prefix)/lib" uv sync --all-groups
 
       - name: Install Dependencies (Windows)
@@ -97,7 +97,7 @@ jobs:
           echo "${{ github.event.inputs.version }}" | sed 's/^v//' > VERSION
 
       - name: Set macOS target architecture
-        if: matrix.os == 'macos-latest'
+        if: startsWith(matrix.os, 'macos-')
         shell: bash
         run: echo "NEGPY_MACOS_ARCH=${{ matrix.arch }}" >> "$GITHUB_ENV"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,21 +27,21 @@ jobs:
       - id: set-matrix
         run: |
           if [ "${{ github.event.inputs.platform }}" == "all" ]; then
-            echo 'matrix=["ubuntu-latest", "windows-latest", "macos-latest"]' >> $GITHUB_OUTPUT
+            echo 'matrix=[{"os":"ubuntu-latest"},{"os":"windows-latest"},{"os":"macos-latest","arch":"arm64"},{"os":"macos-latest","arch":"x86_64"}]' >> $GITHUB_OUTPUT
           elif [ "${{ github.event.inputs.platform }}" == "windows" ]; then
-            echo 'matrix=["windows-latest"]' >> $GITHUB_OUTPUT
+            echo 'matrix=[{"os":"windows-latest"}]' >> $GITHUB_OUTPUT
           elif [ "${{ github.event.inputs.platform }}" == "linux" ]; then
-            echo 'matrix=["ubuntu-latest"]' >> $GITHUB_OUTPUT
+            echo 'matrix=[{"os":"ubuntu-latest"}]' >> $GITHUB_OUTPUT
           elif [ "${{ github.event.inputs.platform }}" == "macos" ]; then
-            echo 'matrix=["macos-latest"]' >> $GITHUB_OUTPUT
+            echo 'matrix=[{"os":"macos-latest","arch":"arm64"},{"os":"macos-latest","arch":"x86_64"}]' >> $GITHUB_OUTPUT
           fi
 
   build:
     needs: setup
     strategy:
       matrix:
-        os: ${{ fromJSON(needs.setup.outputs.matrix) }}
-    name: Build for ${{ matrix.os }}
+        include: ${{ fromJSON(needs.setup.outputs.matrix) }}
+    name: Build for ${{ matrix.os }}${{ matrix.arch && format(' ({0})', matrix.arch) || '' }}
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Code
@@ -96,6 +96,11 @@ jobs:
         run: |
           echo "${{ github.event.inputs.version }}" | sed 's/^v//' > VERSION
 
+      - name: Set macOS target architecture
+        if: matrix.os == 'macos-latest'
+        shell: bash
+        run: echo "NEGPY_MACOS_ARCH=${{ matrix.arch }}" >> "$GITHUB_ENV"
+
       - name: Build and Package Application
         run: uv run python build.py
 
@@ -106,7 +111,7 @@ jobs:
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: negpy-${{ matrix.os }}-${{ github.event.inputs.version }}
+          name: negpy-${{ matrix.os }}${{ matrix.arch && format('-{0}', matrix.arch) || '' }}-${{ github.event.inputs.version }}
           if-no-files-found: error
           path: |
             dist/*.AppImage


### PR DESCRIPTION
## Summary
- split macOS runners by architecture to avoid cross-arch wheel mismatches
- use `macos-14` for arm64 and `macos-15-intel` for x86_64
- install `llvm@20` on macOS and export LLVM env for llvmlite in x86_64 jobs
- enable successful creation of Intel macOS DMG artifacts in release CI

## Why
Intel macOS packaging previously failed due to architecture-incompatible wheels and missing LLVM cmake config for llvmlite.

## Validation
- release workflow now produces an Intel DMG artifact successfully in CI
- arm64 macOS build path remains intact