### PR TITLE
Hide _IR TIFF sidecars from the contact sheet

### DIFF
--- a/negpy/desktop/workers/render.py
+++ b/negpy/desktop/workers/render.py
@@ -391,6 +391,7 @@ class AssetDiscoveryWorker(QObject):
         """
         import os
 
+        from negpy.infrastructure.loaders.constants import is_ir_sidecar_path
         from negpy.kernel.image.logic import calculate_file_hash
 
         discovered_paths = []
@@ -407,6 +408,8 @@ class AssetDiscoveryWorker(QObject):
                 logger.error(f"Discovery error for {path}: {e}")
         # Half-frame re-discovery passes both halves' (identical) paths — hash once.
         discovered_paths = list(dict.fromkeys(discovered_paths))
+        # IR companions ride along with their main TIFF; they are never assets of their own.
+        discovered_paths = [p for p in discovered_paths if not is_ir_sidecar_path(p)]
 
         total = len(discovered_paths)
         valid_assets = []

--- a/negpy/infrastructure/filesystem/watcher.py
+++ b/negpy/infrastructure/filesystem/watcher.py
@@ -1,6 +1,6 @@
 import os
 from typing import List, Set
-from negpy.infrastructure.loaders.constants import SUPPORTED_RAW_EXTENSIONS
+from negpy.infrastructure.loaders.constants import SUPPORTED_RAW_EXTENSIONS, is_ir_sidecar_path
 
 
 class FolderWatchService:
@@ -24,7 +24,7 @@ class FolderWatchService:
                 for entry in it:
                     if entry.is_file():
                         ext = os.path.splitext(entry.name)[1].lower()
-                        if ext in cls.SUPPORTED_EXTS:
+                        if ext in cls.SUPPORTED_EXTS and not is_ir_sidecar_path(entry.path):
                             full_path = os.path.abspath(entry.path)
                             if full_path not in existing_paths:
                                 new_files.append(full_path)

--- a/negpy/infrastructure/loaders/constants.py
+++ b/negpy/infrastructure/loaders/constants.py
@@ -1,3 +1,4 @@
+import os
 from typing import Set
 
 SUPPORTED_TIFF_EXTENSIONS: Set[str] = {
@@ -58,3 +59,30 @@ SUPPORTED_RAW_EXTENSIONS: Set[str] = (
     | SUPPORTED_TIFF_EXTENSIONS
     | SUPPORTED_JPEG_EXTENSIONS
 )
+
+# Longest first: "_ir_valid" must win before "_ir" is tested against the same stem.
+IR_SIDECAR_SUFFIXES: tuple[str, ...] = ("_ir_valid", "_ir")
+
+
+def is_ir_sidecar_path(path: str) -> bool:
+    """True for an `_IR`/`_IR_VALID` TIFF whose main TIFF sits next to it. Asset discovery hides
+    these; TiffLoader reads them off the main file instead. Case-insensitive name compare (not
+    os.path.exists) so a `Frame1.TIF` / `frame1_ir.tif` mix matches on case-sensitive filesystems.
+    An orphan sidecar stays visible — nothing else would ever open it."""
+    base, ext = os.path.splitext(path)
+    if ext.lower() not in SUPPORTED_TIFF_EXTENSIONS:
+        return False
+    stem = os.path.basename(base).lower()
+    for suffix in IR_SIDECAR_SUFFIXES:
+        if not stem.endswith(suffix):
+            continue
+        main = stem[: -len(suffix)]
+        if not main:
+            return False
+        wanted = tuple(main + e for e in sorted(SUPPORTED_TIFF_EXTENSIONS))
+        try:
+            entries = os.listdir(os.path.dirname(path) or ".")
+        except OSError:
+            return False
+        return any(name.lower() in wanted for name in entries)
+    return False

--- a/negpy/infrastructure/loaders/tiff_loader.py
+++ b/negpy/infrastructure/loaders/tiff_loader.py
@@ -6,6 +6,7 @@ from typing import Any, ContextManager, Optional, Tuple
 from negpy.domain.interfaces import IImageLoader
 from negpy.domain.models import ColorSpace
 from negpy.kernel.image.logic import srgb_to_linear, uint8_to_float32, uint16_to_float32
+from negpy.infrastructure.loaders.constants import IR_SIDECAR_SUFFIXES, SUPPORTED_TIFF_EXTENSIONS
 from negpy.infrastructure.loaders.helpers import NonStandardFileWrapper, identify_color_space_from_icc, read_orientation
 from negpy.kernel.system.logging import get_logger
 
@@ -21,6 +22,13 @@ def _normalize_ir_to_float32(ir: np.ndarray) -> np.ndarray:
     if ir.dtype == np.uint16:
         return ir.astype(np.float32) * (1.0 / 65535.0)
     return np.clip(ir.astype(np.float32), 0.0, 1.0)
+
+
+def _ir_suffixes(token: str) -> tuple[str, ...]:
+    """`_ir` → (`_ir.tif`, `_ir.tiff`). Keeps the read side tied to the token set that
+    `is_ir_sidecar_path` hides from asset discovery."""
+    assert token in IR_SIDECAR_SUFFIXES
+    return tuple(token + e for e in sorted(SUPPORTED_TIFF_EXTENSIONS))
 
 
 def _find_sidecar(dirname: str, entries: list[str], stem_lower: str, suffixes: tuple[str, ...]) -> Optional[str]:
@@ -42,7 +50,7 @@ def _read_sidecar_ir(file_path: str) -> Tuple[Optional[np.ndarray], Optional[np.
     except OSError:
         return None, None
 
-    candidate = _find_sidecar(dirname, entries, stem_lower, ("_ir.tif", "_ir.tiff"))
+    candidate = _find_sidecar(dirname, entries, stem_lower, _ir_suffixes("_ir"))
     if candidate is None:
         return None, None
     try:
@@ -52,7 +60,7 @@ def _read_sidecar_ir(file_path: str) -> Tuple[Optional[np.ndarray], Optional[np.
         logger.warning(f"Failed to read IR sidecar {candidate}: {e}")
         return None, None
 
-    mask_candidate = _find_sidecar(dirname, entries, stem_lower, ("_ir_valid.tif", "_ir_valid.tiff"))
+    mask_candidate = _find_sidecar(dirname, entries, stem_lower, _ir_suffixes("_ir_valid"))
     if mask_candidate is None:
         return ir, None
     try:

--- a/tests/test_ir_sidecar_discovery.py
+++ b/tests/test_ir_sidecar_discovery.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import pytest
+
+from negpy.infrastructure.filesystem.watcher import FolderWatchService
+from negpy.infrastructure.loaders.constants import is_ir_sidecar_path
+
+
+def _touch(tmp_path, *names: str) -> None:
+    for name in names:
+        (tmp_path / name).write_bytes(b"")
+
+
+@pytest.mark.parametrize(
+    "name,hidden",
+    [
+        ("frame1.tif", False),
+        ("frame1_IR.tif", True),
+        ("frame1_IR_VALID.tif", True),
+        ("frame1_ir.tiff", True),
+        ("frame1_IR.jpg", False),
+        ("lonely_IR.tif", False),
+        ("_IR.tif", False),
+    ],
+)
+def test_ir_sidecar_predicate(tmp_path, name: str, hidden: bool) -> None:
+    _touch(tmp_path, "frame1.tif", "frame1_IR.tif", "frame1_IR_VALID.tif", "frame1_ir.tiff", "frame1_IR.jpg", "lonely_IR.tif", "_IR.tif")
+    assert is_ir_sidecar_path(str(tmp_path / name)) is hidden
+
+
+def test_main_file_case_mismatch_still_hides_sidecar(tmp_path) -> None:
+    _touch(tmp_path, "Frame2.TIF", "frame2_ir.tif")
+    assert is_ir_sidecar_path(str(tmp_path / "frame2_ir.tif")) is True
+
+
+def test_watcher_skips_ir_sidecars(tmp_path) -> None:
+    _touch(tmp_path, "frame1.tif", "frame1_IR.tif", "frame1_IR_VALID.tif", "orphan_IR.tif")
+
+    found = FolderWatchService.scan_for_new_files(str(tmp_path), set())
+
+    assert sorted(p.rsplit("/", 1)[-1] for p in found) == ["frame1.tif", "orphan_IR.tif"]


### PR DESCRIPTION
## Problem

Loading a folder of scanner TIFFs showed each frame two or three times in the contact sheet: `frame001.tif`, `frame001_IR.tif` and `frame001_IR_VALID.tif` all matched the supported-extension filter and were hashed and imported as standalone assets. `TiffLoader` already reads the IR companion off the main file, so those files should never be assets of their own.

## Change

- `is_ir_sidecar_path()` in `negpy/infrastructure/loaders/constants.py` is the single source of truth for the `_IR` / `_IR_VALID` convention: TIFF extension, stem ending in an IR token, and a main TIFF present in the same directory (case-insensitive name compare, matching the loader's own lookup).
- Both discovery scanners use it: `AssetDiscoveryWorker.process` (covers Add Files / Add Folder / drag-drop / session restore / capture imports) and `FolderWatchService.scan_for_new_files` (hot folder, which would otherwise re-add them seconds later).
- `_read_sidecar_ir` builds its suffix tuples from the same constant so read and hide can't drift.

An orphan `_IR.tif` with no main TIFF beside it stays visible — nothing else would ever open it. Sidecars imported by earlier sessions drop out on next launch, since restore feeds their paths back through the same filter.

## Verification

- `make all` green (2681 passed, 1 skipped).
- New `tests/test_ir_sidecar_discovery.py` covers the predicate (incl. lowercase `_ir`, mixed-case main, orphan, non-TIFF) and the watcher.
- Drove the real `AssetDiscoveryWorker` on a `frame1.tif` + `frame1_IR.tif` + `frame1_IR_VALID.tif` + `orphan_IR.tif` folder: assets = `['frame1.tif', 'orphan_IR.tif']`, and `TiffLoader().load("frame1.tif")` still returns both `ir` and `ir_valid_mask`.