### PR TITLE
Add density-space Print Saturation, composed into the paper's dye crosstalk matrix

### DIFF
--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -104,6 +104,11 @@ A **paper profile** (`paper_profile`, default *Neutral*) overrides the print *ch
 
 Profiles are **mode-aware**: C-41 exposes the RA4 colour papers, B&W exposes the tonal-only B&W papers (paper tone is a Toning job, so B&W profiles carry no colour terms), and E-6 gets only *Neutral*. An incompatible stored value collapses to *Neutral* so it can never leak into a render. Bundled papers: **Neutral**; *B&W* — Ilford Multigrade RC, Ilford Multigrade FB Classic, Foma Fomatone, Foma Fomabrom; *RA4* — Kodak Endura Premier, Fujicolor Crystal Archive. Values are loosely mapped from datasheets (mainly $D_{max}$ is grounded; the knee/midtone tweaks are light character touches).
 
+### Print Saturation
+**Code**: `negpy.features.exposure.papers.resolve_saturation_matrix` / `compose_density_matrices`
+
+Saturation applied in the same density domain and the same matrix slot as a paper's `dye_matrix`, rather than as a post-decode CIELAB $a^{\ast}/b^{\ast}$ scale (contrast with §6's Global Saturation). For density above paper base $e = D - D_{min}$, the saturation matrix is $M(k) = k \cdot I + (1-k) \cdot J$ ($J$ = all-rows-$\tfrac{1}{3}$, the achromatic projection): $k=1$ identity, $k=0$ collapses that channel's row to the achromatic mean, $k>1$ boosts density separation. Composed as $M_{total} = M(k) \cdot M_{dye}$ — saturation outermost, the paper's own dye coupling innermost, so `dye_matrix` keeps acting on the print curve's real density unchanged and saturation layers on top as a final step rather than being partly reabsorbed by the paper's crosstalk. $k$ takes independent per-channel trims (`density_saturation_trim_red/green/blue`) the same way Grade/Toe/Shoulder do; each row still sums to 1 regardless of its own $k$, so neutrals stay flat at any per-channel divergence.
+
 ### Flat (log) master — "for editing elsewhere"
 **Code**: `negpy.features.exposure.processor.PhotometricProcessor._process_flat` → `apply_flat_curve`
 

--- a/negpy/desktop/view/sidebar/tone.py
+++ b/negpy/desktop/view/sidebar/tone.py
@@ -4,7 +4,7 @@ from PyQt6.QtWidgets import QButtonGroup, QComboBox, QDialog, QHBoxLayout
 from negpy.desktop.view.shortcut_registry import tooltip_with_shortcut
 from negpy.desktop.view.sidebar.base import BaseSidebar
 from negpy.desktop.view.styles.templates import section_subheader, wrap_tooltip
-from negpy.desktop.view.widgets.sliders import CompactSlider
+from negpy.desktop.view.widgets.sliders import CompactSlider, PowerWarpSlider
 from negpy.features.exposure.models import EXPOSURE_CONSTANTS, TUNABLE_TARGETS, apply_targets
 
 _CH_SUFFIX = ("red", "green", "blue")
@@ -13,9 +13,10 @@ _CH_COLORS = ("#ff5a5a", "#5adc78", "#5f96ff")
 
 
 class ToneSidebar(BaseSidebar):
-    """Print/zone density, Grade, paper white, and a labeled Paper Response
-    group (paper profile + Snap/Toe/Shoulder) — with a [Global/R/G/B] channel
-    selector scoping Grade/Toe/Shoulder to per-layer trims (crossover correction)."""
+    """Print/zone density, Grade, Print Saturation, paper white, and a labeled
+    Paper Response group (paper profile + Snap/Toe/Shoulder) — with a
+    [Global/R/G/B] channel selector scoping Grade/Toe/Shoulder/Print Saturation
+    to per-layer trims (crossover correction)."""
 
     def _init_ui(self) -> None:
         conf = self.state.config.exposure
@@ -60,6 +61,7 @@ class ToneSidebar(BaseSidebar):
                     f"midtone_gamma_trim_{ch}",
                     f"toe_width_trim_{ch}",
                     f"shoulder_width_trim_{ch}",
+                    f"density_saturation_trim_{ch}",
                 ),
             )
             for btn, ch in zip((self.ch_r_btn, self.ch_g_btn, self.ch_b_btn), _CH_SUFFIX)
@@ -134,6 +136,30 @@ class ToneSidebar(BaseSidebar):
         split_grade_row.addWidget(self.shadow_grade_slider)
         split_grade_row.addWidget(self.highlight_grade_slider)
         self.layout.addLayout(split_grade_row)
+
+        # Density-domain saturation: composed into the same dye_mix slot as the
+        # paper's real dye crosstalk, rather than a post-hoc Lab-space a*/b*
+        # scale — see the density-space color investigation notes. Lives with
+        # the general print parameters (Density/Grade) above Paper Response,
+        # not inside it: it isn't a paper-character control like Snap/Toe/
+        # Shoulder, it's a creative print decision like Density/Grade are.
+        self.density_sat_slider = PowerWarpSlider("Print Saturation", 0.3, 1.6, conf.density_saturation, center=1.0, has_neutral=True)
+        self.density_sat_slider.setToolTip(
+            "Saturation applied in density space — pushes the print's dye densities apart before "
+            "decode, composed into the same matrix slot as the paper's own dye crosstalk, instead of "
+            "scaling CIELAB a*/b* after the fact. 1.0 = off/identity. Travel is concentrated near 1.0 "
+            "for finer control there."
+        )
+        self.density_sat_trim_slider = PowerWarpSlider("Print Saturation", -0.4, 0.4, 0.0, center=0.0, has_neutral=True)
+        self.density_sat_trim_slider.setToolTip(
+            "This layer's Print Saturation trim on top of the global value — pushes/pulls this "
+            "channel's density separation independently. Neutrals stay flat at any trim value."
+        )
+        self.density_sat_trim_slider.setVisible(False)
+        density_sat_row = QHBoxLayout()
+        density_sat_row.addWidget(self.density_sat_slider)
+        density_sat_row.addWidget(self.density_sat_trim_slider)
+        self.layout.addLayout(density_sat_row)
 
         paper_header = section_subheader("PAPER RESPONSE")
         paper_header.setToolTip(
@@ -291,6 +317,7 @@ class ToneSidebar(BaseSidebar):
             (self.sh_w_slider, "shoulder_width"),
             (self.shadow_density_slider, "shadow_density"),
             (self.highlight_density_slider, "highlight_density"),
+            (self.density_sat_slider, "density_saturation"),
         ):
             slider.valueChanged.connect(
                 lambda v, f=field: self.update_config_section("exposure", render=True, persist=False, readback_metrics=False, **{f: v})
@@ -330,8 +357,12 @@ class ToneSidebar(BaseSidebar):
             lambda v: self.update_config_section("exposure", render=True, persist=True, readback_metrics=True, **{grade_trim_field(): v})
         )
 
-        # Width trims live on separate sliders (trim domain ±2 vs global 0.1–5).
-        for slider, base in ((self.toe_w_trim_slider, "toe_width"), (self.sh_w_trim_slider, "shoulder_width")):
+        # Width/density-sat trims live on separate sliders (differing trim vs global domain).
+        for slider, base in (
+            (self.toe_w_trim_slider, "toe_width"),
+            (self.sh_w_trim_slider, "shoulder_width"),
+            (self.density_sat_trim_slider, "density_saturation"),
+        ):
             slider.valueChanged.connect(
                 lambda v, b=base: self.update_config_section(
                     "exposure", render=True, persist=False, readback_metrics=False, **{self._curve_field(b): v}
@@ -383,6 +414,8 @@ class ToneSidebar(BaseSidebar):
             self.toe_w_trim_slider.setVisible(not global_mode)
             self.sh_w_slider.setVisible(global_mode)
             self.sh_w_trim_slider.setVisible(not global_mode)
+            self.density_sat_slider.setVisible(global_mode)
+            self.density_sat_trim_slider.setVisible(not global_mode)
             self.toe_slider.label.setText("Toe" + suffix)
             self.sh_slider.label.setText("Shoulder" + suffix)
             self.midtone_gamma_slider.label.setText("Snap" + suffix)
@@ -407,6 +440,8 @@ class ToneSidebar(BaseSidebar):
                 self.toe_w_trim_slider.setValue(getattr(conf, f"toe_width_trim_{ch}"))
                 self.sh_w_trim_slider.label.setText("Shoulder Width" + suffix)
                 self.sh_w_trim_slider.setValue(getattr(conf, f"shoulder_width_trim_{ch}"))
+                self.density_sat_trim_slider.label.setText("Print Saturation" + suffix)
+                self.density_sat_trim_slider.setValue(getattr(conf, f"density_saturation_trim_{ch}"))
             for w in self._global_only:
                 w.setEnabled(global_mode)
 
@@ -419,6 +454,7 @@ class ToneSidebar(BaseSidebar):
             self.sh_w_slider.setValue(conf.shoulder_width)
             self.shadow_density_slider.setValue(conf.shadow_density)
             self.highlight_density_slider.setValue(conf.highlight_density)
+            self.density_sat_slider.setValue(conf.density_saturation)
 
             self.paper_dmin_btn.setChecked(conf.paper_dmin)
             self.paper_black_btn.setChecked(conf.paper_black)
@@ -446,6 +482,8 @@ class ToneSidebar(BaseSidebar):
             self.midtone_gamma_slider,
             self.shadow_density_slider,
             self.highlight_density_slider,
+            self.density_sat_slider,
+            self.density_sat_trim_slider,
             self.shadow_grade_slider,
             self.highlight_grade_slider,
             self.paper_dmin_btn,

--- a/negpy/desktop/view/widgets/sliders.py
+++ b/negpy/desktop/view/widgets/sliders.py
@@ -422,6 +422,41 @@ class CompactSlider(BaseSlider):
         return super().eventFilter(obj, event)
 
 
+class PowerWarpSlider(CompactSlider):
+    """
+    CompactSlider variant with travel concentrated around `center` via a
+    power-law warp: physical drag near center moves the value slowly (fine
+    control), drag near the min/max extremes moves it quickly (coarse). Value
+    and slider-int conversion stay exact inverses of each other so committed
+    values still round-trip precisely; only the *spacing* is nonlinear.
+    """
+
+    def __init__(self, label: str, min_val: float, max_val: float, default_val: float, center: float, gamma: float = 2.2, **kwargs):
+        self._warp_center = center
+        self._warp_gamma = gamma
+        self._warp_half_lo = center - min_val
+        self._warp_half_hi = max_val - center
+        super().__init__(label, min_val, max_val, default_val, **kwargs)
+
+    def _to_int(self, value: float) -> int:
+        if value >= self._warp_center:
+            half = self._warp_half_hi
+            frac = 0.0 if half <= 0 else (value - self._warp_center) / half
+            sign = 1.0
+        else:
+            half = self._warp_half_lo
+            frac = 0.0 if half <= 0 else (self._warp_center - value) / half
+            sign = -1.0
+        s = sign * max(0.0, frac) ** (1.0 / self._warp_gamma)
+        return round(s * self._precision)
+
+    def _from_int(self, i: int) -> float:
+        s = i / self._precision
+        frac = abs(s) ** self._warp_gamma
+        half = self._warp_half_hi if s >= 0 else self._warp_half_lo
+        return self._warp_center + math.copysign(frac * half, s)
+
+
 class HueSlider(CompactSlider):
     """
     CompactSlider variant for 0–360° hue selection.

--- a/negpy/domain/migrations.py
+++ b/negpy/domain/migrations.py
@@ -35,6 +35,11 @@ DROPPED_KEYS: frozenset[str] = frozenset(
         "auto_cast_removal",  # cast removal became always-on
         "DEFAULT_MATRIX",  # serialized crosstalk default, never a real field
         "surround",  # dim-surround print gamma, removed in #432 (replaced by Snap)
+        # density_chroma_damping / density_divergence_damping: abandoned Dye Mute
+        # reference-signal prototypes, dropped as mathematically redundant with
+        # density_saturation itself.
+        "density_chroma_damping",
+        "density_divergence_damping",
     }
 )
 

--- a/negpy/features/exposure/logic.py
+++ b/negpy/features/exposure/logic.py
@@ -4,7 +4,13 @@ import numpy as np
 from numba import njit, prange  # type: ignore
 
 from negpy.domain.types import ImageBuffer
-from negpy.features.exposure.papers import PaperProfile, effective_constants, resolve_dye_matrix
+from negpy.features.exposure.papers import (
+    PaperProfile,
+    compose_density_matrices,
+    effective_constants,
+    resolve_dye_matrix,
+    resolve_saturation_matrix,
+)
 from negpy.kernel.image.validation import ensure_image
 from negpy.kernel.system.parallel import parallel_njit
 
@@ -398,11 +404,16 @@ def apply_characteristic_curve(
     highlight_density: float = 0.0,
     shadow_grade_deltas: Tuple[float, float, float] = (0.0, 0.0, 0.0),
     highlight_grade_deltas: Tuple[float, float, float] = (0.0, 0.0, 0.0),
+    density_saturation: float = 1.0,
+    density_saturation_trims: Tuple[float, float, float] = (0.0, 0.0, 0.0),
 ) -> ImageBuffer:
     """Applies the asymmetric H&D print curve per channel in log-density space.
 
     ev_map (H×W, EV stops; positive = dodge) with ev_scale (see local_ev_scale)
-    applies per-pixel dodge/burn as print-exposure offsets ahead of the curve."""
+    applies per-pixel dodge/burn as print-exposure offsets ahead of the curve.
+
+    density_saturation(_trims): density-domain saturation, composed into the
+    dye_mix slot (see resolve_saturation_matrix/compose_density_matrices)."""
     c = effective_constants(paper)
     ts = c["toe_shoulder_strength"]
     if midtone_gamma is None:
@@ -415,7 +426,10 @@ def apply_characteristic_curve(
     s_cmy = np.ascontiguousarray(np.array(shadow_cmy, dtype=np.float32))
     h_cmy = np.ascontiguousarray(np.array(highlight_cmy, dtype=np.float32))
     dye = resolve_dye_matrix(paper)
-    dye_mix = np.ascontiguousarray(np.eye(3) if dye is None else dye)
+    sat_k3 = per_channel_density_saturation(density_saturation, density_saturation_trims)
+    sat = resolve_saturation_matrix(sat_k3)
+    composed = compose_density_matrices(dye, sat)
+    dye_mix = np.ascontiguousarray(np.eye(3) if composed is None else composed)
     use_ev = ev_map is not None
     ev_arr = np.ascontiguousarray(ev_map.astype(np.float32)) if ev_map is not None else np.zeros((1, 1), dtype=np.float32)
 
@@ -452,7 +466,7 @@ def apply_characteristic_curve(
         midtone_gamma=np.array([float(midtone_gamma) + snap_trims[ch] for ch in range(3)], dtype=np.float64),
         gamma_width=float(c["paper_gamma_width"]),
         dye_mix=dye_mix,
-        use_dye_mix=dye is not None,
+        use_dye_mix=composed is not None,
         ev_map=ev_arr,
         ev_scale=np.ascontiguousarray(np.array(ev_scale, dtype=np.float32)),
         use_ev=use_ev,
@@ -513,6 +527,26 @@ def grade_to_slope(grade: float, density_range: Optional[float]) -> float:
     rng = min(max(abs(float(rng_in)), 0.3), 3.5)
     k = float(c["grade_contrast_scale"]) * rng / er
     return float(min(max(k, c["slope_min"]), c["slope_max"]))
+
+
+def per_channel_density_saturation(
+    density_saturation: float,
+    trims: Tuple[float, float, float] = (0.0, 0.0, 0.0),
+) -> Tuple[float, float, float]:
+    """
+    Per-layer effective density-saturation k: global value + per-layer trim,
+    clamped to a sane matrix-coefficient range. Mirrors
+    per_channel_toe_shoulder's global+trim convention.
+    """
+
+    def _clamp(v: float) -> float:
+        return min(max(v, 0.0), 3.0)
+
+    return (
+        _clamp(density_saturation + trims[0]),
+        _clamp(density_saturation + trims[1]),
+        _clamp(density_saturation + trims[2]),
+    )
 
 
 def grade_chroma_damping(slope_g: float, strength: float) -> float:

--- a/negpy/features/exposure/models.py
+++ b/negpy/features/exposure/models.py
@@ -90,6 +90,14 @@ class ExposureConfig:
     auto_normalize_contrast: bool = True
     render_intent: str = RenderIntent.PRINT
     paper_profile: str = "neutral"
+    # Density-domain saturation, composed into the dye_mix kernel slot (see
+    # papers.py: resolve_saturation_matrix/compose_density_matrices). 1.0 =
+    # identity. Per-layer trims on top of the global value (crossover
+    # correction), same pattern as grade_trim_red etc.
+    density_saturation: float = 1.0
+    density_saturation_trim_red: float = 0.0
+    density_saturation_trim_green: float = 0.0
+    density_saturation_trim_blue: float = 0.0
 
     def __post_init__(self) -> None:
         """

--- a/negpy/features/exposure/papers.py
+++ b/negpy/features/exposure/papers.py
@@ -165,6 +165,48 @@ def resolve_dye_matrix(paper: PaperProfile | None) -> Optional[np.ndarray]:
     return m / np.maximum(m.sum(axis=1, keepdims=True), 1e-6)
 
 
+# Achromatic projection in density space (all rows 1/3) -- see resolve_saturation_matrix.
+_ACHROMATIC_J = np.full((3, 3), 1.0 / 3.0, dtype=np.float64)
+
+
+def resolve_saturation_matrix(k_rgb: Tuple[float, float, float]) -> Optional[np.ndarray]:
+    """
+    Density-domain saturation matrix, applied to density above paper base
+    (same coordinate as dye_matrix). Row ch is k_rgb[ch]*I[ch] + (1-k_rgb[ch])*J[ch]
+    — each row still sums to 1 regardless of its own k, so per-channel k's
+    diverge (R/G/B pushed independently) without breaking neutral preservation;
+    no per-row normalization needed. k=1 on every channel is identity (returns
+    None so the default path stays byte-exact); k=0 full desaturation (collapse
+    to the achromatic mean) for that channel's row; k>1 boosts density
+    separation.
+    """
+    if k_rgb == (1.0, 1.0, 1.0):
+        return None
+    k = np.array(k_rgb, dtype=np.float64)
+    return np.diag(k) + np.outer(1.0 - k, np.full(3, 1.0 / 3.0, dtype=np.float64))
+
+
+def compose_density_matrices(dye: Optional[np.ndarray], sat: Optional[np.ndarray]) -> Optional[np.ndarray]:
+    """
+    Composite density-domain matrix for the dye_mix kernel slot, or None if
+    both factors are identity (mirrors resolve_dye_matrix's allocation-free
+    common case).
+
+    sat is applied outermost, dye innermost (sat @ dye): dye_matrix keeps
+    acting on the print curve's real density exactly as it always has, and
+    saturation is layered on top as a final creative step rather than being
+    fed back through the paper's physical crosstalk (that would make the
+    slider's effective strength paper-dependent, since some of the push
+    would get reabsorbed by the crosstalk before it reaches display). Do not
+    flip this order.
+    """
+    if dye is None and sat is None:
+        return None
+    d = np.eye(3, dtype=np.float64) if dye is None else dye
+    s = np.eye(3, dtype=np.float64) if sat is None else sat
+    return s @ d
+
+
 # Which paper kind each process mode exposes. E-6 (slide) has no entry — it gets
 # only the neutral default. Keyed by ProcessMode (a StrEnum), so plain-string
 # process_mode values look up fine.

--- a/negpy/features/exposure/processor.py
+++ b/negpy/features/exposure/processor.py
@@ -314,6 +314,17 @@ class PhotometricProcessor:
             highlight_density=self.config.highlight_density,
             shadow_grade_deltas=sg_deltas,
             highlight_grade_deltas=hg_deltas,
+            # B&W collapses to luminance before this call (all channels equal),
+            # so the matrix is already a mathematical no-op there; skip it
+            # explicitly anyway to avoid the wasted per-pixel 3x3 multiply.
+            density_saturation=1.0 if context.process_mode == ProcessMode.BW else self.config.density_saturation,
+            density_saturation_trims=(0.0, 0.0, 0.0)
+            if context.process_mode == ProcessMode.BW
+            else (
+                self.config.density_saturation_trim_red,
+                self.config.density_saturation_trim_green,
+                self.config.density_saturation_trim_blue,
+            ),
         )
 
         if context.process_mode == ProcessMode.BW:

--- a/negpy/services/rendering/gpu_engine.py
+++ b/negpy/services/rendering/gpu_engine.py
@@ -1133,6 +1133,7 @@ class GPUEngine:
             cast_solve_inputs,
             filtration_offsets,
             grade_chroma_damping,
+            per_channel_density_saturation,
             per_channel_toe_shoulder,
             grade_coupled_shape,
             local_ev_scale,
@@ -1144,7 +1145,13 @@ class GPUEngine:
         )
         from negpy.features.exposure.models import EXPOSURE_CONSTANTS
         from negpy.features.exposure.normalization import LogNegativeBounds, luminance_density_range
-        from negpy.features.exposure.papers import effective_constants, effective_paper_profile, resolve_dye_matrix
+        from negpy.features.exposure.papers import (
+            compose_density_matrices,
+            effective_constants,
+            effective_paper_profile,
+            resolve_dye_matrix,
+            resolve_saturation_matrix,
+        )
 
         exp = settings.exposure
         paper = effective_paper_profile(exp.paper_profile, settings.process.process_mode)
@@ -1214,6 +1221,19 @@ class GPUEngine:
         )
         dmin_rgb = paper_dmin_rgb(d_min, paper)
         dye = resolve_dye_matrix(paper)
+        # Density-space Print Saturation, composed into the same dye_mix slot
+        # as the paper's real crosstalk. Mirrors the CPU path
+        # (apply_characteristic_curve) exactly — see negpy/features/exposure/logic.py.
+        if settings.process.process_mode == ProcessMode.BW:
+            sat = None
+        else:
+            sat_k3 = per_channel_density_saturation(
+                exp.density_saturation,
+                (exp.density_saturation_trim_red, exp.density_saturation_trim_green, exp.density_saturation_trim_blue),
+            )
+            sat = resolve_saturation_matrix(sat_k3)
+        composed = compose_density_matrices(dye, sat)
+        dye = composed  # use_dye_mix (below) and dye_rows both key off this
         dye_rows = np.eye(3) if dye is None else dye
 
         # The w-lanes carry per-channel toe (first three vec4s) and shoulder

--- a/tests/test_density_saturation.py
+++ b/tests/test_density_saturation.py
@@ -1,0 +1,115 @@
+"""Density-space Saturation: the matrix helpers (papers.py), the per-channel
+resolve (logic.py), and end-to-end render behavior (identity/no-op, real
+effect, B&W inertness)."""
+
+import numpy as np
+
+from negpy.domain.models import WorkspaceConfig
+from negpy.features.exposure.logic import per_channel_density_saturation
+from negpy.features.exposure.papers import (
+    compose_density_matrices,
+    resolve_dye_matrix,
+    resolve_paper,
+    resolve_saturation_matrix,
+)
+from negpy.services.rendering.engine import DarkroomEngine
+
+
+class TestResolveSaturationMatrix:
+    def test_identity_returns_none(self):
+        assert resolve_saturation_matrix((1.0, 1.0, 1.0)) is None
+
+    def test_full_desaturation_collapses_to_achromatic_mean(self):
+        m = resolve_saturation_matrix((0.0, 0.0, 0.0))
+        np.testing.assert_allclose(m, np.full((3, 3), 1.0 / 3.0))
+
+    def test_rows_sum_to_one_even_with_per_channel_divergence(self):
+        m = resolve_saturation_matrix((1.5, 0.7, 1.0))
+        np.testing.assert_allclose(m.sum(axis=1), [1.0, 1.0, 1.0])
+
+    def test_boost_strengthens_diagonal_weakens_off_diagonal(self):
+        m = resolve_saturation_matrix((2.0, 2.0, 2.0))
+        assert m[0, 0] > 1.0
+        assert m[0, 1] < 0.0
+
+
+class TestComposeDensityMatrices:
+    def test_both_none_is_none(self):
+        assert compose_density_matrices(None, None) is None
+
+    def test_dye_only_returns_dye_unchanged(self):
+        dye = np.array([[0.95, 0.04, 0.01], [0.08, 0.88, 0.04], [0.04, 0.14, 0.82]])
+        result = compose_density_matrices(dye, None)
+        np.testing.assert_allclose(result, dye)
+
+    def test_sat_only_returns_sat_unchanged(self):
+        sat = resolve_saturation_matrix((1.5, 1.0, 1.0))
+        result = compose_density_matrices(None, sat)
+        np.testing.assert_allclose(result, sat)
+
+    def test_composition_is_sat_outermost_dye_innermost(self):
+        """sat @ dye, not dye @ sat -- dye_matrix keeps acting on the print
+        curve's real density unchanged; saturation layers on top as a final
+        creative step. Uses a real (non-commuting) paper matrix so the two
+        orders actually produce different results, proving the order is
+        real and tested, not just documented."""
+        paper = resolve_paper("kodak_endura")
+        dye = resolve_dye_matrix(paper)
+        sat = resolve_saturation_matrix((1.5, 0.8, 1.0))
+        composed = compose_density_matrices(dye, sat)
+        np.testing.assert_allclose(composed, sat @ dye)
+        assert not np.allclose(composed, dye @ sat)
+
+
+class TestPerChannelDensitySaturation:
+    def test_global_only(self):
+        assert per_channel_density_saturation(1.4, (0.0, 0.0, 0.0)) == (1.4, 1.4, 1.4)
+
+    def test_trims_add_to_global(self):
+        assert per_channel_density_saturation(1.0, (0.2, -0.1, 0.0)) == (1.2, 0.9, 1.0)
+
+    def test_clamped_to_matrix_coefficient_range(self):
+        assert per_channel_density_saturation(1.0, (-5.0, 5.0, 0.0)) == (0.0, 3.0, 1.0)
+
+
+class TestDensitySaturationRender:
+    def _render(self, overrides):
+        engine = DarkroomEngine()
+        rng = np.random.default_rng(0)
+        img = rng.uniform(0.05, 0.9, (32, 32, 3)).astype(np.float32)
+        settings = WorkspaceConfig.from_flat_dict({"paper_profile": "neutral", **overrides})
+        return engine.process(img, settings, source_hash="density-sat-test")
+
+    def test_identity_is_exact_noop(self):
+        baseline = self._render({})
+        identity = self._render({"density_saturation": 1.0})
+        np.testing.assert_array_equal(baseline, identity)
+
+    def test_identity_is_exact_noop_with_real_dye_matrix(self):
+        """Same as test_identity_is_exact_noop, but with a paper that has a real
+        (non-identity) dye_matrix -- at density_saturation=1.0, compose_density_matrices
+        multiplies by an identity sat matrix, which is exact in floating point, so this
+        must stay bit-for-bit identical too, not just approximately close."""
+        engine = DarkroomEngine()
+        rng = np.random.default_rng(0)
+        img = rng.uniform(0.05, 0.9, (32, 32, 3)).astype(np.float32)
+        baseline = WorkspaceConfig.from_flat_dict({"paper_profile": "kodak_endura"})
+        identity = WorkspaceConfig.from_flat_dict({"paper_profile": "kodak_endura", "density_saturation": 1.0})
+        r1 = engine.process(img, baseline, source_hash="density-sat-endura-test")
+        r2 = engine.process(img, identity, source_hash="density-sat-endura-test")
+        np.testing.assert_array_equal(r1, r2)
+
+    def test_nonzero_saturation_changes_output(self):
+        baseline = self._render({})
+        boosted = self._render({"density_saturation": 1.6})
+        assert not np.array_equal(baseline, boosted)
+
+    def test_per_channel_trim_changes_output(self):
+        global_only = self._render({"density_saturation": 1.2})
+        with_trim = self._render({"density_saturation": 1.2, "density_saturation_trim_red": 0.3})
+        assert not np.array_equal(global_only, with_trim)
+
+    def test_bw_mode_is_inert(self):
+        bw_off = self._render({"process_mode": "B&W", "density_saturation": 1.0})
+        bw_on = self._render({"process_mode": "B&W", "density_saturation": 1.8})
+        np.testing.assert_allclose(bw_off, bw_on, atol=1e-6)

--- a/tests/test_gpu_curve_parity.py
+++ b/tests/test_gpu_curve_parity.py
@@ -112,6 +112,44 @@ class TestGpuCurveParity(unittest.TestCase):
         self.assertLess(mad, 0.01, f"mean abs diff {mad:.4f}")
         self.assertLess(mx, 0.04, f"max abs diff {mx:.4f}")
 
+    def test_cpu_gpu_match_density_saturation(self):
+        """Density Saturation composes into the same dye_mix slot as the paper's
+        real crosstalk -- uses Kodak Endura (a real, non-identity dye matrix) so
+        this exercises the actual sat @ dye composition, not just the trivial
+        no-paper/identity case."""
+        from negpy.services.rendering.image_processor import ImageProcessor
+
+        processor = ImageProcessor()
+        if processor.engine_gpu is None:
+            self.skipTest("GPU engine not initialised")
+
+        rng = np.random.default_rng(2)
+        h, w = 64, 64
+        grad = np.linspace(0.05, 0.9, w, dtype=np.float32)
+        img = np.repeat(grad[None, :], h, axis=0)
+        img = np.stack([img, img * 0.95, img * 0.9], axis=-1)
+        img = np.ascontiguousarray(img + rng.uniform(0, 0.01, img.shape).astype(np.float32))
+
+        s = WorkspaceConfig()
+        settings = replace(
+            s,
+            exposure=replace(
+                s.exposure,
+                paper_profile="kodak_endura",
+                density_saturation=1.5,
+                density_saturation_trim_red=0.3,
+                density_saturation_trim_blue=-0.2,
+            ),
+        )
+        cpu = self._render(processor, settings, img, prefer_gpu=False)
+        gpu = self._render(processor, settings, img, prefer_gpu=True)
+
+        self.assertEqual(cpu.shape, gpu.shape)
+        mad = float(np.mean(np.abs(cpu - gpu)))
+        mx = float(np.max(np.abs(cpu - gpu)))
+        self.assertLess(mad, 0.01, f"mean abs diff {mad:.4f}")
+        self.assertLess(mx, 0.04, f"max abs diff {mx:.4f}")
+
     def test_cpu_gpu_match_trims_no_dye_mute(self):
         """Dye Mute (LabConfig.chroma_damping) scales chroma toward neutral, which
         masks CPU/GPU chroma disagreements. With it off, the Cast Removal neutral-axis


### PR DESCRIPTION

Adds a Saturation control that operates in density space — composed into the exact same matrix slot as the paper profile's dye crosstalk (dye_matrix) — as an alternative to scaling Lab a*/b* post-decode. New field ExposureConfig.density_saturation (+ per-channel trims), default 1.0 = identity.

Lab Saturation scales a*/b* uniformly around L* — a purely perceptual-space operation with no relationship to how a physical print produces color; it's a math trick applied after decode. This instead pushes/pulls the print's actual per-channel dye densities apart, in the same coordinate space the paper's own dye crosstalk already operates in, composed via sat_matrix @ dye_matrix into one matmul.

Two consequences follow directly from that, not as separate design choices:
- It composes correctly with different paper profiles. Because it's literally the same matrix slot as the profile's dye crosstalk, pushing separation on a paper with real (impure) dye response looks different than on a cleaner profile — the way it would on an actual darkroom print — for free, with no per-paper special-casing.
- Its effect naturally scales with how much density-above-base a channel already has. Saturation is applied to density - paper_base after the full per-channel H&D curve (toe/shoulder/grade/etc.) has already run — so a channel sitting near its shoulder, already compressed by the curve, starts from a smaller density-above-base value than one in the linear region, and gets a proportionally smaller absolute push.

It also supports independent per-channel (R/G/B) trims, matching the existing pattern already used elsewhere in this section (Grade trim, Toe/Shoulder trim, Snap/midtone-gamma trim all support per-layer correction) — none of which the Lab sidebar's controls (Saturation, Vibrance, Dye Mute) currently support at all. That's not incidental to where this control lives: a real paper's dye layers can diverge independently (crossover), and this control can now correct that the same way the other Tone-stage controls already do. Placing it here keeps it consistent with that established convention rather than introducing a first per-channel-capable control in a section that has no precedent for one.

New field, defaults to identity (1.0). compose_density_matrices returns the dye matrix unmodified at default, so output is bit-for-bit unchanged both for the neutral paper (test_identity_is_exact_noop) and for papers with real dye crosstalk like Kodak Endura
(test_identity_is_exact_noop_with_real_dye_matrix). Cannot affect any existing saved edit.

Implemented on both the CPU and GPU render paths — verified by test_cpu_gpu_match_density_saturation (tests/test_gpu_curve_parity.py), which renders through the real GPU compute path with a non-identity paper dye matrix and non-default saturation/trims. No CPU-only fallback or silent no-op under the app's default GPU-first rendering.

- tests/test_density_saturation.py — matrix math (row-stochastic under per-channel divergence, sat @ dye composition order), per-channel resolve, and end-to-end render behavior (exact no-op at identity for both neutral and non-identity-dye papers, real effect, per-channel trims, B&W inertness)
- tests/test_gpu_curve_parity.py::test_cpu_gpu_match_density_saturation — CPU/GPU parity against a real paper dye matrix
- docs/PIPELINE.md updated