### PR TITLE
Remove DNG export, centralize config migrations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,8 @@ NegPy is a film-negative processing desktop app (PyQt6 + WebGPU). Images flow th
 
 Edits persist in SQLite (`edits.db`, keyed by content hash), optionally mirrored to `.negpy` JSON sidecars next to sources. DB wins; a loaded sidecar is promoted into the DB (`negpy/services/assets/sidecar.py`, `session.py`).
 
+**Migrations** (`negpy/domain/migrations.py`) — every legacy fixup for persisted configs lives here, not inline in `from_flat_dict`: `KEY_RENAMES` (renamed fields), `DROPPED_KEYS` (removed fields, dropped without the unknown-key warning), `RETIRED_EXPORT_FORMATS`, and `migrate_flat_config()` for value rewrites. Renaming/removing a config field or retiring an enum value means one entry here. Two exceptions stay in their dataclasses because they must run on *every* construction, not just on load: `ExposureConfig.__post_init__` (legacy grade → ISO R, `cast_removal` bool → strength) and the tuple-rehydrating `__post_init__`s. The module imports nothing from `models.py` (which imports it) — use string literals.
+
 ### Pipeline
 
 - **CPU**: `DarkroomEngine.process()` (`negpy/services/rendering/engine.py`) — base (geometry + normalization) → exposure (incl. dodge/burn) → clahe → retouch → lab → toning → crop → finish. The first five stages are cached per config-hash via `_run_stage()`; the rest run unconditionally.

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ It is built with **Python**, running natively on Linux, macOS, and Windows.
 
 **Colour & Output**
 *   **Colour Management**: Full ICC workflow — auto monitor-profile detection (Linux/macOS/Windows), soft proofing including paper/printer profiles, per-image input/output profiles.
-*   **Print Ready**: Export built for printing — border controls, ICC soft-proofing, [dynamic filename templating](docs/TEMPLATING.md), **export presets** (save + one-click), and **contact sheets**. Formats: JPEG, TIFF, PNG, WebP, JPEG XL, DNG.
-*   **Flat / Digital-Intermediate Export**: Flat, neutral, wide-gamut **16-bit TIFF** (or linear **DNG**) master for Lightroom/Darktable/Photoshop, mapping camera RAWs to ProPhoto via the camera's own matrix.
+*   **Print Ready**: Export built for printing — border controls, ICC soft-proofing, [dynamic filename templating](docs/TEMPLATING.md), **export presets** (save + one-click), and **contact sheets**. Formats: JPEG, TIFF, PNG, WebP, JPEG XL.
+*   **Flat / Digital-Intermediate Export**: Flat, neutral, wide-gamut **16-bit TIFF** master for Lightroom/Darktable/Photoshop, mapping camera RAWs to ProPhoto via the camera's own matrix.
 
 **Workflow & Data**
 *   **Non-destructive**: Original files never touched; edits stored as recipes.

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -116,7 +116,7 @@ $$I_{out} = \text{clip}\big(\text{lift} + \text{gain} \cdot (1 - \text{val}),\ 0
 *   `flat_log_lift` $= 0.10$: the output value the scene **shadow** lands on (black lift).
 *   Result: scene shadow → $0.10$, mid-grey → $\approx 0.46$, highlight → $0.75$ — headroom above white and below black, fully invertible for downstream grading.
 
-Both are **fixed** (no per-frame metering) so an evenly-exposed roll renders identically; manual white balance still rides as an additive per-channel shift in log space. The engine also **bypasses** the creative stages (Local Contrast, Retouch, Lab, Toning, Finish — dodge/burn masks are skipped too) for a flat intent; only Geometry → Normalization → this log map → Crop run. Export is full-resolution; the colour space follows the export selection (color-managed at encode like the print path), as 16-bit TIFF or Linear DNG. CPU engine is forced (no GPU flat shader) for numerical exactness.
+Both are **fixed** (no per-frame metering) so an evenly-exposed roll renders identically; manual white balance still rides as an additive per-channel shift in log space. The engine also **bypasses** the creative stages (Local Contrast, Retouch, Lab, Toning, Finish — dodge/burn masks are skipped too) for a flat intent; only Geometry → Normalization → this log map → Crop run. Export is full-resolution; the colour space follows the export selection (color-managed at encode like the print path), as 16-bit TIFF. CPU engine is forced (no GPU flat shader) for numerical exactness.
 
 ---
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -329,8 +329,7 @@ A scrollable list of every edit step (last 100 kept), newest on top; the current
 ### Output intent
 
 *   **Print** (default): the full creative look you see on screen.
-*   **Flat**: a flat, neutral, low-contrast master that keeps maximum tonal/colour information for editing elsewhere (Lightroom, Darktable, Photoshop). Skips the print look, effects, toning, and vignette, and writes a wide-gamut, high-bit-depth file. Your in-app preview is unaffected.
-    *   **Format**: *16-bit TIFF* (widely compatible) or *Linear DNG*.
+*   **Flat**: a flat, neutral, low-contrast master that keeps maximum tonal/colour information for editing elsewhere (Lightroom, Darktable, Photoshop). Skips the print look, effects, toning, and vignette, and writes a wide-gamut 16-bit TIFF. Your in-app preview is unaffected.
     *   **Preview Flat**: temporarily show the flat master on the canvas without changing your edit.
     *   **Roll Baseline**: measure every visible frame and share one exposure baseline, so flat masters are consistent across a roll (recommended before a flat batch).
 

--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -39,7 +39,6 @@ from negpy.desktop.workers.capture_worker import (
 )
 from negpy.domain.models import (
     ColorSpace,
-    ExportFormat,
     ExportPreset,
     ExportPresetOutputMode,
     ExportResolutionMode,
@@ -2499,17 +2498,6 @@ class AppController(QObject):
         if not enabled and self.state.flat_peek:
             self.toggle_flat_peek(force=False)
 
-    def _flat_export_format(self) -> str:
-        return ExportFormat.DNG if self.state.flat_format == "DNG" else ExportFormat.TIFF
-
-    def set_flat_format(self, fmt: str) -> None:
-        """Set the flat master file format ('TIFF' 16-bit or 'DNG' linear)."""
-        fmt = fmt if fmt in ("TIFF", "DNG") else "TIFF"
-        if self.state.flat_format == fmt:
-            return
-        self.state.flat_format = fmt
-        self.session.save_flat_output_prefs()
-
     def toggle_flat_peek(self, force: Optional[bool] = None) -> None:
         """Preview the flat master render in the canvas without changing the saved edit.
 
@@ -2654,7 +2642,7 @@ class AppController(QObject):
         params = self.state.config
         if self.state.flat_output:
             params = flat_master_config(params)
-            export_conf = flat_export_config(export_conf, fmt=self._flat_export_format())
+            export_conf = flat_export_config(export_conf)
         source_exif = self.state.source_exif.get(self.state.current_file_hash or "")
 
         self._run_export_tasks(
@@ -2706,7 +2694,6 @@ class AppController(QObject):
             self._write_edit_sidecars(files)
 
         flat = self.state.flat_output
-        flat_fmt = self._flat_export_format()
 
         tasks = []
         for f in files:
@@ -2718,7 +2705,7 @@ class AppController(QObject):
                 # Always use current session export path/mode/format even for
                 # per-file exports. Per-file configs from the DB bypass
                 # _apply_sticky_settings and may have stale ABSOLUTE/export_path
-                # or DNG export_fmt values that don't match what the UI shows.
+                # or export_fmt values that don't match what the UI shows.
                 params = replace(
                     params,
                     export=replace(
@@ -2739,7 +2726,7 @@ class AppController(QObject):
 
             if flat:
                 params = flat_master_config(params)
-                final_export = flat_export_config(final_export, fmt=flat_fmt)
+                final_export = flat_export_config(final_export)
 
             bounds_override = None
             if f["hash"] == self.state.current_file_hash:

--- a/negpy/desktop/session.py
+++ b/negpy/desktop/session.py
@@ -129,7 +129,6 @@ class AppState:
     # Flat "for editing elsewhere" master output (digital intermediate).
     # When on, export and the optional preview-peek use the flat render intent.
     flat_output: bool = False
-    flat_format: str = "TIFF"  # "TIFF" (16-bit) or "DNG" (linear)
     # Transient: preview is currently peeking the flat render (not persisted).
     flat_peek: bool = False
 
@@ -433,9 +432,6 @@ class DesktopSessionManager(QObject):
         saved_flat_output = self.repo.get_global_setting("flat_output")
         if saved_flat_output is not None:
             self.state.flat_output = bool(saved_flat_output)
-        saved_flat_format = self.repo.get_global_setting("flat_format")
-        if saved_flat_format in ("TIFF", "DNG"):
-            self.state.flat_format = saved_flat_format
 
         self.state.export_presets = self.repo.load_export_presets()
 
@@ -492,7 +488,6 @@ class DesktopSessionManager(QObject):
     def save_flat_output_prefs(self) -> None:
         """Persists the flat ('for editing elsewhere') output preferences."""
         self.repo.save_global_setting("flat_output", self.state.flat_output)
-        self.repo.save_global_setting("flat_format", self.state.flat_format)
 
     def _apply_sticky_settings(self, config: WorkspaceConfig, only_global: bool = False) -> WorkspaceConfig:
         """

--- a/negpy/desktop/view/sidebar/export.py
+++ b/negpy/desktop/view/sidebar/export.py
@@ -89,7 +89,6 @@ class ExportSidebar(BaseSidebar):
         self.export_main_btn.clicked.connect(self._on_export_clicked)
 
         self.intent_btn_group.idToggled.connect(self._on_flat_output_toggled)
-        self.flat_format_combo.currentIndexChanged.connect(self._on_flat_format_changed)
         self.flat_peek_btn.toggled.connect(lambda checked: self.controller.toggle_flat_peek(force=checked))
         self.flat_bake_btn.clicked.connect(self.controller.request_batch_normalization)
         self.controller.flat_output_changed.connect(self._on_flat_output_changed)
@@ -507,21 +506,6 @@ class ExportSidebar(BaseSidebar):
             self.intent_print_btn.setChecked(True)
         box.addLayout(intent_row)
 
-        self.flat_format_row_widget = QWidget()
-        fmt_row = QHBoxLayout(self.flat_format_row_widget)
-        fmt_row.setContentsMargins(0, 0, 0, 0)
-        fmt_label = field_label("Format")
-        fmt_label.setFixedWidth(90)
-        fmt_row.addWidget(fmt_label)
-        self.flat_format_combo = QComboBox()
-        self.flat_format_combo.addItem("16-bit TIFF", "TIFF")
-        self.flat_format_combo.addItem("Linear DNG", "DNG")
-        idx = self.flat_format_combo.findData(self.state.flat_format)
-        self.flat_format_combo.setCurrentIndex(idx if idx >= 0 else 0)
-        self.flat_format_combo.setToolTip("16-bit TIFF: widely compatible, ready to edit.\nLinear DNG: a linear digital negative.")
-        fmt_row.addWidget(self.flat_format_combo)
-        box.addWidget(self.flat_format_row_widget)
-
         peek_bake_row = QHBoxLayout()
         peek_bake_row.setSpacing(4)
         self.flat_peek_btn = self._tool_toggle(
@@ -539,7 +523,8 @@ class ExportSidebar(BaseSidebar):
         box.addLayout(peek_bake_row)
 
         self.flat_hint_label = hint_label(
-            "Exports a flat master in the selected color space at full resolution by default. Choose Print or Pixels below to downscale."
+            "Exports a flat 16-bit TIFF master in the selected color space at full resolution by default. "
+            "Choose Print or Pixels below to downscale."
         )
         box.addWidget(self.flat_hint_label)
 
@@ -555,7 +540,6 @@ class ExportSidebar(BaseSidebar):
         on = self.intent_flat_btn.isChecked()
         if hasattr(self, "form"):
             self.form.set_flat_mode(on)
-        self.flat_format_row_widget.setVisible(on)
         self.flat_hint_label.setVisible(on)
         self.flat_peek_btn.setVisible(on)
         self._sync_flat_roll_warning()
@@ -577,9 +561,6 @@ class ExportSidebar(BaseSidebar):
         if checked:
             self.controller.set_flat_output(btn_id == 1)
             self._sync_flat_enabled()
-
-    def _on_flat_format_changed(self, _index: int) -> None:
-        self.controller.set_flat_format(self.flat_format_combo.currentData())
 
     def _on_flat_output_changed(self, enabled: bool) -> None:
         self.intent_btn_group.blockSignals(True)
@@ -980,8 +961,6 @@ class ExportSidebar(BaseSidebar):
                 self.intent_flat_btn.setChecked(True)
             else:
                 self.intent_print_btn.setChecked(True)
-            fmt_idx = self.flat_format_combo.findData(self.state.flat_format)
-            self.flat_format_combo.setCurrentIndex(fmt_idx if fmt_idx >= 0 else 0)
             self.flat_peek_btn.setChecked(self.state.flat_peek)
         finally:
             self.block_signals(False)
@@ -1005,7 +984,6 @@ class ExportSidebar(BaseSidebar):
             self.cs_output_path_edit,
             self.cs_template_combo,
             self.sidecars_enabled_btn,
-            self.flat_format_combo,
             self.flat_peek_btn,
         ]
         for w in widgets:

--- a/negpy/desktop/view/widgets/export_presets_dialog.py
+++ b/negpy/desktop/view/widgets/export_presets_dialog.py
@@ -204,7 +204,7 @@ class ExportPresetsDialog(QDialog):
         try:
             is_flat = preset.render_intent == RenderIntent.FLAT
             self.intent_label.setText(
-                "Flat master — exports a neutral log intermediate (16-bit TIFF or linear DNG)."
+                "Flat master — exports a neutral log intermediate (16-bit TIFF)."
                 if is_flat
                 else "Print — exports the full in-app photographic look."
             )

--- a/negpy/desktop/view/widgets/export_settings_form.py
+++ b/negpy/desktop/view/widgets/export_settings_form.py
@@ -443,7 +443,7 @@ class ExportSettingsForm(QWidget):
         """Toggle flat-master export UI: hide delivery formats, adjust size rows.
 
         When ``preset_editor`` is True (Manage Presets dialog), the format row stays
-        visible but limited to TIFF/DNG instead of hiding entirely.
+        visible but limited to 16-bit TIFF instead of hiding entirely.
         """
         enabled = bool(enabled)
         if enabled == self._flat_mode:
@@ -456,7 +456,7 @@ class ExportSettingsForm(QWidget):
             self.fmt_combo.blockSignals(True)
             self.fmt_combo.clear()
             if enabled:
-                flat_formats = [ExportFormat.TIFF.value, ExportFormat.DNG.value]
+                flat_formats = [ExportFormat.TIFF.value]
                 self.fmt_combo.addItems(flat_formats)
                 self.fmt_combo.setCurrentText(current if current in flat_formats else ExportFormat.TIFF.value)
                 self._quality_container.setVisible(False)

--- a/negpy/desktop/view/widgets/tutorial_steps.py
+++ b/negpy/desktop/view/widgets/tutorial_steps.py
@@ -626,7 +626,7 @@ def build(window: "MainWindow") -> list[TutorialStep]:
             title="Export",
             body=(
                 "The <b>Export</b> tab (right panel, now active) is where you save your results.<br><br>"
-                "Choose a format (<b>JPEG</b>, high-bit-depth <b>TIFF</b>, PNG, WebP, JPEG XL, DNG), "
+                "Choose a format (<b>JPEG</b>, high-bit-depth <b>TIFF</b>, PNG, WebP, JPEG XL), "
                 "pick a colour space, and set resolution or print size. The <b>ICC</b> section adds "
                 "monitor-profile display and soft-proofing.<br><br>"
                 "The <b>Export</b> and <b>Export Presets</b> buttons are triggers; each button's "
@@ -642,7 +642,7 @@ def build(window: "MainWindow") -> list[TutorialStep]:
             title="Export — Flat Master",
             body=(
                 "The <b>Flat — for editing elsewhere</b> output intent exports a flat, neutral, "
-                "wide-gamut <b>16-bit TIFF</b> (or linear <b>DNG</b>) digital-intermediate master "
+                "wide-gamut <b>16-bit TIFF</b> digital-intermediate master "
                 "for Lightroom / Darktable / Photoshop.<br><br>"
                 "It skips the creative print look and maps camera RAWs to ProPhoto via the camera's "
                 "own matrix. <b>Preview Flat</b> peeks at the master on the canvas — also on the "

--- a/negpy/desktop/workers/export.py
+++ b/negpy/desktop/workers/export.py
@@ -53,7 +53,6 @@ _EXT = {
     ExportFormat.JPEG: "jpg",
     ExportFormat.TIFF: "tiff",
     ExportFormat.PNG: "png",
-    ExportFormat.DNG: "dng",
     ExportFormat.JXL: "jxl",
     ExportFormat.WEBP: "webp",
 }
@@ -150,11 +149,9 @@ class ExportWorker(QObject):
                     continue
 
                 if bits:
-                    # Skipped for DNG (EXIF re-write strips DNG tags), JXL
-                    # (embed_metadata corrupts the .jxl stream), and WebP
-                    # (embed_metadata has no WebP branch).
+                    # Skipped for JXL (embed_metadata corrupts the .jxl stream) and
+                    # WebP (embed_metadata has no WebP branch).
                     if task.metadata_config is not None and task.export_settings.export_fmt not in (
-                        ExportFormat.DNG,
                         ExportFormat.JXL,
                         ExportFormat.WEBP,
                     ):

--- a/negpy/domain/migrations.py
+++ b/negpy/domain/migrations.py
@@ -1,0 +1,127 @@
+"""
+Backward-compat migrations for persisted configs (edits.db rows, .negpy sidecars,
+export presets). Every legacy key rename, value rewrite and retired-field drop
+belongs here — add new ones to this module, not to ``from_flat_dict``.
+
+Not here: coercions that must run on *every* construction rather than only on load
+— ``ExposureConfig.__post_init__`` (legacy 0-5 paper grade → ISO R, cast_removal
+bool → strength) and the tuple-rehydrating ``__post_init__``s. String literals only
+(no ``domain.models`` import — that module imports this one).
+"""
+
+from typing import Any, Dict
+
+# Old field name → new field name.
+KEY_RENAMES: Dict[str, str] = {
+    "export_border_size": "border_size",
+    "export_border_color": "border_color",
+    # Shadow-neutral + density-balance consolidated into Cast Removal, then Cast
+    # Removal itself became a 0..1 strength (bool True/False coerced to 1.0/0.0 in
+    # ExposureConfig.__post_init__). Preserve a user's saved on/off.
+    "auto_shadow_neutral": "cast_removal_strength",
+    "cast_removal": "cast_removal_strength",
+    # D-Range Clip split into independent luma + colour range clips; the old single
+    # slider maps to the luma axis (colour defaults to its aggressive baseline).
+    "drange_clip": "luma_range_clip",
+}
+
+# Fields removed from the config over time. Every edit saved before the removal
+# still carries them, so they'd warn on every file load; drop them silently and
+# keep the warning for truly unknown keys.
+DROPPED_KEYS: frozenset[str] = frozenset(
+    {
+        "flare",  # veiling-glare floor
+        "ir_inpaint_radius",  # IR stroke synthesis, replaced by score-weighted fill
+        "auto_cast_removal",  # cast removal became always-on
+        "DEFAULT_MATRIX",  # serialized crosstalk default, never a real field
+        "surround",  # dim-surround print gamma, removed in #432 (replaced by Snap)
+    }
+)
+
+# Export formats no longer offered → the closest surviving one. DNG export was
+# removed; TIFF is the other 16-bit master, so a saved DNG preset keeps its bit
+# depth instead of falling through the encoder to 8-bit JPEG.
+RETIRED_EXPORT_FORMATS: Dict[str, str] = {"DNG": "TIFF"}
+
+
+def migrate_export_fmt(fmt: str) -> str:
+    return RETIRED_EXPORT_FORMATS.get(fmt, fmt)
+
+
+def migrate_flat_config(data: Dict[str, Any]) -> Dict[str, Any]:
+    """Rewrite a flat config dict from any older NegPy version in place, and return it.
+
+    Value rewrites run before DROPPED_KEYS is popped — several of them read a key
+    on their way to deleting it.
+    """
+    for old_key, new_key in KEY_RENAMES.items():
+        if old_key in data:
+            data[new_key] = data.pop(old_key)
+
+    # True Black (BPC on) renamed to Paper Black with inverted polarity.
+    if "true_black" in data:
+        data["paper_black"] = not bool(data.pop("true_black"))
+
+    # Single roll-average toggle split into independent luma + colour axes.
+    if "use_roll_average" in data:
+        legacy = bool(data.pop("use_roll_average"))
+        data.setdefault("use_luma_average", legacy)
+        data.setdefault("use_colour_average", legacy)
+
+    # Lab "Separation" moved to the capture side (ProcessConfig crosstalk):
+    # the 1.0–2.0 slider maps to strength 0–1. crosstalk_matrix/crosstalk_profile
+    # keep their key names and re-route to ProcessConfig by field membership;
+    # the old serialized DEFAULT_MATRIX field is dropped.
+    if "color_separation" in data and "crosstalk_strength" not in data:
+        data["crosstalk_strength"] = min(max(float(data.pop("color_separation")) - 1.0, 0.0), 1.0)
+    data.pop("color_separation", None)
+
+    # Vignette became an exposure-domain burn: old ±1 strength (neg = darken)
+    # maps to stops (pos = burn) with an approximate look-preserving factor.
+    if "vignette_strength" in data and "vignette_stops" not in data:
+        data["vignette_stops"] = -2.0 * float(data.pop("vignette_strength"))
+    data.pop("vignette_strength", None)
+
+    # Filed carrier's separate on/off toggle was folded into carrier_width itself
+    # (0 = off) in #542. A pre-#542 save always serialized both keys together, so
+    # if the toggle was off, force width to 0 too — otherwise the leftover numeric
+    # width (2.0 by the old default) reads as "on" under the new width>0 gating,
+    # silently re-enabling a carrier the user had switched off.
+    if "carrier_enabled" in data and not data.pop("carrier_enabled"):
+        data["carrier_width"] = 0.0
+
+    if "use_original_res" in data and "export_resolution_mode" not in data:
+        data["export_resolution_mode"] = "original" if data.pop("use_original_res") else "print"
+    else:
+        data.pop("use_original_res", None)
+
+    if "same_as_source" in data and "output_mode" not in data:
+        data["output_mode"] = "same_as_source" if data.pop("same_as_source") else "absolute"
+    else:
+        data.pop("same_as_source", None)
+
+    # Metadata: migrate legacy combined override fields to structured gear fields.
+    if data.get("camera_override") and not data.get("camera_model"):
+        co = str(data.pop("camera_override", "")).strip()
+        if co and not data.get("camera_make"):
+            parts = co.split(None, 1)
+            if len(parts) == 2:
+                data["camera_make"], data["camera_model"] = parts[0], parts[1]
+            else:
+                data["camera_model"] = co
+        elif co:
+            data["camera_model"] = co
+    else:
+        data.pop("camera_override", None)
+    if data.get("lens_override") and not data.get("lens_model"):
+        data["lens_model"] = str(data.pop("lens_override", "")).strip()
+    else:
+        data.pop("lens_override", None)
+
+    if "export_fmt" in data:
+        data["export_fmt"] = migrate_export_fmt(str(data["export_fmt"]))
+
+    for key in DROPPED_KEYS:
+        data.pop(key, None)
+
+    return data

--- a/negpy/domain/models.py
+++ b/negpy/domain/models.py
@@ -17,25 +17,11 @@ from negpy.features.flatfield.models import FlatFieldConfig
 from negpy.features.rgbscan.models import RgbScanConfig
 from negpy.features.stitch.models import StitchConfig
 from negpy.features.metadata.models import MetadataConfig
+from negpy.domain.migrations import migrate_export_fmt, migrate_flat_config
 from negpy.kernel.system.logging import get_logger
 import negpy.kernel.system.paths as paths
 
 logger = get_logger("domain.models")
-
-# Map of old field names → new field names for backward-compatible deserialization.
-# Add entries here when fields are renamed so old workspace files keep their data.
-MIGRATIONS: Dict[str, str] = {
-    "export_border_size": "border_size",
-    "export_border_color": "border_color",
-    # Shadow-neutral + density-balance consolidated into Cast Removal, then Cast
-    # Removal itself became a 0..1 strength (bool True/False coerced to 1.0/0.0 in
-    # ExposureConfig.__post_init__). Preserve a user's saved on/off.
-    "auto_shadow_neutral": "cast_removal_strength",
-    "cast_removal": "cast_removal_strength",
-    # D-Range Clip split into independent luma + colour range clips; the old single
-    # slider maps to the luma axis (colour defaults to its aggressive baseline).
-    "drange_clip": "luma_range_clip",
-}
 
 
 class AspectRatio(StrEnum):
@@ -139,7 +125,6 @@ class ExportFormat(StrEnum):
     JPEG = "JPEG"
     TIFF = "TIFF"
     PNG = "PNG"
-    DNG = "DNG"
     JXL = "JXL"
     WEBP = "WEBP"
 
@@ -250,6 +235,9 @@ class ExportConfig:
 
     export_sidecars_enabled: bool = False
 
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "export_fmt", migrate_export_fmt(self.export_fmt))
+
 
 @dataclass
 class ExportPreset:
@@ -291,6 +279,9 @@ class ExportPreset:
     export_color_space: str = ColorSpace.SRGB.value
     icc_input_path: Optional[str] = None
     icc_output_path: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        self.export_fmt = migrate_export_fmt(self.export_fmt)
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -412,78 +403,7 @@ class WorkspaceConfig:
 
         local_data = data.pop("local_masks", {})
 
-        # Apply field renames for backward compatibility.
-        for old_key, new_key in MIGRATIONS.items():
-            if old_key in data:
-                data[new_key] = data.pop(old_key)
-
-        # True Black (BPC on) renamed to Paper Black with inverted polarity.
-        if "true_black" in data:
-            data["paper_black"] = not bool(data.pop("true_black"))
-
-        # Single roll-average toggle split into independent luma + colour axes.
-        if "use_roll_average" in data:
-            legacy = bool(data.pop("use_roll_average"))
-            data.setdefault("use_luma_average", legacy)
-            data.setdefault("use_colour_average", legacy)
-
-        # Lab "Separation" moved to the capture side (ProcessConfig crosstalk):
-        # the 1.0–2.0 slider maps to strength 0–1. crosstalk_matrix/crosstalk_profile
-        # keep their key names and re-route to ProcessConfig by field membership;
-        # the old serialized DEFAULT_MATRIX field is dropped.
-        if "color_separation" in data and "crosstalk_strength" not in data:
-            data["crosstalk_strength"] = min(max(float(data.pop("color_separation")) - 1.0, 0.0), 1.0)
-        data.pop("color_separation", None)
-        data.pop("DEFAULT_MATRIX", None)
-        # Vignette became an exposure-domain burn: old ±1 strength (neg = darken)
-        # maps to stops (pos = burn) with an approximate look-preserving factor.
-        if "vignette_strength" in data and "vignette_stops" not in data:
-            data["vignette_stops"] = -2.0 * float(data.pop("vignette_strength"))
-        data.pop("vignette_strength", None)
-        # Flare (veiling-glare floor) was removed; drop the key from old edits silently.
-        data.pop("flare", None)
-        # IR stroke synthesis was replaced by the score-weighted fill; its pad radius is gone.
-        data.pop("ir_inpaint_radius", None)
-        # Auto cast removal became always-on; drop the old toggle key.
-        data.pop("auto_cast_removal", None)
-
-        # Filed carrier's separate on/off toggle was folded into carrier_width itself
-        # (0 = off) in #542. A pre-#542 save always serialized both keys together, so
-        # if the toggle was off, force width to 0 too — otherwise the leftover numeric
-        # width (2.0 by the old default) reads as "on" under the new width>0 gating,
-        # silently re-enabling a carrier the user had switched off.
-        if "carrier_enabled" in data and not data.pop("carrier_enabled"):
-            data["carrier_width"] = 0.0
-
-        if "use_original_res" in data and "export_resolution_mode" not in data:
-            data["export_resolution_mode"] = (
-                ExportResolutionMode.ORIGINAL.value if data.pop("use_original_res") else ExportResolutionMode.PRINT.value
-            )
-        else:
-            data.pop("use_original_res", None)
-
-        if "same_as_source" in data and "output_mode" not in data:
-            data["output_mode"] = ExportPresetOutputMode.SAME_AS_SOURCE if data.pop("same_as_source") else ExportPresetOutputMode.ABSOLUTE
-        else:
-            data.pop("same_as_source", None)
-
-        # Metadata: migrate legacy combined override fields to structured gear fields.
-        if data.get("camera_override") and not data.get("camera_model"):
-            co = str(data.pop("camera_override", "")).strip()
-            if co and not data.get("camera_make"):
-                parts = co.split(None, 1)
-                if len(parts) == 2:
-                    data["camera_make"], data["camera_model"] = parts[0], parts[1]
-                else:
-                    data["camera_model"] = co
-            elif co:
-                data["camera_model"] = co
-        else:
-            data.pop("camera_override", None)
-        if data.get("lens_override") and not data.get("lens_model"):
-            data["lens_model"] = str(data.pop("lens_override", "")).strip()
-        else:
-            data.pop("lens_override", None)
+        data = migrate_flat_config(data)
 
         config_classes = [
             ProcessConfig,
@@ -503,13 +423,7 @@ class WorkspaceConfig:
         for cc in config_classes:
             valid_keys.update(cc.__dataclass_fields__.keys())
 
-        # Fields deliberately removed from the config over time. Every edit saved
-        # before the removal still carries them, so they'd otherwise warn on every
-        # file load; drop silently and keep the warning for truly unknown keys.
-        #   surround: dim-surround print gamma, removed in #432 (replaced by Snap).
-        legacy_keys = {"surround"}
-
-        unknown = set(data) - valid_keys - legacy_keys
+        unknown = set(data) - valid_keys
         if unknown:
             logger.warning("Dropping unknown config keys: %s", sorted(unknown))
 
@@ -604,18 +518,17 @@ def flat_master_config(config: WorkspaceConfig) -> WorkspaceConfig:
     return replace(config, exposure=flat_exposure)
 
 
-def flat_export_config(export: ExportConfig | ExportPreset, fmt: str = ExportFormat.TIFF) -> Any:
+def flat_export_config(export: ExportConfig | ExportPreset) -> Any:
     """
     Override export settings for a flat master. Works on ``ExportConfig`` or
     ``ExportPreset`` — both share the same sizing/format field names — and
     returns the same type it was given.
 
-    Always sets ``export_fmt`` (TIFF 16-bit or DNG). Resolution defaults to
-    full original size; if the user explicitly chose Print or Pixels sizing in
-    the export panel, those settings are honoured so flat masters can be
-    downscaled when requested.
+    Always delivers 16-bit TIFF. Resolution defaults to full original size; if
+    the user explicitly chose Print or Pixels sizing in the export panel, those
+    settings are honoured so flat masters can be downscaled when requested.
     """
-    overrides: Dict[str, Any] = {"export_fmt": fmt}
+    overrides: Dict[str, Any] = {"export_fmt": ExportFormat.TIFF}
     if export.export_resolution_mode not in (
         ExportResolutionMode.PRINT.value,
         ExportResolutionMode.TARGET_PX.value,
@@ -625,12 +538,6 @@ def flat_export_config(export: ExportConfig | ExportPreset, fmt: str = ExportFor
     return replace(export, **overrides)
 
 
-def flat_export_preset(preset: ExportPreset) -> ExportPreset:
-    """Apply flat-master delivery rules to a preset (TIFF/DNG, default full-res)."""
-    fmt = preset.export_fmt if preset.export_fmt in (ExportFormat.TIFF, ExportFormat.DNG) else ExportFormat.TIFF
-    return flat_export_config(preset, fmt=fmt)
-
-
 def resolve_preset_export(
     preset: ExportPreset,
     params: WorkspaceConfig,
@@ -638,4 +545,4 @@ def resolve_preset_export(
     """Return (pipeline_config, delivery_preset) for one preset-driven export task."""
     if preset.render_intent != RenderIntent.FLAT:
         return params, copy.copy(preset)
-    return flat_master_config(params), flat_export_preset(preset)
+    return flat_master_config(params), flat_export_config(preset)

--- a/negpy/services/rendering/image_processor.py
+++ b/negpy/services/rendering/image_processor.py
@@ -685,17 +685,6 @@ class ImageProcessor:
                 predictor=True,
             )
             return output_buf.getvalue(), "tiff"
-        elif fmt == ExportFormat.DNG:
-            # Linear digital-negative master. Greyscale is promoted to RGB so the DNG
-            # is always a 3-sample LinearRaw the host can open. Colour-managed to the
-            # target space so the values match the TIFF master.
-            if is_greyscale:
-                img_lum = float_to_uint_luma(np.ascontiguousarray(buffer), bit_depth=16)
-                img_int = np.stack([img_lum, img_lum, img_lum], axis=-1) if img_lum.ndim == 2 else img_lum
-            else:
-                img_int = float_to_uint16(buffer)
-            img_out, _icc = self._apply_color_management_u16(img_int, working_color_space, color_space, icc_output, icc_input)
-            return self._encode_dng_bytes(img_out), "dng"
         elif fmt == ExportFormat.PNG:
             if is_greyscale:
                 # PIL "I;16" supports 16-bit greyscale, so keep full bit depth here.
@@ -785,24 +774,6 @@ class ImageProcessor:
             output_buf = io.BytesIO()
             self._save_to_pil_buffer(pil_img, output_buf, export_settings, icc_bytes)
             return output_buf.getvalue(), "jpg"
-
-    @staticmethod
-    def _encode_dng_bytes(rgb_u16: np.ndarray) -> bytes:
-        """Write a 16-bit RGB buffer as a LinearRaw DNG and return its bytes."""
-        import shutil
-        import tempfile
-
-        from negpy.infrastructure.scanners.result import ScanResult
-        from negpy.services.scanning.writer import write_dng_linear
-
-        result = ScanResult(rgb=np.ascontiguousarray(rgb_u16), ir=None, dpi=300, device_model="NegPy Flat Master")
-        tmpdir = tempfile.mkdtemp()
-        try:
-            written = write_dng_linear(result, os.path.join(tmpdir, "flat_master"))
-            with open(written, "rb") as fh:
-                return fh.read()
-        finally:
-            shutil.rmtree(tmpdir, ignore_errors=True)
 
     def render_display_array(
         self,

--- a/tests/test_config_deserialization.py
+++ b/tests/test_config_deserialization.py
@@ -2,7 +2,7 @@ import json
 import logging
 import unittest
 from dataclasses import replace
-from negpy.domain.models import ExportResolutionMode, WorkspaceConfig
+from negpy.domain.models import ExportConfig, ExportFormat, ExportPreset, ExportResolutionMode, WorkspaceConfig
 from negpy.features.process.models import ProcessMode
 from negpy.kernel.caching.logic import calculate_config_hash
 
@@ -196,6 +196,18 @@ class TestConfigDeserialization(unittest.TestCase):
     def test_legacy_use_roll_average_does_not_warn(self):
         with self.assertNoLogs("negpy.domain.models", level=logging.WARNING):
             WorkspaceConfig.from_flat_dict({"use_roll_average": True})
+
+    def test_retired_dng_export_migrates_to_tiff(self):
+        # DNG export was removed; a saved edit must land on the other 16-bit
+        # format, not fall through the encoder to 8-bit JPEG.
+        config = WorkspaceConfig.from_flat_dict({"export_fmt": "DNG"})
+        self.assertEqual(config.export.export_fmt, ExportFormat.TIFF)
+
+    def test_retired_dng_export_migrates_outside_flat_dict(self):
+        # Covers the sticky last_export_config path (ExportConfig(**filtered))
+        # and saved export presets, neither of which goes through from_flat_dict.
+        self.assertEqual(ExportConfig(export_fmt="DNG").export_fmt, ExportFormat.TIFF)
+        self.assertEqual(ExportPreset.from_dict({"export_fmt": "DNG"}).export_fmt, ExportFormat.TIFF)
 
     def test_manual_crop_rect_survives_db_roundtrip_as_tuple(self):
         """Manual crop saved to JSON reloads as a list, making the frozen

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -876,7 +876,7 @@ class TestBatchExportFiltering(unittest.TestCase):
         self.visible_indices = [0, 1]
         session_export = self.controller.state.config.export
         # Per-file config has stale SAME_AS_SOURCE (differs from session default
-        # ABSOLUTE) + stale DNG + stale AdobeRGB + stale jpeg_quality — delivery
+        # ABSOLUTE) + stale PNG + stale AdobeRGB + stale jpeg_quality — delivery
         # overrides (mode, fmt, color_space) must use session; sizing (quality) is
         # preserved from per-file.
         stale_export = replace(
@@ -884,7 +884,7 @@ class TestBatchExportFiltering(unittest.TestCase):
             output_mode=ExportPresetOutputMode.SAME_AS_SOURCE,
             export_path="/stale/default",
             output_subfolder="old_sub",
-            export_fmt=ExportFormat.DNG,
+            export_fmt=ExportFormat.PNG,
             export_color_space=ColorSpace.ADOBE_RGB.value,
             jpeg_quality=50,
         )
@@ -902,9 +902,9 @@ class TestBatchExportFiltering(unittest.TestCase):
             self.assertEqual(t.params.export.export_path, "/tmp/out")
             # Format/color-space from session config overrides per-file values so
             # the delivery format matches what the UI shows, not a stale per-file setting.
-            # Without the fix, stale_export.export_fmt=DNG would leak into the export.
+            # Without the fix, stale_export.export_fmt=PNG would leak into the export.
             self.assertEqual(t.params.export.export_fmt, session_export.export_fmt)
-            self.assertNotEqual(t.params.export.export_fmt, ExportFormat.DNG)
+            self.assertNotEqual(t.params.export.export_fmt, ExportFormat.PNG)
             self.assertEqual(t.params.export.export_color_space, session_export.export_color_space)
             self.assertNotEqual(t.params.export.export_color_space, ColorSpace.ADOBE_RGB.value)
             # Quality/sizing from per-file config is preserved

--- a/tests/test_export_presets.py
+++ b/tests/test_export_presets.py
@@ -108,10 +108,10 @@ def test_preset_unknown_keys_dropped():
 
 
 def test_preset_flat_render_intent_round_trip():
-    p = _make_preset(name="Flat Master", render_intent=RenderIntent.FLAT, export_fmt=ExportFormat.DNG)
+    p = _make_preset(name="Flat Master", render_intent=RenderIntent.FLAT, export_fmt=ExportFormat.TIFF)
     p2 = ExportPreset.from_dict(p.to_dict())
     assert p2.render_intent == RenderIntent.FLAT
-    assert p2.export_fmt == ExportFormat.DNG
+    assert p2.export_fmt == ExportFormat.TIFF
 
 
 def test_preset_render_intent_defaults_to_print():
@@ -142,7 +142,7 @@ def test_resolve_preset_export_print_passthrough():
     assert delivery.render_intent == RenderIntent.PRINT
 
 
-def test_flat_export_preset_coerces_delivery_format():
+def test_flat_preset_coerces_delivery_format():
     preset = _make_preset(render_intent=RenderIntent.FLAT, export_fmt=ExportFormat.JPEG)
     _, delivery = resolve_preset_export(preset, WorkspaceConfig())
     assert delivery.export_fmt == ExportFormat.TIFF
@@ -441,18 +441,6 @@ def test_tiff_same_space_preserves_16bit(proc):
     assert tiff_arr.shape == expected.shape
     diff = np.abs(tiff_arr.astype(np.int32) - expected.astype(np.int32))
     assert diff.max() == 0, f"Same-space 16-bit precision lost: max_diff={diff.max()}"
-
-
-def test_dng_cross_space_uses_16bit_cms(proc):
-    """DNG export uses _apply_color_management_u16 (lcms2 16-bit), not
-    the old 3D LUT.  DNG output isn't trivially decodable to check
-    pixel values, but we verify the export succeeds and returns bytes."""
-    buf = _off_axis_buffer()
-    preset = _make_preset(export_fmt=ExportFormat.DNG, export_color_space=ColorSpace.SRGB.value)
-    data, ext = proc._encode_export(buf, preset, ColorSpace.SRGB.value, WORKING_COLOR_SPACE)
-    assert data is not None, "DNG export returned None"
-    assert ext == "dng"
-    assert isinstance(data, bytes) and len(data) > 0, "DNG export returned empty bytes"
 
 
 def test_jxl_cross_space_is_16bit(proc):

--- a/tests/test_export_settings_form.py
+++ b/tests/test_export_settings_form.py
@@ -178,9 +178,6 @@ def test_flat_preset_editor_limits_format_choices(qapp):
     form = ExportSettingsForm()
     form.load(_values(export_fmt=ExportFormat.JPEG))
     form.set_flat_mode(True, preset_editor=True)
-    assert [form.fmt_combo.itemText(i) for i in range(form.fmt_combo.count())] == [
-        ExportFormat.TIFF.value,
-        ExportFormat.DNG.value,
-    ]
+    assert [form.fmt_combo.itemText(i) for i in range(form.fmt_combo.count())] == [ExportFormat.TIFF.value]
     form.set_flat_mode(False, preset_editor=True)
     assert ExportFormat.JPEG.value in [form.fmt_combo.itemText(i) for i in range(form.fmt_combo.count())]

--- a/tests/test_flat_master.py
+++ b/tests/test_flat_master.py
@@ -191,7 +191,7 @@ class TestFlatConfigHelpers(unittest.TestCase):
             export_color_space=ColorSpace.SRGB.value,
             export_resolution_mode=ExportResolutionMode.ORIGINAL.value,
         )
-        out = flat_export_config(src, fmt=ExportFormat.TIFF)
+        out = flat_export_config(src)
         self.assertEqual(out.export_fmt, ExportFormat.TIFF)
         self.assertEqual(out.export_color_space, ColorSpace.SRGB.value)
         self.assertEqual(
@@ -207,7 +207,7 @@ class TestFlatConfigHelpers(unittest.TestCase):
             export_target_long_edge_px=6000,
             paper_aspect_ratio=AspectRatio.R_3_2,
         )
-        out = flat_export_config(src, fmt=ExportFormat.TIFF)
+        out = flat_export_config(src)
         self.assertEqual(out.export_resolution_mode, ExportResolutionMode.TARGET_PX.value)
         self.assertEqual(out.export_target_long_edge_px, 6000)
         self.assertEqual(out.paper_aspect_ratio, AspectRatio.R_3_2)
@@ -219,15 +219,11 @@ class TestFlatConfigHelpers(unittest.TestCase):
             export_dpi=360,
             paper_aspect_ratio=AspectRatio.R_5_4,
         )
-        out = flat_export_config(src, fmt=ExportFormat.TIFF)
+        out = flat_export_config(src)
         self.assertEqual(out.export_resolution_mode, ExportResolutionMode.PRINT.value)
         self.assertEqual(out.export_print_size, 24.0)
         self.assertEqual(out.export_dpi, 360)
         self.assertEqual(out.paper_aspect_ratio, AspectRatio.R_5_4)
-
-    def test_flat_export_config_dng(self):
-        out = flat_export_config(ExportConfig(), fmt=ExportFormat.DNG)
-        self.assertEqual(out.export_fmt, ExportFormat.DNG)
 
     def test_flat_export_target_px_resizes_via_print_service(self):
         """Regression: flat export must not discard Pixels sizing (e.g. 6000px long edge)."""
@@ -238,8 +234,7 @@ class TestFlatConfigHelpers(unittest.TestCase):
             ExportConfig(
                 export_resolution_mode=ExportResolutionMode.TARGET_PX.value,
                 export_target_long_edge_px=6000,
-            ),
-            fmt=ExportFormat.TIFF,
+            )
         )
         result, _ = PrintService.apply_layout(img, export)
         self.assertEqual(max(result.shape[:2]), 6000)
@@ -266,21 +261,6 @@ class TestImageProcessorFlatRouting(unittest.TestCase):
         flat = flat_master_config(WorkspaceConfig())
         self.assertTrue(ImageProcessor._is_flat(flat))
         self.assertFalse(ImageProcessor._is_flat(WorkspaceConfig()))
-
-
-class TestFlatDngEncode(unittest.TestCase):
-    def test_dng_bytes_roundtrip(self):
-        import io
-
-        import tifffile
-
-        rgb = (np.random.rand(16, 16, 3) * 65535).astype(np.uint16)
-        data = ImageProcessor._encode_dng_bytes(rgb)
-        self.assertIsInstance(data, bytes)
-        self.assertGreater(len(data), 0)
-
-        readback = tifffile.imread(io.BytesIO(data))
-        np.testing.assert_array_equal(readback, rgb)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

Removes DNG as an export/delivery format and moves every deserialization-time config migration into one module.

**DNG export gone**: `ExportFormat.DNG`, the encoder branch + `ImageProcessor._encode_dng_bytes`, the export worker's extension/metadata-skip entries, and the flat-master **Format** row (flat masters are always 16-bit TIFF now, so the one-option dropdown plus `AppState.flat_format`, `set_flat_format`, `_flat_export_format` and the persisted `flat_format` setting go with it). `flat_export_config` loses its `fmt` parameter and `flat_export_preset` collapses into it.

**Kept**: DNG as an *input* format (rawpy loader, flat-field file filter, XMP read) and the Scan panel's DNG output — that's scanner acquisition, not export. Export's `_encode_dng_bytes` was the only non-scan caller of `write_dng_linear`.

**New `negpy/domain/migrations.py`**: `KEY_RENAMES` (was `MIGRATIONS`), `DROPPED_KEYS` (absorbs the old `legacy_keys` set), `RETIRED_EXPORT_FORMATS`, and `migrate_flat_config()` holding the ~70 lines lifted out of `WorkspaceConfig.from_flat_dict`, which is now two lines. Retiring a format or renaming a field is one entry there. `ExposureConfig.__post_init__` (legacy grade → ISO R, `cast_removal` bool → strength) deliberately stays put — it must run on every construction, not only on load. Documented in CLAUDE.md.

## Migration

Anything saved with `export_fmt="DNG"` would otherwise hit the encoder's JPEG else-branch — a silent 16→8-bit loss with a `.jpg` extension. It now coerces to 16-bit TIFF, the closest surviving format. `ExportConfig.__post_init__` / `ExportPreset.__post_init__` are the choke point, so export presets, per-file `edits.db` configs, `.negpy` sidecars and the `last_export_config` sticky row are all covered, including through `replace()`. The orphaned `flat_format` global-settings row is left unread and harmless.

## Verification

- `make all` green: 2524 passed, 1 skipped; ruff + ty clean.
- Legacy DB seeded with raw `"DNG"` JSON in all three shapes — preset, sticky (`jpeg_quality=77` preserved), per-file config — all read back TIFF.
- Headless real GUI on a NEF: no Format row, print dropdown `['JPEG','TIFF','PNG','JXL','WEBP']`, preset editor flat list `['TIFF']`, flat export wrote `_DSC0875.tiff` at uint16 6032x4032x3.

closes #640 640