### PR TITLE
Contact sheet: render tiles at proof scale (fixes the remaining memory blowup)

### DIFF
--- a/negpy/services/rendering/image_processor.py
+++ b/negpy/services/rendering/image_processor.py
@@ -15,6 +15,7 @@ from negpy.domain.models import (
     WorkspaceConfig,
     ExportConfig,
     ExportFormat,
+    ExportResolutionMode,
     ColorSpace,
 )
 from negpy.features.process.models import ProcessMode
@@ -792,16 +793,43 @@ class ImageProcessor:
         Mirrors the export render path but at small resolution and in display space,
         so a contact-sheet tile matches the on-canvas look. Returns None on failure.
 
-        The result is downsampled to target_long_px: the caller holds every tile in
-        memory at once, so returning full-res here made peak cost scale with
-        frames x full resolution (a 24MP roll cost ~72MB per tile instead of ~3MB)
-        until allocations failed and tiles were silently dropped.
+        The source is shrunk to target_long_px *before* the pipeline runs, and the
+        paper layout is bounded to the same size. Rendering the full-res source and
+        discarding all but a tile cost ~3.5GB peak RSS (CPU) / ~8GB commit (GPU) per
+        24MP frame, so a large roll exhausted memory and tiles were silently dropped.
         """
         try:
             from negpy.infrastructure.display.color_mgmt import apply_display_transform
 
             f32_buffer, ir_full, _ = self._load_source_f32(file_path, params, fast_decode=fast_decode)
             f32_buffer, ir_full = self._slice_half_source(f32_buffer, ir_full, half, split_x)
+
+            # Proof scale: everything downstream only needs target_long_px. The
+            # cached source buffer is shared, so resize (never mutate) it.
+            f32_buffer = _downsample_to_long_edge(f32_buffer, target_long_px)
+            if ir_full is not None and ir_full.shape[:2] != f32_buffer.shape[:2]:
+                th, tw = f32_buffer.shape[:2]
+                ir_full = cv2.resize(ir_full, (tw, th), interpolation=cv2.INTER_AREA)
+            # Each frame of a contact sheet is decoded once, so the full-res source
+            # cache only pins ~300MB (24MP) across the next frame's decode.
+            self._source_cache_key = None
+            self._source_cache_value = None
+
+            # A Print/Target-px export setting sizes the paper from print_size x DPI,
+            # which would re-inflate the tile to full print resolution right after the
+            # downsample. Bound it with the virtual-DPI trick the UI print preview uses
+            # (PrintService.preview_paper_layout) so borders stay proportional.
+            if params.export.export_resolution_mode != ExportResolutionMode.ORIGINAL.value:
+                virtual_dpi = max(1, int((target_long_px * 2.54) / max(0.1, params.export.export_print_size)))
+                params = dc_replace(
+                    params,
+                    export=dc_replace(
+                        params.export,
+                        export_resolution_mode=ExportResolutionMode.PRINT.value,
+                        export_dpi=virtual_dpi,
+                    ),
+                )
+
             h_raw, w_raw = f32_buffer.shape[:2]
             scale_factor = max(1.0, max(h_raw, w_raw) / float(target_long_px))
 

--- a/tests/test_contact_sheet_tiles.py
+++ b/tests/test_contact_sheet_tiles.py
@@ -10,12 +10,13 @@ single image while the progress dialog still counted every file.
 import os
 import tempfile
 import unittest
-from unittest.mock import MagicMock
+from dataclasses import replace
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import tifffile
 
-from negpy.domain.models import WorkspaceConfig
+from negpy.domain.models import ExportResolutionMode, WorkspaceConfig
 from negpy.desktop.workers.export import ExportTask, ExportWorker
 from negpy.infrastructure.display.color_spaces import WORKING_COLOR_SPACE
 from negpy.services.rendering.image_processor import ImageProcessor, _downsample_to_long_edge
@@ -82,6 +83,58 @@ class TestRenderDisplayArraySize(unittest.TestCase):
         tile = self._render(600, prefer_gpu=False)
         source_px = 1600 * 2400
         self.assertLess(tile.shape[0] * tile.shape[1] * 8, source_px)
+
+    def test_pipeline_runs_at_proof_scale_not_full_res(self):
+        """The expensive half: rendering the full-res source and keeping only a tile
+        cost ~3.5GB peak RSS per 24MP frame. The engine must receive a buffer already
+        shrunk to target_long_px."""
+        seen: list = []
+        real = self.proc.run_pipeline
+
+        def spy(img, *a, **kw):
+            seen.append(img.shape[:2])
+            return real(img, *a, **kw)
+
+        with patch.object(self.proc, "run_pipeline", side_effect=spy):
+            self._render(600, prefer_gpu=False)
+
+        self.assertTrue(seen, "run_pipeline was never called")
+        self.assertLessEqual(max(seen[0]), 600, f"pipeline got a {seen[0]} buffer for a 600px tile")
+
+    def test_print_export_mode_does_not_inflate_the_tile(self):
+        """A Print/Target-px export setting sizes the paper from print_size x DPI;
+        without bounding it the proof render is blown back up to print resolution."""
+        params = replace(
+            WorkspaceConfig(),
+            export=replace(
+                WorkspaceConfig().export,
+                export_resolution_mode=ExportResolutionMode.PRINT.value,
+                export_print_size=60.0,
+                export_dpi=600,  # ~14000px paper if unbounded
+            ),
+        )
+        seen: list = []
+        real = self.proc.run_pipeline
+
+        def spy(img, *a, **kw):
+            seen.append(img.shape[:2])
+            return real(img, *a, **kw)
+
+        with patch.object(self.proc, "run_pipeline", side_effect=spy):
+            tile = self.proc.render_display_array(
+                self.path,
+                params,
+                "hash-print",
+                target_long_px=600,
+                prefer_gpu=False,
+                working_color_space=WORKING_COLOR_SPACE,
+                fast_decode=True,
+            )
+
+        self.assertIsNotNone(tile)
+        self.assertLessEqual(max(seen[0]), 600)
+        # Bounded end to end: the laid-out result never exceeds the tile size either.
+        self.assertLessEqual(max(tile.shape[:2]), 600)
 
 
 class TestContactSheetReportsDroppedTiles(unittest.TestCase):


### PR DESCRIPTION
## The bug

Still reported after #600: *"When I export a contact sheet, the used memory goes through the roof, swap also, and I get only one view on the contact sheet out of my 24 selected views."*

#600 was a real fix but only addressed the *accumulation* side — the tiles the worker holds in a list. It left the dominant cost untouched.

## Root cause

`render_display_array` takes `target_long_px`, but that value only fed `scale_factor`. Nothing downsampled the **input**: `run_pipeline` renders whatever buffer it's given, and the GPU path's `_readback_downsampled` reads the texture back at native size despite the name. So every contact-sheet tile ran the entire pipeline on the **full-resolution source** and then discarded all but a 1200px tile.

Measured per 24MP frame (peak working set / peak commit, `K32GetProcessMemoryInfo`):

| Path | Before | After |
|---|---|---|
| CPU | 3.53 GB / 4.28 GB | **1.23 GB / 1.99 GB** |
| GPU | 1.54 GB / 8.12 GB | **1.23 GB / 2.70 GB** |

Peak is hit on the *first* tile, so this is per-frame transient cost, not accumulation — which is exactly what "memory through the roof + swap" describes. Once an allocation fails, `render_display_array`'s blanket `except` returns `None` and the tile is dropped, leaving a sheet with a handful (or one) of 24 frames. Machine-dependent, so it doesn't reproduce on a high-RAM box — verified 24/24 tiles survive here both before and after; the fix is validated by the memory numbers, not by a repro of the drop.

## Changes

- **Downsample the source (and IR) to `target_long_px` before the pipeline runs.** This is the actual fix. `scale_factor` shrinks proportionally with the buffer, so effect radii land in the same relative place.
- **Bound the paper layout to the tile too.** A Print/Target-px export setting sizes paper from `print_size × DPI`, which would re-inflate the render to full print resolution right after the downsample (a 60cm @ 600dpi setting → ~14000px paper). Bounded with the same virtual-DPI convention `PrintService.preview_paper_layout` already uses for UI previews, so borders stay proportional. `ORIGINAL` mode is deliberately left alone — it can't upscale, and forcing PRINT there would change framing for the default case.
- **Release the full-res source cache after downsampling.** Contact-sheet frames are each decoded once, so that entry only pinned ~300 MB across the next frame's decode. (This is the proof path only; `run_batch` still benefits from the cache for multi-format presets.)

## Notes

- `render_display_array` has no caller outside `run_contact_sheet`, so the blast radius is the contact sheet only.
- Tiles are visually unchanged: mean |delta| ≈ 0.9/255 against pre-fix output on a synthetic hard-edged checkerboard (worst case for resampling), from rendering at proof scale rather than full-res-then-shrink.
- Pre-existing and left alone: the CPU and GPU paths use different `scale_factor` conventions here (CPU derives it from `preview_render_size` inside `run_pipeline`, the GPU call passes it relative to `target_long_px`). Both shrink proportionally so the fix is neutral to it, but they don't match each other — worth a separate look.

## Test plan
- 2 new tests in `tests/test_contact_sheet_tiles.py`: the pipeline must receive a buffer already bounded to `target_long_px` (spying on `run_pipeline`), and a 60cm @ 600dpi Print export must not inflate either the pipeline input or the returned tile. Both verified to fail when the source-downsample and layout-bound are neutered.
- 12 tests in that file pass; 70 across the contact-sheet + export suites.
- Full suite: 2531 passed, 3 pre-existing Windows path-separator failures (`test_effective_input_icc`, `test_output_dir_subfolder_of_source`, `test_sidecar_path`), unrelated.
- `make format` / `ruff check` clean.