### PR TITLE
Camera scanning: a broken live view no longer kills the capture session (part of #658)

### DIFF
--- a/negpy/desktop/view/sidebar/scanlight.py
+++ b/negpy/desktop/view/sidebar/scanlight.py
@@ -994,6 +994,13 @@ class ScanlightSidebar(QWidget):
         self._lv_timer.stop()
         self._lv_target.set_loading(False)  # nothing is buffering; the spinner would lie
         self.lv_window.set_preview_available(False, reason)
+        if self._calibrating_preset:
+            # The stream died mid-run (a Fujifilm giving up its preview, issue #658). The ROI is
+            # already placed and metering only needs stills, so let the run finish rather than
+            # cancelling work that is about to succeed; the window reports why the image froze.
+            self.calib_window.set_status(f"⚠ {reason} The calibration continues without the preview.")
+            self._apply_gating()
+            return
         if self.calib_window.isVisible():
             self.calib_window.close()  # calibration cannot aim at the base without a stream
         # The refusal published the settings JSON on its way out — normally the preview loop's

--- a/negpy/desktop/workers/capture_worker.py
+++ b/negpy/desktop/workers/capture_worker.py
@@ -132,7 +132,12 @@ class CaptureWorker(QObject):
         if self._camera is None:
             # The callback runs on the camera's own preview thread; the signal hop is what
             # moves the report onto the Qt side.
-            self._camera = GphotoCamera(on_preview_died=self.live_view_failed.emit)
+            self._camera = GphotoCamera(
+                on_preview_died=self.live_view_failed.emit,
+                # A stream that fails on a body that still answers is the "no preview" state,
+                # not a dead camera — same UI as a body that never advertised one.
+                on_preview_unusable=self.live_view_unsupported.emit,
+            )
         if not self._camera.is_open():
             try:
                 self._camera.open()

--- a/negpy/infrastructure/capture/gphoto.py
+++ b/negpy/infrastructure/capture/gphoto.py
@@ -100,6 +100,13 @@ _GRID_MARGIN = 8
 _WRITE_SETTLE_S = 3.0
 #: The magnifier itself takes ~1-2 s to engage — the same wait covers it.
 _EVENT_DRAIN_S = 1.0
+#: The quiet window that ends an event drain. Fujifilm bodies deliver post-shot events with
+#: pauses well past 50 ms, and events left unread block their next operation camera-side —
+#: cutting the drain at the first quiet 50 ms is how the X-T5's live view died after every
+#: still (issue #658). So the window is per-body: patient on Fujifilm, snappy elsewhere.
+_DRAIN_SILENCE_MS = 50
+_FUJI_DRAIN_SILENCE_MS = 300
+_FUJI_DRAIN_BUDGET_S = 2.0
 
 _PREVIEW_INTERVAL_S = 0.05  # the body tops out near 24 fps; this leaves headroom
 _SETTINGS_INTERVAL_S = 2.0
@@ -286,6 +293,8 @@ class GphotoCamera:
         # Set once a stream has failed on a body that is otherwise fine, so nothing restarts
         # it: retrying is what walks a Fujifilm off the USB bus entirely (issue #658).
         self._preview_broken = False
+        self._drain_silence_ms = _DRAIN_SILENCE_MS
+        self._drain_budget_s = _EVENT_DRAIN_S
         self._magnifier: Optional[_Magnifier] = None
         self._magnifier_ratios: Optional[tuple[str, str]] = None
         self._magnifier_off = ""
@@ -329,6 +338,9 @@ class GphotoCamera:
         self._model = _model_name(camera)
         self._alive = True
         self._capabilities = self._read_capabilities(camera)
+        if "fuji" in self._capabilities.driver_model.lower():
+            self._drain_silence_ms = _FUJI_DRAIN_SILENCE_MS
+            self._drain_budget_s = _FUJI_DRAIN_BUDGET_S
         logger.info(
             "gphoto2 session open: %s (driver %r, live view %s, settings %s)",
             self._model,
@@ -438,6 +450,9 @@ class GphotoCamera:
             try:
                 widget = camera.get_single_config(_CAPTURE_TARGET)
             except self._gp.GPhoto2Error:
+                # Absence is normal (the X-T5 has no capture-target setting at all), but say
+                # so — the silent skip cost a diagnosis round in issue #658.
+                logger.info("gphoto2: this body has no capture-target setting; leaving it alone")
                 return
             for choice in _choices(self._gp, widget):
                 if re.search(r"\bram\b|sdram", choice, re.IGNORECASE):
@@ -615,15 +630,17 @@ class GphotoCamera:
 
     # ----- capture ---------------------------------------------------------------
 
-    def _drain_events(self, budget_s: float = _EVENT_DRAIN_S) -> None:
+    def _drain_events(self, budget_s: Optional[float] = None) -> None:
         """Consume the events a still leaves behind.
 
-        Skipping this makes the *next* `capture()` fail with a bare `[-1]`.
+        Skipping this makes the *next* `capture()` fail with a bare `[-1]`. The quiet window
+        that ends the drain is per-body (see `_FUJI_DRAIN_SILENCE_MS`): on Fujifilm, events
+        left unread past the first pause are what killed live view after every still.
         """
         camera = self._require()
-        deadline = time.monotonic() + budget_s
+        deadline = time.monotonic() + (self._drain_budget_s if budget_s is None else budget_s)
         while time.monotonic() < deadline:
-            kind, _data = camera.wait_for_event(50)
+            kind, _data = camera.wait_for_event(self._drain_silence_ms)
             if kind == self._gp.GP_EVENT_TIMEOUT:
                 return
 
@@ -786,14 +803,23 @@ class GphotoCamera:
     def _preview_loop(self) -> None:
         next_settings = 0.0
         failures = 0
+        # Drain before the first frame, after every still, and before every retry: Fujifilm
+        # queues post-shot events past the overlapped drain's quiet window, and events left
+        # unread block capture_preview until the camera is power-cycled (issue #658). Costs
+        # one empty wait_for_event on bodies with a clean queue.
+        drain_first = True
         while not self._stop.is_set():
             if self._busy.is_set():  # stand aside for a capture rather than race it for the lock
+                drain_first = True
                 self._stop.wait(0.02)
                 continue
             try:
                 with self._lock:
                     if self._camera is None:
                         return
+                    if drain_first:
+                        self._drain_events()
+                        drain_first = False
                     frame = self._camera.capture_preview()
                     data = bytes(memoryview(frame.get_data_and_size()))
                 self._publish_frame(data)
@@ -803,6 +829,7 @@ class GphotoCamera:
                     next_settings = time.monotonic() + _SETTINGS_INTERVAL_S
             except Exception as exc:  # noqa: BLE001 — a dropped frame must not kill the thread
                 failures += 1
+                drain_first = True  # a failed frame may be blocked by unread events — clear them before retrying
                 logger.warning("gphoto2 live view (%d/%d): %s", failures, _MAX_PREVIEW_FAILURES, exc)
                 if failures >= _MAX_PREVIEW_FAILURES:
                     # Repeated failures used to mean one thing — the body is gone — and the whole

--- a/negpy/infrastructure/capture/gphoto.py
+++ b/negpy/infrastructure/capture/gphoto.py
@@ -253,6 +253,7 @@ class GphotoCamera:
         settings_path: Optional[str] = None,
         gp_module: Optional[Any] = None,
         on_preview_died: Optional[Callable[[str], None]] = None,
+        on_preview_unusable: Optional[Callable[[str], None]] = None,
     ) -> None:
         self._gp = gp_module or _gp()
         self._jpeg_path = jpeg_path or default_jpeg_path()
@@ -261,6 +262,9 @@ class GphotoCamera:
         # normal stop(). Without it a body that stops answering (issue #617: GFX50S II
         # times out with [-110]) leaves the UI spinning on "loading live view" forever.
         self._on_preview_died = on_preview_died
+        # Called instead of the above when the stream fails but the body still answers: the
+        # session stays open and scanning continues, only the preview is given up on.
+        self._on_preview_unusable = on_preview_unusable
         self._camera: Any = None
         self._model = ""
         # Cleared when the body stops answering — unplugging it leaves the handle behind,
@@ -279,6 +283,9 @@ class GphotoCamera:
     def _reset_body_state(self) -> None:
         """Forget controls whose names and semantics belong to one camera body."""
         self._capabilities = CameraCapabilities(driver_model="")
+        # Set once a stream has failed on a body that is otherwise fine, so nothing restarts
+        # it: retrying is what walks a Fujifilm off the USB bus entirely (issue #658).
+        self._preview_broken = False
         self._magnifier: Optional[_Magnifier] = None
         self._magnifier_ratios: Optional[tuple[str, str]] = None
         self._magnifier_off = ""
@@ -726,6 +733,11 @@ class GphotoCamera:
         if self.is_running():
             return
         self.open()
+        if self._preview_broken:
+            # A stream already failed on this body while it kept answering. Restarting it is
+            # what turns one bad preview into a reconnect loop, so refuse until the session is
+            # closed (a reconnect or power cycle clears the flag via _reset_body_state).
+            raise LiveViewUnsupported(self._live_view_refusal())
         if not self._capabilities.preview:
             # Refuse rather than let _preview_loop find out: the body rejects capture_preview
             # at the device level, and that refusal wedges the PTP session until the camera is
@@ -748,6 +760,13 @@ class GphotoCamera:
         not a limit of the camera. Only a body that lacks it in its tethering mode (the a6000)
         genuinely cannot preview — and it still scans.
         """
+        if self._preview_broken:
+            # Advertised the capability, then failed to deliver it — the Fujifilm case. Say so
+            # plainly rather than blaming the connection, and make clear scanning is unaffected.
+            return (
+                f"{self._model or 'this camera'} accepted the connection but its live view does not work "
+                "(a known gap in libgphoto2's Fujifilm support). Scanning still works, just without a preview."
+            )
         if self._capabilities.mtp_mode:
             return (
                 f"{self._model or 'this camera'} is connected in MTP mode, which has no live view. "
@@ -786,20 +805,55 @@ class GphotoCamera:
                 failures += 1
                 logger.warning("gphoto2 live view (%d/%d): %s", failures, _MAX_PREVIEW_FAILURES, exc)
                 if failures >= _MAX_PREVIEW_FAILURES:
-                    # The body stopped answering — unplugged, powered off, or claimed by
-                    # another app. Mark the handle dead so nothing reuses it; don't call
-                    # close() from here, it would join this very thread.
+                    # Repeated failures used to mean one thing — the body is gone — and the whole
+                    # session was dropped. On Fujifilm bodies that verdict is wrong: capture_preview
+                    # returns [-1] forever while the camera happily keeps shooting 85 MB frames
+                    # (issue #658). Tearing the session down there kills a working scan, and the
+                    # reopen-and-retry cycle that follows walks the body off the USB bus entirely.
+                    # So ask the camera before deciding.
+                    if self._camera_answers():
+                        logger.warning("gphoto2: live view failed but the camera still answers — continuing without a preview")
+                        self._preview_broken = True
+                        self._report_preview_stopped(self._on_preview_unusable, self._live_view_refusal())
+                        return
                     logger.warning("gphoto2: camera stopped answering, dropping the session")
-                    self._alive = False
-                    if self._on_preview_died is not None:
-                        try:
-                            self._on_preview_died(str(exc))
-                        except Exception:  # noqa: BLE001 — the report must not break teardown
-                            logger.exception("preview-died callback failed")
+                    self._alive = False  # nothing may reuse the handle; close() would join this thread
+                    self._report_preview_stopped(self._on_preview_died, str(exc))
                     return
                 self._stop.wait(0.5)
                 continue
             self._stop.wait(_PREVIEW_INTERVAL_S)
+
+    def _camera_answers(self) -> bool:
+        """Does the body still respond to a plain property read?
+
+        The one question that separates "this camera is gone" from "only its preview is
+        broken". A config read is the cheapest vendor-neutral liveness check there is, and it
+        touches nothing the preview owns. A body that advertises no CONFIG cannot be asked
+        this way, so it keeps the old verdict — rare, and erring toward the safer teardown.
+        """
+        if not self._capabilities.config:
+            return False
+        try:
+            with self._lock:
+                camera = self._camera
+                if camera is None or not self._alive:
+                    return False
+                name = self._property("iso")
+                if name is None:
+                    return False
+                camera.get_single_config(name)
+            return True
+        except Exception:  # noqa: BLE001 — any failure here means "cannot confirm it is alive"
+            return False
+
+    def _report_preview_stopped(self, callback: Optional[Callable[[str], None]], reason: str) -> None:
+        if callback is None:
+            return
+        try:
+            callback(reason)
+        except Exception:  # noqa: BLE001 — the report must not break teardown
+            logger.exception("preview-stopped callback failed")
 
     def _publish_frame(self, data: bytes) -> None:
         tmp = f"{self._jpeg_path}.part"

--- a/tests/test_capture_gphoto.py
+++ b/tests/test_capture_gphoto.py
@@ -116,6 +116,8 @@ class _Camera:
 
     def capture_preview(self):
         self._check()
+        if self._fake.preview_error:  # only the preview is broken; the body still answers
+            raise _Err(self._fake.preview_error)
         self._fake.previews += 1
         return _File(b"\xff\xd8JPEG")
 
@@ -168,6 +170,7 @@ class FakeGP:
         self.driver_model = driver_model
         self.operations = operations
         self.abilities_error = False
+        self.preview_error = None  # set to a message so capture_preview fails but config reads do not
         self.opened = False
         self.undrained = False
         self.gone = False  # set by unplug(): the body stops answering, as on a pulled cable
@@ -622,6 +625,55 @@ def test_live_view_is_refused_on_a_body_without_the_preview_ability(tmp_path):
     assert fake.previews == 0  # the wedge is avoided, not merely reported
     assert not camera.is_running()
     assert camera.is_open()  # the session itself stays usable — this body still scans
+    camera.close()
+
+
+def test_a_broken_preview_keeps_the_session_alive_when_the_camera_still_answers(fake, tmp_path):
+    """Issue #658: a Fujifilm returns [-1] from capture_preview forever while it keeps shooting.
+    Dropping the session there kills a working scan, and the reopen loop that follows walks the
+    body off the USB bus."""
+    import time
+
+    unusable: list[str] = []
+    died: list[str] = []
+    camera = GphotoCamera(
+        gp_module=fake,
+        jpeg_path=str(tmp_path / "lv.jpg"),
+        settings_path=str(tmp_path / "lv.json"),
+        on_preview_died=died.append,
+        on_preview_unusable=unusable.append,
+    )
+    camera.start()
+    fake.preview_error = "[-1] Unspecified error"  # only the preview breaks; config reads still work
+
+    for _ in range(300):
+        if not camera.is_running():
+            break
+        time.sleep(0.01)
+    else:
+        raise AssertionError("the preview thread never gave up")
+
+    assert unusable and not died  # reported as "no preview", not as a dead camera
+    assert camera.is_open()  # the session a scan needs is untouched
+    camera.close()
+
+
+def test_a_body_with_a_broken_preview_is_not_restarted(fake, tmp_path):
+    """Restarting is what turns one failed preview into a reconnect loop."""
+    import time
+
+    camera = GphotoCamera(gp_module=fake, jpeg_path=str(tmp_path / "lv.jpg"), settings_path=str(tmp_path / "lv.json"))
+    camera.start()
+    fake.preview_error = "[-1] Unspecified error"
+    for _ in range(300):
+        if not camera.is_running():
+            break
+        time.sleep(0.01)
+
+    previews = fake.previews
+    with pytest.raises(LiveViewUnsupported, match="live view does not work"):
+        camera.start()
+    assert fake.previews == previews  # refused without touching the body again
     camera.close()
 
 

--- a/tests/test_capture_gphoto.py
+++ b/tests/test_capture_gphoto.py
@@ -118,12 +118,24 @@ class _Camera:
         self._check()
         if self._fake.preview_error:  # only the preview is broken; the body still answers
             raise _Err(self._fake.preview_error)
+        if self._fake.late_events or self._fake.event_gap:
+            # Fujifilm behaviour (issue #658): post-shot events left unread block the preview.
+            raise _Err("[-1] Unspecified error")
         self._fake.previews += 1
         return _File(b"\xff\xd8JPEG")
 
-    def wait_for_event(self, _ms):
+    def wait_for_event(self, ms):
+        self._fake.event_waits.append(ms)
         if self._fake.undrained:
             self._fake.undrained = False
+            if self._fake.late_events:
+                self._fake.event_gap = True  # the pause that ends an impatient drain early
+            return FakeGP.GP_EVENT_CAPTURE_COMPLETE, None
+        if self._fake.event_gap:
+            self._fake.event_gap = False
+            return FakeGP.GP_EVENT_TIMEOUT, None
+        if self._fake.late_events:
+            self._fake.late_events -= 1
             return FakeGP.GP_EVENT_CAPTURE_COMPLETE, None
         return FakeGP.GP_EVENT_TIMEOUT, None
 
@@ -171,6 +183,9 @@ class FakeGP:
         self.operations = operations
         self.abilities_error = False
         self.preview_error = None  # set to a message so capture_preview fails but config reads do not
+        self.late_events = 0  # post-shot events the body only hands over after a pause (Fujifilm, #658)
+        self.event_gap = False
+        self.event_waits: list[int] = []  # the quiet-window ms passed to each wait_for_event
         self.opened = False
         self.undrained = False
         self.gone = False  # set by unplug(): the body stops answering, as on a pulled cable
@@ -674,6 +689,52 @@ def test_a_body_with_a_broken_preview_is_not_restarted(fake, tmp_path):
     with pytest.raises(LiveViewUnsupported, match="live view does not work"):
         camera.start()
     assert fake.previews == previews  # refused without touching the body again
+    camera.close()
+
+
+def test_fuji_gets_a_patient_event_drain(tmp_path):
+    """The X-T5 delivers post-shot events with pauses past 50 ms; a drain that stops at the
+    first quiet 50 ms leaves them unread, which blocks the next preview (issue #658)."""
+    fuji = FakeGP(driver_model="Fuji Fujifilm X-T5", operations=25)
+    camera = GphotoCamera(gp_module=fuji, jpeg_path=str(tmp_path / "a.jpg"))
+    camera.open()
+    camera._drain_events()
+    assert fuji.event_waits[-1] == 300  # waits out Fujifilm's inter-event pauses
+    camera.close()
+
+    other = FakeGP()
+    camera = GphotoCamera(gp_module=other, jpeg_path=str(tmp_path / "b.jpg"))
+    camera.open()
+    camera._drain_events()
+    assert other.event_waits[-1] == 50  # everyone else keeps the snappy window
+    camera.close()
+
+
+def test_preview_survives_a_still_that_leaves_late_events(fake, tmp_path):
+    """Issue #658's core failure: events the body hands over only after a pause killed every
+    capture_preview after the first still. The preview thread now drains before its first
+    frame after a capture (and before any retry), so the stream survives."""
+    import time
+
+    camera = GphotoCamera(gp_module=fake, jpeg_path=str(tmp_path / "lv.jpg"), settings_path=str(tmp_path / "lv.json"))
+    camera.start()
+    for _ in range(300):
+        if fake.previews:
+            break
+        time.sleep(0.01)
+
+    fake.late_events = 2  # this still's events arrive with a pause the overlapped drain trips over
+    camera.capture(str(tmp_path / "f.ARW"))
+    before = fake.previews
+    for _ in range(300):
+        if fake.previews > before:
+            break
+        time.sleep(0.01)
+    else:
+        raise AssertionError("the preview never came back after the still")
+
+    assert camera.is_running()  # not degraded, not dropped — the stream simply continued
+    assert fake.late_events == 0 and not fake.event_gap  # the queue was actually cleared
     camera.close()
 
 


### PR DESCRIPTION
Part of #658.

The reporter's logs pin the failure precisely. Preview streamed fine for 18 seconds while the crosshair was being placed, then died at the exact moment the first still was taken, and no new session brought it back, only a power cycle. Meanwhile capture itself kept working, moving 85 MB RAF files at ~880 MB/s. A bare `gphoto2 --capture-preview` on a freshly started camera succeeds, because it takes no still. This matches gphoto/gphoto2#671 on the X-T3, where PTP errors also begin after a single capture.

## Root cause hypothesis

Fujifilm bodies deliver their post-shot events with pauses well past 50 ms, and events left unread block the body's next operation. NegPy's event drain stopped at the first quiet 50 ms window, so the tail of every still's events stayed queued, and the next `capture_preview()` ran into the blocked state and returned `[-1]` forever. The reporter's log shows the first capture delivering events for 305 ms, exactly the pattern the old drain truncates.

## What changed

- **The drain's quiet window is per-body**: 300 ms silence with a 2 s budget on Fujifilm (matched on the driver entry), the existing 50 ms elsewhere, so Sony cadence is untouched.
- **The preview thread drains before its first frame, after every still, and before every retry.** On a body with a clean queue this costs one empty `wait_for_event`; on Fujifilm it clears the late events precisely where the preview needs the channel.
- **A broken preview no longer kills the capture session.** Previously three failed preview frames meant "camera is gone": the working session was dropped, the window closed, and the reopen-retry cycle eventually pushed the camera off the USB bus with `[-52]`. Now the loop first asks the body whether it still answers (a plain config read); if it does, only the preview is given up, the scan window stays open without a preview pane (the same degraded state #630 introduced), and scanning continues. A stream dying mid-calibration lets the run finish, the ROI is already placed and metering only needs stills.
- A body without a `capturetarget` setting (the X-T5 has none) is now logged instead of silently skipped, that silence cost a diagnosis round.

## Verification

Unit tests cover: the patient Fujifilm drain vs the snappy default, a preview surviving a still that leaves late events (the reporter's exact failure, modelled in the fake), a preview that fails while config reads still work keeping the session and reporting "unusable", an unplugged body still dropping the session, and a broken preview not being restarted. Regression-tested on a Sony a7C II: live view, scanning, calibration and a pulled cable all behave as before. `make all` is green with and without the optional camera group.

I cannot test a Fujifilm body myself; the reporter has offered to re-test once this lands.