### PR TITLE
Re-meter frames when pasted settings change the analysis region

### DIFF
--- a/negpy/desktop/settings_catalog.py
+++ b/negpy/desktop/settings_catalog.py
@@ -16,6 +16,7 @@ from typing import Any, Callable, Iterable, Mapping, Optional
 
 from negpy.domain.models import WorkspaceConfig
 from negpy.features.metadata.models import PUSH_PULL_LABELS
+from negpy.features.process.models import invalidate_local_bounds
 
 
 class SettingRow:
@@ -213,6 +214,30 @@ CATALOG: list[tuple[str, tuple[SettingRow, ...]]] = [
 
 _DEFAULT = WorkspaceConfig()
 
+# Fields that decide how a frame is metered. Pasting one must drop the target's
+# cached per-frame bounds, or resolve_bounds_detailed keeps short-circuiting on
+# them and the new value never reaches the render. Mirrors what every sidebar
+# handler for these already does. Excluded on purpose: autocrop_ratio (see
+# AppController.set_crop_ratio), rotation, and the white/black points — those
+# apply after the bounds rather than feeding them.
+_BOUNDS_INPUT_FIELDS = frozenset(
+    {
+        "process_mode",
+        "analysis_buffer",
+        "luma_range_clip",
+        "color_range_clip",
+        "crosstalk_strength",
+        "crosstalk_profile",
+        "crosstalk_matrix",
+        "sensor_profile",
+        "sensor_matrix",
+        "auto_crop_enabled",
+        "autocrop_offset",
+        "autocrop_mode",
+        "manual_crop_rect",
+    }
+)
+
 
 def all_rows() -> list[SettingRow]:
     return [r for _title, rows in CATALOG for r in rows]
@@ -243,6 +268,7 @@ def apply_selected_fields(source: WorkspaceConfig, target: WorkspaceConfig, rows
     """Overlay only the chosen rows' fields from source onto target (one replace
     per section). Fields not listed — per-frame bounds, dust spots, heal strokes,
     masks — stay the target's own."""
+    rows = list(rows)
     by_section: dict[str, dict] = {}
     for row in rows:
         src_section = getattr(source, row.section)
@@ -252,6 +278,8 @@ def apply_selected_fields(source: WorkspaceConfig, target: WorkspaceConfig, rows
     out = target
     for section, changes in by_section.items():
         out = replace(out, **{section: replace(getattr(out, section), **changes)})
+    if any(f in _BOUNDS_INPUT_FIELDS for row in rows for f in row.fields):
+        out = replace(out, process=replace(out.process, **invalidate_local_bounds(out.process)))
     return out
 
 

--- a/tests/test_sync_settings.py
+++ b/tests/test_sync_settings.py
@@ -2,6 +2,8 @@
 
 from dataclasses import replace
 
+import pytest
+
 from negpy.desktop.session import _source_effective_bounds
 from negpy.desktop.settings_catalog import (
     CATALOG,
@@ -99,6 +101,47 @@ def test_apply_crosstalk_copies_strength_profile_and_matrix_together():
     assert out.process.crosstalk_strength == 0.4
     assert out.process.crosstalk_profile == "Portra"
     assert out.process.crosstalk_matrix == (1, 0, 0, 0, 1, 0, 0, 0, 1)
+
+
+# ── metering inputs clear the target's per-frame bounds ──────────────────────
+
+
+def _metered_target():
+    c = WorkspaceConfig()
+    return replace(c, process=replace(c.process, local_floors=(0.1, 0.2, 0.3), local_ceils=(0.9, 0.8, 0.7)))
+
+
+@pytest.mark.parametrize("label", ["Analysis Buffer", "Mode", "Range", "Colour", "Crosstalk", "Sensor Calibration", "Manual Crop"])
+def test_apply_metering_row_clears_local_bounds(label):
+    tgt = _metered_target()
+    out = apply_selected_fields(WorkspaceConfig(), tgt, [_row(label)])
+    assert out.process.local_floors == (0.0, 0.0, 0.0)
+    assert out.process.local_ceils == (0.0, 0.0, 0.0)
+
+
+@pytest.mark.parametrize("label", ["White Point", "Black Trim", "Crop Ratio", "Rotation", "Saturation"])
+def test_apply_non_metering_row_keeps_local_bounds(label):
+    tgt = _metered_target()
+    out = apply_selected_fields(WorkspaceConfig(), tgt, [_row(label)])
+    assert out.process.local_floors == (0.1, 0.2, 0.3)
+    assert out.process.local_ceils == (0.9, 0.8, 0.7)
+
+
+def test_apply_metering_row_respects_target_bounds_lock():
+    tgt = _metered_target()
+    tgt = replace(tgt, process=replace(tgt.process, lock_bounds=True))
+    out = apply_selected_fields(WorkspaceConfig(), tgt, [_row("Analysis Buffer")])
+    assert out.process.local_floors == (0.1, 0.2, 0.3)
+    assert out.process.local_ceils == (0.9, 0.8, 0.7)
+
+
+def test_apply_accepts_a_one_shot_iterable():
+    # The bounds check makes a second pass over rows; a generator must not be consumed away.
+    c = WorkspaceConfig()
+    src = replace(c, process=replace(c.process, analysis_buffer=0.2))
+    out = apply_selected_fields(src, _metered_target(), iter([_row("Analysis Buffer")]))
+    assert out.process.analysis_buffer == 0.2
+    assert out.process.local_floors == (0.0, 0.0, 0.0)
 
 
 # ── _source_effective_bounds (roll-baseline broadcast) ───────────────────────


### PR DESCRIPTION
Fixes #637.

## Problem

Change **Analysis Buffer**, paste/apply it across the roll — the stored value changes but the render does not. Nudging the slider off the value and back fixes it; so does cropping.

## Root cause

Metering bounds are cached per frame in `ProcessConfig.local_floors/local_ceils`, and `resolve_bounds_detailed` short-circuits on them:

```python
base = LogNegativeBounds(process.local_floors, process.local_ceils) if process.is_local_initialized else analyze_fn()
```

A frame that already has bounds never re-analyses, whatever `analysis_buffer` says.

Every sidebar handler that touches a metering input already clears them via `invalidate_local_bounds` — that is why the slider and the crop entry points work. The copy/paste path did not, so the target frames kept stale bounds. Same latent bug for pasted Mode, Range, Colour, Crosstalk, Sensor Calibration and the crop rows; Analysis Buffer is just the one that got noticed.

## Change

One guard in `apply_selected_fields`, the shared merge behind paste (Ctrl+V), apply-to-selection, apply-to-roll and preset apply. If any picked row writes a field that decides how the frame is metered, the target's per-frame bounds are cleared so the next render re-analyses.

Excluded on purpose, matching what the sidebars already do:

- `autocrop_ratio` — `AppController.set_crop_ratio` documents why re-metering on a ratio change is wrong (the new ROI is always a subset; re-metering only drifts colour)
- rotation rows — the geometry sidebar's rotation handlers do not invalidate either
- white/black points and trims — applied after the bounds, not inputs to them

`invalidate_local_bounds` is a no-op when the **target** has `lock_bounds=True`, and `lock_bounds` is not a catalog row, so the target frame's own lock is what's honoured.

`rows` is now materialised to a list — the bounds check makes a second pass and generators were being consumed by the first.

## Tests

New cases in `tests/test_sync_settings.py`: parametrized metering rows clear the bounds, non-metering rows leave them, the target's bounds lock is respected, and a one-shot iterable still applies correctly.

`make all` green — 2509 passed, 5 skipped.