### PR TITLE
Let the settings picker apply default values

### DIFF
--- a/negpy/desktop/settings_catalog.py
+++ b/negpy/desktop/settings_catalog.py
@@ -2,16 +2,15 @@
 
 Each SettingRow maps a human label to one or more fields of a WorkspaceConfig
 sub-config. A row is "edited" when any of its fields differs from the default
-config. Grouped rows (per-channel trims, linked metadata) copy their fields as a
+config; the picker offers unedited rows too, so a roll can be reset back to a
+default value. Grouped rows (per-channel trims, linked metadata) copy their fields as a
 unit so linked values can't drift apart. Excluded fields (per-frame bounds/dust/
 heal/masks, machine paths, derived caches) are simply not listed here.
 """
 
 from __future__ import annotations
 
-import json
 from dataclasses import replace
-from functools import lru_cache
 from typing import Any, Callable, Iterable, Mapping, Optional
 
 from negpy.domain.models import WorkspaceConfig
@@ -253,18 +252,18 @@ def _row_edited(row: SettingRow, cfg: WorkspaceConfig) -> bool:
     return any(getattr(src, f) != getattr(dfl, f) for f in row.fields)
 
 
-def edited_sections(cfg: WorkspaceConfig) -> list[tuple[str, list[tuple[SettingRow, str]]]]:
-    """Per display section, the edited rows (differ from default) paired with a
-    formatted value string. Sections with no edited rows are dropped."""
-    out: list[tuple[str, list[tuple[SettingRow, str]]]] = []
+def catalog_sections(cfg: WorkspaceConfig) -> list[tuple[str, list[tuple[SettingRow, str, bool]]]]:
+    """Every display section with all its rows, each paired with a formatted value
+    and whether it differs from default. Rows at their default are included so they
+    can still be applied (resetting a roll back to a default value) — the picker
+    hides them behind a toggle."""
+    out: list[tuple[str, list[tuple[SettingRow, str, bool]]]] = []
     for title, rows in CATALOG:
-        edited = []
+        entries = []
         for r in rows:
-            if _row_edited(r, cfg):
-                values = tuple(getattr(getattr(cfg, r.section), f) for f in r.fields)
-                edited.append((r, _format(r, values)))
-        if edited:
-            out.append((title, edited))
+            values = tuple(getattr(getattr(cfg, r.section), f) for f in r.fields)
+            entries.append((r, _format(r, values), _row_edited(r, cfg)))
+        out.append((title, entries))
     return out
 
 
@@ -293,19 +292,13 @@ def selected_flat_dict(cfg: WorkspaceConfig, rows: Iterable[SettingRow]) -> dict
     return {f: getattr(getattr(cfg, r.section), f) for r in rows for f in r.fields}
 
 
-# json round-trip so tuple-typed defaults compare equal to json-loaded preset values.
-@lru_cache(maxsize=1)
-def _default_flat_json() -> dict[str, Any]:
-    return json.loads(json.dumps(WorkspaceConfig().to_dict()))
-
-
 def preset_summary(data: Mapping[str, Any]) -> str:
-    """One line per display section listing the non-default settings a preset
-    stores, e.g. "Tone: Print Density, Snap". Unknown keys are skipped."""
-    dfl = _default_flat_json()
+    """One line per display section listing the settings a preset stores, e.g.
+    "Tone: Print Density, Snap". Presence, not non-defaultness: a preset may
+    deliberately store a default value. Unknown keys are skipped."""
     lines = []
     for title, rows in CATALOG:
-        labels = [r.label for r in rows if any(f in data and data[f] != dfl.get(f) for f in r.fields)]
+        labels = [r.label for r in rows if any(f in data for f in r.fields)]
         if labels:
             lines.append(f"{title}: {', '.join(labels)}")
     return "\n".join(lines)

--- a/negpy/desktop/view/widgets/granular_settings_dialog.py
+++ b/negpy/desktop/view/widgets/granular_settings_dialog.py
@@ -3,7 +3,6 @@ from PyQt6.QtWidgets import (
     QButtonGroup,
     QCheckBox,
     QDialog,
-    QGridLayout,
     QHBoxLayout,
     QLabel,
     QLineEdit,
@@ -14,15 +13,17 @@ from PyQt6.QtWidgets import (
     QWidget,
 )
 
-from negpy.desktop.settings_catalog import SettingRow, edited_sections
+from negpy.desktop.settings_catalog import SettingRow, catalog_sections
 from negpy.desktop.view.styles.theme import THEME
 from negpy.desktop.view.widgets.collapsible import CollapsibleSection
 
 
 class GranularSettingsDialog(QDialog):
     """Per-setting picker for paste / apply-to-many. Lists one collapsible section
-    per edit area, showing only the settings that differ from default, each with a
-    checkbox and its value. Reuses the shortcut-editor's CollapsibleSection look."""
+    per edit area, each setting with a checkbox and its value. Settings still at
+    their default are built but hidden until "Show unchanged settings" — they must
+    stay pickable so a roll can be reset back to a default value (#656). Reuses the
+    shortcut-editor's CollapsibleSection look."""
 
     def __init__(
         self,
@@ -40,7 +41,8 @@ class GranularSettingsDialog(QDialog):
         show_apply_mode: bool = False,
     ):
         super().__init__(parent)
-        self._checks: list[tuple[QCheckBox, SettingRow]] = []
+        self._checks: list[tuple[QCheckBox, SettingRow, bool, QWidget]] = []
+        self._sections: list[tuple[QWidget, int]] = []
         self._bounds_luma: QCheckBox | None = None
         self._bounds_colour: QCheckBox | None = None
         self._name_edit: QLineEdit | None = None
@@ -77,6 +79,7 @@ class GranularSettingsDialog(QDialog):
         root.addWidget(self._build_sections(source_cfg, show_bounds, exclude_sections), 1)
         root.addLayout(self._build_footer(ask_name))
 
+        self._apply_visibility()
         self._update_apply_enabled()
 
     def _build_scope_row(self, sel_count: int, roll_count: int, show_current: bool = False) -> QHBoxLayout:
@@ -122,9 +125,13 @@ class GranularSettingsDialog(QDialog):
         check_all.clicked.connect(lambda: self._set_all_checked(True))
         check_none = QPushButton("Check None")
         check_none.clicked.connect(lambda: self._set_all_checked(False))
+        self._show_unchanged = QCheckBox("Show unchanged settings")
+        self._show_unchanged.setToolTip("List settings still at their default, so they can be applied too")
+        self._show_unchanged.toggled.connect(self._apply_visibility)
         row.addWidget(check_all)
         row.addWidget(check_none)
         row.addStretch()
+        row.addWidget(self._show_unchanged)
         return row
 
     def _build_sections(self, source_cfg, show_bounds: bool, exclude_sections: frozenset[str] = frozenset()) -> QScrollArea:
@@ -136,13 +143,15 @@ class GranularSettingsDialog(QDialog):
         col.setContentsMargins(0, 0, 0, 0)
         col.setSpacing(THEME.space_sm)
 
-        for title, rows in edited_sections(source_cfg):
+        for title, rows in catalog_sections(source_cfg):
             if title in exclude_sections:
                 continue
+            edited_count = sum(1 for _r, _v, edited in rows if edited)
             section = CollapsibleSection(title, expanded=True)
-            section.set_modified(len(rows))
+            section.set_modified(edited_count)
             section.set_content(self._build_rows(rows))
             col.addWidget(section)
+            self._sections.append((section, edited_count))
 
         if show_bounds:
             section = CollapsibleSection("Roll baseline", expanded=True)
@@ -153,21 +162,27 @@ class GranularSettingsDialog(QDialog):
         scroll.setWidget(container)
         return scroll
 
-    def _build_rows(self, rows: list[tuple[SettingRow, str]]) -> QWidget:
+    def _build_rows(self, rows: list[tuple[SettingRow, str, bool]]) -> QWidget:
         body = QWidget()
-        grid = QGridLayout(body)
-        grid.setContentsMargins(0, 0, 0, 0)
-        grid.setColumnStretch(0, 1)
-        for r, (row, value) in enumerate(rows):
+        col = QVBoxLayout(body)
+        col.setContentsMargins(0, 0, 0, 0)
+        col.setSpacing(0)
+        for row, value, edited in rows:
+            # One widget per row (not a grid) so an unchanged row hides as a unit.
+            line = QWidget()
+            line_layout = QHBoxLayout(line)
+            line_layout.setContentsMargins(0, 0, 0, 0)
             box = QCheckBox(row.label)
-            box.setChecked(True)
+            box.setChecked(edited)
             box.stateChanged.connect(self._update_apply_enabled)
-            self._checks.append((box, row))
+            self._checks.append((box, row, edited, line))
             val = QLabel(value)
             val.setStyleSheet(f"color: {THEME.text_muted};")
             val.setAlignment(Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter)
-            grid.addWidget(box, r, 0)
-            grid.addWidget(val, r, 1)
+            line_layout.addWidget(box)
+            line_layout.addStretch()
+            line_layout.addWidget(val)
+            col.addWidget(line)
         return body
 
     def _build_bounds_rows(self) -> QWidget:
@@ -193,13 +208,30 @@ class GranularSettingsDialog(QDialog):
         return row
 
     def _all_boxes(self) -> list[QCheckBox]:
-        boxes = [box for box, _ in self._checks]
+        boxes = [box for box, _row, _edited, _line in self._checks]
         boxes += [b for b in (self._bounds_luma, self._bounds_colour) if b is not None]
         return boxes
 
+    def _apply_visibility(self) -> None:
+        show_all = self._show_unchanged.isChecked()
+        for box, _row, edited, line in self._checks:
+            if edited:
+                continue
+            line.setVisible(show_all)
+            # A hidden-but-ticked row would keep Apply enabled with nothing on screen.
+            if not show_all:
+                box.setChecked(False)
+        for section, edited_count in self._sections:
+            section.setVisible(show_all or edited_count > 0)
+
     def _set_all_checked(self, checked: bool) -> None:
-        for box in self._all_boxes():
-            box.setChecked(checked)
+        show_all = self._show_unchanged.isChecked()
+        for box, _row, edited, _line in self._checks:
+            if edited or show_all:
+                box.setChecked(checked)
+        for box in (self._bounds_luma, self._bounds_colour):
+            if box is not None:
+                box.setChecked(checked)
 
     def _update_apply_enabled(self) -> None:
         enabled = any(box.isChecked() for box in self._all_boxes())
@@ -216,7 +248,7 @@ class GranularSettingsDialog(QDialog):
         self.accept()
 
     def selected(self) -> list[SettingRow]:
-        return [row for box, row in self._checks if box.isChecked()]
+        return [row for box, row, _edited, _line in self._checks if box.isChecked()]
 
     def name(self) -> str:
         return self._name_edit.text().strip() if self._name_edit is not None else ""

--- a/tests/test_desktop_session.py
+++ b/tests/test_desktop_session.py
@@ -471,6 +471,19 @@ class TestDesktopSessionSync(unittest.TestCase):
         # Other config preserved from target
         self.assertEqual(saved_config.exposure.density, 0.7)
 
+    def test_sync_selected_settings_resets_crop_offset_to_default(self):
+        # #656: pushing the source's default value (offset 0) must clear the target's.
+        self.session.state.selected_file_idx = 0
+        self.session.state.current_file_hash = "hash1"
+        self.session.state.config = WorkspaceConfig(geometry=GeometryConfig(autocrop_offset=0))
+        self.mock_repo.load_file_settings.return_value = WorkspaceConfig(geometry=GeometryConfig(autocrop_offset=3))
+
+        self.session.update_selection([0, 1])
+        self.session.sync_selected_settings([_row("Crop Offset")])
+
+        args, _ = self.mock_repo.save_file_settings.call_args
+        self.assertEqual(args[1].geometry.autocrop_offset, 0)
+
     def test_sync_selected_settings_empty_is_noop(self):
         self.session.state.selected_file_idx = 0
         self.session.state.current_file_hash = "hash1"

--- a/tests/test_file_browser_widget.py
+++ b/tests/test_file_browser_widget.py
@@ -168,7 +168,8 @@ def test_apply_dialog_check_all_and_none(qapp):
     assert not any(box.isChecked() for box in dlg._all_boxes())
     assert not dlg.apply_btn.isEnabled()
     dlg._set_all_checked(True)
-    assert all(box.isChecked() for box in dlg._all_boxes())
+    # unchanged rows stay hidden and unchecked until "Show unchanged settings"
+    assert {r.label for r in dlg.selected()} == {"Print Density", "Manual Crop"}
     assert dlg.apply_btn.isEnabled()
 
 
@@ -182,10 +183,11 @@ def test_apply_dialog_apply_collects_checked_rows_and_scope(qapp):
     assert dlg.scope() == "roll"
 
 
-def test_apply_dialog_only_lists_edited_settings(qapp):
+def test_apply_dialog_only_preselects_edited_settings(qapp):
     dlg = GranularSettingsDialog(None, _edited_cfg(), "IMG_0001.cr2", show_scope=True, sel_count=1, roll_count=3)
-    labels = {r.label for _box, r in dlg._checks}
-    assert labels == {"Print Density", "Manual Crop"}  # nothing else was non-default
+    assert {r.label for r in dlg.selected()} == {"Print Density", "Manual Crop"}  # nothing else was non-default
+    # the rest are still built, just hidden, so they can be applied on demand (#656)
+    assert "Crop Offset" in {row.label for _box, row, _edited, _line in dlg._checks}
 
 
 def test_open_apply_dialog_routes_rows_bounds_scope_to_session(browser, session):

--- a/tests/test_granular_save_mode.py
+++ b/tests/test_granular_save_mode.py
@@ -37,7 +37,8 @@ def test_exclude_sections_hides_geometry_rows(qapp):
         ask_name=True,
         exclude_sections=frozenset({"Crop", "Rotation"}),
     )
-    assert {row.label for _box, row in dlg._checks} == {"Print Density"}
+    assert "Manual Crop" not in {row.label for _box, row, _edited, _line in dlg._checks}
+    assert {row.label for row in dlg.selected()} == {"Print Density"}
 
 
 def test_set_name_prefills_and_enables(qapp):
@@ -61,6 +62,39 @@ def test_scope_current_and_apply_mode(qapp):
     dlg._on_apply()
     assert dlg.scope() == "selection"
     assert dlg.apply_mode() == "replace"
+
+
+def _crop_offset_box(dlg):
+    return next(box for box, row, _edited, _line in dlg._checks if row.label == "Crop Offset")
+
+
+def test_default_valued_row_is_built_hidden_and_unselected(qapp):
+    # #656: source frame back at the default offset must still be applicable.
+    dlg = GranularSettingsDialog(None, _edited_cfg(), "IMG.cr2")
+    box = _crop_offset_box(dlg)
+    assert not box.isChecked()
+    assert "Crop Offset" not in {row.label for row in dlg.selected()}
+
+    dlg._show_unchanged.setChecked(True)
+    box.setChecked(True)
+    assert "Crop Offset" in {row.label for row in dlg.selected()}
+
+
+def test_hiding_unchanged_rows_unchecks_them(qapp):
+    dlg = GranularSettingsDialog(None, _edited_cfg(), "IMG.cr2")
+    dlg._show_unchanged.setChecked(True)
+    dlg._set_all_checked(True)
+    assert "Crop Offset" in {row.label for row in dlg.selected()}
+
+    dlg._show_unchanged.setChecked(False)
+    assert not _crop_offset_box(dlg).isChecked()
+    assert {row.label for row in dlg.selected()} == {"Print Density", "Manual Crop"}
+
+
+def test_check_all_skips_hidden_unchanged_rows(qapp):
+    dlg = GranularSettingsDialog(None, _edited_cfg(), "IMG.cr2")
+    dlg._set_all_checked(True)
+    assert {row.label for row in dlg.selected()} == {"Print Density", "Manual Crop"}
 
 
 def test_default_mode_unchanged(qapp):

--- a/tests/test_settings_catalog_presets.py
+++ b/tests/test_settings_catalog_presets.py
@@ -51,11 +51,15 @@ def test_full_snapshot_preset_applies():
     assert merged == WorkspaceConfig()
 
 
-def test_preset_summary_lists_non_default_settings():
+def test_preset_summary_lists_stored_settings():
     s = preset_summary({"density": 1.5, "wb_cyan": 0.2, "bogus": 1})
     assert s == "Tone: Print Density\nColour: Cyan"
 
 
-def test_preset_summary_skips_defaults_and_empty():
-    assert preset_summary({"density": WorkspaceConfig().exposure.density}) == ""
+def test_preset_summary_lists_a_deliberately_default_value():
+    # A preset may store a default on purpose (#656), so presence decides, not value.
+    assert preset_summary({"density": WorkspaceConfig().exposure.density}) == "Tone: Print Density"
+
+
+def test_preset_summary_empty_for_no_data():
     assert preset_summary({}) == ""

--- a/tests/test_sync_settings.py
+++ b/tests/test_sync_settings.py
@@ -9,7 +9,7 @@ from negpy.desktop.settings_catalog import (
     CATALOG,
     all_rows,
     apply_selected_fields,
-    edited_sections,
+    catalog_sections,
 )
 from negpy.domain.models import WorkspaceConfig
 
@@ -32,29 +32,35 @@ def test_every_catalog_field_exists_on_its_section():
                 assert f in fields, f"{row.label}: {row.section}.{f} is not a real field"
 
 
-# ── edited_sections ──────────────────────────────────────────────────────────
+# ── catalog_sections ─────────────────────────────────────────────────────────
 
 
-def test_edited_sections_empty_for_default_config():
-    assert edited_sections(WorkspaceConfig()) == []
+def test_catalog_sections_lists_every_row_even_for_a_default_config():
+    sections = catalog_sections(WorkspaceConfig())
+    assert [t for t, _rows in sections] == [t for t, _rows in CATALOG]
+    assert sum(len(rows) for _t, rows in sections) == len(all_rows())
+    assert not any(edited for _t, rows in sections for _r, _v, edited in rows)
 
 
-def test_edited_sections_lists_only_changed_rows_and_drops_empty_sections():
+def test_catalog_sections_flags_only_the_changed_row_as_edited():
     c = WorkspaceConfig()
     cfg = replace(c, exposure=replace(c.exposure, density=1.4))
-    sections = edited_sections(cfg)
-    assert len(sections) == 1
-    title, rows = sections[0]
-    assert title == "Tone"
-    assert [r.label for r, _val in rows] == ["Print Density"]
-    assert rows[0][1] == "1.4"  # formatted value
+    edited = [(t, r.label, val) for t, rows in catalog_sections(cfg) for r, val, is_edited in rows if is_edited]
+    assert edited == [("Tone", "Print Density", "1.4")]
 
 
-def test_edited_sections_groups_trim_channels_into_one_row():
+def test_catalog_sections_offers_a_default_valued_row():  # #656: needed to reset a roll back to 0
+    c = WorkspaceConfig()
+    cfg = replace(c, geometry=replace(c.geometry, autocrop_offset=0))
+    crop = dict((r.label, (val, edited)) for t, rows in catalog_sections(cfg) for r, val, edited in rows if t == "Crop")
+    assert crop["Crop Offset"] == ("0", False)
+
+
+def test_catalog_sections_groups_trim_channels_into_one_row():
     c = WorkspaceConfig()
     exp = replace(c.exposure, grade_trim_red=1.0, grade_trim_blue=-2.0)
-    _title, rows = edited_sections(replace(c, exposure=exp))[0]
-    by_label = {r.label: v for r, v in rows}
+    rows = next(rows for title, rows in catalog_sections(replace(c, exposure=exp)) if title == "Tone")
+    by_label = {r.label: v for r, v, _edited in rows}
     # one grouped "Grade Trim" row, value shows all three channels
     assert by_label["Grade Trim"] == "R1 G0 B-2"
 


### PR DESCRIPTION
Fixes #656.

## Problem

`GranularSettingsDialog` built its list from `settings_catalog.edited_sections()`, which only yielded rows differing from `WorkspaceConfig()` defaults. Any setting sitting *at* its default was unreachable — so after applying a positive Crop Offset to a roll, setting the source frame back to 0 and using **Apply Settings** offered no "Crop Offset" row to push out.

Not crop-specific: it affected every catalog row in all three flows sharing the dialog — Apply Settings, Paste Settings, and preset save/edit/apply.

Crop Offset makes it most visible because the startup baseline (`DEFAULT_WORKSPACE_CONFIG`, `negpy/kernel/system/config.py:68`) uses `autocrop_offset=1` while the dataclass default is `0`, so offset 1 always read as edited and offset 0 never did. That baseline mismatch is deliberately left alone — it now only governs which rows are pre-ticked and the section badge count, and the sidebar modified-badges measure against the same dataclass defaults.

## Change

- `settings_catalog.edited_sections()` → `catalog_sections()`: returns every section and row as `(row, formatted_value, edited)`.
- The dialog builds all rows; unedited ones are hidden and unticked behind a new **Show unchanged settings** checkbox, so the default view is identical to before. Rows became one widget each (`QHBoxLayout`) instead of grid cells so they hide as a unit — value labels still right-align the same. Hiding unchecks the rows it hides, and `Check All` skips hidden rows, so Apply can't be enabled with nothing visible ticked.
- `preset_summary` lists stored settings by key presence rather than non-defaultness, since a preset can now deliberately store a default value. (Side effect: legacy full-dump presets list every row in their tooltip — honest, since they do apply everything.)

Session-side paths are untouched: `apply_selected_fields` already copies whatever rows it's handed and already invalidates the target's per-frame bounds for `autocrop_offset`.

## Verification

`make all` green — ruff, ty, 2598 passed / 1 skipped.

Offscreen render of the Apply dialog confirms the default view is unchanged (only `Crop · 1` / `Tone · 1` visible) and that ticking the toggle lists `Crop Offset  0` as selectable.

Tests added:
- `test_desktop_session.py` — syncing "Crop Offset" from a source at 0 onto a target at 3 saves 0 (the reported bug).
- `test_granular_save_mode.py` — default-valued row built-but-unselected, becomes selectable with the toggle, unchecks when hidden again, and `Check All` skips hidden rows.
- `test_sync_settings.py` / `test_settings_catalog_presets.py` — `catalog_sections` flags and the presence-based preset summary.