### PR TITLE
fix: rebase slider commit baseline on external sync

### DIFF
--- a/negpy/desktop/view/widgets/sliders.py
+++ b/negpy/desktop/view/widgets/sliders.py
@@ -200,7 +200,13 @@ class BaseSlider(QWidget):
     def _emit_value(self) -> None:
         self.valueChanged.emit(self.spin.value())
 
-    def setValue(self, value: float) -> None:
+    def setValue(self, value: float, _rebase_commit: bool = True) -> None:
+        """_rebase_commit=True is the external-sync path (a sidebar reflecting a newly
+        loaded config onto this reused widget) and rebases the commit baseline — or a
+        later drag landing on a value some *other* image last committed here would
+        silently no-op in _on_committed. Internal gesture steps (adjust_by, dbl-click
+        reset, label-scrub) pass False so their own trailing _on_committed() still sees
+        the pre-gesture baseline and fires correctly."""
         if self.slider.isSliderDown() or self.spin.hasFocus():
             return
         self.slider.blockSignals(True)
@@ -209,19 +215,21 @@ class BaseSlider(QWidget):
         self.spin.setValue(value)
         self.slider.blockSignals(False)
         self.spin.blockSignals(False)
+        if _rebase_commit:
+            self._last_committed_value = value
 
     def value(self) -> float:
         return self.spin.value()
 
     def adjust_by(self, delta: float) -> None:
         new_value = max(self._min, min(self._max, self.value() + delta))
-        self.setValue(new_value)
+        self.setValue(new_value, _rebase_commit=False)
         self._emit_value()
         self._on_committed()
 
     def mouseDoubleClickEvent(self, event) -> None:
         """Resets to default value."""
-        self.setValue(self._default)
+        self.setValue(self._default, _rebase_commit=False)
         self._emit_value()
         self._on_committed()
 
@@ -359,8 +367,8 @@ class CompactSlider(BaseSlider):
         super()._on_slider_changed(value)
         self._update_edited_state()
 
-    def setValue(self, value: float) -> None:
-        super().setValue(value)
+    def setValue(self, value: float, _rebase_commit: bool = True) -> None:
+        super().setValue(value, _rebase_commit=_rebase_commit)
         self._update_edited_state()
 
     def setEnabled(self, enabled: bool) -> None:
@@ -403,7 +411,7 @@ class CompactSlider(BaseSlider):
                 elif mods & Qt.KeyboardModifier.ControlModifier:
                     sensitivity *= 10.0
                 new_val = max(self._min, min(self._max, self._scrub_start_val + dx * sensitivity))
-                self.setValue(new_val)
+                self.setValue(new_val, _rebase_commit=False)
                 # debounce like groove drags; a direct emit renders per mouse-move
                 self.timer.start()
                 return True
@@ -438,8 +446,8 @@ class HueSlider(CompactSlider):
         super()._on_slider_changed(value)
         self._apply_hue(value / self._precision)
 
-    def setValue(self, value: float) -> None:
-        super().setValue(value)
+    def setValue(self, value: float, _rebase_commit: bool = True) -> None:
+        super().setValue(value, _rebase_commit=_rebase_commit)
         self._apply_hue(value)
 
     def setEnabled(self, enabled: bool) -> None:
@@ -487,8 +495,8 @@ class KelvinSlider(CompactSlider):
         super()._on_slider_changed(value)
         self._apply_temp(self._from_int(value))
 
-    def setValue(self, value: float) -> None:
-        super().setValue(value)
+    def setValue(self, value: float, _rebase_commit: bool = True) -> None:
+        super().setValue(value, _rebase_commit=_rebase_commit)
         self._apply_temp(self.value())
 
     def setEnabled(self, enabled: bool) -> None:

--- a/tests/test_slider_widgets.py
+++ b/tests/test_slider_widgets.py
@@ -60,6 +60,29 @@ def test_label_scrub_debounces_value_changes(qapp):
     slider.timer.stop()
 
 
+def test_setvalue_rebases_commit_baseline_across_reuse(qapp):
+    """Regression for #crosstalk-separation-not-saved: a widget reused across images
+    (setValue() on file switch, e.g. Process sidebar sync_ui()) must rebase its commit
+    baseline, or dragging a later image to the same value the widget last committed for
+    a *different* image silently no-ops the commit (valueCommitted never fires)."""
+    slider = CompactSlider("Separation", 0.0, 1.0, 0.0)
+    committed = MagicMock()
+    slider.valueCommitted.connect(committed)
+
+    slider.adjust_by(1.0)
+    assert slider.value() == 1.0
+    committed.assert_called_once_with(1.0)
+
+    # Simulate switching to another image whose saved value happens to also be 0.0.
+    slider.setValue(0.0)
+    committed.reset_mock()
+
+    # Dragging the new image's slider back up to 1.0 must commit again.
+    slider.adjust_by(1.0)
+    assert slider.value() == 1.0
+    committed.assert_called_once_with(1.0)
+
+
 def test_kelvin_slider_mired_travel(qapp):
     s = KelvinSlider("Temperature")
     # Slider ints are mired*10: 12000K left, 3000K right (warm on the right).


### PR DESCRIPTION
Sliders built on BaseSlider are reused across images; setValue() (called by every sidebar's sync_ui() on file switch, undo, preset-apply, etc.) never touched _last_committed_value, so a later drag landing on the same value some *other* image last committed silently skipped valueCommitted in _on_committed(). Most visible on Crosstalk Separation, since 0.0/1.0 are a common drag target across frames — the edit would sit in memory but never reach the DB, and reverted on the next visit to that image.

setValue() now rebases the baseline by default; the three internal call sites that immediately follow up with their own commit (adjust_by, double-click reset, label-scrub) opt out via _rebase_commit=False so their existing dedup behavior is unchanged.

Fixes #635 