### PR TITLE
Crosstalk: rename the Separation slider to Strength

### DIFF
--- a/crosstalk/README.md
+++ b/crosstalk/README.md
@@ -1,9 +1,10 @@
 # Crosstalk matrix gallery
 
-Community-contributed spectral-crosstalk matrices for NegPy's **Separation** control.
+Community-contributed spectral-crosstalk matrices for NegPy's **Crosstalk** controls
+(Process panel: *Matrix* + *Strength*).
 
 Every `.toml` here is bundled with the app and copied into a user's
-`<Documents>/NegPy/crosstalk/` folder on first run, so they show up in the Lab
+`<Documents>/NegPy/crosstalk/` folder on first run, so they show up in the Process
 sidebar dropdown out of the box.
 
 ## Contributing

--- a/docs/CROSSTALK.md
+++ b/docs/CROSSTALK.md
@@ -103,7 +103,7 @@ have to hand-edit TOML:
   live. The diagonal is fixed — the matrix is row-normalized on apply, which makes the
   diagonal redundant, so only the six mixing terms are editable. The **Preview strength**
   slider only controls how strongly the matrix previews here — it's view-only; use the
-  sidebar **Separation** slider to actually apply it.
+  sidebar **Strength** slider to actually apply it.
 - **Make Editable Copy** clones the selected (locked) matrix into an editable profile.
 - **Save** writes the profile as a `.toml` into `<Documents>/NegPy/crosstalk/` — the same
   folder profiles are read from — so it shows up in the dropdown.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -165,7 +165,7 @@ The foundation of every edit: film type, how the scan is decoded, and how the ne
 **Crosstalk** (hidden in B&W) — spectral dye unmixing applied to the raw negative before inversion:
 
 *   **Matrix**: the crosstalk profile for your film/scanner. *Default* is built-in; drop custom `.toml` matrices in `<Documents>/NegPy/crosstalk/` (see [CROSSTALK.md](CROSSTALK.md)). The slider button opens a matrix editor.
-*   **Separation** (0.0–1.0): strength of the unmix — richer, cleaner colour separation. Because it changes what the analysis reads, **re-run Batch Analysis** after changing it.
+*   **Strength** (0.0–1.0): how much of the unmix to apply — richer, cleaner colour separation. Because it changes what the analysis reads, **re-run Batch Analysis** after changing it.
 
 **Normalize** (E-6 only): auto-stretches a slide's histogram to fill the dynamic range. Useful for faded/expired slides.
 

--- a/negpy/desktop/view/sidebar/controls_panel.py
+++ b/negpy/desktop/view/sidebar/controls_panel.py
@@ -519,7 +519,9 @@ class ControlsPanel(QWidget):
 
         proc.crosstalk_strength_slider.setToolTip(
             tooltip_with_shortcut(
-                "Spectral-crosstalk unmix on the raw negative densities. Higher = richer colour separation; 0 = off",
+                "Spectral-crosstalk unmix on the raw negative densities — how much of the film's matrix to "
+                "apply. 1.0 = each layer's leak fully subtracted from the others; 0 = scanned densities "
+                "untouched. Re-run Batch Analysis after changing it",
                 ["separation_inc", "separation_dec"],
             )
         )

--- a/negpy/desktop/view/sidebar/process.py
+++ b/negpy/desktop/view/sidebar/process.py
@@ -200,7 +200,7 @@ class ProcessSidebar(BaseSidebar):
         matrix_row.addWidget(self.manage_crosstalk_btn)
         self.layout.addLayout(matrix_row)
 
-        self.crosstalk_strength_slider = CompactSlider("Separation", 0.0, 1.0, conf.crosstalk_strength, has_neutral=True)
+        self.crosstalk_strength_slider = CompactSlider("Strength", 0.0, 1.0, conf.crosstalk_strength, has_neutral=True)
         self.layout.addWidget(self.crosstalk_strength_slider)
 
         self.normalize_e6_btn = QPushButton(" Normalize")

--- a/negpy/desktop/view/widgets/crosstalk_editor_dialog.py
+++ b/negpy/desktop/view/widgets/crosstalk_editor_dialog.py
@@ -168,7 +168,7 @@ class CrosstalkEditorDialog(QDialog):
             "• Each off-diagonal slider subtracts one channel's leak from another — e.g. column "
             "green, row red removes green's contamination from red.<br>"
             "• The diagonal is fixed (rows are re-normalized).<br>"
-            "• Raise <b>Separation</b> in the sidebar to dial the effect in."
+            "• Raise <b>Strength</b> in the sidebar to dial the effect in."
         )
         info.setWordWrap(True)
         info.setStyleSheet(
@@ -184,7 +184,7 @@ class CrosstalkEditorDialog(QDialog):
 
         self.preview_strength_slider = CompactSlider("Preview strength", 0.0, 1.0, 1.0, has_neutral=False)
         self.preview_strength_slider.setToolTip(
-            "How strongly the matrix previews here (view-only — set Separation in the sidebar to apply)"
+            "How strongly the matrix previews here (view-only — set Crosstalk Strength in the sidebar to apply)"
         )
         self.preview_strength_slider.valueChanged.connect(lambda _v: self._emit_preview())
         rl.addWidget(self.preview_strength_slider)

--- a/negpy/desktop/view/widgets/tutorial_steps.py
+++ b/negpy/desktop/view/widgets/tutorial_steps.py
@@ -300,7 +300,7 @@ def build(window: "MainWindow") -> list[TutorialStep]:
                 "are linear in negative dye density (Beer–Lambert), so NegPy unmixes them "
                 "with a per-stock matrix in log-density space, <b>before any analysis</b>.<br><br>"
                 "Pick a profile matching your film stock and blend it in with the "
-                "<b>Separation</b> strength.<br><br>"
+                "<b>Strength</b> slider.<br><br>"
                 "Changed the matrix or strength? <b>Re-run Batch Analysis</b> — bounds "
                 "measured under a different matrix are invalid."
             ),


### PR DESCRIPTION
Follow-on to #683, which the squash-merge left behind.

## Why

Naming the print-side control **Dye Separation** left two panels with a Separation-something doing different things — spectral unmix of the negative (Process) vs density-domain saturation of the print (Tone). And `crosstalk_strength` had already absorbed Lab's old "Separation" (`migrations.py`), so the word was carrying three meanings.

Inside the CROSSTALK subheader the pair now reads **Matrix / Strength**, which is what the value is: a 0..1 blend from identity toward the selected matrix.

## What

- `process.py`: slider label `Separation` → `Strength`
- label followed through: `docs/USER_GUIDE.md`, `docs/CROSSTALK.md`, the matrix-editor dialog, the Process tutorial step, `crosstalk/README.md`
- the editor's own *Preview strength* tooltip now says **Crosstalk Strength**, so the two sliders can't be confused
- slider tooltip states its endpoints and the real footgun instead of "Higher = richer colour separation":

  > Spectral-crosstalk unmix on the raw negative densities — how much of the film's matrix to apply. 1.0 = each layer's leak fully subtracted from the others; 0 = scanned densities untouched. Re-run Batch Analysis after changing it

- `crosstalk/README.md` also still said the dropdown lives in the **Lab** sidebar; it's Process

No behaviour change — labels, tooltips and docs only. `separation_inc`/`separation_dec` (Alt+1) already read "Crosstalk up/down" in the registry, so the shortcut list and `?` overlay were already consistent.

## Verification

`make all` — lint, ty, 2759 passed / 1 skipped, on top of the merged main.

## Not included

`tutorial_steps.py` (Lab step) still claims "**Separation** amplifies R/G/B channel differences" — stale since Lab's Separation moved to the capture side; that line wants deleting, not renaming, so it's left for a separate call.