### PR TITLE
Narrow the Dye Separation spread gate to 0.12

### DIFF
--- a/negpy/features/exposure/models.py
+++ b/negpy/features/exposure/models.py
@@ -297,8 +297,10 @@ EXPOSURE_CONSTANTS: Dict[str, Any] = {
     "paper_gamma_width": 0.6,
     # Sigmoid half-point of the Dye Separation mask, in density units of
     # e0/e1/e2 spread. Inlined as a WGSL literal in exposure.wgsl — change both.
-    # ↑ counts more pixels as muted; ↓ narrower muted band.
-    "dye_separation_spread_scale": 0.4,
+    # ↑ counts more pixels as muted; ↓ narrower muted band. Set so the half-point
+    # (scale·ln3) lands near a typical frame's median spread — widen it much and the
+    # mask goes flat across the whole frame and the control collapses into Print Saturation.
+    "dye_separation_spread_scale": 0.12,
 }
 
 # Auto Density / Auto Grade targets the user can retune (Set Targets dialog).

--- a/negpy/features/exposure/shaders/exposure.wgsl
+++ b/negpy/features/exposure/shaders/exposure.wgsl
@@ -174,10 +174,10 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
     if (params.dye_separation != 0.0) {
         let ve = dens - d_min_rgb;
         let spread = max(max(ve.x, ve.y), ve.z) - min(min(ve.x, ve.y), ve.z);
-        // 0.4 mirrors dye_separation_spread_scale in models.py -- change both.
+        // 0.12 mirrors dye_separation_spread_scale in models.py -- change both.
         // spread >= 0 always, so a plain sigmoid never reaches its 0 end
         // (sigmoid(0) = 0.5) -- rescale so s is exactly 0 at spread=0.
-        let s = 2.0 * fast_sigmoid(spread / 0.4) - 1.0;
+        let s = 2.0 * fast_sigmoid(spread / 0.12) - 1.0;
         let mask = select(s, 1.0 - s, params.dye_separation >= 0.0);
         let k = 1.0 + params.dye_separation * mask;
         let ve_mean = (ve.x + ve.y + ve.z) / 3.0;


### PR DESCRIPTION
## Problem

Print Saturation and Dye Separation apply the *same* expansion of density around the achromatic mean:

```
e_out = mean + k * (e - mean)
```

Print Saturation takes `k` straight from the slider; Dye Separation derives it per pixel from `spread = max(e) - min(e)` via a sigmoid gate. The gate is what makes it a distinct control — and at `dye_separation_spread_scale = 0.4` it barely gated.

The mask's half-point sits at `scale · ln(3)` = **0.44** density spread. Measured across four sample renders, that is roughly the **p90** of real content:

| sample | p10 | p50 | p90 |
|---|---|---|---|
| DSCF0966 | 0.041 | 0.122 | 0.459 |
| DSC05311 | 0.064 | 0.174 | 0.379 |
| ra4/21 | 0.064 | 0.140 | 0.450 |
| ra4/22 | 0.021 | 0.091 | 1.028 |

So ~90% of every frame sat on the flat top of the mask, `mask ≈ const`, and the control degenerated into a second Print Saturation.

Confirmed by rendering `density_saturation=1.3` and `dye_separation=+0.3` against a neutral base and correlating the per-pixel deltas:

```
              DSCF0966            DSC05311
scale    corr   unique       corr   unique
 0.4    0.941    0.34       0.973    0.23
 0.25   0.867    0.50       0.929    0.37
 0.15   0.723    0.69       0.823    0.57
 0.12   0.642    0.77       0.752    0.66
 0.08   0.483    0.88       0.595    0.80
```

94–97% correlated at the shipped value.

## Fix

Put the half-point on a typical frame's *median* spread instead of its p90, so the mask uses its full 0..1 range over actual content: `scale = median / ln(3)` gives 0.083–0.158 across the four samples → **0.12**. Correlation against Print Saturation drops to 0.64 / 0.75.

Two literals, kept in sync: `EXPOSURE_CONSTANTS["dye_separation_spread_scale"]` and the inlined WGSL constant in `exposure.wgsl`.

## Notes

- Goldens unaffected — they render `dye_separation=0.0`, which skips the kernel block entirely.
- `test_gpu_curve_parity.py::test_cpu_gpu_match_dye_separation` covers the CPU/GPU sync of the two literals.
- Not addressed here: the scale is a fixed constant, but spread moves with grade/contrast, so a hard grade slides the gate back toward "everything is saturated". Scaling off the frame's own median spread (metered in `NormalizationProcessor`, carried in `context.metrics`, plumbed to the GPU uniform) is the real fix if 0.12 misbehaves across a wider library.

## Verification

`make all` — lint clean, ty clean, 2731 passed / 5 skipped.