### PR TITLE
Disable sensor profile if linear raw is off

### DIFF
--- a/negpy/desktop/view/sidebar/sensor.py
+++ b/negpy/desktop/view/sidebar/sensor.py
@@ -1,7 +1,7 @@
 from PyQt6.QtWidgets import QComboBox, QHBoxLayout
 
 from negpy.desktop.view.sidebar.base import BaseSidebar
-from negpy.desktop.view.styles.templates import field_label, hint_label
+from negpy.desktop.view.styles.templates import field_label, hint_label, wrap_tooltip
 from negpy.features.process.models import invalidate_local_bounds
 from negpy.features.process.sensor import sensor_unmix_available
 from negpy.services.assets.sensor import SensorProfiles
@@ -34,10 +34,17 @@ class SensorSidebar(BaseSidebar):
         row.addWidget(self.calibrate_sensor_btn)
         self.layout.addLayout(row)
 
-        self.linear_raw_hint = hint_label(
-            "Turn on Linear RAW to use a sensor profile — matrices are calibrated against "
-            "neutral white balance, so the as-shot camera gains would misapply them.",
-            kind="warning",
+        # Muted, not warning: this is the normal state for anyone not using Linear
+        # RAW, so it explains the greyed controls rather than flagging a problem.
+        self.linear_raw_hint = hint_label("Requires Linear RAW.")
+        # Disabled widgets don't receive the hover that raises a tooltip, so the
+        # detail hangs off this label rather than the combo it describes.
+        self.linear_raw_hint.setToolTip(
+            wrap_tooltip(
+                "Sensor profiles are calibrated against neutral white balance. With Linear RAW "
+                "off, RAW decodes carry the camera's as-shot gains instead, which would misapply "
+                "the matrix — so it is skipped. Your selection is remembered."
+            )
         )
         self.layout.addWidget(self.linear_raw_hint)
         self._apply_gate(conf)

--- a/negpy/desktop/view/sidebar/sensor.py
+++ b/negpy/desktop/view/sidebar/sensor.py
@@ -1,8 +1,9 @@
 from PyQt6.QtWidgets import QComboBox, QHBoxLayout
 
 from negpy.desktop.view.sidebar.base import BaseSidebar
-from negpy.desktop.view.styles.templates import field_label
+from negpy.desktop.view.styles.templates import field_label, hint_label
 from negpy.features.process.models import invalidate_local_bounds
+from negpy.features.process.sensor import effective_sensor_matrix
 from negpy.services.assets.sensor import SensorProfiles
 
 
@@ -25,7 +26,7 @@ class SensorSidebar(BaseSidebar):
             "cross-channel response in the LINEAR capture, before inversion — a fixed property of "
             "your sensor + light, independent of film. Calibrate it from three bare-light R/G/B "
             "exposures; custom .toml matrices live in the NegPy/sensor folder. Skipped automatically "
-            "for RGB-triplet assets. Re-run Batch Analysis after changing this."
+            "for RGB-triplet assets and when Linear RAW is off. Re-run Batch Analysis after changing this."
             "</td></tr></table>"
         )
         self.calibrate_sensor_btn = self._icon_action("fa5s.vials", "Calibrate the sensor from three bare-light R/G/B exposures", width=32)
@@ -33,6 +34,18 @@ class SensorSidebar(BaseSidebar):
         row.addWidget(self.sensor_combo, 1)
         row.addWidget(self.calibrate_sensor_btn)
         self.layout.addLayout(row)
+
+        self.linear_raw_hint = hint_label(
+            "Needs Linear RAW — matrices are calibrated against neutral white balance, so the as-shot camera gains would misapply them.",
+            kind="warning",
+        )
+        self.linear_raw_hint.setVisible(self._matrix_is_inert(conf))
+        self.layout.addWidget(self.linear_raw_hint)
+
+    @staticmethod
+    def _matrix_is_inert(conf) -> bool:
+        """A profile is selected but the pipeline will skip it."""
+        return conf.sensor_matrix is not None and effective_sensor_matrix(conf) is None
 
     def _connect_signals(self) -> None:
         self.sensor_combo.currentTextChanged.connect(self._on_sensor_profile_changed)
@@ -71,6 +84,9 @@ class SensorSidebar(BaseSidebar):
                 self.sensor_combo.clear()
                 self.sensor_combo.addItems(profiles)
             self.sensor_combo.setCurrentText(conf.sensor_profile)
+            # The selection stays editable so it survives a Linear RAW round-trip;
+            # only the warning marks that it is inert.
+            self.linear_raw_hint.setVisible(self._matrix_is_inert(conf))
         finally:
             self.block_signals(False)
 

--- a/negpy/desktop/view/sidebar/sensor.py
+++ b/negpy/desktop/view/sidebar/sensor.py
@@ -3,7 +3,7 @@ from PyQt6.QtWidgets import QComboBox, QHBoxLayout
 from negpy.desktop.view.sidebar.base import BaseSidebar
 from negpy.desktop.view.styles.templates import field_label, hint_label
 from negpy.features.process.models import invalidate_local_bounds
-from negpy.features.process.sensor import effective_sensor_matrix
+from negpy.features.process.sensor import sensor_unmix_available
 from negpy.services.assets.sensor import SensorProfiles
 
 
@@ -19,7 +19,6 @@ class SensorSidebar(BaseSidebar):
         self.sensor_label = field_label("Profile")
         self.sensor_combo = QComboBox()
         self.sensor_combo.addItems(SensorProfiles.list_profiles())
-        self.sensor_combo.setCurrentText(conf.sensor_profile)
         self.sensor_combo.setToolTip(
             "<table width='280'><tr><td>"
             "Sensor crosstalk correction for single-shot narrowband scans: un-mixes the camera's "
@@ -36,16 +35,24 @@ class SensorSidebar(BaseSidebar):
         self.layout.addLayout(row)
 
         self.linear_raw_hint = hint_label(
-            "Needs Linear RAW — matrices are calibrated against neutral white balance, so the as-shot camera gains would misapply them.",
+            "Turn on Linear RAW to use a sensor profile — matrices are calibrated against "
+            "neutral white balance, so the as-shot camera gains would misapply them.",
             kind="warning",
         )
-        self.linear_raw_hint.setVisible(self._matrix_is_inert(conf))
         self.layout.addWidget(self.linear_raw_hint)
+        self._apply_gate(conf)
 
-    @staticmethod
-    def _matrix_is_inert(conf) -> bool:
-        """A profile is selected but the pipeline will skip it."""
-        return conf.sensor_matrix is not None and effective_sensor_matrix(conf) is None
+    def _apply_gate(self, conf) -> None:
+        """Grey the panel and show "None" while the unmix cannot be applied.
+
+        Display-only: conf.sensor_profile is deliberately left alone, so the
+        selection comes back intact after a Linear RAW round-trip.
+        """
+        available = sensor_unmix_available(conf)
+        self.sensor_combo.setCurrentText(conf.sensor_profile if available else SensorProfiles.NONE_NAME)
+        self.sensor_combo.setEnabled(available)
+        self.calibrate_sensor_btn.setEnabled(available)
+        self.linear_raw_hint.setVisible(not available)
 
     def _connect_signals(self) -> None:
         self.sensor_combo.currentTextChanged.connect(self._on_sensor_profile_changed)
@@ -83,10 +90,7 @@ class SensorSidebar(BaseSidebar):
             if profiles != [self.sensor_combo.itemText(i) for i in range(self.sensor_combo.count())]:
                 self.sensor_combo.clear()
                 self.sensor_combo.addItems(profiles)
-            self.sensor_combo.setCurrentText(conf.sensor_profile)
-            # The selection stays editable so it survives a Linear RAW round-trip;
-            # only the warning marks that it is inert.
-            self.linear_raw_hint.setVisible(self._matrix_is_inert(conf))
+            self._apply_gate(conf)
         finally:
             self.block_signals(False)
 

--- a/negpy/desktop/workers/render.py
+++ b/negpy/desktop/workers/render.py
@@ -11,7 +11,7 @@ from negpy.domain.models import WorkspaceConfig
 from negpy.features.exposure.analysis import output_histogram
 from negpy.features.flatfield.logic import apply_flatfield
 from negpy.features.geometry.batch_autocrop import detect_crop_candidate, resolve_roll_crops
-from negpy.features.process.sensor import apply_sensor_correction
+from negpy.features.process.sensor import apply_sensor_correction, effective_sensor_matrix
 from negpy.features.rgbscan.models import is_rgb_triplet
 from negpy.features.geometry.processor import GeometryProcessor
 from negpy.infrastructure.display.color_spaces import WORKING_COLOR_SPACE
@@ -837,8 +837,9 @@ class NormalizationWorker(QObject):
                     raw = slice_for_asset(raw, f_info)
                     # Bounds must be measured on the same channel mix the render path
                     # normalizes (triplet composites are never sensor-corrected there).
-                    if params is not None and params.process.sensor_matrix is not None and not is_rgb_triplet(params.rgbscan):
-                        raw = await asyncio.to_thread(apply_sensor_correction, raw, params.process.sensor_matrix)
+                    sensor_matrix = effective_sensor_matrix(params.process) if params is not None else None
+                    if sensor_matrix is not None and not is_rgb_triplet(params.rgbscan):
+                        raw = await asyncio.to_thread(apply_sensor_correction, raw, sensor_matrix)
 
                     ctx = PipelineContext(
                         original_size=(raw.shape[1], raw.shape[0]),

--- a/negpy/features/process/sensor.py
+++ b/negpy/features/process/sensor.py
@@ -57,8 +57,23 @@ def apply_sensor_correction(img: ImageBuffer, matrix: Optional[tuple]) -> ImageB
     return np.clip(out, 0.0, None)
 
 
+def effective_sensor_matrix(process: ProcessConfig) -> Optional[tuple]:
+    """The matrix to actually apply, or None when it would land in the wrong basis.
+
+    Matrices are always calibrated from neutral-WB decodes (the dialog forces
+    use_camera_wb=False). With Linear RAW off, a RAW buffer instead carries the
+    camera's as-shot per-channel gains, and a diagonal gain does not commute with
+    the non-diagonal unmix — the leftover term is sign-flipped, so the correction
+    overcorrects rather than degrading gracefully. Skipped entirely there.
+    """
+    if not process.linear_raw:
+        return None
+    return process.sensor_matrix
+
+
 def sensor_token(process: ProcessConfig) -> str:
     """Identity of the baked sensor matrix, folded into the render source hash."""
-    if process.sensor_matrix is None:
+    matrix = effective_sensor_matrix(process)
+    if matrix is None:
         return ""
-    return "|sn:" + ",".join(f"{v:.6g}" for v in process.sensor_matrix)
+    return "|sn:" + ",".join(f"{v:.6g}" for v in matrix)

--- a/negpy/features/process/sensor.py
+++ b/negpy/features/process/sensor.py
@@ -57,16 +57,24 @@ def apply_sensor_correction(img: ImageBuffer, matrix: Optional[tuple]) -> ImageB
     return np.clip(out, 0.0, None)
 
 
-def effective_sensor_matrix(process: ProcessConfig) -> Optional[tuple]:
-    """The matrix to actually apply, or None when it would land in the wrong basis.
+def sensor_unmix_available(process: ProcessConfig) -> bool:
+    """Whether the decode basis can carry the unmix at all.
 
     Matrices are always calibrated from neutral-WB decodes (the dialog forces
     use_camera_wb=False). With Linear RAW off, a RAW buffer instead carries the
     camera's as-shot per-channel gains, and a diagonal gain does not commute with
     the non-diagonal unmix — the leftover term is sign-flipped, so the correction
-    overcorrects rather than degrading gracefully. Skipped entirely there.
+    overcorrects rather than degrading gracefully.
+
+    Single source of truth: the sidebar greys the panel on this, the pipeline
+    skips on effective_sensor_matrix below, so the two cannot disagree.
     """
-    if not process.linear_raw:
+    return process.linear_raw
+
+
+def effective_sensor_matrix(process: ProcessConfig) -> Optional[tuple]:
+    """The baked matrix, or None when the basis makes it invalid to apply."""
+    if not sensor_unmix_available(process):
         return None
     return process.sensor_matrix
 

--- a/negpy/services/rendering/image_processor.py
+++ b/negpy/services/rendering/image_processor.py
@@ -19,7 +19,7 @@ from negpy.domain.models import (
 )
 from negpy.features.process.models import ProcessMode
 from negpy.features.process.logic import linear_raw_token
-from negpy.features.process.sensor import apply_sensor_correction, sensor_token
+from negpy.features.process.sensor import apply_sensor_correction, effective_sensor_matrix, sensor_token
 from negpy.features.exposure.models import RenderIntent
 from negpy.features.flatfield.logic import apply_flatfield, flatfield_token
 from negpy.features.retouch.logic import (
@@ -309,7 +309,7 @@ class ImageProcessor:
         # each channel from its own single-band exposure, so unmixing them would inject
         # crosstalk that was never captured.
         if not skip_flatfield and not is_rgb_triplet(settings.rgbscan):
-            img = apply_sensor_correction(img, settings.process.sensor_matrix)
+            img = apply_sensor_correction(img, effective_sensor_matrix(settings.process))
         h_orig, w_cols = img.shape[:2]
         # Fold the buffer resolution into source_hash: toggling HQ re-decodes the same
         # file at full resolution with unchanged settings, so without this the engine
@@ -542,7 +542,7 @@ class ImageProcessor:
         f32_buffer = apply_exif_orientation(f32_buffer, orientation)
         f32_buffer = apply_flatfield(f32_buffer, params.flatfield)
         if not is_triplet:
-            f32_buffer = apply_sensor_correction(f32_buffer, params.process.sensor_matrix)
+            f32_buffer = apply_sensor_correction(f32_buffer, effective_sensor_matrix(params.process))
         if ir_full is not None:
             ir_full = apply_exif_orientation(ir_full, orientation)
         return f32_buffer, ir_full, source_cs

--- a/tests/test_sensor_calibration.py
+++ b/tests/test_sensor_calibration.py
@@ -7,6 +7,7 @@ from negpy.domain.models import WorkspaceConfig
 from negpy.features.process.sensor import (
     apply_sensor_correction,
     build_sensor_matrix,
+    effective_sensor_matrix,
     measure_capture,
     sensor_token,
 )
@@ -75,6 +76,40 @@ def test_sensor_token_tracks_matrix():
     assert sensor_token(on) != sensor_token(on2) != ""
 
 
+def test_effective_matrix_needs_linear_raw():
+    matrix = (1.0, -0.1, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0)
+    base = WorkspaceConfig().process
+    assert effective_sensor_matrix(base) is None  # no matrix baked
+    on = replace(base, sensor_matrix=matrix, linear_raw=True)
+    assert effective_sensor_matrix(on) == matrix
+    off = replace(on, linear_raw=False)
+    assert effective_sensor_matrix(off) is None
+    # The token must agree, or the render cache would key two identical renders apart.
+    assert sensor_token(off) == ""
+
+
+def test_camera_wb_basis_breaks_the_unmix():
+    """Why the Linear RAW gate exists: a WB gain does not commute with the unmix."""
+    s_true = np.array([[1.0, 0.06, 0.02], [0.08, 1.0, 0.22], [0.02, 0.18, 1.0]])
+    wb = np.diag([2.1, 1.0, 1.55])  # as-shot camera multipliers (use_camera_wb=True)
+
+    def cols(m):
+        return (tuple(m[:, 0]), tuple(m[:, 1]), tuple(m[:, 2]))
+
+    def residual(matrix, buffer_basis):
+        out = np.array(matrix).reshape(3, 3) @ buffer_basis
+        norm = out / np.diag(out)[:, None]  # a leftover diagonal is absorbed downstream
+        return np.abs(norm - np.diag(np.diag(norm))).max()
+
+    neutral = build_sensor_matrix(*cols(s_true))
+    assert residual(neutral, s_true) < 1e-9  # matched basis: exact
+    # Neutral-calibrated matrix on a camera-WB buffer keeps most of the 22% leak.
+    assert residual(neutral, wb @ s_true) > 0.1
+    # Column normalization makes the matrix transform by similarity, so calibrating
+    # in the same WB basis would be exact — the gate, not the math, is the blocker.
+    assert residual(build_sensor_matrix(*cols(wb @ s_true)), wb @ s_true) < 1e-9
+
+
 def test_is_rgb_triplet_truth_table():
     assert not is_rgb_triplet(RgbScanConfig())
     assert not is_rgb_triplet(RgbScanConfig(enabled=True))
@@ -129,3 +164,8 @@ def test_run_pipeline_gates_triplets(monkeypatch):
     calls.clear()
     ip.run_pipeline(img, cfg, "h", render_size_ref=float(APP_CONFIG.preview_render_size), prefer_gpu=False, skip_flatfield=True)
     assert calls == []  # skip_flatfield buffers were corrected at decode already
+
+    calls.clear()
+    wb_cfg = replace(cfg, process=replace(cfg.process, linear_raw=False))
+    ip.run_pipeline(img, wb_cfg, "h", render_size_ref=float(APP_CONFIG.preview_render_size), prefer_gpu=False)
+    assert calls == [None]  # camera-WB buffer: wrong basis for a neutral-WB matrix

--- a/tests/test_sensor_sidebar.py
+++ b/tests/test_sensor_sidebar.py
@@ -1,0 +1,56 @@
+"""The sensor sidebar builds, and surfaces the Linear RAW gate.
+
+A baked matrix is inert while Linear RAW is off (effective_sensor_matrix returns
+None there), so the panel must say so rather than silently doing nothing.
+"""
+
+import sys
+from dataclasses import replace
+from unittest.mock import MagicMock
+
+from PyQt6.QtWidgets import QApplication
+
+from negpy.domain.models import WorkspaceConfig
+from negpy.desktop.view.sidebar.sensor import SensorSidebar
+
+if not QApplication.instance():
+    _app = QApplication(sys.argv)
+
+_MATRIX = (1.0, -0.1, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0)
+
+
+def _sidebar(linear_raw=True, sensor_matrix=None):
+    cfg = WorkspaceConfig()
+    cfg = replace(cfg, process=replace(cfg.process, linear_raw=linear_raw, sensor_matrix=sensor_matrix))
+    ctrl = MagicMock()
+    ctrl.state.config = cfg
+    return SensorSidebar(ctrl)
+
+
+def test_sidebar_builds_with_all_controls():
+    w = _sidebar()
+    for attr in ("sensor_combo", "calibrate_sensor_btn", "linear_raw_hint"):
+        assert hasattr(w, attr), attr
+
+
+def test_hint_only_when_a_matrix_is_inert():
+    # isHidden, not isVisible: the sidebar is never shown here, which would report
+    # every child as invisible regardless of its own setVisible state.
+    assert _sidebar(linear_raw=True, sensor_matrix=_MATRIX).linear_raw_hint.isHidden()
+    assert _sidebar(linear_raw=False, sensor_matrix=None).linear_raw_hint.isHidden()
+    assert not _sidebar(linear_raw=False, sensor_matrix=_MATRIX).linear_raw_hint.isHidden()
+
+
+def test_sync_ui_tracks_linear_raw_toggle():
+    w = _sidebar(linear_raw=True, sensor_matrix=_MATRIX)
+    assert w.linear_raw_hint.isHidden()
+
+    cfg = w.state.config
+    w.state.config = replace(cfg, process=replace(cfg.process, linear_raw=False))
+    w.sync_ui()
+    assert not w.linear_raw_hint.isHidden()
+
+    cfg = w.state.config
+    w.state.config = replace(cfg, process=replace(cfg.process, linear_raw=True))
+    w.sync_ui()
+    assert w.linear_raw_hint.isHidden()

--- a/tests/test_sensor_sidebar.py
+++ b/tests/test_sensor_sidebar.py
@@ -1,27 +1,43 @@
-"""The sensor sidebar builds, and surfaces the Linear RAW gate.
+"""The sensor sidebar builds, and greys itself out when the unmix can't apply.
 
 A baked matrix is inert while Linear RAW is off (effective_sensor_matrix returns
-None there), so the panel must say so rather than silently doing nothing.
+None there), so the panel shows "None" and disables its controls rather than
+leaving a profile that looks selected but does nothing.
 """
 
+import os
 import sys
 from dataclasses import replace
 from unittest.mock import MagicMock
 
+import pytest
 from PyQt6.QtWidgets import QApplication
 
-from negpy.domain.models import WorkspaceConfig
 from negpy.desktop.view.sidebar.sensor import SensorSidebar
+from negpy.domain.models import WorkspaceConfig
+from negpy.kernel.system.config import APP_CONFIG
+from negpy.services.assets.sensor import SensorProfiles
 
 if not QApplication.instance():
     _app = QApplication(sys.argv)
 
-_MATRIX = (1.0, -0.1, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0)
+_MATRIX = (1.0, -0.1, 0.0, 0.0, 1.1, -0.3, 0.0, -0.3, 1.1)
+_NAME = "My Sensor"
 
 
-def _sidebar(linear_raw=True, sensor_matrix=None):
+@pytest.fixture(autouse=True)
+def _isolate(tmp_path, monkeypatch):
+    monkeypatch.setattr(APP_CONFIG, "sensor_dir", str(tmp_path))
+    with open(os.path.join(tmp_path, "my_sensor.toml"), "w", encoding="utf-8") as f:
+        f.write(f'name = "{_NAME}"\nmatrix = [[1.0, -0.1, 0.0], [0.0, 1.1, -0.3], [0.0, -0.3, 1.1]]\n')
+
+
+def _sidebar(linear_raw=True, profile=_NAME, sensor_matrix=_MATRIX):
     cfg = WorkspaceConfig()
-    cfg = replace(cfg, process=replace(cfg.process, linear_raw=linear_raw, sensor_matrix=sensor_matrix))
+    cfg = replace(
+        cfg,
+        process=replace(cfg.process, linear_raw=linear_raw, sensor_profile=profile, sensor_matrix=sensor_matrix),
+    )
     ctrl = MagicMock()
     ctrl.state.config = cfg
     return SensorSidebar(ctrl)
@@ -33,24 +49,49 @@ def test_sidebar_builds_with_all_controls():
         assert hasattr(w, attr), attr
 
 
-def test_hint_only_when_a_matrix_is_inert():
+def test_profile_is_live_with_linear_raw_on():
+    w = _sidebar(linear_raw=True)
+    assert w.sensor_combo.currentText() == _NAME
+    assert w.sensor_combo.isEnabled()
+    assert w.calibrate_sensor_btn.isEnabled()
     # isHidden, not isVisible: the sidebar is never shown here, which would report
     # every child as invisible regardless of its own setVisible state.
-    assert _sidebar(linear_raw=True, sensor_matrix=_MATRIX).linear_raw_hint.isHidden()
-    assert _sidebar(linear_raw=False, sensor_matrix=None).linear_raw_hint.isHidden()
-    assert not _sidebar(linear_raw=False, sensor_matrix=_MATRIX).linear_raw_hint.isHidden()
-
-
-def test_sync_ui_tracks_linear_raw_toggle():
-    w = _sidebar(linear_raw=True, sensor_matrix=_MATRIX)
     assert w.linear_raw_hint.isHidden()
+
+
+def test_panel_greys_out_with_linear_raw_off():
+    w = _sidebar(linear_raw=False)
+    assert w.sensor_combo.currentText() == SensorProfiles.NONE_NAME
+    assert not w.sensor_combo.isEnabled()
+    assert not w.calibrate_sensor_btn.isEnabled()
+    assert not w.linear_raw_hint.isHidden()
+
+
+def test_hint_shows_even_without_a_baked_profile():
+    # Otherwise the controls would be greyed with nothing explaining why.
+    w = _sidebar(linear_raw=False, profile=SensorProfiles.NONE_NAME, sensor_matrix=None)
+    assert not w.linear_raw_hint.isHidden()
+
+
+def test_gate_is_display_only_and_survives_a_round_trip(monkeypatch):
+    w = _sidebar(linear_raw=True)
+    # Forcing the combo to "None" fires currentTextChanged; if that reached the
+    # handler it would persist sensor_profile="None" and lose the user's choice.
+    writes = []
+    monkeypatch.setattr(w, "update_config_section", lambda *a, **k: writes.append(k))
 
     cfg = w.state.config
     w.state.config = replace(cfg, process=replace(cfg.process, linear_raw=False))
     w.sync_ui()
-    assert not w.linear_raw_hint.isHidden()
+    assert w.sensor_combo.currentText() == SensorProfiles.NONE_NAME
+    assert writes == []
+    assert w.state.config.process.sensor_profile == _NAME
+    assert w.state.config.process.sensor_matrix == _MATRIX
 
     cfg = w.state.config
     w.state.config = replace(cfg, process=replace(cfg.process, linear_raw=True))
     w.sync_ui()
+    assert w.sensor_combo.currentText() == _NAME
+    assert w.sensor_combo.isEnabled()
     assert w.linear_raw_hint.isHidden()
+    assert writes == []


### PR DESCRIPTION
## Skip the sensor unmix when Linear RAW is off

Sensor crosstalk matrices are always calibrated from neutral-WB decodes — the calibration dialog hard-codes `use_camera_wb=False`. But the correction was applied unconditionally, including when Linear RAW is off, where a RAW buffer instead carries the camera's as-shot per-channel gains.

Those gains don't commute with the unmix, so the matrix lands in the wrong basis. It doesn't just wash out — the residual comes back **sign-flipped**, so the correction overcorrects. On a representative narrowband response, a 22% green/blue leak was left at 13% with inverted terms. Silently wrong rather than silently weaker, which is why this is worth gating rather than tolerating.

### What this does

- Routes the three apply sites (`run_pipeline`, `_decode_oriented_f32`, and the batch-analysis worker) through `effective_sensor_matrix()`, which returns `None` in that basis.
- Folds the same gate into `sensor_token`, so two configs that render identically also hash identically.
- Greys the Sensor Calibration panel while gated: the dropdown shows `None`,  the calibrate button is disabled, and a muted "Requires Linear RAW." explains why. The reset is display-only — `sensor_profile` is untouched, so the selection survives a Linear RAW round-trip.

### Notes
  
The math itself is basis-agnostic: column normalization makes the matrix transform by similarity, so calibrating in the *same* WB basis would be exact. Lifting the gate later means recording the basis in the profile TOML and requiring a locked manual WB across the three bare-light shots. There's a test covering this so the path stays documented.

Tests added for the gate, the basis mismatch, and the panel state. Full suite green.

Fixes #649
