### PR TITLE
Grain focuser on the toolbar, ring-around off it

### DIFF
--- a/negpy/desktop/view/canvas/overlay.py
+++ b/negpy/desktop/view/canvas/overlay.py
@@ -58,7 +58,7 @@ _ZONE_CLIP_COLOR = QColor(220, 80, 80)  # paper black / paper white, same red th
 _STRIP_LABEL_MIN_PX = 34.0  # below this patch size the two axis labels overlap
 _STRIP_LABEL_INSET_PX = 6.0
 
-_LOUPE_RADIUS_PX = 96.0
+_LOUPE_RADIUS_PX = 128.0
 # Device px per buffer px inside the glass. At fit-zoom on a 1600 px buffer the canvas
 # already shows ~0.75 device px per buffer px, so a literal 1:1 loupe would magnify ~1.3x —
 # visually pointless. 2x always out-magnifies the canvas below 200% zoom.

--- a/negpy/desktop/view/canvas/toolbar.py
+++ b/negpy/desktop/view/canvas/toolbar.py
@@ -163,6 +163,17 @@ class ActionToolbar(QWidget):
             tooltip_with_shortcut("Zone overlay — label each region of the print with its Adams zone", "toggle_zones")
         )
 
+        self.btn_loupe = QToolButton()
+        self.btn_loupe.setCheckable(True)
+        self.btn_loupe.setIcon(qta.icon("fa5s.search-plus", color=icon_color))
+        self.btn_loupe.setToolTip(
+            tooltip_with_shortcut(
+                "Grain focuser — a loupe at the cursor showing the frame's own pixels, with an "
+                "acutance figure for comparing sharpness across the frame (reads true on HQ)",
+                "toggle_grain_focuser",
+            )
+        )
+
         # GPU availability drives the overflow toggle built below (btn moved off the row).
         self._gpu_available = GPUDevice.get().is_available
 
@@ -233,15 +244,6 @@ class ActionToolbar(QWidget):
         self._ov_zones_action.setCheckable(True)
         self._ov_zones_action.setToolTip(
             tooltip_with_shortcut("Zone overlay — label each region of the print with its Adams zone", "toggle_zones")
-        )
-        self._ov_ring_action = overflow_menu.addAction(qta.icon("mdi.target", color=icon_color), "Colour Ring-Around")
-        self._ov_ring_action.setCheckable(True)
-        self._ov_ring_action.setToolTip(
-            tooltip_with_shortcut(
-                "Colour ring-around — print the frame as a 5x5 mosaic, the centre at the current "
-                "filtration and the ring stepping 1cc at a time out to 2cc on magenta and yellow",
-                "toggle_ring_around",
-            )
         )
         self._ov_loupe_action = overflow_menu.addAction(qta.icon("fa5s.search-plus", color=icon_color), "Grain Focuser")
         self._ov_loupe_action.setCheckable(True)
@@ -345,6 +347,7 @@ class ActionToolbar(QWidget):
             self.btn_hq,
             self.btn_compare,
             self.btn_zones,
+            self.btn_loupe,
             self.btn_overflow,
         ]
         for btn in standard_buttons:
@@ -366,7 +369,7 @@ class ActionToolbar(QWidget):
         for btn in (self.btn_zoom_fit, self.btn_zoom_original):
             btn.setCursor(Qt.CursorShape.PointingHandCursor)
 
-        # Single-row layout: toggle_left · prev · next · sep1 · zoom_label · hq · sep2 · rot_l · rot_r · flip_h · flip_v · sep3 · undo · redo · compare · zones · overflow · toggle_right
+        # Single-row layout: toggle_left · prev · next · sep1 · zoom_label · hq · sep2 · rot_l · rot_r · flip_h · flip_v · sep3 · undo · redo · compare · zones · loupe · overflow · toggle_right
         row_layout.addWidget(self.btn_toggle_left)
         row_layout.addWidget(self.btn_prev)
         row_layout.addWidget(self.btn_next)
@@ -388,11 +391,12 @@ class ActionToolbar(QWidget):
         row_layout.addWidget(self.btn_redo)
         row_layout.addWidget(self.btn_compare)
         row_layout.addWidget(self.btn_zones)
+        row_layout.addWidget(self.btn_loupe)
         row_layout.addWidget(self.btn_overflow)
         row_layout.addWidget(self.btn_toggle_right)
 
         # Overflow groups for responsive resize (first listed = first collapsed).
-        self._ov_view_toggles: list = [self.btn_compare, self.btn_zones]
+        self._ov_view_toggles: list = [self.btn_compare, self.btn_zones, self.btn_loupe]
         self._ov_undo_redo: list = [self._sep3, self.btn_undo, self.btn_redo]
         self._ov_zoom_extra: list = [self.btn_zoom_fit, self.btn_zoom_original]
         self._ov_hq_group: list = [self.btn_hq, self._sep2]
@@ -415,11 +419,11 @@ class ActionToolbar(QWidget):
             widget.setChecked(active)
             widget.blockSignals(False)
 
-    def _sync_ring_action(self) -> None:
-        # One shared slot, so the kind gates this or the tone strip checks it too.
-        state = self.controller.state
-        active = (state.test_strip or state.test_strip_pending) and state.test_strip_kind == "colour"
-        self._ov_ring_action.setChecked(active)
+    def _on_grain_focuser_changed(self, active: bool) -> None:
+        for widget in (self.btn_loupe, self._ov_loupe_action):
+            widget.blockSignals(True)
+            widget.setChecked(active)
+            widget.blockSignals(False)
 
     def _on_flat_peek_changed(self, active: bool) -> None:
         self.btn_flat_peek.blockSignals(True)
@@ -453,11 +457,9 @@ class ActionToolbar(QWidget):
         self.btn_zones.toggled.connect(lambda checked: self.controller.toggle_zones_overlay(force=checked))
         self._ov_zones_action.triggered.connect(lambda checked: self.controller.toggle_zones_overlay(force=checked))
         self.controller.zones_overlay_changed.connect(self._on_zones_changed)
-        self._ov_ring_action.triggered.connect(lambda checked: self.controller.toggle_ring_around(force=checked))
-        self.controller.test_strip_changed.connect(lambda _up: self._sync_ring_action())
-        # Overflow-only, so `triggered` can't re-fire on the programmatic setChecked below.
+        self.btn_loupe.toggled.connect(lambda checked: self.controller.toggle_grain_focuser(force=checked))
         self._ov_loupe_action.triggered.connect(lambda checked: self.controller.toggle_grain_focuser(force=checked))
-        self.controller.grain_focuser_changed.connect(self._ov_loupe_action.setChecked)
+        self.controller.grain_focuser_changed.connect(self._on_grain_focuser_changed)
         self._ov_gpu_action.toggled.connect(self._on_gpu_toggled)
         self.controller.zoom_changed.connect(self._on_zoom_changed)
 
@@ -633,6 +635,7 @@ class ActionToolbar(QWidget):
         self.btn_flat_peek.setChecked(state.flat_peek)
         self._ov_flat_peek_action.setChecked(state.flat_peek)
         self._on_zones_changed(state.zones_overlay)
+        self._on_grain_focuser_changed(state.grain_focuser)
 
         geo = state.config.geometry
         self.btn_flip_h.setChecked(geo.flip_horizontal)

--- a/negpy/desktop/view/keyboard_shortcuts.py
+++ b/negpy/desktop/view/keyboard_shortcuts.py
@@ -26,10 +26,14 @@ def _context_undo(controller) -> None:
 
 
 def _context_cancel(controller, window) -> None:
-    """Esc ladder: a test strip is dismissed first (it owns the canvas while up), then
-    in-progress tool geometry (polyline points, straighten line), then the tool itself."""
+    """Esc ladder: a test strip is dismissed first (it owns the canvas while up), then the
+    grain focuser loupe, then in-progress tool geometry (polyline points, straighten line),
+    then the tool itself."""
     if controller.state.test_strip or controller.state.test_strip_pending:
         controller.toggle_test_strip(force=False)
+        return
+    if controller.state.grain_focuser:
+        controller.toggle_grain_focuser(force=False)
         return
     if not window.canvas.overlay.cancel_in_progress():
         controller.cancel_active_tool()

--- a/tests/test_canvas_polyline_finish.py
+++ b/tests/test_canvas_polyline_finish.py
@@ -188,6 +188,7 @@ def test_context_cancel_two_stage() -> None:
     controller, window = MagicMock(), MagicMock()
     controller.state.test_strip = False
     controller.state.test_strip_pending = False
+    controller.state.grain_focuser = False
     window.canvas.overlay.cancel_in_progress.return_value = True
     _context_cancel(controller, window)
     controller.cancel_active_tool.assert_not_called()
@@ -204,6 +205,7 @@ def test_context_cancel_dismisses_a_test_strip_before_any_tool() -> None:
 
     controller, window = MagicMock(), MagicMock()
     controller.state.test_strip_pending = False
+    controller.state.grain_focuser = False
     window.canvas.overlay.cancel_in_progress.return_value = True
 
     controller.state.test_strip = True
@@ -219,6 +221,23 @@ def test_context_cancel_dismisses_a_test_strip_before_any_tool() -> None:
     controller.state.test_strip_pending = True
     _context_cancel(controller, window)
     controller.toggle_test_strip.assert_called_once_with(force=False)
+
+
+def test_context_cancel_closes_the_grain_focuser_before_any_tool() -> None:
+    from unittest.mock import MagicMock
+
+    from negpy.desktop.view.keyboard_shortcuts import _context_cancel
+
+    controller, window = MagicMock(), MagicMock()
+    controller.state.test_strip = False
+    controller.state.test_strip_pending = False
+    controller.state.grain_focuser = True
+    window.canvas.overlay.cancel_in_progress.return_value = True
+
+    _context_cancel(controller, window)
+    controller.toggle_grain_focuser.assert_called_once_with(force=False)
+    window.canvas.overlay.cancel_in_progress.assert_not_called()
+    controller.cancel_active_tool.assert_not_called()
 
 
 def _crop_overlay(rect=(0.2, 0.2, 0.8, 0.8)) -> CanvasOverlay:

--- a/tests/test_canvas_toolbar.py
+++ b/tests/test_canvas_toolbar.py
@@ -19,6 +19,7 @@ def _make_toolbar() -> ActionToolbar:
     controller.session.state.compare_mode = False
     controller.session.state.flat_peek = False
     controller.session.state.zones_overlay = False
+    controller.session.state.grain_focuser = False
     controller.session.state.selected_file_idx = 0
     controller.session.state.undo_index = 0
     controller.session.state.max_history_index = 0
@@ -102,7 +103,6 @@ class TestCanvasToolbarResponsive(unittest.TestCase):
             tb._ov_compare_action,
             tb._ov_flat_peek_action,
             tb._ov_zones_action,
-            tb._ov_ring_action,
             tb._ov_loupe_action,
             tb._ov_undo_action,
             tb._ov_redo_action,
@@ -111,6 +111,22 @@ class TestCanvasToolbarResponsive(unittest.TestCase):
             tb._ov_flip_h_action,
             tb._ov_flip_v_action,
         ]
+
+    def test_grain_focuser_button_drives_the_controller(self):
+        tb = _make_toolbar()
+        tb.btn_loupe.click()
+        tb.controller.toggle_grain_focuser.assert_called_once_with(force=True)
+
+        # A programmatic state sync must not echo back as another toggle.
+        tb._on_grain_focuser_changed(False)
+        self.assertFalse(tb.btn_loupe.isChecked())
+        tb.controller.toggle_grain_focuser.assert_called_once_with(force=True)
+
+    def test_ring_around_is_not_in_the_toolbar(self):
+        tb = _make_toolbar()
+        labels = [a.text() for a in tb.btn_overflow.menu().actions()]
+        self.assertNotIn("Colour Ring-Around", labels)
+        self.assertFalse(hasattr(tb, "_ov_ring_action"))
 
     def test_overflow_menu_always_shows_full_action_set(self):
         """Regression: the overflow menu previously mirrored only whatever the row's


### PR DESCRIPTION
## What

- **Colour ring-around removed from the canvas toolbar.** It already has a button in the Colour sidebar right next to the M/Y filtration it steps; the overflow-menu copy (plus its `test_strip_changed` sync slot) was a second place to look for the same thing. The `Shift+F` shortcut and the sidebar button are untouched.
- **Grain focuser promoted to a toolbar button** — checkable `search-plus` next to Before/After and the zone overlay, in the same responsive collapse group. The overflow action stays as a mirror (the menu is meant to carry the full action set), both synced through one slot so a programmatic check can't echo back as a toggle.
- **Esc closes the loupe.** New rung in the cancel ladder: test strip → grain focuser → in-progress tool geometry → the tool itself.
- **Loupe radius 96 → 128 px.** Magnification stays 2x, so the glass covers more of the frame rather than showing bigger pixels.

## Tests

`make all` green. New: loupe button drives the controller and survives a state sync without re-firing; ring-around absent from the toolbar; Esc rung closes the focuser before anything below it.