### PR TITLE
fix: chroma denoise no longer blooms colour across edges

### DIFF
--- a/negpy/desktop/settings_catalog.py
+++ b/negpy/desktop/settings_catalog.py
@@ -138,7 +138,7 @@ CATALOG: list[tuple[str, tuple[SettingRow, ...]]] = [
         _row("Sharpen Method", "lab", "sharpen_method"),
         _row("Radius", "lab", "sharpen_radius"),
         _row("Masking", "lab", "sharpen_masking"),
-        _row("Denoise", "lab", "chroma_denoise"),
+        _row("Chroma Denoise", "lab", "chroma_denoise"),
         _row("Glow", "lab", "glow_amount"),
         _row("Halation", "lab", "halation_strength"),
     )),

--- a/negpy/desktop/view/sidebar/lab.py
+++ b/negpy/desktop/view/sidebar/lab.py
@@ -53,7 +53,7 @@ class LabSidebar(BaseSidebar):
 
         row2 = QHBoxLayout()
         self.clahe_slider = CompactSlider("CLAHE", 0.0, 1.0, conf.clahe_strength)
-        self.chroma_denoise_slider = CompactSlider("Denoise", 0.0, 5.0, conf.chroma_denoise)
+        self.chroma_denoise_slider = CompactSlider("Chroma Denoise", 0.0, 5.0, conf.chroma_denoise)
         row2.addWidget(self.clahe_slider)
         row2.addWidget(self.chroma_denoise_slider)
         self.layout.addLayout(row2)

--- a/negpy/features/lab/logic.py
+++ b/negpy/features/lab/logic.py
@@ -231,9 +231,17 @@ def apply_saturation(img: ImageBuffer, saturation: float) -> ImageBuffer:
     return ensure_image(np.clip(res_rgb, 0.0, 1.0))
 
 
+# Chroma-similarity sigma for the denoise range term, in CIELAB a*/b* units. Taps
+# further than this in chroma are rejected, so a saturated object cannot bleed colour
+# past its own edge. Mirrored as a WGSL literal in lab.wgsl.
+CHROMA_DENOISE_SIGMA_R = 15.0
+
+
 def apply_chroma_denoise(img: ImageBuffer, radius: float, scale_factor: float = 1.0) -> ImageBuffer:
     """
-    Smooths A and B channels in LAB space to reduce color noise.
+    Edge-aware smoothing of A and B in LAB space to reduce color noise. Weighting taps
+    by chroma similarity as well as distance stops the isotropic blur this replaced from
+    blooming a saturated object's colour into its surroundings.
     """
     if radius <= 0:
         return img
@@ -241,14 +249,13 @@ def apply_chroma_denoise(img: ImageBuffer, radius: float, scale_factor: float = 
     lab = rgb_to_lab_working(img.astype(np.float32))
     l_chan, a, b = cv2.split(lab)
 
-    k_radius = radius * scale_factor
-    k_size = max(3, int(k_radius * 2 + 1) | 1)
-    sigma = k_radius
+    sigma = radius * scale_factor
+    # bilateralFilter takes 1 or 3 channels; the zero plane adds nothing to the L1
+    # range distance. d<=0 lets OpenCV derive the window from sigmaSpace.
+    ab = cv2.merge([a, b, np.zeros_like(a)])
+    smoothed = cv2.bilateralFilter(ab, 0, CHROMA_DENOISE_SIGMA_R, sigma)
 
-    a_blur = cv2.GaussianBlur(a, (k_size, k_size), sigma)
-    b_blur = cv2.GaussianBlur(b, (k_size, k_size), sigma)
-
-    res_lab = cv2.merge([l_chan, a_blur, b_blur])
+    res_lab = cv2.merge([l_chan, smoothed[:, :, 0], smoothed[:, :, 1]])
     res_rgb = lab_to_rgb_working(res_lab)
 
     return ensure_image(np.clip(res_rgb, 0.0, 1.0))

--- a/negpy/features/lab/shaders/lab.wgsl
+++ b/negpy/features/lab/shaders/lab.wgsl
@@ -113,6 +113,10 @@ const FIBONACCI_64 = array<vec2<f32>, 64>(
 // accumulator the same way a Gaussian convolution kernel is normalized (sum=1).
 const BLOOM_GAUSS_SUM = 27.668145;
 
+// Chroma-similarity sigma for the denoise range term (CIELAB a*/b* units).
+// Mirrors CHROMA_DENOISE_SIGMA_R in lab/logic.py.
+const CHROMA_DENOISE_SIGMA_R = 15.0;
+
 // Working-space TRC (Adobe RGB: pure 563/256 gamma). Lab is the encoded->linear
 // transition: input samples are decoded; the highlight/sharpen perceptual domain uses the same TRC.
 fn oetf_encode(c: vec3<f32>) -> vec3<f32> {
@@ -218,26 +222,32 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
     var color = load_lin(coords);
 
     // 1. Chroma Denoise
-    // Variable-radius blur of the CIELAB a*/b* channels. The Fibonacci-disk taps
-    // (weighted exp(-r^2 * 2), normalised by BLOOM_GAUSS_SUM) approximate a Gaussian
-    // of sigma = radius / 2, so radius = 2 * chroma_denoise * scale_factor matches the
-    // CPU path's GaussianBlur sigma of (chroma_denoise * scale_factor). This previously
-    // used a fixed 5x5 kernel that ignored the slider, so the strength never changed on
-    // GPU — inadequate for the heavy chroma noise of inverted C41 negatives.
+    // Variable-radius bilateral filter on the CIELAB a*/b* channels. The Fibonacci-disk
+    // taps (weighted exp(-r^2 * 2)) approximate a Gaussian of sigma = radius / 2, so
+    // radius = 2 * chroma_denoise * scale_factor matches the CPU path's sigmaSpace of
+    // (chroma_denoise * scale_factor). The range term rejects taps whose chroma differs
+    // from the centre — without it an isotropic blur bleeds a saturated object's colour
+    // outward as a halo. L1 chroma distance mirrors OpenCV's bilateralFilter so the two
+    // paths stay in parity. Weights are normalised by their own sum (not BLOOM_GAUSS_SUM,
+    // which still serves the fixed-weight glow/halation taps below).
     if (params.chroma_denoise > 0.0) {
         let radius = 2.0 * params.chroma_denoise * params.scale_factor;
         if (radius >= 0.5) {
             let current_lab = rgb_to_lab(color);
-            var blur_ab = vec2<f32>(0.0);
+            var blur_ab = current_lab.yz;
+            var wsum = 1.0;
             for (var tap = 0; tap < 64; tap++) {
                 let offset = FIBONACCI_64[tap];
                 let s_coord = clamp(coords + vec2<i32>(offset * radius), vec2<i32>(0), vec2<i32>(dims) - 1);
                 let s_lab = rgb_to_lab(load_lin(s_coord));
                 let r = length(offset);
-                let w = exp(-r * r * 2.0);
+                let d = s_lab.yz - current_lab.yz;
+                let dc = abs(d.x) + abs(d.y);
+                let w = exp(-r * r * 2.0) * exp(-dc * dc / (2.0 * CHROMA_DENOISE_SIGMA_R * CHROMA_DENOISE_SIGMA_R));
                 blur_ab += s_lab.yz * w;
+                wsum += w;
             }
-            blur_ab = blur_ab / BLOOM_GAUSS_SUM;
+            blur_ab = blur_ab / wsum;
             color = lab_to_rgb(vec3<f32>(current_lab.x, blur_ab.x, blur_ab.y));
         }
     }

--- a/tests/test_lab_logic.py
+++ b/tests/test_lab_logic.py
@@ -277,6 +277,24 @@ class TestLabLogic(unittest.TestCase):
         np.testing.assert_array_almost_equal(lab[:, :, 0], res_lab[:, :, 0], decimal=0)
         self.assertLess(float(np.var(res_lab[:, :, 1])), float(np.var(lab[:, :, 1])))
 
+    def test_chroma_denoise_does_not_bleed_across_edge(self) -> None:
+        """A saturated region must not tint its neighbours — an isotropic blur haloed."""
+        rng = np.random.default_rng(0)
+        img = np.full((120, 120, 3), 0.5, dtype=np.float32)
+        lab = rgb_to_lab_working(img)
+        lab[:, :, 1] += rng.normal(0, 5, (120, 120)).astype(np.float32)
+        lab[:, 60:, 1] += 40.0  # saturated block on the right half
+        noisy = lab_to_rgb_working(lab)
+
+        res_lab = rgb_to_lab_working(apply_chroma_denoise(noisy, radius=5.0))
+
+        # Clean side, right up against the edge: must stay near its own a*, not pick up
+        # the block's +40. The old GaussianBlur contaminated this band by ~18 units.
+        halo = float(np.abs(res_lab[:, 48:60, 1].mean(axis=0) - lab[:, 48:60, 1].mean(axis=0)).max())
+        self.assertLess(halo, 3.0)
+        # Still denoises well away from the edge.
+        self.assertLess(float(np.var(res_lab[:, :40, 1])), float(np.var(lab[:, :40, 1])))
+
 
 class TestGlowAndHalation(unittest.TestCase):
     def _highlight_image(self) -> np.ndarray:


### PR DESCRIPTION
## Problem

Raising the Lab **Denoise** slider removed chroma noise but haloed anything strongly coloured — a red skirt tinted the pavement around it, a hedge bled green onto the path.

## Cause

`apply_chroma_denoise` smoothed a\*/b\* with an isotropic `cv2.GaussianBlur`, and `lab.wgsl` did the same via 64 Fibonacci-disk taps normalised by `BLOOM_GAUSS_SUM`. Neither looked at edges, so the blur sampled a saturated object and deposited its colour outside the object.

## Fix

Both paths weight each tap by chroma similarity as well as spatial distance. Taps landing on a differently-coloured region get near-zero weight, so colour can't cross an edge; flat noisy areas still average fully.

- Range term uses **L1 chroma distance**, mirroring OpenCV's `bilateralFilter`, so CPU and GPU stay in parity.
- `CHROMA_DENOISE_SIGMA_R = 15.0`, mirrored as a WGSL literal per the constants-parity rule.
- GPU normalises by its own accumulated weight sum, centre tap seeded at weight 1 so the sum can't collapse. `BLOOM_GAUSS_SUM` untouched — glow/halation still use it.

## Why sigma 15

Measured, not guessed. Synthetic step edge (40 a\* units, noise σ=5, sigmaSpace 5):

| | flat noise | halo |
|---|---|---|
| Gaussian (old) | 0.29 | **18.45** |
| bilateral σr=8 | 2.05 | 0.26 |
| **bilateral σr=15** | **0.90** | **0.97** |
| bilateral σr=20 | 0.63 | 3.25 |
| bilateral σr=30 | 0.46 | 8.66 |

15 is the knee — halo 19× better than the old blur while flat-area noise still drops 5.0 → 0.90.

On a real X-Trans scan, driven through the actual app, chroma gain on the ring of low-chroma pixels bordering saturated ones: mean **5.58 → 2.74**, p95 **12.01 → 6.17**.

## Tests

New `test_chroma_denoise_does_not_bleed_across_edge`. Verified it fails on the old implementation (halo 17.35 against a 3.0 limit), so it pins the regression rather than just passing.

`make all`: 2522 passed, 5 skipped, lint + type clean. `TestLabParity::test_chroma_denoise` passes unchanged.

## Tradeoff

Bilateral costs ~0.87s at 26MP versus ~0.2s for the two Gaussians. Only paid when the slider is above 0.
