### PR TITLE
Draft: density-space Vibrance/anti-vibrance + spatially-modulated Dye Mute (extends #667)

### DIFF
--- a/negpy/desktop/view/sidebar/tone.py
+++ b/negpy/desktop/view/sidebar/tone.py
@@ -11,6 +11,20 @@ _CH_SUFFIX = ("red", "green", "blue")
 _CH_LABEL = ("", " R", " G", " B")
 _CH_COLORS = ("#ff5a5a", "#5adc78", "#5f96ff")
 
+# PROTOTYPE A/B strengths for Density Vibrance vs Lab Vibrance, matched by
+# overall mean-chroma effect on a real test frame (07.raw, neutral paper) —
+# see the density-saturation investigation memory for the render scan.
+# Boost direction (+0.5 density / 1.50 Lab) is a fair comparison: both target
+# the same population (muted pixels). Compress direction (-0.5 density /
+# 0.33 Lab) is magnitude-matched only -- Lab's sub-1.0 desaturates MUTED
+# pixels further, Density's negative compresses VIVID pixels; they'll look
+# different even at "equal" overall chroma change, not just differently
+# strong. Not a bug, worth seeing directly in the A/B.
+_VIBRANCE_AB_DENSITY_BOOST = 0.5
+_VIBRANCE_AB_LAB_BOOST = 1.50
+_VIBRANCE_AB_DENSITY_COMPRESS = -0.5
+_VIBRANCE_AB_LAB_COMPRESS = 0.33
+
 
 class ToneSidebar(BaseSidebar):
     """Print/zone density, Grade, Print Saturation, paper white, and a labeled
@@ -157,6 +171,77 @@ class ToneSidebar(BaseSidebar):
         density_sat_row.addWidget(self.dye_mute_slider)
         self.layout.addLayout(density_sat_row)
 
+        self.density_damping_spatial_btn = self._labeled_toggle(
+            "fa5s.bullseye",
+            "Spatial Damping (proto)",
+            conf.density_damping_spatial,
+            "PROTOTYPE: applies Dye Mute's strength above per-pixel (via the same spread-based mask "
+            "Vibrance uses), replacing rather than layering on top of the uniform grade-coupled "
+            "damping -- near-neutral pixels get little or none of it, already-separated pixels get "
+            "up to the full strength. Off (default) = today's flat/uniform damping, unchanged.",
+        )
+        self.layout.addWidget(self.density_damping_spatial_btn)
+
+        self.density_vibrance_slider = PowerWarpSlider("Density Vibrance (proto)", -1.0, 1.0, 0.0, center=0.0, has_neutral=True)
+        self.density_vibrance_slider.setToolTip(
+            "PROTOTYPE: per-pixel density-domain Vibrance/anti-vibrance. Positive boosts muted "
+            "pixels (leaves already-vivid ones alone, classic Vibrance); negative compresses vivid "
+            "pixels (leaves muted ones alone, anti-vibrance) — one signed control, the target "
+            "flips with sign. Runs after Print Saturation/Dye Mute, on the same composed density."
+        )
+        self.layout.addWidget(self.density_vibrance_slider)
+
+        # PROTOTYPE: fixed-strength A/B/baseline quick-switch — Density Vibrance
+        # vs Lab Vibrance at matched overall-chroma strengths (see the constants
+        # above), so the two can be compared precisely instead of eyeballed.
+        self.vibrance_off_btn = self._labeled_toggle("fa5s.ban", "Off", True, "Baseline: both Vibrance tools off/identity.")
+        self.vibrance_density_boost_btn = self._labeled_toggle(
+            "fa5s.circle",
+            f"Density +{_VIBRANCE_AB_DENSITY_BOOST}",
+            False,
+            "Density Vibrance boost, matched by overall chroma effect to the Lab Vibrance boost button.",
+        )
+        self.vibrance_lab_boost_btn = self._labeled_toggle(
+            "fa5s.circle",
+            f"Lab {_VIBRANCE_AB_LAB_BOOST}",
+            False,
+            "Lab Vibrance boost, matched by overall chroma effect to the Density Vibrance boost button — "
+            "a fair comparison, both target the same (muted) pixels.",
+        )
+        self.vibrance_density_compress_btn = self._labeled_toggle(
+            "fa5s.circle",
+            f"Density {_VIBRANCE_AB_DENSITY_COMPRESS}",
+            False,
+            "Density anti-vibrance: compresses already-vivid pixels, leaves muted ones alone.",
+        )
+        self.vibrance_lab_compress_btn = self._labeled_toggle(
+            "fa5s.circle",
+            f"Lab {_VIBRANCE_AB_LAB_COMPRESS}",
+            False,
+            "Lab Vibrance below 1.0: desaturates already-MUTED pixels further, leaves vivid ones alone. "
+            "Matched to the Density compress button by overall chroma effect only — NOT the same "
+            "population of pixels, will look different even at equal average strength.",
+        )
+        self.vibrance_ab_group = QButtonGroup(self)
+        self.vibrance_ab_group.setExclusive(True)
+        for btn in (
+            self.vibrance_off_btn,
+            self.vibrance_density_boost_btn,
+            self.vibrance_lab_boost_btn,
+            self.vibrance_density_compress_btn,
+            self.vibrance_lab_compress_btn,
+        ):
+            self.vibrance_ab_group.addButton(btn)
+        vibrance_ab_row1 = QHBoxLayout()
+        vibrance_ab_row1.addWidget(self.vibrance_off_btn)
+        vibrance_ab_row1.addWidget(self.vibrance_density_boost_btn)
+        vibrance_ab_row1.addWidget(self.vibrance_lab_boost_btn)
+        self.layout.addLayout(vibrance_ab_row1)
+        vibrance_ab_row2 = QHBoxLayout()
+        vibrance_ab_row2.addWidget(self.vibrance_density_compress_btn)
+        vibrance_ab_row2.addWidget(self.vibrance_lab_compress_btn)
+        self.layout.addLayout(vibrance_ab_row2)
+
         paper_header = section_subheader("PAPER RESPONSE")
         paper_header.setToolTip(
             "The paper's characteristic (Hurter–Driffield) curve: how print density responds to "
@@ -230,6 +315,8 @@ class ToneSidebar(BaseSidebar):
             self.shadow_density_slider,
             self.highlight_density_slider,
             self.dye_mute_slider,
+            self.density_vibrance_slider,
+            self.density_damping_spatial_btn,
         )
 
     def _open_targets_dialog(self) -> None:
@@ -302,12 +389,28 @@ class ToneSidebar(BaseSidebar):
         self.test_strip_btn.setEnabled(not pending)
         self.test_strip_btn.setToolTip(wrap_tooltip(self._test_strip_tooltip(printing=pending)))
 
+    def _on_vibrance_ab(self, density_vibrance: float, lab_vibrance: float) -> None:
+        """Sets Density Vibrance and Lab Vibrance together (different config
+        sections), pinning both tools' Saturation to identity so the A/B
+        isolates Vibrance alone regardless of what those sliders were left at."""
+        from dataclasses import replace as dc_replace
+
+        new_exposure = dc_replace(self.state.config.exposure, density_vibrance=density_vibrance, density_saturation=1.0)
+        new_lab = dc_replace(self.state.config.lab, vibrance=lab_vibrance, saturation=1.0)
+        self.update_config_root(render=True, persist=True, readback_metrics=True, exposure=new_exposure, lab=new_lab)
+
     def _connect_signals(self) -> None:
         self.paper_combo.currentIndexChanged.connect(self._on_paper_changed)
         # The strip is session state, not config, and any render drops it — so the button
         # has to follow the controller rather than sync_ui.
         self.controller.test_strip_changed.connect(self._sync_test_strip_btn)
         self.ch_btn_group.idToggled.connect(lambda _id, checked: self.sync_ui() if checked else None)
+
+        self.vibrance_off_btn.clicked.connect(lambda: self._on_vibrance_ab(0.0, 1.0))
+        self.vibrance_density_boost_btn.clicked.connect(lambda: self._on_vibrance_ab(_VIBRANCE_AB_DENSITY_BOOST, 1.0))
+        self.vibrance_lab_boost_btn.clicked.connect(lambda: self._on_vibrance_ab(0.0, _VIBRANCE_AB_LAB_BOOST))
+        self.vibrance_density_compress_btn.clicked.connect(lambda: self._on_vibrance_ab(_VIBRANCE_AB_DENSITY_COMPRESS, 1.0))
+        self.vibrance_lab_compress_btn.clicked.connect(lambda: self._on_vibrance_ab(0.0, _VIBRANCE_AB_LAB_COMPRESS))
 
         for slider, field in (
             (self.density_slider, "density"),
@@ -318,6 +421,7 @@ class ToneSidebar(BaseSidebar):
             (self.highlight_density_slider, "highlight_density"),
             (self.density_sat_slider, "density_saturation"),
             (self.dye_mute_slider, "density_saturation_damping"),
+            (self.density_vibrance_slider, "density_vibrance"),
         ):
             slider.valueChanged.connect(
                 lambda v, f=field: self.update_config_section("exposure", render=True, persist=False, readback_metrics=False, **{f: v})
@@ -379,6 +483,7 @@ class ToneSidebar(BaseSidebar):
             (self.paper_black_btn, "paper_black"),
             (self.auto_density_btn, "auto_exposure"),
             (self.auto_grade_btn, "auto_normalize_contrast"),
+            (self.density_damping_spatial_btn, "density_damping_spatial"),
         ):
             btn.toggled.connect(
                 lambda checked, f=field: self.update_config_section(
@@ -457,17 +562,44 @@ class ToneSidebar(BaseSidebar):
             self.highlight_density_slider.setValue(conf.highlight_density)
             self.density_sat_slider.setValue(conf.density_saturation)
             self.dye_mute_slider.setValue(conf.density_saturation_damping)
+            self.density_vibrance_slider.setValue(conf.density_vibrance)
+            lab_vibrance = self.state.config.lab.vibrance
+            if conf.density_vibrance == 0.0 and lab_vibrance == 1.0:
+                self.vibrance_off_btn.setChecked(True)
+            elif conf.density_vibrance == _VIBRANCE_AB_DENSITY_BOOST and lab_vibrance == 1.0:
+                self.vibrance_density_boost_btn.setChecked(True)
+            elif lab_vibrance == _VIBRANCE_AB_LAB_BOOST and conf.density_vibrance == 0.0:
+                self.vibrance_lab_boost_btn.setChecked(True)
+            elif conf.density_vibrance == _VIBRANCE_AB_DENSITY_COMPRESS and lab_vibrance == 1.0:
+                self.vibrance_density_compress_btn.setChecked(True)
+            elif lab_vibrance == _VIBRANCE_AB_LAB_COMPRESS and conf.density_vibrance == 0.0:
+                self.vibrance_lab_compress_btn.setChecked(True)
+            else:
+                for b in (
+                    self.vibrance_off_btn,
+                    self.vibrance_density_boost_btn,
+                    self.vibrance_lab_boost_btn,
+                    self.vibrance_density_compress_btn,
+                    self.vibrance_lab_compress_btn,
+                ):
+                    b.setChecked(False)
 
             self.paper_dmin_btn.setChecked(conf.paper_dmin)
             self.paper_black_btn.setChecked(conf.paper_black)
             self.auto_density_btn.setChecked(conf.auto_exposure)
             self.auto_grade_btn.setChecked(conf.auto_normalize_contrast)
+            self.density_damping_spatial_btn.setChecked(conf.density_damping_spatial)
         finally:
             self.block_signals(False)
 
     def block_signals(self, blocked: bool) -> None:
         for w in (
             self.paper_combo,
+            self.vibrance_off_btn,
+            self.vibrance_density_boost_btn,
+            self.vibrance_lab_boost_btn,
+            self.vibrance_density_compress_btn,
+            self.vibrance_lab_compress_btn,
             self.ch_global_btn,
             self.ch_r_btn,
             self.ch_g_btn,
@@ -487,11 +619,13 @@ class ToneSidebar(BaseSidebar):
             self.density_sat_slider,
             self.density_sat_trim_slider,
             self.dye_mute_slider,
+            self.density_vibrance_slider,
             self.shadow_grade_slider,
             self.highlight_grade_slider,
             self.paper_dmin_btn,
             self.paper_black_btn,
             self.auto_density_btn,
             self.auto_grade_btn,
+            self.density_damping_spatial_btn,
         ):
             w.blockSignals(blocked)

--- a/negpy/desktop/view/sidebar/tone.py
+++ b/negpy/desktop/view/sidebar/tone.py
@@ -523,6 +523,16 @@ class ToneSidebar(BaseSidebar):
             self.density_sat_slider.setVisible(global_mode and not is_bw)
             self.density_sat_trim_slider.setVisible(not global_mode and not is_bw)
             self.dye_mute_slider.setVisible(not is_bw)
+            self.density_vibrance_slider.setVisible(not is_bw)
+            self.density_damping_spatial_btn.setVisible(not is_bw)
+            for w in (
+                self.vibrance_off_btn,
+                self.vibrance_density_boost_btn,
+                self.vibrance_lab_boost_btn,
+                self.vibrance_density_compress_btn,
+                self.vibrance_lab_compress_btn,
+            ):
+                w.setVisible(not is_bw)
             self.toe_slider.label.setText("Toe" + suffix)
             self.sh_slider.label.setText("Shoulder" + suffix)
             self.midtone_gamma_slider.label.setText("Snap" + suffix)

--- a/negpy/desktop/view/sidebar/tone.py
+++ b/negpy/desktop/view/sidebar/tone.py
@@ -15,14 +15,15 @@ _CH_COLORS = ("#ff5a5a", "#5adc78", "#5f96ff")
 # overall mean-chroma effect on a real test frame (07.raw, neutral paper) —
 # see the density-saturation investigation memory for the render scan.
 # Boost direction (+0.5 density / 1.50 Lab) is a fair comparison: both target
-# the same population (muted pixels). Compress direction (-0.5 density /
-# 0.33 Lab) is magnitude-matched only -- Lab's sub-1.0 desaturates MUTED
-# pixels further, Density's negative compresses VIVID pixels; they'll look
-# different even at "equal" overall chroma change, not just differently
-# strong. Not a bug, worth seeing directly in the A/B.
+# the same population (muted pixels). Compress direction has no real Lab
+# equivalent to match against -- Lab's sub-1.0 desaturates MUTED pixels
+# further, Density's negative compresses VIVID pixels, a different
+# population entirely -- so 0.33 is just a fixed reference point on the Lab
+# slider, not a matched value. -0.3 density keeps the demo moderate rather
+# than maximally aggressive.
 _VIBRANCE_AB_DENSITY_BOOST = 0.5
 _VIBRANCE_AB_LAB_BOOST = 1.50
-_VIBRANCE_AB_DENSITY_COMPRESS = -0.5
+_VIBRANCE_AB_DENSITY_COMPRESS = -0.3
 _VIBRANCE_AB_LAB_COMPRESS = 0.33
 
 

--- a/negpy/features/exposure/logic.py
+++ b/negpy/features/exposure/logic.py
@@ -88,6 +88,12 @@ def _apply_print_curve_kernel(
     ev_map: np.ndarray,
     ev_scale: np.ndarray,
     use_ev: bool,
+    vibrance_strength: float = 0.0,
+    vibrance_scale: float = 0.4,
+    use_vibrance: bool = False,
+    damp_global: float = 1.0,
+    damp_scale: float = 0.4,
+    use_spatial_damp: bool = False,
     bpc: bool = False,
 ) -> np.ndarray:
     """
@@ -210,6 +216,78 @@ def _apply_print_curve_kernel(
                 dens[0] = d_min_rgb[0] + dye_mix[0, 0] * e0 + dye_mix[0, 1] * e1 + dye_mix[0, 2] * e2
                 dens[1] = d_min_rgb[1] + dye_mix[1, 0] * e0 + dye_mix[1, 1] * e1 + dye_mix[1, 2] * e2
                 dens[2] = d_min_rgb[2] + dye_mix[2, 0] * e0 + dye_mix[2, 1] * e1 + dye_mix[2, 2] * e2
+
+            if use_spatial_damp:
+                # PROTOTYPE: per-pixel-modulated Dye Mute -- damp_global is the same
+                # frame-wide scalar the flat version folds into dye_mix
+                # (grade_chroma_damping), but here it's only applied in
+                # proportion to how separated THIS pixel already is: near-neutral
+                # pixels get none of it, already-separated pixels get up to the full
+                # damp_global strength. Runs where the flat version conceptually did
+                # (right after dye_mix, before Vibrance), so ordering relative to
+                # Vibrance matches the flat version's ordering relative to it today.
+                de0 = dens[0] - d_min_rgb[0]
+                de1 = dens[1] - d_min_rgb[1]
+                de2 = dens[2] - d_min_rgb[2]
+                de_max = de0
+                if de1 > de_max:
+                    de_max = de1
+                if de2 > de_max:
+                    de_max = de2
+                de_min = de0
+                if de1 < de_min:
+                    de_min = de1
+                if de2 < de_min:
+                    de_min = de2
+                d_spread = de_max - de_min
+                # Same 0-at-spread=0 rescale as Vibrance's mask (see below) -- a plain
+                # sigmoid never reaches 0 since sigmoid(0)=0.5.
+                d_mask = 2.0 * _fast_sigmoid(d_spread / damp_scale) - 1.0
+                d_k = 1.0 + (damp_global - 1.0) * d_mask
+                de_mean = (de0 + de1 + de2) / 3.0
+                dens[0] = d_min_rgb[0] + de_mean + d_k * (de0 - de_mean)
+                dens[1] = d_min_rgb[1] + de_mean + d_k * (de1 - de_mean)
+                dens[2] = d_min_rgb[2] + de_mean + d_k * (de2 - de_mean)
+
+            if use_vibrance:
+                # PROTOTYPE: per-pixel density-domain Vibrance/anti-vibrance, on top
+                # of whatever dye_mix (paper crosstalk + Density Sat/Dye Mute) already
+                # did. spread tracks how separated THIS pixel's channels already are;
+                # the sigmoid mask targets low-spread (muted) pixels for a positive
+                # strength (classic Vibrance: boost muted, leave vivid alone) or
+                # high-spread (vivid) pixels for a negative strength (anti-vibrance:
+                # leave muted alone, compress vivid) -- a sign flip on the mask
+                # target, not just on the formula (a plain sign flip on one mask
+                # gives "boost/cut the muted colors", never touches vivid ones).
+                ve0 = dens[0] - d_min_rgb[0]
+                ve1 = dens[1] - d_min_rgb[1]
+                ve2 = dens[2] - d_min_rgb[2]
+                ve_max = ve0
+                if ve1 > ve_max:
+                    ve_max = ve1
+                if ve2 > ve_max:
+                    ve_max = ve2
+                ve_min = ve0
+                if ve1 < ve_min:
+                    ve_min = ve1
+                if ve2 < ve_min:
+                    ve_min = ve2
+                spread = ve_max - ve_min
+                # spread >= 0 always, so a plain sigmoid never reaches its 0 end
+                # (sigmoid(0) = 0.5, not 0) -- rescale so s is exactly 0 at
+                # spread=0 and approaches 1 as spread grows, so the mask reaches
+                # its true target-population strength at the boundary instead of
+                # topping out at half-strength there.
+                s = 2.0 * _fast_sigmoid(spread / vibrance_scale) - 1.0
+                if vibrance_strength >= 0.0:
+                    mask = 1.0 - s
+                else:
+                    mask = s
+                k = 1.0 + vibrance_strength * mask
+                ve_mean = (ve0 + ve1 + ve2) / 3.0
+                dens[0] = d_min_rgb[0] + ve_mean + k * (ve0 - ve_mean)
+                dens[1] = d_min_rgb[1] + ve_mean + k * (ve1 - ve_mean)
+                dens[2] = d_min_rgb[2] + ve_mean + k * (ve2 - ve_mean)
 
             for ch in range(3):
                 transmittance = 10.0 ** (-dens[ch])
@@ -503,6 +581,9 @@ def apply_characteristic_curve(
     highlight_grade_deltas: Tuple[float, float, float] = (0.0, 0.0, 0.0),
     density_saturation: float = 1.0,
     density_saturation_trims: Tuple[float, float, float] = (0.0, 0.0, 0.0),
+    density_saturation_damping: float = 0.0,
+    density_vibrance: float = 0.0,
+    density_damping_spatial: bool = False,
 ) -> ImageBuffer:
     """Applies the asymmetric H&D print curve per channel in log-density space.
 
@@ -510,7 +591,28 @@ def apply_characteristic_curve(
     applies per-pixel dodge/burn as print-exposure offsets ahead of the curve.
 
     density_saturation(_trims): density-domain saturation, composed into the
-    dye_mix slot (see resolve_saturation_matrix/compose_density_matrices)."""
+    dye_mix slot (see resolve_saturation_matrix/compose_density_matrices).
+    #667's frame-uniform grade-coupled damping (grade_saturation_damping) is
+    applied by the caller before this value arrives here, not in this function.
+
+    density_saturation_damping/density_damping_spatial: PROTOTYPE -- when
+    density_damping_spatial is True, this strength drives a *per-pixel*
+    damping (via the same spread-based mask density_vibrance uses, see
+    _apply_print_curve_kernel) applied inside the kernel, replacing rather
+    than layering on top of the caller's uniform grade_saturation_damping
+    pre-multiply -- no slope_g/grade coupling at all in this path, spread
+    is the only signal. Mapped linearly (damp_global = 1 - strength, same
+    direct convention as vibrance_strength) rather than through
+    grade_saturation_damping's exponential shape, since there's no slope
+    input left to exponentiate. False (default) leaves this value unused --
+    the caller has already folded #667's uniform damping into
+    density_saturation itself.
+
+    density_vibrance: PROTOTYPE per-pixel density-domain Vibrance/anti-vibrance
+    (see _apply_print_curve_kernel), signed: >0 boosts muted pixels toward
+    more separation (leaves already-vivid pixels alone), <0 compresses vivid
+    pixels (leaves muted pixels alone). Runs inside the kernel, after
+    dye_mix, on top of whatever Density Sat/Dye Mute already composed in."""
     c = effective_constants(paper)
     ts = c["toe_shoulder_strength"]
     if midtone_gamma is None:
@@ -567,6 +669,12 @@ def apply_characteristic_curve(
         ev_map=ev_arr,
         ev_scale=np.ascontiguousarray(np.array(ev_scale, dtype=np.float32)),
         use_ev=use_ev,
+        vibrance_strength=float(density_vibrance),
+        vibrance_scale=float(c["vibrance_spread_scale"]),
+        use_vibrance=density_vibrance != 0.0,
+        damp_global=max(0.0, 1.0 - float(density_saturation_damping)) if density_damping_spatial else 1.0,
+        damp_scale=float(c["vibrance_spread_scale"]),
+        use_spatial_damp=density_damping_spatial and density_saturation_damping != 0.0,
         bpc=bool(bpc),
     )
     return ensure_image(res)

--- a/negpy/features/exposure/models.py
+++ b/negpy/features/exposure/models.py
@@ -99,6 +99,15 @@ class ExposureConfig:
     density_saturation_trim_green: float = 0.0
     density_saturation_trim_blue: float = 0.0
     density_saturation_damping: float = 0.0
+    # PROTOTYPE: per-pixel density-domain Vibrance/anti-vibrance, signed:
+    # >0 boosts muted pixels (classic Vibrance), <0 compresses vivid pixels
+    # (anti-vibrance) — one control, mask target flips with sign. 0.0 = off.
+    density_vibrance: float = 0.0
+    # PROTOTYPE: applies density_saturation_damping's strength per-pixel (via
+    # the same spread-based mask Vibrance uses) instead of #667's uniform
+    # (slope_min/slope_g)^strength formula. False (default) = #667's shipped
+    # behaviour, unchanged.
+    density_damping_spatial: bool = False
 
     def __post_init__(self) -> None:
         """
@@ -293,6 +302,12 @@ EXPOSURE_CONSTANTS: Dict[str, Any] = {
     # Density half-width over which the midtone gamma boost eases to the tails.
     # ↑ wider, more gradual S; ↓ tighter, more localized midtone boost.
     "paper_gamma_width": 0.6,
+    # PROTOTYPE: density-domain Vibrance/anti-vibrance per-pixel mask scale
+    # (density units of e0/e1/e2 spread). Sigmoid half-point separating
+    # "muted" from "vivid" pixels — not yet empirically validated by eye,
+    # a starting guess only. ↑ classifies more pixels as muted (mask reaches
+    # further into higher-spread territory); ↓ narrower muted band.
+    "vibrance_spread_scale": 0.4,
 }
 
 # Auto Density / Auto Grade targets the user can retune (Set Targets dialog).

--- a/negpy/features/exposure/processor.py
+++ b/negpy/features/exposure/processor.py
@@ -233,7 +233,11 @@ class PhotometricProcessor:
         )
         context.metrics["print_slopes"] = slopes
 
-        damp = grade_saturation_damping(slopes[1], self.config.density_saturation_damping)
+        # PROTOTYPE: when density_damping_spatial is on, the per-pixel spread signal
+        # replaces this uniform grade-coupled damp entirely (Option A) -- the kernel
+        # applies density_saturation_damping itself, so no pre-multiply here.
+        spatial_damp = self.config.density_damping_spatial and context.process_mode != ProcessMode.BW
+        damp = 1.0 if spatial_damp else grade_saturation_damping(slopes[1], self.config.density_saturation_damping)
 
         cmy_max = EXPOSURE_CONSTANTS["cmy_max_density"]
         cmy_offsets = filtration_offsets(
@@ -328,6 +332,9 @@ class PhotometricProcessor:
                 self.config.density_saturation_trim_green,
                 self.config.density_saturation_trim_blue,
             ),
+            density_saturation_damping=0.0 if context.process_mode == ProcessMode.BW else self.config.density_saturation_damping,
+            density_vibrance=0.0 if context.process_mode == ProcessMode.BW else self.config.density_vibrance,
+            density_damping_spatial=False if context.process_mode == ProcessMode.BW else self.config.density_damping_spatial,
         )
 
         if context.process_mode == ProcessMode.BW:

--- a/negpy/features/exposure/shaders/exposure.wgsl
+++ b/negpy/features/exposure/shaders/exposure.wgsl
@@ -17,14 +17,18 @@ struct ExposureUniforms {
     d_max: f32,
     a_toe_base: f32,
     a_sh_base: f32,
-    // Free slot (ex-width_ref; toeshoulder_width_ref is the 2.5 literal below).
-    pad0: f32,
+    // PROTOTYPE: density-domain Vibrance/anti-vibrance strength, signed (was
+    // "Free slot (ex-width_ref)"; toeshoulder_width_ref is the 2.5 literal below).
+    vibrance_strength: f32,
     toe_height: f32,
     sh_height: f32,
     zone_center: f32,
     shoulder_width_g: f32,
-    // Free slot (ex-surround_gamma).
-    pad1: f32,
+    // PROTOTYPE: per-pixel-modulated Dye Mute scalar (was "Free slot
+    // ex-surround_gamma") -- 1.0 (identity) unless density_damping_spatial is
+    // on, in which case this is the flat damp scalar that would otherwise
+    // have been folded into dye_r/dye_g/dye_b above.
+    damp_global: f32,
     mode: u32,
     v_star: f32,
     shoulder_width_b: f32,
@@ -166,6 +170,37 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
             dot(params.dye_g.xyz, e),
             dot(params.dye_b.xyz, e),
         );
+    }
+
+    // PROTOTYPE: per-pixel-modulated Dye Mute -- damp_global is the same flat
+    // scalar the uniform version folds into dye_r/dye_g/dye_b, applied here in
+    // proportion to how separated this pixel already is. Runs where the flat
+    // version conceptually did (right after the dye mix, before Vibrance).
+    // Mirrors the CPU kernel's use_spatial_damp block exactly.
+    if (params.damp_global != 1.0) {
+        let de = dens - d_min_rgb;
+        let d_spread = max(max(de.x, de.y), de.z) - min(min(de.x, de.y), de.z);
+        let d_mask = 2.0 * fast_sigmoid(d_spread / 0.4) - 1.0;
+        let d_k = 1.0 + (params.damp_global - 1.0) * d_mask;
+        let de_mean = (de.x + de.y + de.z) / 3.0;
+        dens = d_min_rgb + vec3<f32>(de_mean) + d_k * (de - vec3<f32>(de_mean));
+    }
+
+    // PROTOTYPE: per-pixel density-domain Vibrance/anti-vibrance, on top of
+    // whatever the dye mix above already did. Mirrors the CPU kernel exactly
+    // (_apply_print_curve_kernel) -- see that function's comment for why the
+    // mask target flips with sign instead of just the formula's sign.
+    if (params.vibrance_strength != 0.0) {
+        let ve = dens - d_min_rgb;
+        let spread = max(max(ve.x, ve.y), ve.z) - min(min(ve.x, ve.y), ve.z);
+        // 0.4 mirrors vibrance_spread_scale in models.py -- change together.
+        // spread >= 0 always, so a plain sigmoid never reaches its 0 end
+        // (sigmoid(0) = 0.5) -- rescale so s is exactly 0 at spread=0.
+        let s = 2.0 * fast_sigmoid(spread / 0.4) - 1.0;
+        let mask = select(s, 1.0 - s, params.vibrance_strength >= 0.0);
+        let k = 1.0 + params.vibrance_strength * mask;
+        let ve_mean = (ve.x + ve.y + ve.z) / 3.0;
+        dens = d_min_rgb + vec3<f32>(ve_mean) + k * (ve - vec3<f32>(ve_mean));
     }
 
     var transmittance = pow(vec3<f32>(10.0), -dens);

--- a/negpy/services/rendering/gpu_engine.py
+++ b/negpy/services/rendering/gpu_engine.py
@@ -1224,13 +1224,22 @@ class GPUEngine:
         # Density-space Print Saturation, composed into the same dye_mix slot
         # as the paper's real crosstalk. Mirrors the CPU path
         # (apply_characteristic_curve) exactly — see negpy/features/exposure/logic.py.
+        damp_global = 1.0  # packed into the uniform block below regardless of mode
         if settings.process.process_mode == ProcessMode.BW:
             sat = None
         else:
+            # PROTOTYPE: density_damping_spatial replaces (not layers with) #667's
+            # uniform grade_saturation_damping pre-multiply -- Option A, see
+            # apply_characteristic_curve's docstring for the full rationale and
+            # the damp_global = 1 - strength mapping this mirrors.
+            spatial = exp.density_damping_spatial
+            damp = 1.0 if spatial else grade_saturation_damping(slopes[1], exp.density_saturation_damping)
             sat_k3 = per_channel_density_saturation(
-                exp.density_saturation * grade_saturation_damping(slopes[1], exp.density_saturation_damping),
+                exp.density_saturation * damp,
                 (exp.density_saturation_trim_red, exp.density_saturation_trim_green, exp.density_saturation_trim_blue),
             )
+            if spatial and exp.density_saturation_damping != 0.0:
+                damp_global = max(0.0, 1.0 - exp.density_saturation_damping)
             sat = resolve_saturation_matrix(sat_k3)
         composed = compose_density_matrices(dye, sat)
         dye = composed  # use_dye_mix (below) and dye_rows both key off this
@@ -1272,14 +1281,22 @@ class GPUEngine:
                 pc["d_max"],
                 pc["toe_sharpness_base"],
                 pc["shoulder_sharpness_base"],
-                # Free slot (ex-width_ref; toeshoulder_width_ref is a WGSL literal).
-                0.0,
+                # PROTOTYPE: density-domain Vibrance/anti-vibrance strength (was
+                # "Free slot ex-width_ref"; toeshoulder_width_ref is a WGSL literal).
+                # Explicit B&W guard mirrors the CPU path (PhotometricProcessor) --
+                # the shader's own post-curve B&W re-collapse would erase any
+                # resulting chroma anyway, but zero it here too rather than lean
+                # on a different safety net than CPU uses.
+                0.0 if settings.process.process_mode == ProcessMode.BW else float(exp.density_vibrance),
                 pc["toe_height"],
                 pc["shoulder_height"],
                 pc["anchor_target_density"],
                 _sw3[1],
-                # Free slot (ex-surround_gamma).
-                0.0,
+                # PROTOTYPE: per-pixel-modulated Dye Mute scalar (was "Free slot
+                # ex-surround_gamma") -- 1.0 (identity) unless density_damping_spatial
+                # is on, in which case this is the flat damp_total that would
+                # otherwise have been folded into dye_rows above.
+                float(damp_global),
                 mode_val,
                 _reference_linear_value(d_min, paper),
                 _sw3[2],

--- a/tests/test_density_vibrance.py
+++ b/tests/test_density_vibrance.py
@@ -1,0 +1,88 @@
+"""Density-space Vibrance/anti-vibrance and the per-pixel-modulated Dye Mute
+toggle: identity/no-op, real effect in both directions, B&W inertness, and
+the Option A equivalence for density_damping_spatial (per-pixel spread
+replaces, rather than layers with, #667's uniform grade_saturation_damping)."""
+
+import numpy as np
+from dataclasses import replace
+
+from negpy.domain.models import WorkspaceConfig
+from negpy.features.exposure.logic import grade_saturation_damping
+from negpy.services.rendering.engine import DarkroomEngine
+from negpy.services.rendering.image_processor import PipelineContext
+
+
+def _render(overrides):
+    engine = DarkroomEngine()
+    rng = np.random.default_rng(0)
+    img = rng.uniform(0.05, 0.9, (32, 32, 3)).astype(np.float32)
+    settings = WorkspaceConfig.from_flat_dict({"paper_profile": "neutral", **overrides})
+    return engine.process(img, settings, source_hash="density-vibrance-test")
+
+
+class TestDensityVibranceRender:
+    def test_identity_is_exact_noop(self):
+        baseline = _render({})
+        identity = _render({"density_vibrance": 0.0})
+        np.testing.assert_array_equal(baseline, identity)
+
+    def test_boost_changes_output(self):
+        baseline = _render({})
+        boosted = _render({"density_vibrance": 0.5})
+        assert not np.array_equal(baseline, boosted)
+
+    def test_compress_changes_output(self):
+        baseline = _render({})
+        compressed = _render({"density_vibrance": -0.3})
+        assert not np.array_equal(baseline, compressed)
+
+    def test_boost_and_compress_are_not_a_simple_sign_flip(self):
+        """Boost targets muted pixels, compress targets vivid pixels -- different
+        populations, so equal-magnitude boost/compress must not be mirror images."""
+        boosted = _render({"density_vibrance": 0.4})
+        compressed = _render({"density_vibrance": -0.4})
+        assert not np.array_equal(boosted, compressed)
+
+    def test_bw_mode_is_inert(self):
+        bw_off = _render({"process_mode": "B&W", "density_vibrance": 0.0})
+        bw_on = _render({"process_mode": "B&W", "density_vibrance": 0.6})
+        np.testing.assert_allclose(bw_off, bw_on, atol=1e-6)
+
+
+class TestDensityDampingSpatial:
+    def test_off_by_default_matches_uniform_damping_bit_exact(self):
+        """density_damping_spatial=False (default) must be byte-identical to
+        manually pre-multiplying density_saturation by grade_saturation_damping
+        -- #667's own uniform damping path, untouched. This is the actual
+        proof that Option A only changes behavior when spatial is explicitly on."""
+        engine = DarkroomEngine()
+        rng = np.random.default_rng(2)
+        img = rng.uniform(0.05, 0.9, (32, 32, 3)).astype(np.float32)
+        base = WorkspaceConfig.from_flat_dict({"paper_profile": "kodak_endura", "grade": 90.0})
+
+        with_damp = replace(base, exposure=replace(base.exposure, density_saturation=1.0, density_saturation_damping=0.3))
+        ctx1 = PipelineContext(scale_factor=1.0, original_size=img.shape[:2], process_mode=with_damp.process.process_mode)
+        out1 = engine.process(img, with_damp, source_hash="spatial-off-test", context=ctx1)
+        slope_g = ctx1.metrics["print_slopes"][1]
+        damp = grade_saturation_damping(slope_g, 0.3)
+
+        manual = replace(base, exposure=replace(base.exposure, density_saturation=1.0 * damp, density_saturation_damping=0.0))
+        ctx2 = PipelineContext(scale_factor=1.0, original_size=img.shape[:2], process_mode=manual.process.process_mode)
+        out2 = engine.process(img, manual, source_hash="spatial-off-test", context=ctx2)
+
+        np.testing.assert_array_equal(out1, out2)
+
+    def test_spatial_on_changes_output_vs_uniform(self):
+        uniform = _render({"paper_profile": "kodak_endura", "density_saturation_damping": 0.3, "density_damping_spatial": False})
+        spatial = _render({"paper_profile": "kodak_endura", "density_saturation_damping": 0.3, "density_damping_spatial": True})
+        assert not np.array_equal(uniform, spatial)
+
+    def test_spatial_on_is_inert_at_zero_strength(self):
+        baseline = _render({"density_damping_spatial": False})
+        spatial_zero = _render({"density_damping_spatial": True, "density_saturation_damping": 0.0})
+        np.testing.assert_array_equal(baseline, spatial_zero)
+
+    def test_bw_mode_is_inert(self):
+        bw_off = _render({"process_mode": "B&W", "density_damping_spatial": False})
+        bw_on = _render({"process_mode": "B&W", "density_damping_spatial": True, "density_saturation_damping": 0.4})
+        np.testing.assert_allclose(bw_off, bw_on, atol=1e-6)

--- a/tests/test_gpu_curve_parity.py
+++ b/tests/test_gpu_curve_parity.py
@@ -218,6 +218,72 @@ class TestGpuCurveParity(unittest.TestCase):
         self.assertLess(mad, 0.01, f"mean abs diff {mad:.4f}")
         self.assertLess(mx, 0.04, f"max abs diff {mx:.4f}")
 
+    def test_cpu_gpu_match_density_vibrance(self):
+        """PROTOTYPE: per-pixel density-domain Vibrance/anti-vibrance, both
+        directions -- the sigmoid-masked per-pixel blend runs in the CPU kernel
+        and the WGSL shader independently, so they can drift."""
+        from negpy.services.rendering.image_processor import ImageProcessor
+
+        processor = ImageProcessor()
+        if processor.engine_gpu is None:
+            self.skipTest("GPU engine not initialised")
+
+        rng = np.random.default_rng(3)
+        h, w = 64, 64
+        grad = np.linspace(0.05, 0.9, w, dtype=np.float32)
+        img = np.repeat(grad[None, :], h, axis=0)
+        img = np.stack([img, img * 0.95, img * 0.9], axis=-1)
+        img = np.ascontiguousarray(img + rng.uniform(0, 0.01, img.shape).astype(np.float32))
+
+        s = WorkspaceConfig()
+        for vibrance in (0.5, -0.3):
+            settings = replace(s, exposure=replace(s.exposure, paper_profile="kodak_endura", density_vibrance=vibrance))
+            cpu = self._render(processor, settings, img, prefer_gpu=False)
+            gpu = self._render(processor, settings, img, prefer_gpu=True)
+
+            self.assertEqual(cpu.shape, gpu.shape)
+            mad = float(np.mean(np.abs(cpu - gpu)))
+            mx = float(np.max(np.abs(cpu - gpu)))
+            self.assertLess(mad, 0.01, f"vibrance={vibrance}: mean abs diff {mad:.4f}")
+            self.assertLess(mx, 0.04, f"vibrance={vibrance}: max abs diff {mx:.4f}")
+
+    def test_cpu_gpu_match_spatial_damping(self):
+        """PROTOTYPE: density_damping_spatial=True replaces (not layers with)
+        #667's uniform grade_saturation_damping -- the per-pixel spread-masked
+        damp_global blend runs in the CPU kernel and the WGSL shader
+        independently, so they can drift."""
+        from negpy.services.rendering.image_processor import ImageProcessor
+
+        processor = ImageProcessor()
+        if processor.engine_gpu is None:
+            self.skipTest("GPU engine not initialised")
+
+        rng = np.random.default_rng(4)
+        h, w = 64, 64
+        grad = np.linspace(0.05, 0.9, w, dtype=np.float32)
+        img = np.repeat(grad[None, :], h, axis=0)
+        img = np.stack([img, img * 0.95, img * 0.9], axis=-1)
+        img = np.ascontiguousarray(img + rng.uniform(0, 0.01, img.shape).astype(np.float32))
+
+        s = WorkspaceConfig()
+        settings = replace(
+            s,
+            exposure=replace(
+                s.exposure,
+                paper_profile="kodak_endura",
+                density_saturation_damping=0.4,
+                density_damping_spatial=True,
+            ),
+        )
+        cpu = self._render(processor, settings, img, prefer_gpu=False)
+        gpu = self._render(processor, settings, img, prefer_gpu=True)
+
+        self.assertEqual(cpu.shape, gpu.shape)
+        mad = float(np.mean(np.abs(cpu - gpu)))
+        mx = float(np.max(np.abs(cpu - gpu)))
+        self.assertLess(mad, 0.01, f"mean abs diff {mad:.4f}")
+        self.assertLess(mx, 0.04, f"max abs diff {mx:.4f}")
+
     def test_cpu_gpu_match_clahe(self):
         """CLAHE at full strength (issue #524 regression). 128x128 keeps each
         8x8 tile at >=256 samples so a handful of upstream f32/f64 bin flips


### PR DESCRIPTION
# Draft: density-space Vibrance/anti-vibrance + spatially-modulated Dye Mute (extends #667)

## What

Two related, additive controls, both off by default:

- **Density Vibrance** — a signed per-pixel Vibrance/anti-vibrance control in density space (`ExposureConfig.density_vibrance`).
- **Spatial Damping** — an alternate, per-pixel application mode for Dye Mute (`ExposureConfig.density_damping_spatial`), using the same masking mechanism as anti-vibrance.

This is a **draft** — I'm looking for your read on whether the direction is worth continuing, not asking you to merge as-is.  I already had some A/B testing built in that I decided to keep as it might make your testing easier. Happy to close and keep iterating if it doesn't look right, or rip out some of the A/B features. 

## Why

`#667` moved Dye Mute into density space as a single frame-wide scalar, grade-coupled via `slope_g`. That fixed the domain problem (density vs. post-decode Lab), but the correction is still uniform — it can't distinguish a near-neutral pixel from an already-separated one.

Anti-vibrance needed the same distinction (compress already-vivid pixels, leave muted ones alone), so one per-pixel masking mechanism ended up answering both:
- Applied on its own — **Density Vibrance**, sign-flippable, boost muted or compress vivid.
- Applied to Dye Mute's strength instead of the Vibrance slider's — **Spatial Damping**, the same correction redistributed by how separated each pixel already is, instead of applied uniformly.

Same math, two applications — not three separate ideas.

## What each control does

**Dye Mute** — unchanged: `#667` exactly as shipped, one flat `(slope_min/slope_g)^strength` damp applied uniformly, grade-coupled. This PR doesn't touch its default behavior.

**Spatial Damping** (new toggle, off by default) — Dye Mute run through anti-vibrance's math instead of the uniform formula. Same strength value, same field, redistributed per-pixel via `d_k = 1 + (damp_global - 1) * mask` — the same shape as the anti-vibrance formula below, just fed by Dye Mute's strength.
- **Off** — byte-identical to `#667` (verified, see Testing).
- **On** — same strength, scaled by how separated each pixel already is: near-neutral pixels get none of it, already-separated pixels get up to full strength. Replaces the uniform formula rather than layering on it — see "Replace vs. layer" below.

Doesn't touch the Vibrance slider or Print Saturation — a second application of the masking trick, not a shared control.

**Density Vibrance** (new slider, `-1.0` to `1.0`, `0` = off):
- **Positive** — classic Vibrance: boosts muted pixels (mask targets low-spread pixels).
- **Negative** — real anti-vibrance: compresses vivid pixels (mask targets high-spread pixels — the same mask Spatial Damping reuses), leaves muted pixels alone. Lab's Vibrance has no equivalent here — its sub-1.0 branch just desaturates the muted population further.

The mask targets a genuinely different population depending on sign — not just a negated output.

**A/B row** (`Off / Density +0.5 / Lab 1.50 / Density -0.3 / Lab 0.33`) — left over from my own testing against Lab Vibrance, not built specifically for review, but there if useful. The boost pair is a fair comparison (both target muted pixels, matched by chroma effect). The compress pair is magnitude-matched only — Lab's 0.33 desaturates muted pixels further, Density's -0.3 compresses vivid pixels, so they'll look different even at "equal" strength.

**Shared constant to flag:** all three per-pixel behaviors — Vibrance boost, anti-vibrance, Spatial Damping — share one tunable, `vibrance_spread_scale = 0.4` (`exposure/models.py`), controlling how much per-pixel separation counts as "vivid enough" to affect. It's an unvalidated starting guess. Tuning it for one effect will retune all three at once — that's the main risk of the unified-mask approach, and worth deciding now whether that coupling is acceptable or whether it needs decoupling before this ships.

## Honest note on the boost direction

Density Vibrance's boost direction converged with Lab Vibrance at realistic settings in my testing, only diverging at extremes — I can't confidently say one is better. Including it anyway since it costs nothing and the A/B row makes it checkable, but the real case for this PR is the compress direction, which Lab has no equivalent of at all.

## Replace vs. layer

Spatial Damping replaces the uniform `grade_saturation_damping` pre-multiply when it's on, rather than layering on top. I lean toward replace for three reasons: your own `#667` PR already diagnosed the failure mode of uncoordinated stacking (Lab Saturation vs. old Dye Mute fighting each other); and two of my own earlier prototypes (a global chroma-damping signal, then a per-channel-divergence version — both dropped, see `DROPPED_KEYS`) turned out mathematically redundant with `density_saturation` once measured. Flagging this as a decision point rather than deciding it unilaterally — layer is a reasonable position if you'd rather.

## Risk / compatibility

Both fields default to off/identity (`density_vibrance=0.0`, `density_damping_spatial=False`) — can't affect any existing saved edit. With Spatial Damping off, Dye Mute is unchanged from `#667`, verified bit-exact (`test_off_by_default_matches_uniform_damping_bit_exact`).

Implemented on CPU and GPU, mirrored in the WGSL shader — no CPU-only fallback.

## Testing

- `tests/test_density_vibrance.py` — identity/no-op, boost and compress each change output and aren't a simple sign flip of each other, B&W inertness, bit-exact proof Spatial Damping off matches `#667`'s uniform path.
- `tests/test_gpu_curve_parity.py` — new CPU/GPU parity for Density Vibrance (both directions) and Spatial Damping — neither covered by the existing `test_cpu_gpu_match_dye_mute`, which only exercises the uniform path.
