### PR TITLE
Stop IR Removal mottling clean film on noisy scanner IR planes

### DIFF
--- a/negpy/features/retouch/logic.py
+++ b/negpy/features/retouch/logic.py
@@ -53,6 +53,15 @@ _IR_GAMMA_FALLBACK = 1.5
 # Below this the beam is blocked outright — holder, not film. Coolscan rolls: margin 98% under
 # it, in-frame dust bottoms at 0.17. ponytail: absolute; a low-IR-gain scanner would want a percentile.
 _IR_DEAD_FLOOR = 0.05
+# Clean-film pivot: normalize_ir's base is a local max, so clean film sits ~k·σ_IR under 1,
+# where depending on the scanner. Left absolute, a Coolscan 5000 (ratio median 0.945) put
+# 84% of the frame below _IR_GAIN_IDENTITY, starving _ir_clean_base into its local-max
+# fallback — no cap, mottled film at every slider position (#647). Measured at detection
+# scale, on the same ratio it corrects; not on the full-res plane.
+_IR_NOISE_SIGMA = 3.0
+# Bounds the rescale so >50% coverage (median inside the dust) can't scale the ratio clean
+# and silently disable IR removal. ponytail: absolute; the knob if a scanner needs more.
+_IR_PIVOT_LO = 0.60
 # Crosstalk unmixing: dye/silver absorbs some IR, so the IR plane carries a ghost of
 # the image that normalize_ir's spatial high-pass can't see (a sharp edge survives it).
 _IR_XTALK_MAX = 0.8  # per-channel exponent cap; ≥0 only — density can only block IR
@@ -951,6 +960,22 @@ def _ir_clean_base(img_det: np.ndarray, ratio: np.ndarray) -> np.ndarray:
     return np.where(den > _IR_CAP_MIN_SUPPORT, base, dil)
 
 
+def _ir_pivot_rescale(ratio: np.ndarray, live: np.ndarray) -> np.ndarray:
+    """Rescale so the measured clean-film floor lands on ``_IR_GAIN_IDENTITY`` (see the
+    constants block). ``live`` only: the dead-margin 1.0s inflate σ ~20% on a strip scan.
+    MAD, not std, so a dusty minority can't move the floor."""
+    sample = ratio[live]
+    if sample.size < 500:  # nothing measurable: leave the landmarks alone
+        return ratio
+    med = float(np.median(sample))
+    sigma = 1.4826 * float(np.median(np.abs(sample - med)))
+    pivot = float(np.clip(med - _IR_NOISE_SIGMA * sigma, _IR_PIVOT_LO, _IR_GAIN_IDENTITY))
+    if pivot <= _IR_PIVOT_LO:
+        logger.warning("IR dust: clean-film pivot floored at %.2f (IR σ %.3f) — very noisy IR plane", _IR_PIVOT_LO, sigma)
+    # A clipped pivot is an exact no-op: x/x is 1.0 in IEEE, float32 × 1.0 exact.
+    return (ratio * (_IR_GAIN_IDENTITY / pivot)).astype(np.float32)
+
+
 def ir_ratio_and_gain(ir_det: np.ndarray, img_det: np.ndarray) -> Tuple[np.ndarray, np.ndarray, bool, Tuple[float, ...]]:
     """Detection-scale ``(ratio, gain HxWx3, degenerate, gammas)`` for IR-division
     attenuation: semi-transparent dust recovered by ``RGB / ratio^γ``, γ per channel from
@@ -960,7 +985,8 @@ def ir_ratio_and_gain(ir_det: np.ndarray, img_det: np.ndarray) -> Tuple[np.ndarr
     ratio = normalize_ir(plane)
     # No film under the head is not a defect; left as a dip the holder margin would score
     # as one giant routed component and swamp the routing budget.
-    ratio[plane < _IR_DEAD_FLOOR] = 1.0
+    live = plane >= _IR_DEAD_FLOOR
+    ratio[~live] = 1.0
     img_det = np.ascontiguousarray(img_det, dtype=np.float32)
     if img_det.shape[:2] != ratio.shape[:2]:
         img_det = cv2.resize(img_det, (ratio.shape[1], ratio.shape[0]), interpolation=cv2.INTER_AREA)
@@ -970,6 +996,9 @@ def ir_ratio_and_gain(ir_det: np.ndarray, img_det: np.ndarray) -> Tuple[np.ndarr
     # On the fitted exponent, not on how far the ratio dips: a few percent of IR noise
     # (deepened by the min-preserving downsample) read as silver on clean C41 rolls.
     degenerate = ghost > _IR_DEGENERATE_GHOST
+    # After the unmixing, never before: it clips log(ratio) at 1.0, and a rescaled clean
+    # population piles into that clip and flattens the fitted exponent.
+    ratio = _ir_pivot_rescale(ratio, live)
 
     gammas = _fit_refraction_gammas(ratio, vis_log, img_det)
     base = np.clip(ratio / _IR_GAIN_IDENTITY, 1e-4, 1.0)

--- a/tests/test_ir_dust.py
+++ b/tests/test_ir_dust.py
@@ -7,8 +7,12 @@ import tifffile
 
 from negpy.domain.models import WorkspaceConfig
 from negpy.features.retouch.logic import (
+    _IR_CAP_MIN_SUPPORT,
+    _IR_CAP_WIN,
+    _IR_GAIN_IDENTITY,
     _IR_GAMMA_FALLBACK,
     _IR_GAMMA_HI,
+    _IR_PIVOT_LO,
     _IR_SCORE_FLOOR,
     _IR_WRITE_HI,
     _IR_WRITE_LO,
@@ -293,6 +297,10 @@ def test_ir_dead_margins_do_not_mask_the_frame():
     # :19, not :20 — the erode legitimately bleeds the in-frame gate transition 1 px in.
     assert float(score[:, :19].min()) > _IR_WRITE_HI, "the margin is never rebuilt"
     assert float(score[speck].min()) < _IR_WRITE_LO, "the real speck still is"
+    # σ 0.025 makes this a #647 frame too: 86% of it sat in the write band, unnoticed
+    # because the asserts above only sample the margin and the speck. The rescale also
+    # lifts the forced-clean margin past 1.0, which the ratio bound above allows.
+    assert float((score < _IR_WRITE_HI).mean()) < 0.02, "the noise floor is not a defect"
 
 
 def test_ir_noisy_clean_film_is_not_degenerate():
@@ -304,6 +312,135 @@ def test_ir_noisy_clean_film_is_not_degenerate():
 
     _, _, degenerate, _ = ir_ratio_and_gain(ir, img)
     assert not degenerate
+
+
+def _noisy_ir(sigma: float, h: int = 400, w: int = 300, seed: int = 0) -> np.ndarray:
+    """Clean film on a scanner whose IR plane carries `sigma` of noise."""
+    return np.clip(0.85 + np.random.default_rng(seed).normal(0, sigma, (h, w)), 0.0, 1.0).astype(np.float32)
+
+
+def _flat_visible(h: int = 400, w: int = 300, seed: int = 1) -> np.ndarray:
+    return np.clip(0.5 + np.random.default_rng(seed).normal(0, 0.01, (h, w, 3)), 1e-3, 1.0).astype(np.float32)
+
+
+def _cap_fallback_fraction(ratio: np.ndarray) -> float:
+    """Fraction of the frame where _ir_clean_base has too few clean pixels and drops to
+    its blur(dilate) local-max estimate — i.e. where the cap stops capping."""
+    win = (_IR_CAP_WIN, _IR_CAP_WIN)
+    return float((cv2.blur((ratio >= _IR_GAIN_IDENTITY).astype(np.float32), win) <= _IR_CAP_MIN_SUPPORT).mean())
+
+
+def test_ir_pivot_is_a_no_op_on_a_quiet_scanner():
+    """A noiseless plane measures its clean floor above _IR_GAIN_IDENTITY, clips to it and
+    divides by exactly 1.0 — bit-identical, not merely close. Deliberately noiseless: at
+    σ 0.004 the pivot lands at 0.9695 (factor 1.0005), which is not array_equal."""
+    ir = np.full((200, 200), 0.9, dtype=np.float32)
+    ir[98:102, 98:102] = 0.1
+    img = np.full((200, 200, 3), 0.5, dtype=np.float32)
+    img[98:102, 98:102] = 0.05
+
+    ratio, _, _, _ = ir_ratio_and_gain(ir.copy(), img)
+    assert np.array_equal(ratio, normalize_ir(ir))
+
+
+def test_ir_pivot_tracks_the_scan_noise():
+    """The pivot is measured, not assumed: the clean-film level it normalizes away grows
+    with the scanner's IR noise, and the noise floor stays out of the write band at every
+    level. Pins the mechanism — an absolute pivot cannot satisfy all three σ at once."""
+    medians = []
+    for sigma in (0.004, 0.020, 0.040):
+        ratio, gain, degenerate, _ = ir_ratio_and_gain(_noisy_ir(sigma), _flat_visible())
+        assert not degenerate, f"clean C41 at σ {sigma} must not read as silver"
+        assert float((gain > 1.05).mean()) < 0.01, f"σ {sigma}: the bake lifted the noise floor"
+        medians.append(float(np.median(ratio)))
+    assert medians[0] < medians[1] < medians[2], medians
+
+
+def test_ir_noise_floor_neither_writes_nor_gains():
+    """Issue #647. At the Coolscan 5000's MAD-σ 0.027 the whole frame sat under the absolute
+    pivot: the division tier lifted 32% of it >5% (slider-blind, hence the inert-feeling
+    threshold) and the fill wrote to 99.6%. Clean film must come out untouched."""
+    ratio, gain, _, _ = ir_ratio_and_gain(_noisy_ir(0.027), _flat_visible())
+    score = ir_defect_score(ratio, ir_detect_cutoff(0.66, True))
+    assert float((score < _IR_WRITE_HI).mean()) < 0.01
+    assert float((gain > 1.05).mean()) < 0.01
+
+
+def test_ir_cap_support_survives_a_noisy_plane():
+    """The root cause, asserted directly. _ir_clean_base weights by (ratio >= identity), so
+    once noise pushes the clean fraction under _IR_CAP_MIN_SUPPORT the window falls back to
+    blur(dilate), a local max that licenses the lift it exists to cap. 99.9% here, before."""
+    ratio, _, _, _ = ir_ratio_and_gain(_noisy_ir(0.027), _flat_visible())
+    assert _cap_fallback_fraction(ratio) < 0.01
+
+
+def test_ir_speck_survives_a_noisy_plane():
+    """The other side of #647: suppressing the noise floor must not suppress signal. Guards
+    against 'fixing' the mottle by quietly turning detection off."""
+    ir, img = _noisy_ir(0.027), _flat_visible()
+    speck = (slice(200, 208), slice(150, 158))
+    ir[speck] *= 0.35
+    img[speck] *= 0.55
+
+    ratio, gain, _, _ = ir_ratio_and_gain(ir, img)
+    score = ir_defect_score(ratio, ir_detect_cutoff(0.66, True))
+    assert abs(float(score[speck].min()) - _IR_SCORE_FLOOR) < 1e-6, "the speck must still take the full fill"
+    assert float(gain[speck].max()) > 1.05, "...and the division tier must still recover it"
+    assert float((score < _IR_WRITE_HI).mean()) < 0.02, "while the surrounding noise stays clean"
+
+
+def test_ir_pivot_is_robust_to_dusty_frames():
+    """MAD, not σ: the clean-film level must be read off the film, not shifted by the dust.
+    ~5% coverage may not move it, and every speck must still heal. Fails if the estimator
+    is ever swapped for a mean/std pair."""
+    clean, img = _noisy_ir(0.027, seed=3), _flat_visible(seed=4)
+    dusty = clean.copy()
+    centers = [(y, x) for y in range(10, 390, 18) for x in range(10, 290, 18)]
+    for y, x in centers:
+        dusty[y : y + 4, x : x + 4] *= 0.25
+
+    ratio_clean, _, _, _ = ir_ratio_and_gain(clean, img)
+    ratio_dusty, _, _, _ = ir_ratio_and_gain(dusty, img)
+    assert abs(float(np.median(ratio_dusty)) - float(np.median(ratio_clean))) < 0.01
+
+    score = ir_defect_score(ratio_dusty, ir_detect_cutoff(0.66, True))
+    cores = score[[y + 1 for y, _ in centers], [x + 1 for _, x in centers]]
+    assert float((cores <= _IR_SCORE_FLOOR + 1e-6).mean()) == 1.0, "every speck still reaches the floor"
+
+
+def test_ir_pivot_ignores_dead_margins():
+    """The holder margin is forced to ratio 1.0, and that cluster sits ~2.7σ off the film
+    median — left in the sample it drags the median up and inflates σ, so the measurement
+    must run on live pixels only. Cropping the margins away may not change the result."""
+    rng = np.random.default_rng(3)
+    ir = np.clip(0.85 + rng.normal(0, 0.025, (400, 300)), 0.0, 1.0).astype(np.float32)
+    img = np.full((400, 300, 3), 0.5, dtype=np.float32)
+    ir[:, :20] = ir[:, -20:] = 0.004
+    img[:, :20] = img[:, -20:] = 0.002
+    speck = (slice(200, 208), slice(150, 158))
+    ir[speck] *= 0.35
+    img[speck] *= 0.55
+
+    full, _, _, _ = ir_ratio_and_gain(ir, img)
+    cropped, _, _, _ = ir_ratio_and_gain(ir[:, 20:-20].copy(), img[:, 20:-20].copy())
+    assert abs(float(np.median(full)) - float(np.median(cropped))) < 0.02
+
+    cut = ir_detect_cutoff(0.66, True)
+    assert (
+        abs(float((ir_defect_score(full, cut) < _IR_WRITE_HI).mean()) - float((ir_defect_score(cropped, cut) < _IR_WRITE_HI).mean())) < 0.01
+    )
+
+
+def test_ir_pivot_floor_bounds_the_rescale():
+    """_IR_PIVOT_LO is what stops an adaptive pivot from rescaling a garbage plane clean and
+    silently rendering IR removal inert — the one failure mode the measurement introduces.
+    At σ 0.15 the pivot floors, and an opaque core must still reach the score floor."""
+    ir = _noisy_ir(0.15, seed=5)
+    ir[200:212, 150:162] = 0.10  # over _IR_DEAD_FLOOR: a defect, not an empty gate
+    ratio, _, _, _ = ir_ratio_and_gain(ir, _flat_visible(seed=6))
+    assert float(np.median(ratio)) <= _IR_GAIN_IDENTITY / _IR_PIVOT_LO + 1e-6
+    score = ir_defect_score(ratio, ir_detect_cutoff(0.66, True))
+    assert abs(float(score[202:210, 152:160].min()) - _IR_SCORE_FLOOR) < 1e-6
 
 
 def _ghosted_frame(ghost: float, size: int = 240):


### PR DESCRIPTION
(MAYBE) Fixes #647.

## What was wrong

Not a mis-tuned threshold. `normalize_ir` divides by `blur(dilate(ir))`, and `dilate` is a local **max**, so the base rides the IR noise's upper envelope and clean film settles ~2.5·σ_IR below 1.0 instead of at 1.0. Where it settles is a property of the scanner, but every landmark downstream was anchored to the absolute `_IR_GAIN_IDENTITY = 0.97`.

The damage lands in `_ir_clean_base`, the cap that stops the division tier over-lifting. It weights support by `ratio >= 0.97`, and once the clean fraction falls under `_IR_CAP_MIN_SUPPORT` the 9×9 window drops to a `blur(dilate)` local-max estimate that licenses the very lift it exists to hold back. Both tiers only lighten the negative, which reads as dark mottle in the positive.

`@webmogul1`'s frames and the local `nkscan2` rolls measure the same ratio statistics (median 0.945–0.963, 62–89% below 0.97), yet only one set mottles. **The boundary is a cliff, not a gradient.** Adding σ=0.005 of IR noise to a healthy roll:

| | clean frac | cap fallback | gain > 1.05 | mottle (hp-σ, flattest 20%) |
|---|---|---|---|---|
| roll_00 as scanned | 65.4% | 0.4% | 0.63% | ×0.99 |
| roll_00 + σ 0.005 | 24.0% | **56.1%** | 29.9% | **×2.47** |

Two units of the same scanner model can sit on opposite sides. Isolating each anchor at that operating point shows the fill tier is not the culprit:

| variant | mottle |
|---|---|
| today | ×2.47 |
| cap `w_clean` anchored | ×0.99 |
| gain pivot anchored | ×0.98 |
| score/cutoff anchored | ×2.60 (no help) |

Which also explains why **IR Threshold** felt inert: neither the division tier nor the cap ever sees it.

## The fix

Measure the clean-film floor per frame and rescale the ratio onto it, so every absolute landmark keeps meaning what it says:

```python
pivot = clip(median(ratio[live]) - 3 * MAD, _IR_PIVOT_LO, _IR_GAIN_IDENTITY)
ratio *= _IR_GAIN_IDENTITY / pivot
```

Rescaling instead of threading a pivot through the gain, cap, score and γ band: the dilate bias is multiplicative, so dividing it out is its exact inverse, and five signatures plus the overlay's `0.97` literal stay correct untouched. 31 lines in one function, no config field, no UI change.

MAD rather than std so a dusty minority cannot move the floor. `live` pixels only, since the dead-margin `1.0`s inflate σ ~20% on a strip scan. Runs after the crosstalk unmixing, which clips `log(ratio)` at 1.0. The pivot derives from the source IR alone, so `_ir_ratio_gain`'s per-source memo and its deliberate slider-blindness both survive.

## Verification

Real Coolscan scans, slider 0.66:

| | cap fallback | gain>1.05 | write | at-floor | mottle |
|---|---|---|---|---|---|
| roll_00 before | 0.4% | 0.63% | 15.8% | 0.868% | ×0.99 |
| roll_00 after | 0.01% | 0.09% | 2.7% | 0.798% | ×0.97 |
| roll_00 +σ0.005 before | 56.1% | 29.9% | 77.0% | 0.967% | **×2.47** |
| roll_00 +σ0.005 after | 0.01% | 0.05% | 1.6% | 0.779% | **×0.97** |
| roll_05 before | 2.3% | 3.11% | 37.6% | 3.844% | ×1.05 |
| roll_05 after | 0.45% | 1.18% | 8.7% | 2.901% | ×1.05 |

- Real dust is preserved: deep-defect output lift 1.211 → **1.233**, slightly better, because the cap is no longer disarmed.
- A quiet scanner measures above the identity point, clips to it and multiplies by exactly 1.0, so its render is **bit-identical**. Zero existing tests changed behaviour.
- `make all` green: 2593 passed, 1 skipped.
- 8 new tests. 6 fail without the fix; the 3 that don't were mutation-tested and each bites under the mistake it targets (std-for-MAD, dropped pivot floor, dropped validity mask).
- Preview vs export pivot: byte-identical IR planes, zero delta, so WYSIWYG holds.
- Headless E2E in the real app: `has_ir=True`, 0.632% of pixels changed, added texture in smooth areas ×1.000.

Also pins a latent hole in `test_ir_dead_margins_do_not_mask_the_frame`: its σ 0.025 fixture was **already** a #647 frame with 86% of it in the write band, unnoticed because the existing asserts only sampled the margin columns and the speck.

## Trade-off worth a look

On the noisier roll_05, at-floor detection drops 3.844% → 2.901% (−25%). Checked visually rather than assumed: its heavily dusty frame comes out the same before and after, so the loss was noise, not dust. You cannot detect below the noise floor.

Note this does **not** widen the slider's range (roll_00 sweep goes from `53.8%→8.2%` to `7.0%→2.1%`). What changes is that it now modulates real defect coverage instead of how much of the noise floor gets corrected.

No changelog entry: `docs/CHANGELOG.md` is written at release time from the commit log.
