### PR TITLE
feat: clear the thumbnail cache from the Manage Database dialog

### DIFF
--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -558,6 +558,15 @@ class AppController(QObject):
             self.set_status("GENERATING THUMBNAILS...")
             self.thumbnail_requested.emit(missing)
 
+    def clear_thumbnail_cache(self) -> None:
+        """Drops cached thumbnails on disk and in memory, then regenerates loaded ones."""
+        self.asset_store.clear_thumbnails()
+        # Must precede generate_missing_thumbnails: it only enqueues names absent here.
+        self.state.thumbnails.clear()
+        self.state.rendered_thumbnails.clear()
+        self.session.asset_model.refresh()
+        self.generate_missing_thumbnails()
+
     def _on_thumbnail_progress(self, current: int, total: int, name: str) -> None:
         self.set_status(f"THUMBNAIL {current}/{total}: {name}")
         self.status_progress_requested.emit(current, total)

--- a/negpy/desktop/view/canvas/toolbar.py
+++ b/negpy/desktop/view/canvas/toolbar.py
@@ -567,7 +567,7 @@ class ActionToolbar(QWidget):
     def _show_database_dialog(self) -> None:
         from negpy.desktop.view.widgets.database_dialog import DatabaseDialog
 
-        DatabaseDialog(self.session.repo, self.window()).exec()
+        DatabaseDialog(self.session.repo, self.controller, self.window()).exec()
 
     def _update_ui_state(self) -> None:
         state = self.session.state

--- a/negpy/desktop/view/widgets/database_dialog.py
+++ b/negpy/desktop/view/widgets/database_dialog.py
@@ -42,15 +42,17 @@ def _human_bytes(n: int) -> str:
 class DatabaseDialog(QDialog):
     """View what the app has stored in SQLite and clear it.
 
-    Two clear actions: 'Clear Saved Edits' drops per-image looks/history/marks so a
-    reloaded image starts from defaults; 'Reset Everything' wipes both databases
-    (also presets, rig profiles, preferences). Both confirm first; the counts and
-    sizes refresh in place after a clear.
+    Three clear actions: 'Clear Saved Edits' drops per-image looks/history/marks so a
+    reloaded image starts from defaults; 'Clear Thumbnails' empties the on-disk
+    thumbnail cache; 'Reset Everything' wipes both databases (also presets, rig
+    profiles, preferences) but leaves thumbnails alone. All confirm first; the counts
+    and sizes refresh in place after a clear.
     """
 
-    def __init__(self, repo, parent: Optional[QWidget] = None) -> None:
+    def __init__(self, repo, controller, parent: Optional[QWidget] = None) -> None:
         super().__init__(parent)
         self.repo = repo
+        self.controller = controller
         self.setWindowTitle("Manage Database")
         self.setMinimumWidth(420)
         self.setStyleSheet(f"QDialog {{ background: {THEME.bg_dark}; }}")
@@ -75,9 +77,9 @@ class DatabaseDialog(QDialog):
         root.addWidget(self._size_label)
 
         note = QLabel(
-            "Clearing only affects this app's database. Source files are never touched. "
-            "If you export .negpy sidecars, those still exist next to your images and can "
-            "restore an edit when that image is reloaded."
+            "Clearing only affects this app's database and its thumbnail cache. Source files are "
+            "never touched. If you export .negpy sidecars, those still exist next to your images "
+            "and can restore an edit when that image is reloaded."
         )
         note.setWordWrap(True)
         note.setStyleSheet(f"color: {THEME.text_muted}; font-size: {THEME.font_size_xs}px;")
@@ -94,6 +96,10 @@ class DatabaseDialog(QDialog):
         self.clear_edits_btn.setToolTip("Drop saved per-image edits, undo history and keep/reject marks. Keeps presets and rig profiles.")
         self.clear_edits_btn.clicked.connect(self._on_clear_edits)
 
+        self.clear_thumbs_btn = QPushButton("Clear Thumbnails")
+        self.clear_thumbs_btn.setToolTip("Delete the cached file-grid thumbnails. They are regenerated as images are loaded.")
+        self.clear_thumbs_btn.clicked.connect(self._on_clear_thumbnails)
+
         self.reset_all_btn = QPushButton("Reset Everything")
         self.reset_all_btn.setToolTip(
             "Wipe the entire database: edits, history, marks, rig profiles, export presets and all app preferences."
@@ -109,6 +115,7 @@ class DatabaseDialog(QDialog):
         close_btn.clicked.connect(self.accept)
 
         row.addWidget(self.clear_edits_btn)
+        row.addWidget(self.clear_thumbs_btn)
         row.addWidget(self.reset_all_btn)
         row.addStretch(1)
         row.addWidget(close_btn)
@@ -144,9 +151,12 @@ class DatabaseDialog(QDialog):
             for key, label in _TOOLING_ROWS:
                 self._stat_row(r, key, label)
                 r += 1
+            self._add_separator(r)
+            self._stat_row(r + 1, "thumbnails", "Cached thumbnails")
         self._refresh()
 
     def _refresh(self) -> None:
+        thumb_count, thumb_bytes = self.controller.asset_store.thumbnail_stats()
         try:
             stats = self.repo.database_stats()
         except Exception:
@@ -154,10 +164,11 @@ class DatabaseDialog(QDialog):
                 lbl.setText("—")
             self._size_label.setText("Could not read the database.")
             return
+        stats["thumbnails"] = thumb_count
         for key, lbl in self._value_labels.items():
             lbl.setText(f"{stats.get(key, 0):,}")
-        total = stats.get("edits_db_bytes", 0) + stats.get("settings_db_bytes", 0)
-        self._size_label.setText(f"On disk: {_human_bytes(total)}")
+        db_bytes = stats.get("edits_db_bytes", 0) + stats.get("settings_db_bytes", 0)
+        self._size_label.setText(f"On disk: {_human_bytes(db_bytes)} databases + {_human_bytes(thumb_bytes)} thumbnails")
         self._update_enabled(stats)
 
     def _update_enabled(self, stats: dict) -> None:
@@ -165,13 +176,14 @@ class DatabaseDialog(QDialog):
         total = edits + sum(stats.get(k, 0) for k in ("normalization_rolls", "flatfield_profiles", "export_presets", "app_preferences"))
         self.clear_edits_btn.setEnabled(edits > 0)
         self.reset_all_btn.setEnabled(total > 0)
+        self.clear_thumbs_btn.setEnabled(stats.get("thumbnails", 0) > 0)
 
-    def _confirm(self, title: str, text: str, ok_label: str) -> bool:
+    def _confirm(self, title: str, text: str, ok_label: str, informative: str = "This cannot be undone.") -> bool:
         box = QMessageBox(self)
         box.setIcon(QMessageBox.Icon.Warning)
         box.setWindowTitle(title)
         box.setText(text)
-        box.setInformativeText("This cannot be undone.")
+        box.setInformativeText(informative)
         ok = box.addButton(ok_label, QMessageBox.ButtonRole.DestructiveRole)
         box.addButton("Cancel", QMessageBox.ButtonRole.RejectRole)
         box.setDefaultButton(box.buttons()[-1])  # default to Cancel
@@ -190,6 +202,20 @@ class DatabaseDialog(QDialog):
             self.repo.clear_saved_edits()
         except Exception as exc:
             QMessageBox.critical(self, "Clear failed", f"Could not clear the database:\n{exc}")
+        self._refresh()
+
+    def _on_clear_thumbnails(self) -> None:
+        if not self._confirm(
+            "Clear Thumbnails",
+            "Delete every cached thumbnail?\n\nThumbnails for the images currently loaded are rebuilt straight away.",
+            "Clear Thumbnails",
+            "A large library takes a while to regenerate.",
+        ):
+            return
+        try:
+            self.controller.clear_thumbnail_cache()
+        except Exception as exc:
+            QMessageBox.critical(self, "Clear failed", f"Could not clear the thumbnail cache:\n{exc}")
         self._refresh()
 
     def _on_reset_all(self) -> None:

--- a/negpy/infrastructure/storage/local_asset_store.py
+++ b/negpy/infrastructure/storage/local_asset_store.py
@@ -108,6 +108,23 @@ class LocalAssetStore(IAssetStore):
         if os.path.exists(session_dir):
             shutil.rmtree(session_dir)
 
+    def thumbnail_stats(self) -> Tuple[int, int]:
+        """(count, total bytes) of cached thumbnails."""
+        try:
+            entries = [e for e in os.scandir(self.thumb_dir) if e.is_file()]
+        except OSError:
+            return 0, 0
+        return len(entries), sum(e.stat().st_size for e in entries)
+
+    def clear_thumbnails(self) -> None:
+        """Drops every cached thumbnail; the dir stays usable."""
+        try:
+            shutil.rmtree(self.thumb_dir, ignore_errors=True)
+            os.makedirs(self.thumb_dir, exist_ok=True)
+            logger.info("Thumbnail cache cleared.")
+        except Exception as e:
+            logger.error(f"Failed to clear thumbnails: {e}")
+
     def clear_all(self) -> None:
         """Nukes the cache."""
         try:

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -45,5 +45,39 @@ class TestThumbnailCacheSize(unittest.TestCase):
         self.assertIsNone(self.store.get_thumbnail("h_absent"))
 
 
+class TestThumbnailCacheClearing(unittest.TestCase):
+    """The Manage Database dialog reports and empties the thumbnail cache."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.store = LocalAssetStore(self._tmp.name, os.path.join(self._tmp.name, "icc"))
+        self.store.initialize()
+
+    def _save(self, file_hash):
+        ts = APP_CONFIG.thumbnail_size
+        self.store.save_thumbnail(file_hash, Image.new("RGB", (ts, ts), (10, 20, 30)))
+
+    def test_stats_report_count_and_bytes(self):
+        self._save("h1")
+        self._save("h2")
+        count, size = self.store.thumbnail_stats()
+        self.assertEqual(count, 2)
+        on_disk = sum(os.path.getsize(os.path.join(self.store.thumb_dir, f)) for f in os.listdir(self.store.thumb_dir))
+        self.assertEqual(size, on_disk)
+
+    def test_stats_are_zero_without_a_cache_dir(self):
+        os.rmdir(self.store.thumb_dir)
+        self.assertEqual(self.store.thumbnail_stats(), (0, 0))
+
+    def test_clear_empties_the_cache_and_leaves_it_usable(self):
+        self._save("h1")
+        self.store.clear_thumbnails()
+        self.assertEqual(self.store.thumbnail_stats(), (0, 0))
+        self.assertIsNone(self.store.get_thumbnail("h1"))
+        self._save("h2")
+        self.assertIsNotNone(self.store.get_thumbnail("h2"))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1810,3 +1810,67 @@ class TestCompareFlatPeekInteraction(unittest.TestCase):
             self.controller.rerender_active_view()
         _, kwargs = rr.call_args
         self.assertIsNone(kwargs.get("config_override"))
+
+
+class TestClearThumbnailCache(unittest.TestCase):
+    """'Clear Thumbnails' has to drop the disk cache and the in-memory icons, then refill."""
+
+    def setUp(self):
+        self.mock_session_manager = MagicMock(spec=DesktopSessionManager)
+        self.mock_session_manager.state = AppState()
+        self.mock_session_manager.repo = MagicMock()
+        self.mock_session_manager.asset_model = MagicMock()
+
+        with (
+            patch("negpy.desktop.controller.RenderWorker") as mock_rw_class,
+            patch("negpy.desktop.controller.PreviewManager") as mock_pm_class,
+        ):
+            mock_rw_class.return_value = MagicMock()
+            mock_pm_class.return_value = MagicMock(spec=PreviewManager)
+            self.controller = AppController(self.mock_session_manager)
+        self.controller.asset_store = MagicMock()
+
+    def tearDown(self):
+        import gc
+
+        for thread in [
+            self.controller.render_thread,
+            self.controller.export_thread,
+            self.controller.thumb_thread,
+            self.controller.norm_thread,
+            self.controller.discovery_thread,
+            self.controller.preview_load_thread,
+            self.controller.scan_thread,
+        ]:
+            if thread is not None and thread.isRunning():
+                thread.quit()
+                thread.wait()
+        del self.controller
+        gc.collect()
+
+    def test_clear_wipes_disk_and_memory(self):
+        state = self.mock_session_manager.state
+        state.thumbnails["a"] = object()
+        state.rendered_thumbnails.add("a")
+        self.controller.generate_missing_thumbnails = MagicMock()
+
+        self.controller.clear_thumbnail_cache()
+
+        self.controller.asset_store.clear_thumbnails.assert_called_once_with()
+        self.assertEqual(state.thumbnails, {})
+        self.assertEqual(state.rendered_thumbnails, set())
+        self.mock_session_manager.asset_model.refresh.assert_called_once_with()
+        self.controller.generate_missing_thumbnails.assert_called_once_with()
+
+    def test_regeneration_runs_against_an_emptied_cache(self):
+        # generate_missing_thumbnails only enqueues names absent from state.thumbnails,
+        # so clearing has to happen first or nothing comes back.
+        state = self.mock_session_manager.state
+        state.uploaded_files = [{"name": "a", "path": "/a.dng", "hash": "h1"}]
+        state.thumbnails["a"] = object()
+        seen = []
+        self.controller.generate_missing_thumbnails = MagicMock(side_effect=lambda: seen.append(dict(state.thumbnails)))
+
+        self.controller.clear_thumbnail_cache()
+
+        self.assertEqual(seen, [{}])


### PR DESCRIPTION
## Summary

Follow-up to #579. That dialog clears SQLite but deliberately never touched the thumbnail cache, so the JPEGs in `<user dir>/cache/thumbnails/` were only removable by hand. They also leak: `get_thumbnail` treats a size mismatch as a miss but never deletes the stale file, so every `thumbnail_size` change orphans the whole cache.

Adds to **Manage Database…**:

- a **Cached thumbnails** row (count), with its bytes broken out in the on-disk line — `On disk: 60.0 KB databases + 4.8 KB thumbnails`
- a **Clear Thumbnails** button, enabled only when the cache has entries

Clearing wipes the cache dir *and* the in-memory icons, then regenerates thumbnails for the currently loaded files so the file grid never sits empty. The confirmation says "A large library takes a while to regenerate" rather than "cannot be undone" — thumbnails come back on their own.

**Reset Everything stays database-only**, unchanged from #579.

## Implementation notes

- `LocalAssetStore` gains `thumbnail_stats()` and `clear_thumbnails()`; not added to the `IAssetStore` Protocol, which nothing needs and would only give the test fakes dead stubs.
- `AppController.clear_thumbnail_cache()` owns the ordering: the in-memory `state.thumbnails` must be cleared *before* `generate_missing_thumbnails()`, which only enqueues names absent from it. Canvas-rendered (positive) thumbs drop back to source-decode placeholders until the frame renders again.
- `DatabaseDialog` now takes the controller alongside the repo; `_confirm()` gained an `informative` parameter.

## Test plan
- [x] 5 new unit tests: stats count/bytes, missing cache dir, clear-then-still-usable, and two controller tests covering the wipe and the clear-before-regenerate ordering — each confirmed to fail against a sabotaged no-op
- [x] `make all` — ruff + ty clean, 2526 passed / 5 skipped
- [x] Driven headlessly against the real app (Xvfb): opened through the ⋯ menu handler, row read 3, clicked through the confirmation, cache dir emptied and stayed usable, row refreshed to 0, button disabled