### PR TITLE
fix: align the zoom buttons with the rest of the canvas toolbar

### DIFF
--- a/negpy/desktop/view/canvas/toolbar.py
+++ b/negpy/desktop/view/canvas/toolbar.py
@@ -344,6 +344,8 @@ class ActionToolbar(QWidget):
             self.btn_flip_v,
             self.btn_undo,
             self.btn_redo,
+            self.btn_zoom_fit,
+            self.btn_zoom_original,
             self.btn_hq,
             self.btn_compare,
             self.btn_zones,
@@ -362,11 +364,6 @@ class ActionToolbar(QWidget):
         for btn in (self.btn_rot_l, self.btn_rot_r):
             btn.setIconSize(rotate_icon_size)
             btn.setFixedHeight(btn_height)
-            btn.setCursor(Qt.CursorShape.PointingHandCursor)
-
-        # Custom-sized buttons skip the standard sizing above but must share the
-        # same hover cursor as the rest of the toolbar.
-        for btn in (self.btn_zoom_fit, self.btn_zoom_original):
             btn.setCursor(Qt.CursorShape.PointingHandCursor)
 
         # Single-row layout: toggle_left · prev · next · sep1 · zoom_label · hq · sep2 · rot_l · rot_r · flip_h · flip_v · sep3 · undo · redo · compare · zones · loupe · overflow · toggle_right

--- a/tests/test_canvas_toolbar.py
+++ b/tests/test_canvas_toolbar.py
@@ -93,6 +93,38 @@ class TestCanvasToolbarResponsive(unittest.TestCase):
         self.assertTrue(tb.btn_undo.isVisible())
         self.assertTrue(tb.btn_zoom_fit.isVisible())
 
+    def test_every_visible_control_shares_one_row_height(self):
+        """btn_zoom_fit/btn_zoom_original once skipped the standard sizing loop and fell
+        back to style defaults (29px and 25px against everyone else's 32), leaving their
+        hover rectangles visibly short of their neighbours'."""
+        tb = _make_toolbar()
+        tb.set_available_width(1600)
+        tb.show()
+        QApplication.processEvents()
+
+        row = [
+            tb.btn_toggle_left,
+            tb.btn_prev,
+            tb.btn_next,
+            tb.zoom_label,
+            tb.btn_zoom_fit,
+            tb.btn_zoom_original,
+            tb.btn_hq,
+            tb.btn_rot_l,
+            tb.btn_rot_r,
+            tb.btn_flip_h,
+            tb.btn_flip_v,
+            tb.btn_undo,
+            tb.btn_redo,
+            tb.btn_compare,
+            tb.btn_zones,
+            tb.btn_loupe,
+            tb.btn_overflow,
+            tb.btn_toggle_right,
+        ]
+        edges = {(w.geometry().y(), w.geometry().bottom()) for w in row if w.isVisible()}
+        self.assertEqual(len(edges), 1, f"toolbar controls disagree on top/bottom edges: {sorted(edges)}")
+
     def _all_overflow_actions(self, tb: ActionToolbar) -> list:
         return [
             tb._ov_hq_action,


### PR DESCRIPTION
btn_zoom_fit and btn_zoom_original were never in standard_buttons, so they missed setIconSize/setFixedHeight and fell back to style defaults — 29px and 25px tall against every other control's 32, leaving their hover rectangles visibly short at the top and bottom. The cursor-only loop they did get called them "custom-sized", but nothing set a size on them; that comment described canvas_color_btns, which left the tuple in 69a2934.