### PR TITLE
Fix glow/halation luma to use Adobe RGB weights, not Rec.709

### DIFF
--- a/negpy/features/lab/logic.py
+++ b/negpy/features/lab/logic.py
@@ -281,7 +281,7 @@ def apply_glow_and_halation(
     if glow_amount > 0.0:
         # Highlight mask in the display domain (keeps the 0.5 threshold); bloom is linear.
         enc = working_oetf_encode(img)
-        luma = enc[:, :, 0] * 0.2126 + enc[:, :, 1] * 0.7152 + enc[:, :, 2] * 0.0722
+        luma = enc[:, :, 0] * np.float32(LUM_R) + enc[:, :, 1] * np.float32(LUM_G) + enc[:, :, 2] * np.float32(LUM_B)
         threshold = 0.5
         glow_mask = np.clip((luma - threshold) / (1.0 - threshold), 0.0, 1.0) ** 2
         base_r = max(3, int(15 * scale_factor))
@@ -292,7 +292,7 @@ def apply_glow_and_halation(
         result = result + glow_blur * glow_amount
 
     if halation_strength > 0.0:
-        lin_luma = img[:, :, 0] * 0.2126 + img[:, :, 1] * 0.7152 + img[:, :, 2] * 0.0722
+        lin_luma = img[:, :, 0] * np.float32(LUM_R) + img[:, :, 1] * np.float32(LUM_G) + img[:, :, 2] * np.float32(LUM_B)
         t = HALATION_THRESHOLD_LINEAR
         hal_mask = np.clip((lin_luma - t) / (1.0 - t), 0.0, 1.0) ** 2
         base_r = max(5, int(25 * scale_factor))

--- a/negpy/features/lab/shaders/lab.wgsl
+++ b/negpy/features/lab/shaders/lab.wgsl
@@ -30,7 +30,9 @@ const SHARPEN_OVERSHOOT_DARK = 2.0;
 const SHARPEN_MASK_T_HI = 10.0;
 const RL_EPS = 1e-6;
 
-const LUMA_COEFFS = vec3<f32>(0.2126, 0.7152, 0.0722);
+// Adobe RGB (1998) -> XYZ D65 luminance row (Yn=1) — mirrors LUM_R/LUM_G/LUM_B in
+// logic.py and the y row in rgb_to_lab below.
+const WORKING_LUMA_COEFFS = vec3<f32>(0.2973769, 0.6273491, 0.0752741);
 
 // CIELAB L* from linear luminance Y (D65, Yn=1) — mirrors _lab_l_from_y in logic.py.
 fn lab_l_from_y(y_in: f32) -> f32 {
@@ -359,7 +361,7 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
                 let g_coord = clamp(coords + vec2<i32>(g_off), vec2<i32>(0), vec2<i32>(dims) - 1);
                 let g_samp = load_lin(g_coord);
                 // Glow is a print-side lens effect: mask stays in display domain.
-                let g_luma = dot(oetf_encode(g_samp), LUMA_COEFFS);
+                let g_luma = dot(oetf_encode(g_samp), WORKING_LUMA_COEFFS);
                 let g_hl = max(0.0, (g_luma - HIGHLIGHT_THRESHOLD) / (1.0 - HIGHLIGHT_THRESHOLD));
                 let g_r = length(offset);  // normalised radius in [0,1]
                 let g_w = exp(-g_r * g_r * 2.0);
@@ -370,7 +372,7 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
                 let h_off = offset * HAL_RADIUS;
                 let h_coord = clamp(coords + vec2<i32>(h_off), vec2<i32>(0), vec2<i32>(dims) - 1);
                 let h_samp = load_lin(h_coord);
-                let h_luma = dot(h_samp, LUMA_COEFFS);
+                let h_luma = dot(h_samp, WORKING_LUMA_COEFFS);
                 let h_hl = max(0.0, (h_luma - HALATION_THRESHOLD_LINEAR) / (1.0 - HALATION_THRESHOLD_LINEAR));
                 let h_r = length(offset);
                 let h_w = exp(-h_r * h_r * 2.0);


### PR DESCRIPTION
## Bug

`apply_glow_and_halation()` in `features/lab/logic.py` hardcoded Rec.709 luma
weights (0.2126/0.7152/0.0722) for both the glow highlight mask and the
halation mask, even though the buffer at this point is scene-linear Adobe RGB
(1998) — the same buffer `apply_rl_sharpening`, a few lines above in the same
file, already handles correctly via `LUM_R/LUM_G/LUM_B` (the Adobe RGB → XYZ
D65 Y row).

The GPU shader (`lab.wgsl`) had the identical split: a separate Rec.709
`LUMA_COEFFS` used only by the glow/halation taps, while the file's own
`rgb_to_lab()` already used the correct Adobe RGB Y row a few lines below.

## Fix

- CPU: both call sites now use `LUM_R/LUM_G/LUM_B`.
- GPU: renamed `LUMA_COEFFS` → `WORKING_LUMA_COEFFS` with the correct Adobe
  RGB values, keeping CPU/GPU in parity.

## Testing

- Full suite: 2493 passed, 6 skipped, 7 deselected, 0 failed. No golden
  values needed regeneration — `glow_amount`/`halation_strength` default to
  0.0 and the function no-ops at zero, so no default-config test exercises
  this path.
- Manually verified on a real scan (bus interior, mixed warm highlights)
  with glow=halation=0.5: max pixel diff 11/255, mean diff 0.05. Diff is
  concentrated almost entirely in bright, red-heavy highlight regions (mean
  brightness 149 vs. 45 image-wide, mean R value 176 vs. 60 image-wide) —
  consistent with R's weight increasing the most (0.213→0.297). Highlight
  clipping indicator moved from 1.7% to 1.8% at identical slider settings.
- Effect is real and correctly localized to highlights, but small — not
  something a user would likely notice by eye. This is a correctness fix
  (wrong luminance formula for the buffer's actual primaries) rather than a
  fix for a visible artifact.

---
Diagnosed and implemented with Claude Code; verified manually on a real scan
before opening this PR.