### PR TITLE
Added support for IR channels from 64 bit HDRi RAW DNGs

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -289,6 +289,7 @@ An **Overlay** button cycles the detection overlay (Off → Marked → IR) so yo
 **IR Removal** — uses the scanner's infrared channel to remove dust invisible to the colour dyes (only enabled when the scan carries an IR plane):
 
 *   Toggle **IR Removal** and set **IR Threshold** (0.05–0.95; lower catches more).
+*   The IR plane is read from 4-channel TIFFs and DNGs (VueScan, NegPy's own scanner output), SilverFast's iSRD TIFFs and 64-bit **HDRi RAW DNGs**, and `_IR.tif` sidecars. Scan to HDRi (not plain HDR) if you want IR data in the file; B&W and Kodachrome block infrared like dust does, so those frames are skipped automatically.
 
 **Manual Heal** (header shows the current spot count):
 

--- a/negpy/infrastructure/loaders/ir_planes.py
+++ b/negpy/infrastructure/loaders/ir_planes.py
@@ -1,0 +1,47 @@
+"""Reading an infrared plane out of a TIFF-structured container.
+
+Shared by `TiffLoader` and `RawpyLoader`: SilverFast stores the iSRD infrared record as a
+separate full-resolution grayscale page in both its HDRi TIFFs and its HDRi DNGs, so the
+page search is one implementation with the candidate pages supplied by the caller (which
+page counts as the main image differs between the two containers).
+"""
+
+from typing import Any, Iterable, Optional
+
+import numpy as np
+
+_NEW_SUBFILE_TYPE = 254
+_TRANSPARENCY_MASK = 4  # NewSubfileType bit SilverFast marks the IR page with
+_MIN_IS_BLACK = 1
+
+
+def normalize_ir_to_float32(ir: np.ndarray) -> np.ndarray:
+    """Single-channel uint8/uint16/float ndarray → float32 in [0,1]."""
+    if ir.ndim == 3:
+        ir = ir[:, :, 0]
+    if ir.dtype == np.uint8:
+        return ir.astype(np.float32) * (1.0 / 255.0)
+    if ir.dtype == np.uint16:
+        return ir.astype(np.float32) * (1.0 / 65535.0)
+    return np.clip(ir.astype(np.float32), 0.0, 1.0)
+
+
+def find_ir_plane(pages: Iterable[Any], main_h: int, main_w: int) -> Optional[np.ndarray]:
+    """First page at exactly (main_h, main_w) that reads as an IR plane, normalized to [0,1].
+
+    A page qualifies on either marker scanner stacks use: NewSubfileType=4 (transparency
+    mask) or a grayscale photometric. The exact-dims match is what keeps thumbnails and
+    reduced-resolution previews out, and it also implies a single sample per pixel — a
+    multi-sample page's `shape` carries a third axis and can never compare equal.
+    """
+    for page in pages:
+        if getattr(page, "shape", None) != (main_h, main_w):
+            continue
+        tags = getattr(page, "tags", None) or {}
+        nst = tags.get(_NEW_SUBFILE_TYPE)
+        photometric = getattr(page, "photometric", None)
+        is_mask_page = nst is not None and nst.value == _TRANSPARENCY_MASK
+        is_grayscale = photometric is not None and int(photometric) == _MIN_IS_BLACK
+        if is_mask_page or is_grayscale:
+            return normalize_ir_to_float32(page.asarray())
+    return None

--- a/negpy/infrastructure/loaders/rawpy_loader.py
+++ b/negpy/infrastructure/loaders/rawpy_loader.py
@@ -7,6 +7,7 @@ import tifffile
 
 from negpy.domain.interfaces import IImageLoader
 from negpy.infrastructure.loaders.helpers import NonStandardFileWrapper, read_orientation
+from negpy.infrastructure.loaders.ir_planes import find_ir_plane
 from negpy.kernel.system.logging import get_logger
 
 logger = get_logger(__name__)
@@ -15,9 +16,9 @@ logger = get_logger(__name__)
 _LINEAR_RAW = 34892
 
 
-def _find_linearraw_page(tif: "tifffile.TiffFile") -> Optional[Any]:
-    """Return the page carrying 4-sample LinearRaw data: page 0 itself (NegPy's own
-    single-IFD DNGs) or one of its SubIFDs (VueScan/Adobe-style thumbnail + SubIFD DNGs)."""
+def _find_linearraw_page(tif: "tifffile.TiffFile", samples: int) -> Optional[Any]:
+    """Return the page carrying `samples`-sample LinearRaw data: page 0 itself (NegPy's own
+    single-IFD DNGs) or one of its SubIFDs (VueScan/SilverFast-style thumbnail + SubIFD DNGs)."""
     page0 = tif.pages[0]
     for page in (page0, *(page0.pages or [])):
         tags = getattr(page, "tags", None)
@@ -27,9 +28,13 @@ def _find_linearraw_page(tif: "tifffile.TiffFile") -> Optional[Any]:
         photo_tag = tags.get("PhotometricInterpretation")
         spp = int(spp_tag.value) if spp_tag is not None else 0
         photo = int(photo_tag.value) if photo_tag is not None else 0
-        if spp == 4 and photo == _LINEAR_RAW:
+        if spp == samples and photo == _LINEAR_RAW:
             return page
     return None
+
+
+def _is_dng(file_path: str) -> bool:
+    return os.path.splitext(file_path)[1].lower() == ".dng"
 
 
 def _peek_linearraw_4ch(file_path: str) -> Optional[Tuple[np.ndarray, np.ndarray]]:
@@ -39,12 +44,11 @@ def _peek_linearraw_4ch(file_path: str) -> Optional[Tuple[np.ndarray, np.ndarray
     put the full-res data in a SubIFD behind a reduced-resolution thumbnail IFD0 — both are
     checked. Returns None for camera DNGs (Bayer, 3-channel, etc.) so rawpy can handle them.
     """
-    ext = os.path.splitext(file_path)[1].lower()
-    if ext != ".dng":
+    if not _is_dng(file_path):
         return None
     try:
         with tifffile.TiffFile(file_path) as tif:
-            page = _find_linearraw_page(tif)
+            page = _find_linearraw_page(tif, samples=4)
             if page is None:
                 return None
             arr = page.asarray()  # type: ignore[attr-defined]
@@ -67,10 +71,38 @@ def _peek_linearraw_4ch(file_path: str) -> Optional[Tuple[np.ndarray, np.ndarray
     return rgb, ir
 
 
+def _peek_hdri_ir_page(file_path: str) -> Optional[np.ndarray]:
+    """IR plane of a SilverFast HDRi DNG, or None.
+
+    SilverFast writes the frame as a *3*-sample LinearRaw SubIFD behind a thumbnail IFD0 and
+    puts the infrared record in its own full-resolution grayscale page (NewSubfileType=4) —
+    the same layout as its HDRi TIFFs, so only the IR needs reading here: libraw decodes
+    3-sample LinearRaw faithfully (a pass-through at `user_wb=[1,1,1,1]`), and keeping it on
+    the rawpy path preserves the embedded-thumbnail splash and the half-size fast preview.
+    """
+    if not _is_dng(file_path):
+        return None
+    try:
+        with tifffile.TiffFile(file_path) as tif:
+            main = _find_linearraw_page(tif, samples=3)
+            if main is None:
+                return None
+            main_h, main_w = int(main.shape[0]), int(main.shape[1])
+            # Top-level pages are where SilverFast puts it; SubIFDs are searched too for
+            # tools that nest it. The main page carries 3 samples, so a 2-D dims match
+            # cannot select the image itself.
+            candidates = [*tif.pages, *(tif.pages[0].pages or [])]
+            return find_ir_plane(candidates, main_h, main_w)
+    except Exception as e:
+        logger.warning(f"DNG IR-page peek failed for {file_path}: {e}")
+    return None
+
+
 class RawpyLoader(IImageLoader):
     """
     Standard RAW loader (libraw). For LinearRaw 4-channel DNGs (RGB + IR), bypasses
-    rawpy and reads via tifffile so the IR plane is preserved.
+    rawpy and reads via tifffile so the IR plane is preserved. SilverFast HDRi DNGs keep
+    the libraw decode and get their IR from a separate grayscale page.
     """
 
     def load(self, file_path: str) -> Tuple[ContextManager[Any], dict]:
@@ -93,7 +125,7 @@ class RawpyLoader(IImageLoader):
             "raw_flip": 0,
             # Decoded output_color=raw, so the file's own tags characterise nothing here.
             "color_space": None,
-            "ir": None,
+            "ir": _peek_hdri_ir_page(file_path),
         }
 
         return raw, metadata

--- a/negpy/infrastructure/loaders/tiff_loader.py
+++ b/negpy/infrastructure/loaders/tiff_loader.py
@@ -8,20 +8,10 @@ from negpy.domain.models import ColorSpace
 from negpy.kernel.image.logic import srgb_to_linear, uint8_to_float32, uint16_to_float32
 from negpy.infrastructure.loaders.constants import IR_SIDECAR_SUFFIXES, SUPPORTED_TIFF_EXTENSIONS
 from negpy.infrastructure.loaders.helpers import NonStandardFileWrapper, identify_color_space_from_icc, read_orientation
+from negpy.infrastructure.loaders.ir_planes import find_ir_plane, normalize_ir_to_float32
 from negpy.kernel.system.logging import get_logger
 
 logger = get_logger(__name__)
-
-
-def _normalize_ir_to_float32(ir: np.ndarray) -> np.ndarray:
-    """Single-channel uint8/uint16/float ndarray → float32 in [0,1]."""
-    if ir.ndim == 3:
-        ir = ir[:, :, 0]
-    if ir.dtype == np.uint8:
-        return ir.astype(np.float32) * (1.0 / 255.0)
-    if ir.dtype == np.uint16:
-        return ir.astype(np.float32) * (1.0 / 65535.0)
-    return np.clip(ir.astype(np.float32), 0.0, 1.0)
 
 
 def _ir_suffixes(token: str) -> tuple[str, ...]:
@@ -55,7 +45,7 @@ def _read_sidecar_ir(file_path: str) -> Tuple[Optional[np.ndarray], Optional[np.
         return None, None
     try:
         arr = tifffile.imread(candidate)
-        ir = _normalize_ir_to_float32(np.asarray(arr))
+        ir = normalize_ir_to_float32(np.asarray(arr))
     except Exception as e:
         logger.warning(f"Failed to read IR sidecar {candidate}: {e}")
         return None, None
@@ -85,19 +75,11 @@ def _read_sidecar_ir(file_path: str) -> Tuple[Optional[np.ndarray], Optional[np.
 
 
 def _read_ir_from_extra_page(file_path: str, main_h: int, main_w: int) -> Optional[np.ndarray]:
-    """Finds a grayscale page at full resolution — SilverFast iSRD stores IR as page 2 with NewSubfileType=4."""
+    """Finds a grayscale page at full resolution — SilverFast iSRD stores IR as page 2 with
+    NewSubfileType=4. Page 0 is the main image here, so it is never a candidate."""
     try:
         with tifffile.TiffFile(file_path) as tif:
-            for page in tif.pages[1:]:
-                if page.shape != (main_h, main_w):
-                    continue
-                tags = getattr(page, "tags", None) or {}
-                nst = tags.get(254)
-                photometric = getattr(page, "photometric", None)
-                is_mask_page = nst is not None and nst.value == 4
-                is_grayscale = photometric is not None and int(photometric) == 1
-                if is_mask_page or is_grayscale:
-                    return _normalize_ir_to_float32(page.asarray())
+            return find_ir_plane(tif.pages[1:], main_h, main_w)
     except Exception as e:
         logger.warning(f"Failed to read extra-page IR from {file_path}: {e}")
     return None
@@ -136,7 +118,7 @@ def _extract_ir_from_extrasamples(file_path: str, img: np.ndarray) -> Tuple[np.n
 
     is_ir = extrasamples_kind == 0 or not tag_present
     if is_ir:
-        return np.ascontiguousarray(img[:, :, :3]), _normalize_ir_to_float32(img[:, :, 3])
+        return np.ascontiguousarray(img[:, :, :3]), normalize_ir_to_float32(img[:, :, 3])
     return np.ascontiguousarray(img[:, :, :3]), None
 
 

--- a/negpy/services/rendering/image_processor.py
+++ b/negpy/services/rendering/image_processor.py
@@ -533,11 +533,12 @@ class ImageProcessor:
         f32_buffer = uint16_to_float32(rgb)
 
         if ir_full is not None and ir_full.shape[:2] != f32_buffer.shape[:2]:
-            # half-size decode only; CPU retouch silently skips a mismatched IR
-            import cv2
-
+            # Defensive: no current IR carrier half-sizes (libraw ignores half_size on
+            # stacked LinearRaw, NonStandardFileWrapper is excluded from fast decode), but a
+            # mismatched plane must be rescaled or CPU retouch silently skips it. Routed
+            # through downsample_ir, not INTER_AREA, so a sub-pixel hair keeps its dip.
             ih, iw = f32_buffer.shape[:2]
-            ir_full = cv2.resize(ir_full, (iw, ih), interpolation=cv2.INTER_AREA)
+            ir_full = downsample_ir(ir_full, max(ih, iw), dims=(iw, ih))
 
         orientation = metadata.get("orientation", 1)
         f32_buffer = apply_exif_orientation(f32_buffer, orientation)

--- a/negpy/services/rendering/preview_manager.py
+++ b/negpy/services/rendering/preview_manager.py
@@ -196,6 +196,10 @@ class PreviewManager:
         # IR channel travels with the preview; resize it to match the final preview dims.
         # Min-preserving, not INTER_AREA: this is the only place the full-res IR exists,
         # so a sub-pixel hair's dip has to survive *here* or dust detection never sees it.
+        # The dims equality holds for every IR source: libraw ignores half_size on the
+        # stacked LinearRaw a SilverFast HDRi DNG decodes as, and the other IR carriers
+        # arrive as NonStandardFileWrapper, which use_fast excludes. A plane that does
+        # mismatch belongs to another frame (a stale sidecar) and is dropped, not scaled.
         if ir_full is not None and ir_full.shape[:2] == (h_p, w_p):
             ph, pw = preview_raw.shape[:2]
             if (ph, pw) != ir_full.shape[:2]:

--- a/tests/test_ir_dust.py
+++ b/tests/test_ir_dust.py
@@ -191,6 +191,79 @@ def test_rawpy_loader_dng_thumbnail_subifd_ir():
         assert metadata["ir"].shape == (h, w)
 
 
+def _write_silverfast_hdri_dng(path: str, h: int, w: int, ir_level: int = 50000) -> np.ndarray:
+    """A SilverFast 9 HDRi DNG, as `HighDef.dng` off a Plustek OpticFilm 8200i is built:
+    a thumbnail IFD0 whose SubIFD carries the full-res *3*-sample LinearRaw frame, a
+    reduced-resolution RGB preview page, and the infrared record as its own full-res
+    grayscale page. Returns the RGB written into the SubIFD."""
+    rgb = np.random.randint(0, 65535, (h, w, 3)).astype(np.uint16)
+    thumb = np.zeros((max(1, h // 8), max(1, w // 8), 3), dtype=np.uint16)
+    preview = np.zeros((max(1, h // 2), max(1, w // 2), 3), dtype=np.uint16)
+    ir = np.full((h, w), ir_level, dtype=np.uint16)
+    dng_tags = [
+        (50706, 1, 4, (1, 4, 0, 0), True),  # DNGVersion
+        (50707, 1, 4, (1, 0, 0, 0), True),  # DNGBackwardVersion
+    ]
+    with tifffile.TiffWriter(path) as tw:
+        tw.write(thumb, photometric="rgb", subfiletype=1, subifds=1, extratags=dng_tags)
+        tw.write(rgb, photometric=34892, subfiletype=0, planarconfig="contig")
+        tw.write(preview, photometric="rgb", subfiletype=1)
+        tw.write(ir, photometric="minisblack", subfiletype=0)
+    return rgb
+
+
+def test_silverfast_hdri_dng_ir_page_is_found():
+    """The layout the 4-sample peek misses: RGB and IR are separate pages, so the IR is
+    matched on the *full-res* dims of the LinearRaw SubIFD — not IFD0's thumbnail dims."""
+    from negpy.infrastructure.loaders.rawpy_loader import _peek_hdri_ir_page
+
+    h, w = 40, 24
+    with tempfile.TemporaryDirectory() as td:
+        path = os.path.join(td, "HighDef.dng")
+        _write_silverfast_hdri_dng(path, h, w)
+        ir = _peek_hdri_ir_page(path)
+    assert ir is not None
+    assert ir.shape == (h, w)
+    assert ir.dtype == np.float32
+    assert abs(float(ir.mean()) - (50000.0 / 65535.0)) < 1e-3
+
+
+def test_silverfast_hdri_dng_keeps_the_libraw_decode():
+    """Only the IR is read here: a 3-sample LinearRaw is decoded faithfully by libraw, and
+    staying on the rawpy object keeps the embedded-thumbnail splash and fast preview.
+    rawpy is patched because libraw rejects a hand-built minimal DNG."""
+    from unittest.mock import MagicMock, patch
+
+    h, w = 40, 24
+    with tempfile.TemporaryDirectory() as td:
+        path = os.path.join(td, "HighDef.dng")
+        _write_silverfast_hdri_dng(path, h, w)
+        sentinel = MagicMock(name="rawpy_object")
+        with patch("negpy.infrastructure.loaders.rawpy_loader.rawpy.imread", return_value=sentinel) as imread:
+            ctx_mgr, metadata = LoaderFactory().get_loader(path)
+
+    imread.assert_called_once_with(path)
+    assert ctx_mgr is sentinel, "the RGB must still come from libraw"
+    assert metadata["ir"] is not None
+    assert metadata["ir"].shape == (h, w)
+
+
+def test_hdri_ir_peek_skips_files_without_a_linearraw_frame():
+    """A camera DNG (or any RGB TIFF wearing a .dng name) has no LinearRaw page, so there is
+    no full-res frame to match an IR plane against and the peek must stay out of the way."""
+    from negpy.infrastructure.loaders.rawpy_loader import _peek_hdri_ir_page
+
+    with tempfile.TemporaryDirectory() as td:
+        path = os.path.join(td, "camera.dng")
+        tifffile.imwrite(path, np.full((20, 16, 3), 1000, dtype=np.uint16), photometric="rgb")
+        assert _peek_hdri_ir_page(path) is None
+
+        # ...and a grayscale page alone is not enough: without the frame it could be a B&W scan.
+        mono = os.path.join(td, "mono.dng")
+        tifffile.imwrite(mono, np.full((20, 16), 1000, dtype=np.uint16), photometric="minisblack")
+        assert _peek_hdri_ir_page(mono) is None
+
+
 def test_tiff_loader_silverfast_multipage_ir():
     """SilverFast iSRD: IR stored as page 2 with NewSubfileType=4 (transparency mask)."""
     h, w = 16, 24

--- a/tests/test_preview_manager.py
+++ b/tests/test_preview_manager.py
@@ -286,6 +286,39 @@ def test_load_linear_preview_ir_preview_resized_with_downscale() -> None:
     assert max(out_meta["ir_preview"].shape) == 80
 
 
+def test_ir_preview_survives_the_stacked_dng_fast_path() -> None:
+    """A SilverFast HDRi DNG keeps its libraw decode, making it the one IR carrier that reaches
+    the fast path (the others arrive as NonStandardFileWrapper, which use_fast excludes).
+    half_size is still requested, and IR survives only because libraw ignores it on a stacked
+    LinearRaw and returns full-res — should that ever start halving, ir_preview goes None and
+    IR Removal greys out with no error anywhere."""
+    rgb_u16 = np.full((120, 160, 3), 20000, dtype=np.uint16)
+    ir = np.full((120, 160), 0.9, dtype=np.float32)
+
+    raw = MagicMock()
+    raw.raw_type = rawpy.RawType.Stack
+    raw.raw_pattern = np.zeros((2, 2), dtype=np.uint8)
+    raw.sizes = SimpleNamespace(raw_height=120, raw_width=160, iheight=120, iwidth=160)
+    raw.postprocess = MagicMock(return_value=rgb_u16)
+
+    class _Ctx:
+        def __enter__(self) -> MagicMock:
+            return raw
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+    with patch("negpy.services.rendering.preview_manager.loader_factory") as lf:
+        lf.get_loader.return_value = (_Ctx(), {"color_space": None, "orientation": 1, "ir": ir})
+        buf, _dims, out_meta = PreviewManager().load_linear_preview("/fake/HighDef.dng", use_camera_wb=False)
+
+    _, kwargs = raw.postprocess.call_args
+    assert kwargs.get("half_size") is True, "the fast path is what makes this the case worth pinning"
+    assert out_meta["ir_preview"] is not None
+    assert out_meta["ir_preview"].shape == buf.shape[:2]
+    assert np.allclose(out_meta["ir_preview"], 0.9, atol=1e-4)
+
+
 def test_ir_preview_survives_warm_cache_hit() -> None:
     """A warm cache hit must still carry ir_preview — the cache stores/returns metadata."""
     data = np.full((120, 160, 3), 0.5, dtype=np.float32)


### PR DESCRIPTION
## Summary

- Enable **IR Removal** for SilverFast **64-bit HDRi RAW DNGs** (RGB + separate infrared page), e.g. Plustek OpticFilm 8200i scans from SilverFast 9.
- SilverFast stores RGB as a 3-sample LinearRaw SubIFD and IR as a full-res grayscale page (`NewSubfileType=4`). NegPy already handled that layout for HDRi TIFFs and VueScan-style 4-channel DNGs; HDRi DNGs now get the same IR path while libraw still decodes the RGB (splash thumbnail + half-size preview preserved).
- Shared IR-page finder (`ir_planes.py`), preview/export paths keep IR aligned when RGB and IR resolutions differ, and min-preserving IR downsample so sub-pixel hairs aren’t averaged away.

## Test plan

- [x] Open a SilverFast 64-bit HDRi RAW `.dng` in NegPy — Finish → Retouch: **IR Removal** is enabled (not greyed out).
- [x] Enable IR Removal; cycle Overlay to **IR** and confirm the infrared plane looks correct (not blank / not a second RGB).
- [x] Confirm dust/scratches are cleaned; tune **IR Threshold** if needed.
- [ ] Spot-check an existing VueScan 4-channel DNG and a SilverFast HDRi TIFF still load IR as before.
- [x] `uv run pytest tests/test_ir_dust.py tests/test_preview_manager.py -v`