### PR TITLE
Camera scanning: delete each tethered shot off the body after download (part of #658)

### DIFF
--- a/negpy/infrastructure/capture/gphoto.py
+++ b/negpy/infrastructure/capture/gphoto.py
@@ -5,7 +5,7 @@ source: libgphoto2 keeps a single PTP session per body, so previews, property wr
 stills all ride the same handle behind one lock. It writes the preview JPEG and a
 settings JSON to the same paths the previous helper used, so the UI polls them unchanged.
 
-Four behaviours of the library shape this module; each is guarded below:
+Five behaviours of the library shape this module; each is guarded below:
 
 * Reading a value off a choice widget that has **no** choices dereferences a NULL and
   kills the process with SIGSEGV — no `except` can catch it. See `_safe_value`.
@@ -16,6 +16,9 @@ Four behaviours of the library shape this module; each is guarded below:
   small worker so the wait overlaps the next channel's LED settle (`_finish_shot_async`).
 * Choice strings are run through gettext, so on a German desktop `focusmode` reads
   'Manuell'. The message locale is pinned before the library loads. See `_pin_locale`.
+* A downloaded shot must also be *deleted* off the body. Bodies without a capture-target
+  setting (Fujifilm) keep every tethered object and refuse further captures once their
+  buffer fills — the X-T5 dies at exactly shot #13, ~1 GB. See the delete in `capture`.
 
 Vendors name the same control differently and expose different subsets of it, so every
 property is looked up rather than assumed — see `_PROPERTIES` and `_MAGNIFIERS`. Only Sony
@@ -684,6 +687,15 @@ class GphotoCamera:
                     camera_file = camera.file_get(path.folder, path.name, self._gp.GP_FILE_TYPE_NORMAL)
                     data = bytes(memoryview(camera_file.get_data_and_size()))
                     t_download = time.perf_counter()
+                    try:
+                        # Delete the downloaded shot from the body. On a self-recycling RAM
+                        # target (Sony sdram) this is redundant at worst, but a body without
+                        # a capture target keeps every tethered object: the X-T5 holds ~1 GB,
+                        # then refuses capture #13 outright with a bare [-1] (issue #658 —
+                        # both reporter sessions died at exactly the 13th shot).
+                        camera.file_delete(path.folder, path.name)
+                    except self._gp.GPhoto2Error as exc:
+                        logger.debug("gphoto2: could not delete %s off the camera: %s", path.name, exc)
                 except BaseException:
                     # A failed shot drains inline, still under the lock: the error must leave a
                     # clean queue behind before the preview or a retry can touch the session.

--- a/tests/test_capture_gphoto.py
+++ b/tests/test_capture_gphoto.py
@@ -107,12 +107,23 @@ class _Camera:
     def capture(self, _kind):
         if self._fake.undrained:
             raise _Err("[-1] unspecified error")
+        if self._fake.object_capacity is not None and self._fake.stored_objects >= self._fake.object_capacity:
+            # Fujifilm behaviour (issue #658): the tether buffer holds every un-deleted shot
+            # and the body refuses the next trigger outright once it is full.
+            raise _Err("[-1] unspecified error")
         self._fake.undrained = True
         self._fake.captures += 1
+        self._fake.stored_objects += 1
         return _Path(self._fake.raw_name)
 
     def file_get(self, _folder, _name, _kind):
         return _File(b"RAWDATA" * 3)
+
+    def file_delete(self, _folder, _name):
+        if self._fake.reject_deletes:
+            raise _Err("[-2] bad parameters")
+        self._fake.deletes += 1
+        self._fake.stored_objects = max(0, self._fake.stored_objects - 1)
 
     def capture_preview(self):
         self._check()
@@ -186,6 +197,10 @@ class FakeGP:
         self.late_events = 0  # post-shot events the body only hands over after a pause (Fujifilm, #658)
         self.event_gap = False
         self.event_waits: list[int] = []  # the quiet-window ms passed to each wait_for_event
+        self.stored_objects = 0  # tethered shots the body still holds (deletes drain this)
+        self.object_capacity = None  # int → refuse captures when full, as the X-T5 does (#658)
+        self.deletes = 0
+        self.reject_deletes = False  # a body whose RAM target refuses the delete
         self.opened = False
         self.undrained = False
         self.gone = False  # set by unplug(): the body stops answering, as on a pulled cable
@@ -303,6 +318,30 @@ def test_three_captures_in_a_row_succeed(cam, tmp_path):
     # Without the drain the second capture raises "[-1] unspecified error".
     for channel in "RGB":
         cam.capture(str(tmp_path / f"f_{channel}.ARW"))
+
+
+def test_capture_deletes_the_downloaded_shot_off_the_camera(cam, fake, tmp_path):
+    cam.capture(str(tmp_path / "f.ARW"))
+    assert fake.deletes == 1 and fake.stored_objects == 0
+
+
+def test_captures_outlast_a_fuji_style_tether_buffer(fake, tmp_path):
+    """Issue #658: the X-T5 keeps every un-deleted tethered shot and refuses the 13th capture
+    once ~1 GB is held (both reporter sessions died at exactly shot #13). With the delete
+    after every download the buffer never fills, so a roll scans through."""
+    fake.object_capacity = 2
+    camera = GphotoCamera(gp_module=fake)
+    camera.open()
+    for i in range(6):
+        camera.capture(str(tmp_path / f"f{i}.ARW"))
+    assert fake.captures == 6  # far past the capacity a delete-less client wedges at
+    camera.close()
+
+
+def test_a_refused_delete_does_not_fail_the_capture(cam, fake, tmp_path):
+    fake.reject_deletes = True  # e.g. a self-recycling RAM target that has nothing to delete
+    out = cam.capture(str(tmp_path / "f.ARW"))
+    assert out.endswith(".ARW")  # the image is already downloaded; the delete is best-effort
 
 
 def test_capture_sets_the_shutter_first(cam, fake, tmp_path):


### PR DESCRIPTION
Part of #658, the remaining capture failure after #674.

The reporter's two sessions pinpoint it: both died at exactly the 13th shot. Eleven calibration captures plus one scan channel succeeded and the 13th returned a bare `[-1]`; after a power cycle, four full frames (twelve captures) succeeded and the 13th failed again. Twelve shots at ~85 MB is about a gigabyte. The refusal is instant, no exposure happens, while property reads keep working, which is why the session-liveness probe from #674 does not catch it.

## Cause

A body without a `capturetarget` setting (the X-T5 has none, it reports `PTP Device Prop Not Supported` for it) keeps every tethered shot as an object in its internal buffer until the host deletes it. NegPy downloaded each shot but never deleted it, so the buffer filled and the body refused further triggers. A power cycle empties the buffer, which is exactly why the reporter got twelve more shots each time.

## Fix

`capture()` now deletes the shot off the body right after the download, inside the same lock. Best effort: on a self-recycling RAM target (Sony `sdram`) the delete is redundant or refused, so a failure is logged at debug and never fails the capture, the image is already on disk at that point.

There is a fair chance this also restores live view on these bodies: the preview dies the moment the first un-deleted shot enters the buffer and returns after a power cycle, so the pending object may be what blocks it. The reporter's next test will tell; nothing in this PR depends on that being true.

## Verification

The fake now models the tether buffer: with a capacity of 2 and no deletes, the third capture is refused, and with the delete in place six captures run through. A refused delete does not fail the capture. Regression-tested on a Sony a7C II, scanning behaves as before. `make all` is green with and without the optional camera group.