### PR TITLE
fix: keep the BEFORE badge in sync with the rendered frame

### DIFF
--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -935,6 +935,7 @@ class AppController(QObject):
                 self.state.last_metrics["base_positive"] = memo["base_positive"]
                 self.state.last_metrics["content_rect"] = memo.get("content_rect")
                 self.state.last_metrics["splash"] = False
+                self.state.last_metrics["compare"] = False
             self.image_updated.emit()
 
         self.state.preview_raw = None
@@ -1008,6 +1009,7 @@ class AppController(QObject):
         with self.state.metrics_lock:
             self.state.last_metrics["base_positive"] = raw
             self.state.last_metrics["splash"] = True
+            self.state.last_metrics["compare"] = False
         self.image_updated.emit()
 
     def _on_preview_load_failed(self, file_path: str, message: str) -> None:
@@ -2428,6 +2430,7 @@ class AppController(QObject):
             crop_preview_full=crop_preview_full,
             ephemeral=ephemeral,
             memo_key=memo_key,
+            compare=self.state.compare_mode,
         )
 
         if self._is_rendering:

--- a/negpy/desktop/view/canvas/overlay.py
+++ b/negpy/desktop/view/canvas/overlay.py
@@ -467,7 +467,9 @@ class CanvasOverlay(QWidget):
         if self._rotation_grid_visible:
             self._draw_rotation_grid(painter, visible_rect)
 
-        if getattr(self.state, "compare_mode", False):
+        # Keyed off the painted frame, not state.compare_mode: the toggle flips before
+        # its render lands, so the flag would badge the *edit* as BEFORE on slow renders.
+        if self.state.last_metrics.get("compare", False):
             self._draw_compare_badge(painter, visible_rect)
 
     def _draw_grid(self, painter: QPainter, rect: QRectF, divisions: int, alpha: int) -> None:

--- a/negpy/desktop/view/main_window.py
+++ b/negpy/desktop/view/main_window.py
@@ -399,7 +399,6 @@ class MainWindow(QMainWindow):
         self.controller.session.settings_synced.connect(lambda msg: self.canvas.hud.showMessage(msg, timeout=2500))
         self.controller.tool_sync_requested.connect(self._sync_tool_buttons)
         self.controller.config_updated.connect(self.canvas.overlay.update)
-        self.controller.compare_changed.connect(lambda _on: self.canvas.overlay.update())
         self.controller.analysis_buffer_preview_requested.connect(self.canvas.overlay.show_analysis_buffer)
         self.controller.rotation_guide_requested.connect(self.canvas.overlay.show_rotation_grid)
         self.controller.crop_guide_changed.connect(self.canvas.overlay.update)

--- a/negpy/desktop/workers/render.py
+++ b/negpy/desktop/workers/render.py
@@ -48,6 +48,9 @@ class RenderTask:
     # Identity of everything that shaped these pixels; non-empty makes the result
     # eligible for the navigate-back render memo (echoed in metrics).
     memo_key: str = ""
+    # These pixels are the before/after baseline, not the edit. Echoed in metrics so
+    # the BEFORE badge tracks what is painted, not the pending toggle.
+    compare: bool = False
 
 
 @dataclass(frozen=True)
@@ -218,6 +221,7 @@ class RenderWorker(QObject):
             metrics["source_hash"] = task.source_hash
             metrics["ephemeral"] = task.ephemeral
             metrics["memo_key"] = task.memo_key
+            metrics["compare"] = task.compare
 
             self.finished.emit(result, metrics)
             self.metrics_updated.emit(metrics)

--- a/tests/test_compare_badge.py
+++ b/tests/test_compare_badge.py
@@ -1,0 +1,140 @@
+"""The BEFORE badge must track the frame on screen, not the toggle.
+
+Compare flips state.compare_mode and *then* requests a render; on a slow render (HQ,
+large scan) the badge would appear over the still-displayed edit, labelling the after
+image as the before one. The flag travels with the render task and comes back in
+metrics, so the badge only lights once the baseline pixels land.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+
+from negpy.domain.models import WorkspaceConfig
+
+
+class TestCompareFlagRoundTrip(unittest.TestCase):
+    def test_worker_echoes_the_compare_flag_into_metrics(self):
+        with patch("negpy.desktop.workers.render.ImageProcessor") as MockIP:
+            from negpy.desktop.workers.render import RenderTask, RenderWorker
+
+            # Fresh metrics dict per call — a shared one would be mutated by the second render.
+            MockIP.return_value.run_pipeline.side_effect = lambda *a, **k: (np.zeros((2, 2, 3), np.float32), {})
+            worker = RenderWorker()
+            seen: list = []
+            worker.finished.connect(lambda _r, m: seen.append(m))
+
+            common = dict(buffer=np.zeros((2, 2, 3), np.float32), config=WorkspaceConfig(), preview_size=512.0)
+            worker.process(RenderTask(source_hash="f1", compare=True, **common))
+            worker.process(RenderTask(source_hash="f1", compare=False, **common))
+
+        self.assertTrue(seen[0]["compare"])
+        self.assertFalse(seen[1]["compare"])
+
+
+class TestOverlayBadgeCondition(unittest.TestCase):
+    """The badge is keyed off the painted frame's metrics, not state.compare_mode."""
+
+    def _badge_drawn(self, *, compare_mode: bool, painted_compare: bool) -> bool:
+        from PyQt6.QtCore import QRectF
+        from PyQt6.QtGui import QPainter, QPixmap
+
+        from negpy.desktop.session import AppState
+        from negpy.desktop.view.canvas.overlay import CanvasOverlay
+
+        state = AppState()
+        state.compare_mode = compare_mode
+        state.last_metrics["compare"] = painted_compare
+        overlay = CanvasOverlay(state)
+        overlay._view_rect = QRectF(0, 0, 200, 160)
+
+        pixmap = QPixmap(200, 160)
+        painter = QPainter(pixmap)
+        with patch.object(overlay, "_draw_compare_badge") as badge:
+            overlay._draw_ui(painter)
+        painter.end()
+        return badge.called
+
+    def test_toggle_alone_does_not_badge_the_still_displayed_edit(self):
+        self.assertFalse(self._badge_drawn(compare_mode=True, painted_compare=False))
+
+    def test_baseline_frame_badges_even_after_the_toggle_flips_back(self):
+        self.assertTrue(self._badge_drawn(compare_mode=False, painted_compare=True))
+
+
+class TestCompareBadgeFollowsPaintedFrame(unittest.TestCase):
+    """Overlay reads last_metrics['compare']; assert what that dict holds over a toggle."""
+
+    def setUp(self):
+        from negpy.desktop.controller import AppController
+        from negpy.desktop.session import AppState, DesktopSessionManager
+        from negpy.services.rendering.preview_manager import PreviewManager
+
+        self.mock_session_manager = MagicMock(spec=DesktopSessionManager)
+        self.mock_session_manager.state = AppState()
+        self.mock_session_manager.repo = MagicMock()
+        with (
+            patch("negpy.desktop.controller.RenderWorker") as mock_rw_class,
+            patch("negpy.desktop.controller.PreviewManager") as mock_pm_class,
+        ):
+            mock_rw_class.return_value = MagicMock()
+            mock_pm_class.return_value = MagicMock(spec=PreviewManager)
+            mock_pm_class.return_value.load_linear_preview.return_value = (None, (0, 0), {})
+            self.controller = AppController(self.mock_session_manager)
+        self.controller.state.preview_raw = np.empty((8, 8, 3), dtype=np.float32)
+        self.tasks: list = []
+        self.controller.render_requested.connect(self.tasks.append)
+
+    def tearDown(self):
+        import gc
+
+        for thread in [
+            self.controller.render_thread,
+            self.controller.export_thread,
+            self.controller.thumb_thread,
+            self.controller.norm_thread,
+            self.controller.discovery_thread,
+            self.controller.preview_load_thread,
+            self.controller.scan_thread,
+        ]:
+            if thread is not None and thread.isRunning():
+                thread.quit()
+                thread.wait()
+        del self.controller
+        gc.collect()
+
+    def _finish(self, task) -> None:
+        """Stand in for the worker completing `task`."""
+        self.controller._on_render_finished(None, {"base_positive": np.zeros((2, 2, 3), np.float32), "compare": task.compare})
+
+    def test_badge_waits_for_the_baseline_render(self):
+        self.controller.toggle_compare()
+        self.assertTrue(self.controller.state.compare_mode)
+        # Render still in flight: the edit is on screen, so no badge yet.
+        self.assertFalse(self.controller.state.last_metrics.get("compare", False))
+
+        self._finish(self.tasks[-1])
+        self.assertTrue(self.controller.state.last_metrics["compare"])
+
+    def test_badge_persists_until_the_edit_is_repainted(self):
+        self.controller.toggle_compare()
+        self._finish(self.tasks[-1])
+
+        self.controller._is_rendering = False
+        self.controller.toggle_compare()
+        self.assertFalse(self.controller.state.compare_mode)
+        # Baseline pixels are still displayed — badge stays up until the edit lands.
+        self.assertTrue(self.controller.state.last_metrics["compare"])
+
+        self._finish(self.tasks[-1])
+        self.assertFalse(self.controller.state.last_metrics["compare"])
+
+    def test_splash_and_memo_repaints_clear_a_stale_badge(self):
+        self.controller.state.last_metrics["compare"] = True
+        self.controller._on_splash_preview(self.controller._requested_file_path, np.zeros((2, 2, 3), np.float32), (2, 2))
+        self.assertFalse(self.controller.state.last_metrics["compare"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
toggle_compare() flipped state.compare_mode and only then requested a render, and the badge was drawn straight off that flag. On a slow render (HQ, large scan) the badge appeared over the still-displayed edit, so the after image sat there labelled BEFORE — and toggling back dropped the badge while the baseline was still on screen.

Carry the flag on RenderTask and echo it in metrics, alongside the existing ephemeral/memo_key frame identity, so the overlay keys off the pixels it is painting. The memo and splash fast paths clear it explicitly since they paint the edit without going through the worker.

The compare_changed -> overlay.update() connection is gone: it existed only to repaint the badge on toggle, which was the repaint that lied.

Fixes #654 