### PR TITLE
fix: open panel guides centred on the main window

### DIFF
--- a/negpy/desktop/view/sidebar/controls_panel.py
+++ b/negpy/desktop/view/sidebar/controls_panel.py
@@ -306,7 +306,10 @@ class ControlsPanel(QWidget):
 
         section.expanded_changed.connect(lambda checked, k=key: repo.save_global_setting(f"section_expanded_{k}", checked))
         if section.info_btn:
-            section.info_requested.connect(lambda k=key, t=title: SectionHelpDialog(k, t, self).exec())
+            # Parent the dialog to the section, not to self: ControlsPanel is never added to a
+            # layout (only its pages are), so as a dialog parent it centres the guide on a
+            # phantom 0,0 window instead of the main window.
+            section.info_requested.connect(lambda k=key, t=title, s=section: SectionHelpDialog(k, t, s).exec())
         return section
 
     def _connect_signals(self) -> None:

--- a/negpy/desktop/view/widgets/section_help_dialog.py
+++ b/negpy/desktop/view/widgets/section_help_dialog.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Optional
 
 from PyQt6.QtCore import Qt
-from PyQt6.QtWidgets import QDialog, QFrame, QHBoxLayout, QLabel, QPushButton, QTextBrowser, QVBoxLayout
+from PyQt6.QtWidgets import QDialog, QFrame, QHBoxLayout, QLabel, QPushButton, QTextBrowser, QVBoxLayout, QWidget
 
 from negpy.desktop.view.styles.theme import THEME
 from negpy.kernel.system.paths import get_resource_path
@@ -64,7 +64,7 @@ def guide_markdown(key: str) -> str:
 class SectionHelpDialog(QDialog):
     """Modal reference for one panel, rendered from the user guide."""
 
-    def __init__(self, key: str, title: str, parent: Optional[QDialog] = None):
+    def __init__(self, key: str, title: str, parent: Optional[QWidget] = None):
         super().__init__(parent)
         heading = f"Reading the {title} panel"
         self.setWindowTitle(heading)

--- a/tests/test_section_help_dialog.py
+++ b/tests/test_section_help_dialog.py
@@ -1,8 +1,12 @@
 """The ⓘ in a section header and the guide it renders out of docs/USER_GUIDE.md."""
 
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
 import pytest
 from PyQt6.QtCore import QPoint, Qt
 from PyQt6.QtTest import QTest
+from PyQt6.QtWidgets import QWidget
 
 from negpy.desktop.view.widgets.collapsible import CollapsibleSection
 from negpy.desktop.view.widgets.section_help_dialog import SectionHelpDialog, _guides, guide_markdown, has_guide
@@ -72,6 +76,21 @@ def test_the_info_button_is_opt_in() -> None:
     """CollapsibleSection also backs the Export, Metadata and Scan sections, which have no guide."""
     assert CollapsibleSection("Plain").info_btn is None
     assert CollapsibleSection("Analysis", info=True).info_btn is not None
+
+
+def test_the_guide_is_parented_to_the_section_not_the_panel() -> None:
+    """Qt centres a dialog on parent.window(). ControlsPanel is never added to a layout —
+    only its pages are — so as the parent it centres the guide on a phantom window at 0,0
+    and the guide opens in the screen corner. The section is in the tree."""
+    from negpy.desktop.view.sidebar import controls_panel as cp
+
+    panel = SimpleNamespace(controller=SimpleNamespace(session=SimpleNamespace(repo=SimpleNamespace(get_global_setting=lambda _k: None))))
+    parents: list[object] = []
+    with patch.object(cp, "SectionHelpDialog", lambda k, t, parent: parents.append(parent) or MagicMock()):
+        section = cp.ControlsPanel._make_section(panel, "Analysis", "analysis", QWidget())
+        section.info_requested.emit()
+
+    assert parents == [section]
 
 
 def test_clicking_info_asks_for_help_without_collapsing_the_section() -> None:


### PR DESCRIPTION
The ⓘ on a sidebar section opened its guide in the top-left corner of the screen; every other dialog centres on the app window.

## Cause

`ControlsPanel` never enters the widget tree — `RightPanel._init_ui()` builds it only to harvest `.pages`, and those pages get reparented into the tab stack. The panel object itself stays a hidden, parentless top-level widget at 0,0.

`QDialog::adjustPosition` centres on `parent.window()`, and `controls_panel.py:309` passed that orphan as the parent, so Qt requested 0,0 and the compositor honoured it. The Analysis ⓘ never had the bug: it passes `RightPanel`, which is in the tree.

## Fix

Parent the guide to the emitting section. Also corrects the dialog's `parent` annotation, which claimed `Optional[QDialog]`.

Measured with `hyprctl clients` against the running app, main window at `[18, 64] 1890x2078`:

| dialog parent | placement |
| --- | --- |
| `ControlsPanel` (before) | `[0, 0]` |
| section widget (after) | `[593, 703]` — centred |

## Tests

`test_the_guide_is_parented_to_the_section_not_the_panel` asserts the parent `_make_section` wires up.

`make all`: lint and type clean, 2760 passed / 5 skipped.