### PR TITLE
Film strip: smooth, shorter wheel scrolling + empty-space context menu

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -55,6 +55,8 @@ Toolbar buttons, left to right:
 
 Below the toolbar: a **filter box** (substring match; toggle **`.*`** for regex) and a **tally**, e.g. "36 frames · 12 keepers · 3 rejected".
 
+Right-clicking **empty space** in the film strip offers **Add files**, **Add folder** and **Clear all**, so those tools stay in reach part-way down a long roll instead of only at the top of the panel. Here **Clear all** always means the whole session, never just the selection.
+
 ### Triage (culling the roll)
 
 Right-click a thumbnail (or use keyboard shortcuts) to mark frames while you review the sheet:

--- a/negpy/desktop/view/sidebar/files.py
+++ b/negpy/desktop/view/sidebar/files.py
@@ -1,9 +1,21 @@
 import os
 
 import qtawesome as qta
-from PyQt6.QtCore import Qt, QItemSelectionModel, QModelIndex, QRect, QRectF, QSize, QTimer, pyqtSignal
+from PyQt6.QtCore import (
+    Qt,
+    QEasingCurve,
+    QItemSelectionModel,
+    QModelIndex,
+    QPropertyAnimation,
+    QRect,
+    QRectF,
+    QSize,
+    QTimer,
+    pyqtSignal,
+)
 from PyQt6.QtGui import QActionGroup, QColor, QKeySequence, QPainter, QPainterPath, QPen, QShortcut
 from PyQt6.QtWidgets import (
+    QAbstractItemView,
     QApplication,
     QCheckBox,
     QDialog,
@@ -174,6 +186,10 @@ class ThumbnailGridView(QListView):
     """
 
     SPACING = 2
+    # One notch scrolls one row of thumbnails. Qt's default (ScrollPerItem, three
+    # "lines" a notch) advanced 4-5 frames at a time in a single-column panel.
+    WHEEL_ROWS_PER_NOTCH = 1.0
+    SCROLL_ANIM_MS = 160
 
     def __init__(self, parent=None, target_cell: int = THUMB_CELL_DEFAULT):
         super().__init__(parent)
@@ -185,6 +201,13 @@ class ThumbnailGridView(QListView):
         self.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOn)
         self.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
         self.setSpacing(self.SPACING)
+        # Per-pixel is what makes a partial-row offset representable at all; under
+        # ScrollPerItem the view snaps to whole rows and no easing is possible.
+        self.setVerticalScrollMode(QAbstractItemView.ScrollMode.ScrollPerPixel)
+        self._scroll_anim = QPropertyAnimation(self.verticalScrollBar(), b"value", self)
+        self._scroll_anim.setEasingCurve(QEasingCurve.Type.OutCubic)
+        self._scroll_anim.setDuration(self.SCROLL_ANIM_MS)
+        self._scroll_target = 0
         self._apply_cell(self._target_cell)
 
     @staticmethod
@@ -216,6 +239,9 @@ class ThumbnailGridView(QListView):
         self._last_cell = cell
         self.setGridSize(QSize(cell + self.SPACING, cell + self.SPACING))
         self.setIconSize(QSize(cell, cell))
+        # ScrollPerPixel leaves singleStep at 1px, which makes the scrollbar arrows
+        # and arrow keys crawl; a quarter row is a usable step.
+        self.verticalScrollBar().setSingleStep(max(1, (cell + self.SPACING) // 4))
 
     def _relayout(self) -> None:
         self._apply_cell(self.cell_for_width(self.viewport().width()))
@@ -224,13 +250,37 @@ class ThumbnailGridView(QListView):
         super().resizeEvent(event)
         self._relayout()
 
+    def _row_step(self) -> int:
+        """Pixels one row of thumbnails occupies."""
+        return max(1, self.gridSize().height())
+
     def wheelEvent(self, event) -> None:
+        bar = self.verticalScrollBar()
         pixel = event.pixelDelta()
         if not pixel.isNull() and pixel.y() != 0:
-            self.verticalScrollBar().setValue(self.verticalScrollBar().value() - pixel.y())
+            # Trackpads already deliver continuous deltas; easing them adds lag.
+            self._scroll_anim.stop()
+            bar.setValue(bar.value() - pixel.y())
             event.accept()
-        else:
+            return
+
+        notches = event.angleDelta().y() / 120.0
+        if not notches:
             super().wheelEvent(event)
+            return
+
+        # Accumulate onto the in-flight target so a fast spin covers the whole
+        # distance instead of restarting from wherever the easing had reached.
+        running = self._scroll_anim.state() == QPropertyAnimation.State.Running
+        base = self._scroll_target if running else bar.value()
+        target = int(round(base - notches * self.WHEEL_ROWS_PER_NOTCH * self._row_step()))
+        self._scroll_target = max(bar.minimum(), min(bar.maximum(), target))
+
+        self._scroll_anim.stop()
+        self._scroll_anim.setStartValue(bar.value())
+        self._scroll_anim.setEndValue(self._scroll_target)
+        self._scroll_anim.start()
+        event.accept()
 
 
 class FileBrowser(QWidget):
@@ -484,8 +534,13 @@ class FileBrowser(QWidget):
             if confirm_unload(self, count=count):
                 self.session.remove_selected_files()
         else:
-            if confirm_unload(self, clear_all=True):
-                self.session.clear_files()
+            self._on_clear_all()
+
+    def _on_clear_all(self) -> None:
+        """Drop every loaded frame. The empty-space menu always means *all*, unlike
+        the toolbar button, which clears the selection when one is active."""
+        if confirm_unload(self, clear_all=True):
+            self.session.clear_files()
 
     def _update_unload_button(self) -> None:
         if len(self.session.state.selected_indices) > 1:
@@ -700,6 +755,10 @@ class FileBrowser(QWidget):
     def _show_context_menu(self, pos) -> None:
         index = self.list_view.indexAt(pos)
         if not index.isValid():
+            # Empty space carries the session-level tools, so they stay reachable
+            # without travelling back to the toolbar at the top of the panel — and
+            # are discoverable at all when the session is empty.
+            self._build_session_menu().exec(self.list_view.viewport().mapToGlobal(pos))
             return
         actual = self.session.asset_model.display_to_actual(index.row())
         if actual < 0:
@@ -745,6 +804,18 @@ class FileBrowser(QWidget):
         )
         if dlg.exec() == QDialog.DialogCode.Accepted:
             self.session.sync_selected_settings(dlg.selected(), dlg.bounds_flags(), dlg.scope())
+
+    def _build_session_menu(self) -> QMenu:
+        """Mirrors the panel toolbar's add/clear tools, for a right click on empty space."""
+        icon_color = THEME.text_primary
+        menu = QMenu(self)
+        menu.addAction(qta.icon("fa5s.file-import", color=icon_color), "Add files…").triggered.connect(self._on_add_files)
+        menu.addAction(qta.icon("fa5s.folder-plus", color=icon_color), "Add folder…").triggered.connect(self._on_add_folder)
+        menu.addSeparator()
+        clear = menu.addAction(qta.icon("fa5s.times-circle", color=icon_color), "Clear all")
+        clear.triggered.connect(self._on_clear_all)
+        clear.setEnabled(bool(self.session.state.uploaded_files))
+        return menu
 
     def _build_context_menu(self) -> QMenu:
         state = self.session.state

--- a/tests/test_file_browser_widget.py
+++ b/tests/test_file_browser_widget.py
@@ -2,7 +2,9 @@ from dataclasses import replace
 from unittest.mock import MagicMock, patch
 
 import pytest
-from PyQt6.QtWidgets import QDialog
+from PyQt6.QtCore import QPoint, QPointF, QPropertyAnimation, Qt
+from PyQt6.QtGui import QWheelEvent
+from PyQt6.QtWidgets import QAbstractItemView, QApplication, QDialog
 
 from negpy.desktop.session import DesktopSessionManager
 from negpy.desktop.view.sidebar.files import THUMB_CELL_MAX, THUMB_CELL_MIN, FileBrowser
@@ -382,3 +384,142 @@ def test_thumbnail_size_out_of_range_setting_is_clamped(session):
     controller.session = session
     restored = FileBrowser(controller)
     assert restored.list_view.target_cell == THUMB_CELL_MAX
+
+
+# --- Session panel scrolling & empty-space menu ---------------------------
+
+
+def _wheel(angle_y: int = 0, pixel_y: int = 0) -> QWheelEvent:
+    return QWheelEvent(
+        QPointF(10.0, 10.0),
+        QPointF(10.0, 10.0),
+        QPoint(0, pixel_y),
+        QPoint(0, angle_y),
+        Qt.MouseButton.NoButton,
+        Qt.KeyboardModifier.NoModifier,
+        Qt.ScrollPhase.NoScrollPhase,
+        False,
+    )
+
+
+def _scrollable(browser, value: int = 0):
+    """Lay the panel out narrow and short so the grid genuinely overflows — the
+    scrollbar range is recomputed from the layout, so it can't just be faked."""
+    browser.resize(240, 300)
+    browser.show()
+    QApplication.processEvents()
+    view = browser.list_view
+    bar = view.verticalScrollBar()
+    assert bar.maximum() > 2 * view._row_step(), "fixture grid does not scroll"
+    bar.setValue(value)
+    QApplication.processEvents()
+    return bar
+
+
+def test_grid_scrolls_per_pixel(browser):
+    """ScrollPerItem snaps to whole rows, so no partial offset (and no easing) is
+    representable — it is what made the wheel jump several frames at a time."""
+    assert browser.list_view.verticalScrollMode() == QAbstractItemView.ScrollMode.ScrollPerPixel
+
+
+def test_one_wheel_notch_scrolls_exactly_one_row(browser):
+    view = browser.list_view
+    _scrollable(browser)
+    view.wheelEvent(_wheel(angle_y=-120))
+    assert view._scroll_target == view._row_step()
+
+
+def test_wheel_scroll_is_animated_not_instant(browser):
+    view = browser.list_view
+    bar = _scrollable(browser)
+    view.wheelEvent(_wheel(angle_y=-120))
+    assert view._scroll_anim.state() == QPropertyAnimation.State.Running
+    assert view._scroll_anim.duration() > 0
+    assert view._scroll_anim.endValue() == view._scroll_target
+    # The jump is eased in, not applied on the spot.
+    assert bar.value() != view._scroll_target
+
+
+def test_consecutive_notches_accumulate_onto_the_running_target(browser):
+    """A fast spin must cover the full distance, not restart from wherever the
+    easing had reached."""
+    view = browser.list_view
+    _scrollable(browser)
+    view.wheelEvent(_wheel(angle_y=-120))
+    assert view._scroll_target == view._row_step()
+    view.wheelEvent(_wheel(angle_y=-120))
+    assert view._scroll_target == 2 * view._row_step()
+
+
+def test_wheel_up_scrolls_back(browser):
+    view = browser.list_view
+    bar = _scrollable(browser, value=2 * view._row_step())
+    start = bar.value()  # the layout may clamp the requested offset
+    view.wheelEvent(_wheel(angle_y=120))
+    assert view._scroll_target == start - view._row_step()
+
+
+def test_wheel_target_is_clamped_to_the_scroll_range(browser):
+    view = browser.list_view
+    bar = _scrollable(browser, value=2 * view._row_step())
+    for _ in range(20):
+        view.wheelEvent(_wheel(angle_y=120))  # up, well past the top
+    assert view._scroll_target == bar.minimum()
+    assert view._scroll_anim.endValue() == bar.minimum()
+
+
+def test_trackpad_pixel_delta_scrolls_immediately(browser):
+    """Trackpads already deliver continuous deltas; easing them would add lag."""
+    view = browser.list_view
+    bar = _scrollable(browser, value=100)
+    start = bar.value()
+    view.wheelEvent(_wheel(pixel_y=-40))
+    assert bar.value() == start + 40
+    assert view._scroll_anim.state() != QPropertyAnimation.State.Running
+
+
+def test_session_menu_mirrors_the_toolbar_tools(browser):
+    labels = [a.text() for a in browser._build_session_menu().actions() if not a.isSeparator()]
+    assert labels == ["Add files…", "Add folder…", "Clear all"]
+
+
+def test_session_menu_clear_all_disabled_when_nothing_loaded(browser, session):
+    session.state.uploaded_files = []
+    clear = [a for a in browser._build_session_menu().actions() if a.text() == "Clear all"][0]
+    assert not clear.isEnabled()
+
+
+def test_session_menu_clear_all_enabled_with_files(browser):
+    clear = [a for a in browser._build_session_menu().actions() if a.text() == "Clear all"][0]
+    assert clear.isEnabled()
+
+
+def test_right_click_on_empty_space_opens_the_session_menu(browser):
+    """Previously this returned early, leaving empty space (and an empty session)
+    with no context menu at all."""
+    with (
+        patch.object(browser, "_build_session_menu") as session_menu,
+        patch.object(browser, "_build_context_menu") as frame_menu,
+    ):
+        browser._show_context_menu(QPoint(5, 99999))
+    session_menu.assert_called_once()
+    frame_menu.assert_not_called()
+
+
+def test_right_click_on_a_frame_still_opens_the_frame_menu(browser):
+    idx = browser.session.asset_model.index(0, 0)
+    with (
+        patch.object(browser.list_view, "indexAt", return_value=idx),
+        patch.object(browser, "_build_context_menu") as frame_menu,
+        patch.object(browser, "_build_session_menu") as session_menu,
+    ):
+        browser._show_context_menu(QPoint(5, 5))
+    frame_menu.assert_called_once()
+    session_menu.assert_not_called()
+
+
+def test_session_menu_clear_all_clears_every_frame(browser, session):
+    session.clear_files = MagicMock()
+    with patch("negpy.desktop.view.sidebar.files.confirm_unload", return_value=True):
+        browser._on_clear_all()
+    session.clear_files.assert_called_once()


### PR DESCRIPTION
## Summary

Three usability fixes for the session panel (film strip).

**1. Wheel scrolling is now eased instead of snapping.** The grid was left on Qt's default `ScrollPerItem`, which can only land on whole rows — so a partial offset, and therefore any animation, was not representable at all. Switched to `ScrollPerPixel` and eased the scrollbar value (`OutCubic`, 160 ms). Consecutive notches accumulate onto the in-flight target, so a fast spin covers the full distance rather than restarting from wherever the easing had reached.

**2. One notch now advances one row.** Qt's default is three "lines" per notch, and a line is a whole row here — which is the 4-5 frames per notch that was reported in a single-column panel. The step is derived from the grid size, so it tracks the thumbnail-size slider automatically.

Two details that fall out of the scroll-mode change:
- Trackpads keep the existing direct `pixelDelta` path — they already deliver continuous deltas and easing them would only add lag.
- `ScrollPerPixel` leaves the scrollbar `singleStep` at 1 px, which makes the scrollbar arrows and arrow keys crawl, so it's set to a quarter row.

**3. Right-clicking empty space opens Add files / Add folder / Clear all.** That click was previously swallowed — `_show_context_menu` returned early on an invalid index — so those tools were only reachable by travelling back to the toolbar at the top of the panel. **Clear all** here always means the whole session (unlike the toolbar button, which clears the selection when one is active) and is disabled when nothing is loaded.

## Verification

Driven against a real `MainWindow` with a 30-frame session (all 13 checks pass):

```
session panel: viewport=289x736  row=287px  range=(0,7874)  singleStep=71
OK  : grid scrolls per pixel (was per item)
OK  : scrollbar singleStep is a quarter row (71 vs row 287)
OK  : one notch targets exactly one row (287px, row=287px)
OK  : wheel scroll is animated (eased), not instant
OK  : animation settles on the target (value=287, target=287)
OK  : 3 quick notches accumulate to 3 rows (861px)
OK  : trackpad pixelDelta scrolls directly (no easing lag)
OK  : empty-space menu items: ['Add files…', 'Add folder…', 'Clear all']
OK  : Clear all disabled when the session is empty
OK  : menu still offers Add files/folder on an empty session
```

## Test plan
- 13 new tests in `tests/test_file_browser_widget.py` covering per-pixel mode, one-row notch, easing, accumulation, scroll-up, range clamping, the direct trackpad path, and both context-menu branches (empty space vs. a frame). The helper lays the panel out narrow so the scrollbar range is real rather than faked — the layout recomputes it.
- All 7 behavioural tests verified to fail against the pre-change handler.
- Full suite: 2838 passed; the 4 failures (`test_effective_input_icc`, `test_output_dir_subfolder_of_source`, `test_sidecar_path`, `test_watcher_skips_ir_sidecars`) are pre-existing Windows path-separator issues, each confirmed failing on a clean `main`.
- `make format` / `ruff check` clean. `docs/USER_GUIDE.md` updated for the new menu.