### PR TITLE
Zone system overlay on the canvas preview

### DIFF
--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -179,6 +179,7 @@ class AppController(QObject):
     rotation_guide_requested = pyqtSignal()
     crop_guide_changed = pyqtSignal()
     dust_overlay_changed = pyqtSignal()
+    zones_overlay_changed = pyqtSignal(bool)
     asset_discovery_requested = pyqtSignal(AssetDiscoveryTask)
     stitch_requested = pyqtSignal(object)
     thumbnail_requested = pyqtSignal(list)
@@ -1156,6 +1157,12 @@ class AppController(QObject):
         cur = self.state.dust_overlay_mode if self.state.dust_overlay_mode in seq else "off"
         self.state.dust_overlay_mode = seq[(seq.index(cur) + 1) % len(seq)]
         self.dust_overlay_changed.emit()
+
+    def toggle_zones_overlay(self, force: Optional[bool] = None) -> None:
+        """Adams-zone box overlay. Repaint only — the boxes are carved from the frame
+        the canvas already holds, so no re-render is needed."""
+        self.state.zones_overlay = (not self.state.zones_overlay) if force is None else bool(force)
+        self.zones_overlay_changed.emit(self.state.zones_overlay)
 
     def handle_crop_rect_changed(self, nx1: float, ny1: float, nx2: float, ny2: float, persist: bool) -> None:
         """Live-updates (persist=False) or commits (persist=True) the manual crop rect

--- a/negpy/desktop/session.py
+++ b/negpy/desktop/session.py
@@ -99,6 +99,9 @@ class AppState:
     # session-only diagnostic — never persisted.
     dust_overlay_mode: str = "off"
 
+    # Adams-zone box overlay on the canvas; display-only, session-only — never persisted.
+    zones_overlay: bool = False
+
     # Reverse scroll-wheel zoom direction on the image viewer (scroll up = zoom out).
     invert_zoom_scroll: bool = False
 

--- a/negpy/desktop/view/canvas/overlay.py
+++ b/negpy/desktop/view/canvas/overlay.py
@@ -5,7 +5,7 @@ from typing import Dict, List, Optional, Tuple
 import cv2
 import numpy as np
 import qtawesome as qta
-from PyQt6.QtCore import QPointF, QRectF, QSize, Qt, QTimer, pyqtSignal
+from PyQt6.QtCore import QLineF, QPointF, QRectF, QSize, Qt, QTimer, pyqtSignal
 from PyQt6.QtGui import QColor, QCursor, QImage, QKeySequence, QMouseEvent, QPainter, QPainterPath, QPen, QPixmap, QPolygonF, QShortcut
 from PyQt6.QtWidgets import QWidget
 
@@ -38,7 +38,8 @@ _DUST_MARK_LUMA = QColor(57, 255, 20)  # neon green — auto-luma detection
 _DUST_MARK_IR = QColor(255, 0, 255)  # neon magenta — IR detection
 _IR_CORRECTED_ALPHA = 55  # dim magenta wash over IR-division-corrected regions
 
-_ZONE_LINE_ALPHA = 90
+_ZONE_LINE_ALPHA = 150
+_ZONE_LINE_SHADOW_ALPHA = 110  # dark underlay so the white edges hold over blown highlights
 _ZONE_LABEL_MIN_PX = 16.0  # below this cell size the numerals collide into noise
 _ZONE_CLIP_COLOR = QColor(220, 80, 80)  # paper black / paper white, same red the zone strip warns with
 
@@ -664,23 +665,30 @@ class CanvasOverlay(QWidget):
         cw = rect.width() / cols
         ch = rect.height() / rows
 
-        pen = QPen(QColor(255, 255, 255, _ZONE_LINE_ALPHA), 2.0)
-        pen.setCosmetic(True)
-        painter.setPen(pen)
-        painter.setBrush(Qt.BrushStyle.NoBrush)
-        painter.drawRect(rect)
+        edges: List[QLineF] = []
         for r in range(rows):
             y0, y1 = rect.y() + r * ch, rect.y() + (r + 1) * ch
             for c in range(1, cols):
                 if zones[r, c] != zones[r, c - 1]:
                     x = rect.x() + c * cw
-                    painter.drawLine(QPointF(x, y0), QPointF(x, y1))
+                    edges.append(QLineF(QPointF(x, y0), QPointF(x, y1)))
         for r in range(1, rows):
             y = rect.y() + r * ch
             for c in range(cols):
                 if zones[r, c] != zones[r - 1, c]:
                     x0 = rect.x() + c * cw
-                    painter.drawLine(QPointF(x0, y), QPointF(x0 + cw, y))
+                    edges.append(QLineF(QPointF(x0, y), QPointF(x0 + cw, y)))
+
+        painter.setBrush(Qt.BrushStyle.NoBrush)
+        for color, width in (
+            (QColor(0, 0, 0, _ZONE_LINE_SHADOW_ALPHA), 3.5),
+            (QColor(255, 255, 255, _ZONE_LINE_ALPHA), 1.5),
+        ):
+            pen = QPen(color, width)
+            pen.setCosmetic(True)
+            painter.setPen(pen)
+            painter.drawRect(rect)
+            painter.drawLines(edges)
 
         if min(cw, ch) < _ZONE_LABEL_MIN_PX:
             return
@@ -690,6 +698,10 @@ class CanvasOverlay(QWidget):
         painter.save()
         font = painter.font()
         font.setBold(True)
+        if font.pointSizeF() > 0:  # px-sized fonts (stylesheet) report -1 here
+            font.setPointSizeF(font.pointSizeF() * 1.25)
+        else:
+            font.setPixelSize(round(font.pixelSize() * 1.25))
         painter.setFont(font)
         for col, row, zone in self._zone_labels:
             cell = QRectF(rect.x() + col * cw, rect.y() + row * ch, cw, ch)

--- a/negpy/desktop/view/canvas/overlay.py
+++ b/negpy/desktop/view/canvas/overlay.py
@@ -687,6 +687,10 @@ class CanvasOverlay(QWidget):
         widget_rect = QRectF(self.rect())
         label_white = QColor(255, 255, 255, 230)
         shadow = QColor(0, 0, 0, 160)
+        painter.save()
+        font = painter.font()
+        font.setBold(True)
+        painter.setFont(font)
         for col, row, zone in self._zone_labels:
             cell = QRectF(rect.x() + col * cw, rect.y() + row * ch, cw, ch)
             if not widget_rect.intersects(cell):
@@ -697,6 +701,7 @@ class CanvasOverlay(QWidget):
             painter.drawText(cell.translated(1.0, 1.0), Qt.AlignmentFlag.AlignCenter, label)
             painter.setPen(_ZONE_CLIP_COLOR if zone in (0, 10) else label_white)
             painter.drawText(cell, Qt.AlignmentFlag.AlignCenter, label)
+        painter.restore()
 
     def _draw_placed_heals(self, painter: QPainter) -> None:
         """Thin outlines of committed heals (strokes + legacy spots) while a retouch tool is active."""

--- a/negpy/desktop/view/canvas/overlay.py
+++ b/negpy/desktop/view/canvas/overlay.py
@@ -13,6 +13,8 @@ from negpy.desktop.converters import ImageConverter
 from negpy.desktop.session import AppState, ToolMode
 from negpy.desktop.view.canvas.crop_guides import CropGuide, guide_shapes
 from negpy.desktop.view.styles.theme import THEME
+from negpy.features.exposure.analysis import zone_grid, zone_region_labels
+from negpy.features.exposure.densitometer import zone_roman
 from negpy.features.geometry.logic import rotation_drag_angle, smooth_polyline, straighten_delta_degrees, translate_manual_crop_rect
 from negpy.features.local.logic import _rasterise_mask
 from negpy.features.retouch.models import HEAL_SIZE_REF
@@ -35,6 +37,10 @@ _MASK_RASTER_MAX = 384  # px cap for feathered overlay rasters
 _DUST_MARK_LUMA = QColor(57, 255, 20)  # neon green — auto-luma detection
 _DUST_MARK_IR = QColor(255, 0, 255)  # neon magenta — IR detection
 _IR_CORRECTED_ALPHA = 55  # dim magenta wash over IR-division-corrected regions
+
+_ZONE_LINE_ALPHA = 90
+_ZONE_LABEL_MIN_PX = 16.0  # below this cell size the numerals collide into noise
+_ZONE_CLIP_COLOR = QColor(220, 80, 80)  # paper black / paper white, same red the zone strip warns with
 
 
 def grid_interior_fractions(divisions: int) -> List[float]:
@@ -150,6 +156,13 @@ class CanvasOverlay(QWidget):
         # Same, for the auto-corrected-region magenta wash (ir_corrected_mask +
         # inpainted hair masks), keyed per mask object identity.
         self._wash_cache: Dict[int, Tuple[tuple, QImage]] = {}
+
+        # Zone overlay: the frame it reads, plus the per-cell zone grid and one label
+        # anchor per merged region. No id()-keyed cache — update_buffer invalidates
+        # unconditionally, so it can't go stale.
+        self._zone_source: Optional[np.ndarray] = None
+        self._zone_cells: Optional[np.ndarray] = None
+        self._zone_labels: List[Tuple[int, int, int]] = []
 
         # Working screen points while a selected-mask vertex is dragged/added.
         self._local_edit_verts: Optional[List[QPointF]] = None
@@ -306,6 +319,8 @@ class CanvasOverlay(QWidget):
         monitor_icc_bytes: Optional[bytes] = None,
     ) -> None:
         self._content_rect = content_rect
+        self._zone_source = buffer if isinstance(buffer, np.ndarray) else None
+        self._zone_cells = None  # rebuilt lazily on the next zones paint
         if buffer is not None:
             self._qimage = ImageConverter.to_qimage(buffer, color_space, monitor_icc_bytes)
             self._current_size = (self._qimage.width(), self._qimage.height())
@@ -464,6 +479,10 @@ class CanvasOverlay(QWidget):
         if self.state.dust_overlay_mode != "off":
             self._draw_dust_overlay(painter)
 
+        # Crop/analysis modes show the uncropped frame, so the boxes wouldn't line up.
+        if self.state.zones_overlay and not self.state.flat_peek and self._tool_mode not in (ToolMode.CROP_MANUAL, ToolMode.ANALYSIS_DRAW):
+            self._draw_zone_grid(painter)
+
         if self._rotation_grid_visible:
             self._draw_rotation_grid(painter, visible_rect)
 
@@ -617,6 +636,67 @@ class CanvasOverlay(QWidget):
         painter.drawRoundedRect(badge, 4, 4)
         painter.setPen(QColor(THEME.accent_primary))
         painter.drawText(badge, Qt.AlignmentFlag.AlignCenter, label)
+
+    def _draw_zone_grid(self, painter: QPainter) -> None:
+        """Adams-zone map over the image content: a fixed grid whose internal edges are
+        drawn only where the zone changes, so neighbouring cells of the same zone merge
+        into one region carrying a single numeral. Paper black (0) and paper white (X)
+        are flagged red.
+
+        ponytail: the grid is image-space, built once per render, so it scales with zoom
+        instead of reflowing under the cursor while panning; zoom deep enough and you're
+        inside one cell. Rebuild from the visible sub-rect if that ever matters."""
+        if self._zone_cells is None:
+            src = self._zone_source
+            if src is None:
+                return
+            if self._content_rect is not None:
+                ox, oy, cw, ch = self._content_rect
+                src = src[oy : oy + ch, ox : ox + cw]
+            self._zone_cells = zone_grid(src)
+            if self._zone_cells is None:
+                return
+            self._zone_labels = zone_region_labels(self._zone_cells)
+
+        zones = self._zone_cells
+        rows, cols = zones.shape
+        rect = self._content_view_rect()
+        cw = rect.width() / cols
+        ch = rect.height() / rows
+
+        pen = QPen(QColor(255, 255, 255, _ZONE_LINE_ALPHA), 2.0)
+        pen.setCosmetic(True)
+        painter.setPen(pen)
+        painter.setBrush(Qt.BrushStyle.NoBrush)
+        painter.drawRect(rect)
+        for r in range(rows):
+            y0, y1 = rect.y() + r * ch, rect.y() + (r + 1) * ch
+            for c in range(1, cols):
+                if zones[r, c] != zones[r, c - 1]:
+                    x = rect.x() + c * cw
+                    painter.drawLine(QPointF(x, y0), QPointF(x, y1))
+        for r in range(1, rows):
+            y = rect.y() + r * ch
+            for c in range(cols):
+                if zones[r, c] != zones[r - 1, c]:
+                    x0 = rect.x() + c * cw
+                    painter.drawLine(QPointF(x0, y), QPointF(x0 + cw, y))
+
+        if min(cw, ch) < _ZONE_LABEL_MIN_PX:
+            return
+        widget_rect = QRectF(self.rect())
+        label_white = QColor(255, 255, 255, 230)
+        shadow = QColor(0, 0, 0, 160)
+        for col, row, zone in self._zone_labels:
+            cell = QRectF(rect.x() + col * cw, rect.y() + row * ch, cw, ch)
+            if not widget_rect.intersects(cell):
+                continue
+            label = zone_roman(float(zone))
+            # Drop shadow first — white numerals vanish against a blown highlight.
+            painter.setPen(shadow)
+            painter.drawText(cell.translated(1.0, 1.0), Qt.AlignmentFlag.AlignCenter, label)
+            painter.setPen(_ZONE_CLIP_COLOR if zone in (0, 10) else label_white)
+            painter.drawText(cell, Qt.AlignmentFlag.AlignCenter, label)
 
     def _draw_placed_heals(self, painter: QPainter) -> None:
         """Thin outlines of committed heals (strokes + legacy spots) while a retouch tool is active."""

--- a/negpy/desktop/view/canvas/toolbar.py
+++ b/negpy/desktop/view/canvas/toolbar.py
@@ -148,11 +148,19 @@ class ActionToolbar(QWidget):
         self.btn_compare.setIcon(qta.icon("fa5s.adjust", color=icon_color))
         self.btn_compare.setToolTip(tooltip_with_shortcut("Before / After — show the auto baseline", "toggle_compare"))
 
+        # Overflow-only (kept as a state holder so the checked-state mirror still works).
         self.btn_flat_peek = QToolButton()
         self.btn_flat_peek.setCheckable(True)
         self.btn_flat_peek.setIcon(qta.icon("fa5s.eye", color=icon_color))
         self.btn_flat_peek.setToolTip(
             tooltip_with_shortcut("Peek flat scan — temporarily show the flat master (does not change your edit)", "toggle_flat_peek")
+        )
+
+        self.btn_zones = QToolButton()
+        self.btn_zones.setCheckable(True)
+        self.btn_zones.setIcon(qta.icon("mdi.grid", color=icon_color))
+        self.btn_zones.setToolTip(
+            tooltip_with_shortcut("Zone overlay — label each region of the print with its Adams zone", "toggle_zones")
         )
 
         # GPU availability drives the overflow toggle built below (btn moved off the row).
@@ -220,6 +228,11 @@ class ActionToolbar(QWidget):
         self._ov_flat_peek_action.setCheckable(True)
         self._ov_flat_peek_action.setToolTip(
             tooltip_with_shortcut("Peek flat scan — temporarily show the flat master (does not change your edit)", "toggle_flat_peek")
+        )
+        self._ov_zones_action = overflow_menu.addAction(qta.icon("mdi.grid", color=icon_color), "Zone Overlay")
+        self._ov_zones_action.setCheckable(True)
+        self._ov_zones_action.setToolTip(
+            tooltip_with_shortcut("Zone overlay — label each region of the print with its Adams zone", "toggle_zones")
         )
         self._ov_undo_action = overflow_menu.addAction(qta.icon("mdi.undo", color=icon_color), "Undo")
         self._ov_undo_action.setToolTip(tooltip_with_shortcut("Undo", "undo"))
@@ -313,7 +326,7 @@ class ActionToolbar(QWidget):
             self.btn_redo,
             self.btn_hq,
             self.btn_compare,
-            self.btn_flat_peek,
+            self.btn_zones,
             self.btn_overflow,
         ]
         for btn in standard_buttons:
@@ -335,7 +348,7 @@ class ActionToolbar(QWidget):
         for btn in (self.btn_zoom_fit, self.btn_zoom_original):
             btn.setCursor(Qt.CursorShape.PointingHandCursor)
 
-        # Single-row layout: toggle_left · prev · next · sep1 · zoom_label · hq · sep2 · rot_l · rot_r · flip_h · flip_v · sep3 · undo · redo · compare · flat_peek · overflow · toggle_right
+        # Single-row layout: toggle_left · prev · next · sep1 · zoom_label · hq · sep2 · rot_l · rot_r · flip_h · flip_v · sep3 · undo · redo · compare · zones · overflow · toggle_right
         row_layout.addWidget(self.btn_toggle_left)
         row_layout.addWidget(self.btn_prev)
         row_layout.addWidget(self.btn_next)
@@ -356,18 +369,18 @@ class ActionToolbar(QWidget):
         row_layout.addWidget(self.btn_undo)
         row_layout.addWidget(self.btn_redo)
         row_layout.addWidget(self.btn_compare)
-        row_layout.addWidget(self.btn_flat_peek)
+        row_layout.addWidget(self.btn_zones)
         row_layout.addWidget(self.btn_overflow)
         row_layout.addWidget(self.btn_toggle_right)
 
         # Overflow groups for responsive resize (first listed = first collapsed).
-        self._ov_compare_peek: list = [self.btn_compare, self.btn_flat_peek]
+        self._ov_view_toggles: list = [self.btn_compare, self.btn_zones]
         self._ov_undo_redo: list = [self._sep3, self.btn_undo, self.btn_redo]
         self._ov_zoom_extra: list = [self.btn_zoom_fit, self.btn_zoom_original]
         self._ov_hq_group: list = [self.btn_hq, self._sep2]
         self._ov_flip_rotate: list = [self.btn_rot_l, self.btn_rot_r, self.btn_flip_h, self.btn_flip_v, self._sep3]
         self._collapse_groups: list = [
-            self._ov_compare_peek,
+            self._ov_view_toggles,
             self._ov_undo_redo,
             self._ov_zoom_extra,
             self._ov_hq_group,
@@ -377,6 +390,12 @@ class ActionToolbar(QWidget):
         v_layout.addLayout(row_layout)
         # Size the pill to its controls; don't stretch it across the canvas.
         main_layout.addWidget(container, 0, Qt.AlignmentFlag.AlignCenter)
+
+    def _on_zones_changed(self, active: bool) -> None:
+        for widget in (self.btn_zones, self._ov_zones_action):
+            widget.blockSignals(True)
+            widget.setChecked(active)
+            widget.blockSignals(False)
 
     def _on_flat_peek_changed(self, active: bool) -> None:
         self.btn_flat_peek.blockSignals(True)
@@ -407,6 +426,9 @@ class ActionToolbar(QWidget):
         self.controller.compare_changed.connect(self._ov_compare_action.setChecked)
         self.btn_flat_peek.toggled.connect(lambda checked: self.controller.toggle_flat_peek(force=checked))
         self.controller.flat_peek_changed.connect(self._on_flat_peek_changed)
+        self.btn_zones.toggled.connect(lambda checked: self.controller.toggle_zones_overlay(force=checked))
+        self._ov_zones_action.triggered.connect(lambda checked: self.controller.toggle_zones_overlay(force=checked))
+        self.controller.zones_overlay_changed.connect(self._on_zones_changed)
         self._ov_gpu_action.toggled.connect(self._on_gpu_toggled)
         self.controller.zoom_changed.connect(self._on_zoom_changed)
 
@@ -581,6 +603,7 @@ class ActionToolbar(QWidget):
         self._ov_compare_action.setChecked(state.compare_mode)
         self.btn_flat_peek.setChecked(state.flat_peek)
         self._ov_flat_peek_action.setChecked(state.flat_peek)
+        self._on_zones_changed(state.zones_overlay)
 
         geo = state.config.geometry
         self.btn_flip_h.setChecked(geo.flip_horizontal)

--- a/negpy/desktop/view/keyboard_shortcuts.py
+++ b/negpy/desktop/view/keyboard_shortcuts.py
@@ -93,6 +93,7 @@ class ShortcutManager:
             "local_draw": lambda: _toggle_tool_button(self.window, "tone", controls.local_sidebar.draw_btn),
             "analysis_draw": lambda: _toggle_tool_button(self.window, "setup", controls.process_sidebar.analysis_region_btn),
             "toggle_flat_peek": controller.toggle_flat_peek,
+            "toggle_zones": controller.toggle_zones_overlay,
             "cancel_tool": lambda: _context_cancel(controller, self.window),
             "toggle_left_panel": self.window.toggle_session_dock,
             "toggle_right_panel": self.window.toggle_controls_dock,

--- a/negpy/desktop/view/main_window.py
+++ b/negpy/desktop/view/main_window.py
@@ -404,6 +404,7 @@ class MainWindow(QMainWindow):
         self.controller.rotation_guide_requested.connect(self.canvas.overlay.show_rotation_grid)
         self.controller.crop_guide_changed.connect(self.canvas.overlay.update)
         self.controller.dust_overlay_changed.connect(self.canvas.overlay.update)
+        self.controller.zones_overlay_changed.connect(lambda _on: self.canvas.overlay.update())
 
         self.controller.status_message_requested.connect(self.canvas.hud.showMessage)
         self.controller.status_progress_requested.connect(self.canvas.hud.set_progress)

--- a/negpy/desktop/view/shortcut_registry.py
+++ b/negpy/desktop/view/shortcut_registry.py
@@ -41,6 +41,7 @@ REGISTRY: dict[str, ShortcutEntry] = {
     "local_draw": ShortcutEntry("Shift+B", "Toggle dodge & burn mask draw", "Tools"),
     "analysis_draw": ShortcutEntry("Shift+R", "Toggle analysis region draw", "Tools"),
     "toggle_flat_peek": ShortcutEntry("|", "Peek flat scan (digital intermediate)", "Tools"),
+    "toggle_zones": ShortcutEntry("Shift+Z", "Adams zone overlay", "Tools"),
     "cancel_tool": ShortcutEntry("Esc", "Cancel active tool (first press clears in-progress points)", "Tools"),
     "cyan_dec": ShortcutEntry("", "Cyan down", "Exposure"),
     "cyan_inc": ShortcutEntry("", "Cyan up", "Exposure"),

--- a/negpy/features/exposure/analysis.py
+++ b/negpy/features/exposure/analysis.py
@@ -1,8 +1,9 @@
-"""Analysis-panel histogram/zone math. Pure NumPy, no Qt."""
+"""Analysis-panel histogram/zone math. Pure NumPy/OpenCV, no Qt."""
 
 from functools import lru_cache
-from typing import Any, Optional, Tuple
+from typing import Any, List, Optional, Tuple
 
+import cv2
 import numpy as np
 
 from negpy.kernel.image.logic import get_luminance, working_oetf_encode
@@ -83,6 +84,48 @@ def zone_warnings(occ: np.ndarray) -> Tuple[bool, bool]:
     shadow = float(occ[2] + occ[3]) < ZONE_EMPTY and float(occ[0] + occ[1]) > ZONE_LOADED
     highlight = float(occ[7] + occ[8]) < ZONE_EMPTY and float(occ[9]) > ZONE_LOADED
     return shadow, highlight
+
+
+ZONE_GRID_CELLS = 24  # cells along the frame's long edge
+
+
+def zone_grid(rgb: Any, cells: int = ZONE_GRID_CELLS) -> Optional[np.ndarray]:
+    """Integer Adams zone (0..10) per cell of a fixed grid over a display-encoded H×W×3
+    frame; None if the frame isn't one. Cells are square-ish whatever the aspect, and the
+    area-average over a cell is what damps grain — no extra smoothing needed.
+
+    The frame is sRGB- rather than Adobe-RGB-encoded on the soft-proof/splash path; the
+    ruler hinge differs by ~0.04 zone there, under the rounding step, so we don't branch.
+    """
+    rgb = np.asarray(rgb)
+    if rgb.ndim != 3 or rgb.shape[-1] < 3 or min(rgb.shape[:2]) < 2:
+        return None
+    h, w = rgb.shape[:2]
+    # Slice first: INTER_AREA straight off a full-res HQ buffer costs ~50 ms.
+    step = max(1, min(h, w) // (4 * cells))
+    small = np.ascontiguousarray(rgb[::step, ::step, :3], dtype=np.float32)
+    scale = cells / max(small.shape[:2])
+    sh, sw = small.shape[:2]
+    small = cv2.resize(small, (max(1, round(sw * scale)), max(1, round(sh * scale))), interpolation=cv2.INTER_AREA)
+    z = np.nan_to_num(zone_of_encoded(get_luminance(small)))
+    return np.rint(z).astype(np.int32)
+
+
+def zone_region_labels(zones: np.ndarray) -> List[Tuple[int, int, int]]:
+    """One label anchor per contiguous same-zone region: [(col, row, zone)].
+
+    Anchors are snapped to a cell the region actually owns, so a concave region's numeral
+    can't land outside it (its centroid can).
+    """
+    out: List[Tuple[int, int, int]] = []
+    for zone in np.unique(zones):
+        count, comp, _, centroids = cv2.connectedComponentsWithStats((zones == zone).astype(np.uint8), connectivity=4)
+        for i in range(1, count):  # 0 is the background (everything not this zone)
+            ys, xs = np.nonzero(comp == i)
+            cx, cy = centroids[i]
+            j = int(np.argmin((xs - cx) ** 2 + (ys - cy) ** 2))
+            out.append((int(xs[j]), int(ys[j]), int(zone)))
+    return out
 
 
 def density_histogram(normalized_log: np.ndarray, roi: Optional[Tuple[int, int, int, int]] = None) -> np.ndarray:

--- a/tests/test_canvas_toolbar.py
+++ b/tests/test_canvas_toolbar.py
@@ -18,6 +18,7 @@ def _make_toolbar() -> ActionToolbar:
     controller.session.state.hq_preview = False
     controller.session.state.compare_mode = False
     controller.session.state.flat_peek = False
+    controller.session.state.zones_overlay = False
     controller.session.state.selected_file_idx = 0
     controller.session.state.undo_index = 0
     controller.session.state.max_history_index = 0

--- a/tests/test_zone_grid.py
+++ b/tests/test_zone_grid.py
@@ -1,0 +1,54 @@
+import numpy as np
+
+from negpy.features.exposure.analysis import ZONE_GRID_CELLS, zone_grid, zone_region_labels
+from negpy.kernel.image.logic import working_oetf_encode
+
+
+def _flat(value: float, h: int = 180, w: int = 240) -> np.ndarray:
+    return np.full((h, w, 3), value, dtype=np.float32)
+
+
+def _mid() -> float:
+    return float(working_oetf_encode(np.asarray([0.18], dtype=np.float32))[0])
+
+
+def test_grid_is_square_ish_cells_on_the_long_edge():
+    zones = zone_grid(_flat(0.5, 180, 240))
+    assert zones.shape == (round(ZONE_GRID_CELLS * 180 / 240), ZONE_GRID_CELLS)
+
+
+def test_mid_gray_reads_zone_five_everywhere():
+    assert np.all(zone_grid(_flat(_mid())) == 5)
+
+
+def test_uniform_frame_is_one_region_labelled_at_its_centre():
+    zones = zone_grid(_flat(_mid()))
+    rows, cols = zones.shape
+    assert zone_region_labels(zones) == [(cols // 2 - 1, rows // 2 - 1, 5)]
+
+
+def test_black_and_white_halves_are_one_region_each():
+    img = _flat(0.0)
+    img[:, 120:] = 1.0
+    labels = zone_region_labels(zone_grid(img))
+    assert len(labels) == 2
+    assert {zone for *_, zone in labels} == {0, 10}
+
+
+def test_grain_does_not_shatter_a_flat_field_into_confetti():
+    rng = np.random.default_rng(0)
+    grainy = np.clip(_flat(_mid(), 1067, 1600) + rng.normal(0, 0.05, (1067, 1600, 3)), 0.0, 1.0).astype(np.float32)
+    # A noisy but tonally uniform field must merge, not read as a grid of identical labels.
+    assert len(zone_region_labels(zone_grid(grainy))) <= 3
+
+
+def test_label_anchor_sits_inside_its_own_region():
+    rng = np.random.default_rng(1)
+    zones = zone_grid(rng.random((1067, 1600, 3), dtype=np.float32))
+    for col, row, zone in zone_region_labels(zones):
+        assert zones[row, col] == zone
+
+
+def test_degenerate_input_has_no_grid():
+    assert zone_grid(np.zeros((1, 240, 3), dtype=np.float32)) is None
+    assert zone_grid(np.zeros((180, 240), dtype=np.float32)) is None


### PR DESCRIPTION
## What

A togglable Adams-zone map over the preview canvas, so you can see *where* each zone falls in the frame instead of hovering pixel by pixel.

Until now zones were reported in two places, both in the right sidebar: the 10-cell zone strip (whole-frame occupancy) and the spot densitometer (one pixel under the cursor). Neither answers the question a printer actually asks — is that sky VIII or blown, does the shadow side of the face still hold III.

Toggle it from the toolbar (grid icon) or `Shift+Z`.

## How it looks

A fixed grid is laid over the print, 24 cells along the long edge. Neighbouring cells that share a zone merge into one region — the edge between them is simply not drawn — and each region carries a single Roman numeral at its centre. Paper black (0) and paper white (X) are flagged red.

## Notes

- The ruler is the existing `zone_of_encoded`, the same one the sidebar strip and the densitometer report, so the three can't disagree.
- The grid is built once per render from the frame the canvas already holds, so toggling costs a repaint, not a re-render. It's image-space, so it stays pinned to the picture rather than reflowing under the cursor while panning.
- Cells are area-averages, which is what damps grain — an earlier adaptive-subdivision pass shattered a grassy field into a confetti of identical labels.
- Hidden during flat peek and while the crop/analysis tools are open (those show the uncropped frame); kept on in before/after.
- Peek Flat Scan moves off the toolbar row into the overflow menu to make room.

## Verification

`make all` green (2532 passed). New `tests/test_zone_grid.py` covers cell geometry, the mid-gray anchor, region merging, the grain case, and that a label anchor always lands inside its own region. Also rendered over a real scan off-screen to check the look.