### PR TITLE
Favourites panel, and overflow menus for both side panels

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -25,6 +25,7 @@ The right-hand tabs are arranged in the order you actually work, which mirrors t
 | **Exposure** | sun | Filtration · Tone · Dodge & Burn | White balance, print density/contrast/curve/saturation, local burns |
 | **Colour** | palette | Lab · Toning | Chroma, sharpening, effects, split/chemical toning |
 | **Finish** | brush | Retouch · Finishing | Dust removal, vignette, border, carrier |
+| **Favourites** | star | Your chosen sliders | Quick access to the controls you use most |
 | **History** | clock | Edit history | Step back through every change |
 | **Export** | file | Export settings | Format, size, colour, batch output |
 | **Metadata** | tags | Archival metadata | Original camera/lens/film details |
@@ -33,6 +34,8 @@ The right-hand tabs are arranged in the order you actually work, which mirrors t
 You don't have to touch every panel. NegPy's defaults are tuned to produce a good print straight away, and most frames need only a crop, maybe a white-balance nudge, and export.
 
 A small **dot** on a panel header (and on a tab icon) means you've changed something from its default. Every panel header has a **reset** action to return that panel to defaults, and an **ⓘ** that opens this guide at that panel's section.
+
+Both side panels can be narrowed to give the canvas more room. As the controls panel shrinks, tab icons that no longer fit move into a **»** menu at the right of the tab bar; the tab you are on always stays visible.
 
 ---
 
@@ -56,6 +59,8 @@ Toolbar buttons, left to right:
 Below the toolbar: a **filter box** (substring match; toggle **`.*`** for regex) and a **tally**, e.g. "36 frames · 12 keepers · 3 rejected".
 
 Right-clicking **empty space** in the film strip offers **Add files**, **Add folder** and **Clear all**, so those tools stay in reach part-way down a long roll instead of only at the top of the panel. Here **Clear all** always means the whole session, never just the selection.
+
+Narrow the panel and the toolbar buttons that no longer fit move into a **»** menu at its right edge, so the panel can be squeezed down to give the image more room without losing any tool.
 
 ### Triage (culling the roll)
 
@@ -393,7 +398,23 @@ The paper margin takes the mat colour, so it runs into the border with no seam.
 
 ---
 
-## 9. History tab
+## 9. Favourites tab
+
+The sliders you reach for most, gathered in one place so a routine edit no longer costs a tab
+switch and a scroll. Empty until you fill it.
+
+*   **Edit Favourites**: opens a picker. Tick sliders on the left, order them on the right with
+    the arrow buttons, then **Apply**.
+*   The panel then shows those sliders in your chosen order. They are the *same* controls as in
+    their home panels — moving one here moves it there, and vice versa. Nothing is duplicated or
+    moved out of its own tab.
+*   A favourite hides itself when its original does. Favourite a Filtration slider and it will
+    disappear while you are in black & white, where it has nothing to act on.
+*   Your selection is remembered between sessions.
+
+---
+
+## 10. History tab
 
 A scrollable list of every edit step (last 100 kept), newest on top; the current step is bold.
 
@@ -402,7 +423,7 @@ A scrollable list of every edit step (last 100 kept), newest on top; the current
 
 ---
 
-## 10. Export tab
+## 11. Export tab
 
 ### Output intent
 
@@ -435,7 +456,7 @@ The primary **Export** action. Its chevron menu picks the scope: current frame (
 
 ---
 
-## 11. Metadata tab
+## 12. Metadata tab
 
 Archival metadata for the **original analog capture** (camera, lens, film, process), written into exported files as EXIF and embedded XMP so DAMs like Lightroom show your film gear rather than the scanner.
 
@@ -466,7 +487,7 @@ When you set capture gear, it's written to standard EXIF and the digitizing rig 
 
 ---
 
-## 12. Scan tab
+## 13. Scan tab
 
 Capture film directly into NegPy (Linux and macOS; unavailable on Windows). Two collapsible sections:
 
@@ -477,7 +498,7 @@ Camera scanning needs the optional `python-gphoto2` dependency (`pip install gph
 
 ---
 
-## 13. Startup Override (`override.toml`)
+## 14. Startup Override (`override.toml`)
 
 If NegPy crashes on launch or has rendering glitches, you can force backend settings without touching code. On first run NegPy creates `Documents/NegPy/override.toml` with defaults for your OS. Edit it and restart.
 

--- a/negpy/desktop/view/keyboard_shortcuts.py
+++ b/negpy/desktop/view/keyboard_shortcuts.py
@@ -13,7 +13,8 @@ from negpy.desktop.view.shortcut_registry import (
     set_current_bindings,
     slider_step_for,
 )
-from negpy.desktop.view.slider_shortcut_groups import SLIDER_GROUP_BY_ACTION, sign_for_action
+from negpy.desktop.view.slider_shortcut_groups import SLIDER_GROUP_BY_ACTION, SLIDER_GROUPS, sign_for_action
+from negpy.desktop.view.slider_targets import slider_widget_map
 
 
 def _context_undo(controller) -> None:
@@ -108,6 +109,7 @@ class ShortcutManager:
             "toggle_left_panel": self.window.toggle_session_dock,
             "toggle_right_panel": self.window.toggle_controls_dock,
             "reset_panel_layout": self.window.reset_panel_layout,
+            "tab_favourites": lambda: right.show_tab_by_key("favourites"),
             "tab_setup": lambda: right.show_tab_by_key("setup"),
             "tab_geometry": lambda: right.show_tab_by_key("geometry"),
             "tab_tone": lambda: right.show_tab_by_key("tone"),
@@ -130,96 +132,11 @@ class ShortcutManager:
             "show_analysis_help": self.window.right_panel.show_analysis_help,
         }
 
-        slider_targets: dict[str, Callable[[], object]] = {
-            "cyan_inc": lambda: controls.colour_sidebar.cyan_slider,
-            "cyan_dec": lambda: controls.colour_sidebar.cyan_slider,
-            "magenta_up": lambda: controls.colour_sidebar.magenta_slider,
-            "magenta_down": lambda: controls.colour_sidebar.magenta_slider,
-            "yellow_up": lambda: controls.colour_sidebar.yellow_slider,
-            "yellow_down": lambda: controls.colour_sidebar.yellow_slider,
-            "temp_warm": lambda: controls.colour_sidebar.temp_slider,
-            "temp_cool": lambda: controls.colour_sidebar.temp_slider,
-            "density_up": lambda: controls.tone_sidebar.density_slider,
-            "density_down": lambda: controls.tone_sidebar.density_slider,
-            "grade_up": lambda: controls.tone_sidebar.grade_slider,
-            "grade_down": lambda: controls.tone_sidebar.grade_slider,
-            "toe_inc": lambda: controls.tone_sidebar.toe_slider,
-            "toe_dec": lambda: controls.tone_sidebar.toe_slider,
-            "toe_width_inc": lambda: controls.tone_sidebar.toe_w_slider,
-            "toe_width_dec": lambda: controls.tone_sidebar.toe_w_slider,
-            "shoulder_inc": lambda: controls.tone_sidebar.sh_slider,
-            "shoulder_dec": lambda: controls.tone_sidebar.sh_slider,
-            "shoulder_width_inc": lambda: controls.tone_sidebar.sh_w_slider,
-            "shoulder_width_dec": lambda: controls.tone_sidebar.sh_w_slider,
-            "snap_inc": lambda: controls.tone_sidebar.midtone_gamma_slider,
-            "snap_dec": lambda: controls.tone_sidebar.midtone_gamma_slider,
-            "shadow_density_inc": lambda: controls.tone_sidebar.shadow_density_slider,
-            "shadow_density_dec": lambda: controls.tone_sidebar.shadow_density_slider,
-            "highlight_density_inc": lambda: controls.tone_sidebar.highlight_density_slider,
-            "highlight_density_dec": lambda: controls.tone_sidebar.highlight_density_slider,
-            "shadow_grade_inc": lambda: controls.tone_sidebar.shadow_grade_slider,
-            "shadow_grade_dec": lambda: controls.tone_sidebar.shadow_grade_slider,
-            "highlight_grade_inc": lambda: controls.tone_sidebar.highlight_grade_slider,
-            "highlight_grade_dec": lambda: controls.tone_sidebar.highlight_grade_slider,
-            "offset_inc": lambda: controls.geometry_sidebar.offset_slider,
-            "offset_dec": lambda: controls.geometry_sidebar.offset_slider,
-            "fine_rot_inc": lambda: controls.geometry_sidebar.fine_rot_slider,
-            "fine_rot_dec": lambda: controls.geometry_sidebar.fine_rot_slider,
-            "analysis_buffer_inc": lambda: controls.process_sidebar.analysis_buffer_slider,
-            "analysis_buffer_dec": lambda: controls.process_sidebar.analysis_buffer_slider,
-            "luma_range_clip_inc": lambda: controls.process_sidebar.luma_range_clip_slider,
-            "luma_range_clip_dec": lambda: controls.process_sidebar.luma_range_clip_slider,
-            "color_range_clip_inc": lambda: controls.process_sidebar.color_range_clip_slider,
-            "color_range_clip_dec": lambda: controls.process_sidebar.color_range_clip_slider,
-            "white_point_inc": lambda: controls.process_sidebar.white_point_slider,
-            "white_point_dec": lambda: controls.process_sidebar.white_point_slider,
-            "black_point_inc": lambda: controls.process_sidebar.black_point_slider,
-            "black_point_dec": lambda: controls.process_sidebar.black_point_slider,
-            "separation_inc": lambda: controls.process_sidebar.crosstalk_strength_slider,
-            "separation_dec": lambda: controls.process_sidebar.crosstalk_strength_slider,
-            "chroma_denoise_inc": lambda: controls.lab_sidebar.chroma_denoise_slider,
-            "chroma_denoise_dec": lambda: controls.lab_sidebar.chroma_denoise_slider,
-            "saturation_inc": lambda: controls.lab_sidebar.saturation_slider,
-            "saturation_dec": lambda: controls.lab_sidebar.saturation_slider,
-            "dye_separation_inc": lambda: controls.tone_sidebar.dye_separation_slider,
-            "dye_separation_dec": lambda: controls.tone_sidebar.dye_separation_slider,
-            "separation_damping_inc": lambda: controls.tone_sidebar.separation_damping_slider,
-            "separation_damping_dec": lambda: controls.tone_sidebar.separation_damping_slider,
-            "clahe_inc": lambda: controls.lab_sidebar.clahe_slider,
-            "clahe_dec": lambda: controls.lab_sidebar.clahe_slider,
-            "sharpen_inc": lambda: controls.lab_sidebar.sharpen_slider,
-            "sharpen_dec": lambda: controls.lab_sidebar.sharpen_slider,
-            "glow_inc": lambda: controls.lab_sidebar.glow_slider,
-            "glow_dec": lambda: controls.lab_sidebar.glow_slider,
-            "halation_inc": lambda: controls.lab_sidebar.halation_slider,
-            "halation_dec": lambda: controls.lab_sidebar.halation_slider,
-            "threshold_inc": lambda: controls.retouch_sidebar.threshold_slider,
-            "threshold_dec": lambda: controls.retouch_sidebar.threshold_slider,
-            "auto_size_inc": lambda: controls.retouch_sidebar.auto_size_slider,
-            "auto_size_dec": lambda: controls.retouch_sidebar.auto_size_slider,
-            "manual_size_inc": lambda: controls.retouch_sidebar.manual_size_slider,
-            "manual_size_dec": lambda: controls.retouch_sidebar.manual_size_slider,
-            "selenium_inc": lambda: controls.toning_sidebar.selenium_slider,
-            "selenium_dec": lambda: controls.toning_sidebar.selenium_slider,
-            "sepia_inc": lambda: controls.toning_sidebar.sepia_slider,
-            "sepia_dec": lambda: controls.toning_sidebar.sepia_slider,
-            "shadow_hue_inc": lambda: controls.toning_sidebar.shadow_hue_slider,
-            "shadow_hue_dec": lambda: controls.toning_sidebar.shadow_hue_slider,
-            "shadow_strength_inc": lambda: controls.toning_sidebar.shadow_str_slider,
-            "shadow_strength_dec": lambda: controls.toning_sidebar.shadow_str_slider,
-            "highlight_hue_inc": lambda: controls.toning_sidebar.highlight_hue_slider,
-            "highlight_hue_dec": lambda: controls.toning_sidebar.highlight_hue_slider,
-            "highlight_strength_inc": lambda: controls.toning_sidebar.highlight_str_slider,
-            "highlight_strength_dec": lambda: controls.toning_sidebar.highlight_str_slider,
-            "vignette_str_inc": lambda: controls.finish_sidebar.vignette_burn_slider,
-            "vignette_str_dec": lambda: controls.finish_sidebar.vignette_burn_slider,
-            "vignette_size_inc": lambda: controls.finish_sidebar.vignette_size_slider,
-            "vignette_size_dec": lambda: controls.finish_sidebar.vignette_size_slider,
-            "border_size_inc": lambda: controls.finish_sidebar.border_slider,
-            "border_size_dec": lambda: controls.finish_sidebar.border_slider,
-        }
-        for action_id, getter in slider_targets.items():
-            actions[action_id] = self._slider_adjuster(getter, action_id)
+        widgets = slider_widget_map(controls)
+        for group in SLIDER_GROUPS:
+            getter = widgets[group.id]
+            actions[group.inc_action] = self._slider_adjuster(getter, group.inc_action)
+            actions[group.dec_action] = self._slider_adjuster(getter, group.dec_action)
         return actions
 
     def apply_bindings(self, bindings: dict[str, str]) -> None:

--- a/negpy/desktop/view/shortcut_registry.py
+++ b/negpy/desktop/view/shortcut_registry.py
@@ -141,6 +141,7 @@ REGISTRY: dict[str, ShortcutEntry] = {
     "tab_export": ShortcutEntry("Ctrl+7", "Export tab", "Tabs"),
     "tab_metadata": ShortcutEntry("Ctrl+8", "Metadata tab", "Tabs"),
     "tab_scan": ShortcutEntry("Ctrl+9", "Scan tab", "Tabs"),
+    "tab_favourites": ShortcutEntry("Ctrl+0", "Favourites tab", "Tabs"),
     "fit_view": ShortcutEntry("0", "Fit to window", "View"),
     "zoom_100": ShortcutEntry("1", "Zoom 100%", "View"),
     "zoom_200": ShortcutEntry("2", "Zoom 200%", "View"),

--- a/negpy/desktop/view/sidebar/favourites.py
+++ b/negpy/desktop/view/sidebar/favourites.py
@@ -1,0 +1,101 @@
+import qtawesome as qta
+from PyQt6.QtWidgets import QDialog, QHBoxLayout, QPushButton, QVBoxLayout, QWidget
+
+from negpy.desktop.controller import AppController
+from negpy.desktop.view.sidebar.base import BaseSidebar
+from negpy.desktop.view.slider_shortcut_groups import SLIDER_GROUPS
+from negpy.desktop.view.slider_targets import SLIDER_ATTRS, slider_widget_map
+from negpy.desktop.view.styles.templates import hint_label
+from negpy.desktop.view.styles.theme import THEME
+from negpy.desktop.view.widgets.favourites_dialog import FavouritesDialog
+from negpy.desktop.view.widgets.sliders import clone_slider
+
+_SETTING_KEY = "favourite_sliders"
+
+
+def load_favourites(repo) -> list[str]:
+    """Drop ids that no longer exist so a retired slider degrades quietly."""
+    stored = repo.get_global_setting(_SETTING_KEY)
+    if not isinstance(stored, list):
+        return []
+    return [slider_id for slider_id in stored if slider_id in SLIDER_ATTRS]
+
+
+class FavouritesSidebar(BaseSidebar):
+    """User-chosen sliders gathered in one tab. Each favourite is a *mirror* of the real
+    control, not the control itself — a QWidget has one parent, so re-parenting would tear
+    the slider out of its home section. The mirror forwards to the original, which keeps its
+    existing binding, mode-gating and channel-retargeting intact."""
+
+    SIDE_MARGIN = 5
+
+    def __init__(self, controller: AppController, controls):
+        self.controls = controls
+        self._mirrors: list[tuple[object, object]] = []
+        super().__init__(controller)
+
+    def _init_ui(self) -> None:
+        row = QHBoxLayout()
+        self.edit_btn = QPushButton("  Edit Favourites")
+        self.edit_btn.setIcon(qta.icon("fa5s.sliders-h", color=THEME.text_primary))
+        self.edit_btn.setToolTip("Choose which sliders appear here, and in what order")
+        self.edit_btn.clicked.connect(self._open_editor)
+        row.addWidget(self.edit_btn)
+        row.addStretch()
+        self.layout.addLayout(row)
+
+        self.empty_hint = hint_label("No favourites yet — use Edit Favourites to pick the sliders you reach for most.")
+        self.empty_hint.setWordWrap(True)
+        self.layout.addWidget(self.empty_hint)
+
+        self._container = QWidget()
+        self._container_layout = QVBoxLayout(self._container)
+        self._container_layout.setContentsMargins(0, 0, 0, 0)
+        self._container_layout.setSpacing(THEME.space_sm)
+        self.layout.addWidget(self._container)
+        self.layout.addStretch(1)
+
+        self._rebuild()
+
+    def _connect_signals(self) -> None:
+        # Not controller.config_updated: sidebar syncing is debounced 150ms and this signal
+        # fires at the end of it, so the originals already hold the fresh values.
+        self.controls.modified_synced.connect(self.sync_ui)
+
+    def _choices(self) -> list[tuple[str, str, str]]:
+        widgets = slider_widget_map(self.controls)
+        return [(group.id, group.category, widgets[group.id]().label.text()) for group in SLIDER_GROUPS]
+
+    def _open_editor(self) -> None:
+        repo = self.controller.session.repo
+        dlg = FavouritesDialog(self, self._choices(), load_favourites(repo))
+        if dlg.exec() == QDialog.DialogCode.Accepted:
+            repo.save_global_setting(_SETTING_KEY, dlg.selected_ids())
+            self._rebuild()
+
+    def _rebuild(self) -> None:
+        for clone, _ in self._mirrors:
+            clone.setParent(None)
+            clone.deleteLater()
+        self._mirrors.clear()
+
+        widgets = slider_widget_map(self.controls)
+        for slider_id in load_favourites(self.controller.session.repo):
+            src = widgets[slider_id]()
+            clone = clone_slider(src)
+            clone.valueChanged.connect(lambda v, s=src: s.mirror_value(v, commit=False))
+            clone.valueCommitted.connect(lambda v, s=src: s.mirror_value(v, commit=True))
+            self._container_layout.addWidget(clone)
+            self._mirrors.append((clone, src))
+
+        self.empty_hint.setVisible(not self._mirrors)
+        self.sync_ui()
+
+    def sync_ui(self) -> None:
+        for clone, src in self._mirrors:
+            clone.setValue(src.value())
+            # isHidden(), not isVisible(): the latter is False whenever the home section is
+            # collapsed or its tab is off-screen, which would blank every favourite. Only an
+            # explicit setVisible(False) — the B&W / E6 mode gating — should hide a mirror.
+            clone.setVisible(not src.isHidden())
+            clone.setEnabled(src.isEnabled())

--- a/negpy/desktop/view/sidebar/files.py
+++ b/negpy/desktop/view/sidebar/files.py
@@ -40,6 +40,7 @@ from PyQt6.QtWidgets import (
 from negpy.desktop.controller import AppController
 from negpy.desktop.session import _source_effective_bounds
 from negpy.desktop.view.confirm import confirm_unload
+from negpy.desktop.view.widgets.overflow_bar import OverflowBar
 from negpy.desktop.view.styles.theme import THEME
 from negpy.desktop.view.widgets.granular_settings_dialog import GranularSettingsDialog, open_paste_dialog
 from negpy.infrastructure.filesystem.watcher import FolderWatchService
@@ -152,11 +153,11 @@ class _ThumbnailDelegate(QStyledItemDelegate):
         painter.restore()
 
 
-# Thumbnail size preference (px), as set by the filmstrip's size slider. The default
-# is chosen so one column fills the session sidebar at its minimum width (~240px
-# viewport) — the sidebar can't be dragged narrower, so this is the smallest the
-# filmstrip is ever laid out at, and a single full-width frame is the most legible
-# use of it. Dropping toward THUMB_CELL_MIN fits a second column at that same width.
+# Thumbnail size preference (px), as set by the filmstrip's size slider. The default is
+# chosen so one column fills the session sidebar at a typical narrow width (~240px viewport),
+# where a single full-width frame is the most legible use of it. Dropping toward
+# THUMB_CELL_MIN fits a second column at that same width. (The panel can now be dragged
+# narrower still — the toolbar overflows — and the grid simply keeps one column.)
 #
 # The maximum is the default: the slider only shrinks frames. Anything larger just
 # holds a widened sidebar at one column — cells fill the panel, so a 500px-wide
@@ -328,8 +329,7 @@ class FileBrowser(QWidget):
         icon_size = QSize(16, 16)
         btn_height = 28
 
-        toolbar_row = QHBoxLayout()
-        toolbar_row.setSpacing(4)
+        toolbar_row = OverflowBar(height=btn_height, spacing=4)
 
         self.add_files_btn = QToolButton()
         self.add_files_btn.setIcon(qta.icon("fa5s.file-import", color=THEME.text_primary))
@@ -427,19 +427,26 @@ class FileBrowser(QWidget):
             btn.setFixedHeight(btn_height)
             btn.setCursor(Qt.CursorShape.PointingHandCursor)
 
-        toolbar_row.addWidget(self.add_files_btn)
-        toolbar_row.addWidget(self.add_folder_btn)
-        toolbar_row.addWidget(self.unload_btn)
-        toolbar_row.addWidget(self._create_separator())
-        toolbar_row.addWidget(self.hot_folder_btn)
-        toolbar_row.addWidget(self.rgb_scan_btn)
-        toolbar_row.addWidget(self.half_frame_btn)
-        toolbar_row.addWidget(self.apply_btn)
-        toolbar_row.addStretch()
-        toolbar_row.addWidget(self._create_separator())
-        toolbar_row.addWidget(self.sheet_btn)
-        toolbar_row.addWidget(self.sort_btn)
-        layout.addLayout(toolbar_row)
+        # OverflowBar rather than a QHBoxLayout: a plain row made the whole session panel
+        # unshrinkable below every button laid end to end, so each new tool widened it for good.
+        for widget, label in (
+            (self.add_files_btn, "Add files"),
+            (self.add_folder_btn, "Add folder"),
+            (self.unload_btn, "Clear all"),
+            (None, None),
+            (self.hot_folder_btn, "Hot Folder"),
+            (self.rgb_scan_btn, "RGB Scan"),
+            (self.half_frame_btn, "Half Frame"),
+            (self.apply_btn, "Apply settings"),
+            (None, None),
+            (self.sheet_btn, "Sheet filter"),
+            (self.sort_btn, "Sort"),
+        ):
+            if widget is None:
+                toolbar_row.add_separator(self._create_separator())
+            else:
+                toolbar_row.add_button(widget, label)
+        layout.addWidget(toolbar_row)
 
         saved_sort = self.session.repo.get_global_setting("file_sort_order") or "name"
         saved_desc = self.session.repo.get_global_setting("file_sort_descending") or False
@@ -454,6 +461,9 @@ class FileBrowser(QWidget):
             qta.icon("fa5s.search", color=THEME.text_secondary),
             QLineEdit.ActionPosition.LeadingPosition,
         )
+        # The elastic item in this row: its natural minimum is what now keeps the panel from
+        # narrowing further, and the other two here are fixed-width by design.
+        self.search_input.setMinimumWidth(40)
         self.regex_btn = QPushButton(".*")
         self.regex_btn.setCheckable(True)
         self.regex_btn.setFixedWidth(36)
@@ -461,8 +471,8 @@ class FileBrowser(QWidget):
         search_row.addWidget(self.search_input)
         search_row.addWidget(self.regex_btn)
 
-        # Thumbnail size lives here rather than the toolbar row above, which already
-        # overflows the sidebar's minimum width with its eight buttons.
+        # Thumbnail size lives here rather than the toolbar row above, to keep that row's
+        # overflow menu to file actions.
         saved_cell = self.session.repo.get_global_setting("thumbnail_cell_size") or THUMB_CELL_DEFAULT
         self.thumb_size_slider = QSlider(Qt.Orientation.Horizontal)
         self.thumb_size_slider.setRange(THUMB_CELL_MIN, THUMB_CELL_MAX)

--- a/negpy/desktop/view/sidebar/right_panel.py
+++ b/negpy/desktop/view/sidebar/right_panel.py
@@ -4,7 +4,6 @@ from typing import Any, Dict
 import qtawesome as qta
 from PyQt6.QtCore import Qt, QSize
 from PyQt6.QtWidgets import (
-    QHBoxLayout,
     QPushButton,
     QScrollArea,
     QSplitter,
@@ -17,6 +16,7 @@ from negpy.desktop.controller import AppController
 from negpy.desktop.view.shortcut_registry import tooltip_with_shortcut
 from negpy.desktop.view.sidebar.controls_panel import ControlsPanel
 from negpy.desktop.view.sidebar.export import ExportSidebar
+from negpy.desktop.view.sidebar.favourites import FavouritesSidebar
 from negpy.desktop.view.sidebar.history import HistoryPanel
 from negpy.desktop.view.sidebar.metadata import MetadataSidebar
 from negpy.desktop.view.styles.templates import EditedDot
@@ -24,6 +24,7 @@ from negpy.desktop.view.styles.theme import THEME
 from negpy.desktop.view.widgets.charts import PhotometricCurveWidget, StepWedgeWidget, ZoneStripWidget
 from negpy.desktop.view.widgets.collapsible import CollapsibleSection
 from negpy.desktop.view.widgets.stats import DensitometerRow, NegativeStatsWidget
+from negpy.desktop.view.widgets.overflow_bar import OverflowBar
 
 
 class RightPanel(QWidget):
@@ -90,6 +91,7 @@ class RightPanel(QWidget):
 
         # Tab content widgets
         self.controls_panel = ControlsPanel(self.controller)
+        self.favourites_sidebar = FavouritesSidebar(self.controller, self.controls_panel)
         self.export_sidebar = ExportSidebar(self.controller)
         self.metadata_sidebar = MetadataSidebar(self.controller)
         self.history_panel = HistoryPanel(self.controller)
@@ -115,16 +117,15 @@ class RightPanel(QWidget):
             (page["key"], page["icon_name"], page["tooltip"], page["widget"], page["sections"]) for page in self.controls_panel.pages
         ]
         tab_specs += [
+            ("favourites", "fa5s.star", "Favourites", self.favourites_sidebar, []),
             ("history", "fa5s.history", "History", self.history_panel, []),
             ("export", "fa5s.file-export", "Export", self.export_sidebar, []),
             ("metadata", "fa5s.tags", "Metadata", self.metadata_sidebar, []),
             ("scan", "fa5s.camera-retro", "Scan", self.scan_page, []),
         ]
 
-        # Icon-only tab switcher
-        switcher_layout = QHBoxLayout()
-        switcher_layout.setContentsMargins(0, 0, 0, 0)
-        switcher_layout.setSpacing(0)
+        # Icon-only tab switcher; spills into a » menu when the panel is narrowed
+        self.switcher = OverflowBar(tile=True, height=38, min_item=36)
 
         self.stack = QStackedWidget()
         self.stack.setContentsMargins(0, 8, 0, 0)
@@ -149,7 +150,7 @@ class RightPanel(QWidget):
             btn.setFixedHeight(38)
             btn.edited_dot = EditedDot(btn)
             btn.clicked.connect(lambda _checked=False, idx=i: self._switch_tab(idx))
-            switcher_layout.addWidget(btn, 1)
+            self.switcher.add_button(btn, tooltip)
 
             self.stack.addWidget(wrap_scroll(content))
             self._tab_buttons.append(btn)
@@ -169,7 +170,7 @@ class RightPanel(QWidget):
         tabs_vbox = QVBoxLayout(tabs_container)
         tabs_vbox.setContentsMargins(0, 0, 0, 0)
         tabs_vbox.setSpacing(0)
-        tabs_vbox.addLayout(switcher_layout)
+        tabs_vbox.addWidget(self.switcher)
         tabs_vbox.addWidget(self.stack, 1)
 
         # Vertical splitter lets the user resize Analysis vs. the tabs below
@@ -278,6 +279,7 @@ class RightPanel(QWidget):
         self.stack.setCurrentIndex(index)
         for i, btn in enumerate(self._tab_buttons):
             btn.setChecked(i == index)
+        self.switcher.set_pinned(index)
         self._refresh_tab_icons()
 
         # The heal/scratch tools live on the tab hosting the Retouch section;

--- a/negpy/desktop/view/slider_targets.py
+++ b/negpy/desktop/view/slider_targets.py
@@ -1,0 +1,66 @@
+"""Slider id -> live widget, the one registry of controls addressable by id.
+
+Keyed by `SliderShortcutGroup.id`; both the keyboard shortcuts (inc/dec actions) and the
+Favourites panel resolve their widgets through here."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from operator import attrgetter
+
+SLIDER_ATTRS: dict[str, str] = {
+    "cyan": "colour_sidebar.cyan_slider",
+    "magenta": "colour_sidebar.magenta_slider",
+    "yellow": "colour_sidebar.yellow_slider",
+    "temperature": "colour_sidebar.temp_slider",
+    "density": "tone_sidebar.density_slider",
+    "grade": "tone_sidebar.grade_slider",
+    "toe": "tone_sidebar.toe_slider",
+    "toe_width": "tone_sidebar.toe_w_slider",
+    "shoulder": "tone_sidebar.sh_slider",
+    "shoulder_width": "tone_sidebar.sh_w_slider",
+    "snap": "tone_sidebar.midtone_gamma_slider",
+    "shadow_density": "tone_sidebar.shadow_density_slider",
+    "highlight_density": "tone_sidebar.highlight_density_slider",
+    "shadow_grade": "tone_sidebar.shadow_grade_slider",
+    "highlight_grade": "tone_sidebar.highlight_grade_slider",
+    "dye_separation": "tone_sidebar.dye_separation_slider",
+    "separation_damping": "tone_sidebar.separation_damping_slider",
+    "offset": "geometry_sidebar.offset_slider",
+    "fine_rot": "geometry_sidebar.fine_rot_slider",
+    "analysis_buffer": "process_sidebar.analysis_buffer_slider",
+    "luma_range_clip": "process_sidebar.luma_range_clip_slider",
+    "color_range_clip": "process_sidebar.color_range_clip_slider",
+    "white_point": "process_sidebar.white_point_slider",
+    "black_point": "process_sidebar.black_point_slider",
+    "separation": "process_sidebar.crosstalk_strength_slider",
+    "chroma_denoise": "lab_sidebar.chroma_denoise_slider",
+    "saturation": "lab_sidebar.saturation_slider",
+    "clahe": "lab_sidebar.clahe_slider",
+    "sharpen": "lab_sidebar.sharpen_slider",
+    "glow": "lab_sidebar.glow_slider",
+    "halation": "lab_sidebar.halation_slider",
+    "threshold": "retouch_sidebar.threshold_slider",
+    "auto_size": "retouch_sidebar.auto_size_slider",
+    "manual_size": "retouch_sidebar.manual_size_slider",
+    "selenium": "toning_sidebar.selenium_slider",
+    "sepia": "toning_sidebar.sepia_slider",
+    "shadow_hue": "toning_sidebar.shadow_hue_slider",
+    "shadow_strength": "toning_sidebar.shadow_str_slider",
+    "highlight_hue": "toning_sidebar.highlight_hue_slider",
+    "highlight_strength": "toning_sidebar.highlight_str_slider",
+    "vignette_str": "finish_sidebar.vignette_burn_slider",
+    "vignette_size": "finish_sidebar.vignette_size_slider",
+    "border_size": "finish_sidebar.border_slider",
+}
+
+
+def slider_widget_map(controls) -> dict[str, Callable[[], object]]:
+    """Resolve lazily: sidebars rebuild their widgets, so a getter must re-read the
+    attribute rather than capture the instance."""
+    return {slider_id: _bind(controls, path) for slider_id, path in SLIDER_ATTRS.items()}
+
+
+def _bind(controls, path: str) -> Callable[[], object]:
+    getter = attrgetter(path)
+    return lambda: getter(controls)

--- a/negpy/desktop/view/widgets/favourites_dialog.py
+++ b/negpy/desktop/view/widgets/favourites_dialog.py
@@ -1,0 +1,186 @@
+import qtawesome as qta
+from PyQt6.QtCore import Qt
+from PyQt6.QtGui import QColor, QFont
+from PyQt6.QtWidgets import (
+    QDialog,
+    QHBoxLayout,
+    QLabel,
+    QListWidget,
+    QListWidgetItem,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from negpy.desktop.view.styles.templates import dialog_pane_qss, hint_label, pane_header_qss
+from negpy.desktop.view.styles.theme import THEME
+
+_ID_ROLE = Qt.ItemDataRole.UserRole
+
+
+class FavouritesDialog(QDialog):
+    """Column-chooser for the Favourites panel: tick sliders on the left, order them on the
+    right. Takes plain (id, category, label) triples rather than widgets so it stays testable
+    without a live controls panel."""
+
+    def __init__(self, parent, choices: list[tuple[str, str, str]], selected: list[str]):
+        super().__init__(parent)
+        self._choices = choices
+        known = {slider_id for slider_id, _, _ in choices}
+        self._chosen = [slider_id for slider_id in selected if slider_id in known]
+        self._label_by_id = {slider_id: label for slider_id, _, label in choices}
+
+        self.setWindowTitle("Edit Favourites")
+        self.setStyleSheet(f"QDialog {{ background: {THEME.bg_dark}; }}")
+        self.resize(620, 560)
+
+        root = QVBoxLayout(self)
+        root.setContentsMargins(THEME.space_2xl, THEME.space_2xl, THEME.space_2xl, THEME.space_2xl)
+        root.setSpacing(THEME.space_xl)
+
+        panes = QHBoxLayout()
+        panes.setSpacing(THEME.space_xl)
+        panes.addWidget(self._build_available(), 1)
+        panes.addWidget(self._build_chosen(), 1)
+        root.addLayout(panes)
+        root.addWidget(hint_label("Favourites mirror the real controls — editing one here is the same as editing it in its own panel."))
+        root.addLayout(self._build_footer())
+
+        self._rebuild_chosen()
+
+    def _build_available(self) -> QWidget:
+        pane = QWidget()
+        pane.setStyleSheet(dialog_pane_qss())
+        layout = QVBoxLayout(pane)
+        layout.setContentsMargins(0, 0, THEME.space_xl, 0)
+        layout.setSpacing(THEME.space_sm)
+
+        title = QLabel("AVAILABLE")
+        title.setStyleSheet(pane_header_qss())
+        layout.addWidget(title)
+
+        self.available_list = QListWidget()
+        self.available_list.setObjectName("preset_list")
+        self.available_list.itemChanged.connect(self._on_item_toggled)
+        layout.addWidget(self.available_list)
+
+        self.available_list.blockSignals(True)
+        current_category = None
+        for slider_id, category, label in self._choices:
+            if category != current_category:
+                current_category = category
+                header = QListWidgetItem(category.upper())
+                header.setFlags(Qt.ItemFlag.NoItemFlags)
+                font = QFont(header.font())
+                font.setBold(True)
+                header.setFont(font)
+                header.setForeground(QColor(THEME.text_muted))
+                self.available_list.addItem(header)
+            item = QListWidgetItem(label)
+            item.setData(_ID_ROLE, slider_id)
+            item.setFlags(item.flags() | Qt.ItemFlag.ItemIsUserCheckable)
+            item.setCheckState(Qt.CheckState.Checked if slider_id in self._chosen else Qt.CheckState.Unchecked)
+            self.available_list.addItem(item)
+        self.available_list.blockSignals(False)
+        return pane
+
+    def _build_chosen(self) -> QWidget:
+        pane = QWidget()
+        layout = QVBoxLayout(pane)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(THEME.space_sm)
+
+        title = QLabel("FAVOURITES")
+        title.setStyleSheet(pane_header_qss())
+        layout.addWidget(title)
+
+        self.chosen_list = QListWidget()
+        self.chosen_list.setObjectName("preset_list")
+        layout.addWidget(self.chosen_list)
+
+        row = QHBoxLayout()
+        self.up_btn = QPushButton()
+        self.up_btn.setIcon(qta.icon("fa5s.arrow-up", color=THEME.text_primary))
+        self.up_btn.setToolTip("Move up")
+        self.up_btn.setFixedWidth(36)
+        self.up_btn.clicked.connect(self._move_up)
+
+        self.down_btn = QPushButton()
+        self.down_btn.setIcon(qta.icon("fa5s.arrow-down", color=THEME.text_primary))
+        self.down_btn.setToolTip("Move down")
+        self.down_btn.setFixedWidth(36)
+        self.down_btn.clicked.connect(self._move_down)
+
+        self.remove_btn = QPushButton()
+        self.remove_btn.setIcon(qta.icon("fa5s.times", color=THEME.text_primary))
+        self.remove_btn.setToolTip("Remove from favourites")
+        self.remove_btn.setFixedWidth(36)
+        self.remove_btn.clicked.connect(self._remove_selected)
+
+        for btn in (self.up_btn, self.down_btn, self.remove_btn):
+            row.addWidget(btn)
+        row.addStretch()
+        layout.addLayout(row)
+        return pane
+
+    def _build_footer(self) -> QHBoxLayout:
+        row = QHBoxLayout()
+        row.addStretch()
+        cancel = QPushButton("Cancel")
+        cancel.clicked.connect(self.reject)
+        self.apply_btn = QPushButton("Apply")
+        self.apply_btn.setProperty("primary", True)
+        self.apply_btn.clicked.connect(self.accept)
+        row.addWidget(cancel)
+        row.addWidget(self.apply_btn)
+        return row
+
+    def _on_item_toggled(self, item: QListWidgetItem) -> None:
+        slider_id = item.data(_ID_ROLE)
+        if slider_id is None:
+            return
+        checked = item.checkState() == Qt.CheckState.Checked
+        if checked and slider_id not in self._chosen:
+            self._chosen.append(slider_id)
+        elif not checked and slider_id in self._chosen:
+            self._chosen.remove(slider_id)
+        self._rebuild_chosen()
+
+    def _rebuild_chosen(self, select_row: int = -1) -> None:
+        self.chosen_list.clear()
+        for slider_id in self._chosen:
+            item = QListWidgetItem(self._label_by_id[slider_id])
+            item.setData(_ID_ROLE, slider_id)
+            self.chosen_list.addItem(item)
+        if 0 <= select_row < len(self._chosen):
+            self.chosen_list.setCurrentRow(select_row)
+
+    def _set_checked(self, slider_id: str, checked: bool) -> None:
+        for i in range(self.available_list.count()):
+            item = self.available_list.item(i)
+            if item.data(_ID_ROLE) == slider_id:
+                self.available_list.blockSignals(True)
+                item.setCheckState(Qt.CheckState.Checked if checked else Qt.CheckState.Unchecked)
+                self.available_list.blockSignals(False)
+                return
+
+    def _move_up(self) -> None:
+        row = self.chosen_list.currentRow()
+        if row > 0:
+            self._chosen[row - 1], self._chosen[row] = self._chosen[row], self._chosen[row - 1]
+            self._rebuild_chosen(row - 1)
+
+    def _move_down(self) -> None:
+        row = self.chosen_list.currentRow()
+        if 0 <= row < len(self._chosen) - 1:
+            self._chosen[row + 1], self._chosen[row] = self._chosen[row], self._chosen[row + 1]
+            self._rebuild_chosen(row + 1)
+
+    def _remove_selected(self) -> None:
+        row = self.chosen_list.currentRow()
+        if 0 <= row < len(self._chosen):
+            self._set_checked(self._chosen.pop(row), False)
+            self._rebuild_chosen(min(row, len(self._chosen) - 1))
+
+    def selected_ids(self) -> list[str]:
+        return list(self._chosen)

--- a/negpy/desktop/view/widgets/overflow_bar.py
+++ b/negpy/desktop/view/widgets/overflow_bar.py
@@ -1,0 +1,152 @@
+import qtawesome as qta
+from PyQt6.QtCore import QSize
+from PyQt6.QtWidgets import QMenu, QToolButton, QWidget
+
+from negpy.desktop.view.styles.theme import THEME
+
+
+class OverflowBar(QWidget):
+    """A row of buttons that spills what doesn't fit into a » menu, so its minimum width is
+    one button rather than the sum of them. Without this, every button added to a panel
+    widened that panel permanently.
+
+    Geometry is placed by hand: a QHBoxLayout's minimum is the sum of its children's, which is
+    the floor being removed here. QToolBar has a native extension menu but it is unusable for
+    widget-based bars — items added with addWidget() become QWidgetActions that its extension
+    popup cannot host, leaving the » button with an empty menu.
+
+    Two shapes, per `tile`:
+      tile=True  — equal-width tabs filling the bar (the right panel's tab strip)
+      tile=False — natural widths packed left, separators allowed (the file browser toolbar)
+    """
+
+    OVERFLOW_W = 30
+
+    def __init__(self, *, tile: bool = False, height: int = 38, spacing: int = 0, min_item: int = 36, parent=None):
+        super().__init__(parent)
+        self._tile = tile
+        self._height = height
+        self._spacing = spacing
+        self._min_item = min_item
+        self._items: list[tuple[QWidget, str | None]] = []
+        self._button_items: list[int] = []
+        self._pinned_item = -1
+        self._hidden: list[int] = []
+        self.setFixedHeight(height)
+
+        self.overflow_btn = QToolButton(self)
+        self.overflow_btn.setIcon(qta.icon("fa5s.angle-double-right", color=THEME.text_secondary))
+        self.overflow_btn.setIconSize(QSize(16, 16))
+        self.overflow_btn.setToolTip("More")
+        self.overflow_btn.setFixedHeight(height)
+        self.overflow_btn.clicked.connect(self._show_overflow_menu)
+        self.overflow_btn.hide()
+
+    def add_button(self, btn: QWidget, label: str) -> None:
+        btn.setParent(self)
+        self._button_items.append(len(self._items))
+        self._items.append((btn, label))
+
+    def add_separator(self, sep: QWidget) -> None:
+        """Decoration: never listed in the overflow menu, and dropped when it would trail."""
+        sep.setParent(self)
+        self._items.append((sep, None))
+
+    @property
+    def buttons(self) -> list[QWidget]:
+        return [self._items[i][0] for i in self._button_items]
+
+    def set_pinned(self, button_index: int) -> None:
+        """The button that must stay visible (the active tab). -1 for none."""
+        self._pinned_item = self._button_items[button_index] if button_index >= 0 else -1
+        self._relayout()
+
+    def minimumSizeHint(self) -> QSize:
+        return QSize(self._min_item + self.OVERFLOW_W, self._height)
+
+    def sizeHint(self) -> QSize:
+        if self._tile:
+            return QSize(max(1, len(self._items)) * self._min_item, self._height)
+        widths = [w.sizeHint().width() for w, _ in self._items]
+        return QSize(sum(widths) + self._spacing * max(0, len(widths) - 1), self._height)
+
+    def resizeEvent(self, event) -> None:
+        self._relayout()
+        super().resizeEvent(event)
+
+    def _visible_items(self, avail: int) -> list[int]:
+        count = len(self._items)
+        if self._tile:
+            if avail >= count * self._min_item:
+                return list(range(count))
+            fits = max(1, (avail - self.OVERFLOW_W) // self._min_item)
+            if 0 <= self._pinned_item and self._pinned_item >= fits:
+                return list(range(fits - 1)) + [self._pinned_item]
+            return list(range(fits))
+
+        widths = [w.sizeHint().width() for w, _ in self._items]
+        if sum(widths) + self._spacing * max(0, count - 1) <= avail:
+            return list(range(count))
+        budget = avail - self.OVERFLOW_W
+        visible: list[int] = []
+        used = 0
+        for i, width in enumerate(widths):
+            step = width + (self._spacing if visible else 0)
+            if used + step > budget:
+                break
+            used += step
+            visible.append(i)
+        while visible and self._items[visible[-1]][1] is None:
+            visible.pop()
+        return visible
+
+    def _relayout(self) -> None:
+        if not self._items:
+            return
+        avail = self.width()
+        visible = self._visible_items(avail)
+        self._hidden = [i for i in range(len(self._items)) if i not in visible]
+
+        if self._tile:
+            strip = avail - (self.OVERFLOW_W if self._hidden else 0)
+            share = max(1, len(visible))
+            x = 0
+            for slot, i in enumerate(visible):
+                width = strip // share + (1 if slot < strip % share else 0)
+                self._items[i][0].setGeometry(x, 0, width, self._height)
+                x += width
+        else:
+            x = 0
+            for i in visible:
+                width = self._items[i][0].sizeHint().width()
+                self._items[i][0].setGeometry(x, 0, width, self._height)
+                x += width + self._spacing
+
+        for i in visible:
+            self._items[i][0].show()
+        for i in self._hidden:
+            self._items[i][0].hide()
+
+        if any(self._items[i][1] is not None for i in self._hidden):
+            self.overflow_btn.setGeometry(max(0, avail - self.OVERFLOW_W), 0, self.OVERFLOW_W, self._height)
+            self.overflow_btn.show()
+        else:
+            self.overflow_btn.hide()
+
+    def build_overflow_menu(self) -> QMenu:
+        menu = QMenu(self)
+        for i in self._hidden:
+            widget, label = self._items[i]
+            if label is None:
+                continue
+            action = menu.addAction(widget.icon(), label)
+            action.setEnabled(widget.isEnabled())
+            if widget.isCheckable():
+                action.setCheckable(True)
+                action.setChecked(widget.isChecked())
+            action.triggered.connect(lambda _checked=False, w=widget: w.click())
+        return menu
+
+    def _show_overflow_menu(self) -> None:
+        menu = self.build_overflow_menu()
+        menu.exec(self.overflow_btn.mapToGlobal(self.overflow_btn.rect().bottomLeft()))

--- a/negpy/desktop/view/widgets/sliders.py
+++ b/negpy/desktop/view/widgets/sliders.py
@@ -227,6 +227,17 @@ class BaseSlider(QWidget):
         self._emit_value()
         self._on_committed()
 
+    def mirror_value(self, value: float, commit: bool) -> None:
+        """Drive this slider from a mirror copy of it (see clone_slider), so the mirror's
+        gesture runs the original's own binding chain instead of writing config itself.
+
+        _rebase_commit=False for the same reason as adjust_by: it leaves the commit baseline
+        pre-gesture, or the trailing _on_committed() would see no change and never fire."""
+        self.setValue(value, _rebase_commit=False)
+        self._emit_value()
+        if commit:
+            self._on_committed()
+
     def mouseDoubleClickEvent(self, event) -> None:
         """Resets to default value."""
         self.setValue(self._default, _rebase_commit=False)
@@ -537,6 +548,34 @@ class KelvinSlider(CompactSlider):
     def setEnabled(self, enabled: bool) -> None:
         super().setEnabled(enabled)
         self._apply_temp(self.value())
+
+
+def clone_slider(src: CompactSlider) -> CompactSlider:
+    """A second widget onto the same control, for the Favourites panel: a QWidget has one
+    parent, so a favourite mirrors its slider rather than re-parenting it out of its section.
+
+    Exact-type dispatch, and unhandled classes raise: a PowerWarpSlider rebuilt as a plain
+    CompactSlider would keep its range but silently lose its nonlinear travel."""
+    label = src.label.text()
+    cls = type(src)
+    if cls is HueSlider:
+        return HueSlider(label, src._default)
+    if cls is KelvinSlider:
+        return KelvinSlider(label)
+    if cls is CompactSlider:
+        return CompactSlider(
+            label,
+            src._min,
+            src._max,
+            src._default,
+            step=src.spin.singleStep(),
+            precision=src._precision,
+            color=src._label_color,
+            has_neutral=src.slider.objectName() == "neutral_slider",
+            unit=src.spin.suffix(),
+            inverted=src.slider.invertedAppearance(),
+        )
+    raise TypeError(f"clone_slider: unhandled slider class {cls.__name__}")
 
 
 class RangeSlider(QWidget):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,8 @@ markers = [
     "metrics: opt-in performance metrics tests",
 ]
 addopts = "-m 'not slow'"
+# Lets test modules share helpers via `from conftest import ...` (FakeRepo/FakeController).
+pythonpath = ["tests"]
 
 [tool.ruff]
 line-length = 140

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,48 @@ def qapp():
     app.processEvents()
 
 
+class FakeRepo:
+    """Real global-setting storage; everything else a sidebar pokes (flat-field profiles,
+    presets, …) falls through to a MagicMock."""
+
+    def __init__(self, **data):
+        from unittest.mock import MagicMock
+
+        self._mock = MagicMock()
+        self.data = dict(data)
+
+    def get_global_setting(self, key, default=None):
+        return self.data.get(key, default)
+
+    def save_global_setting(self, key, value):
+        self.data[key] = value
+
+    def __getattr__(self, name):
+        return getattr(self._mock, name)
+
+
+class FakeController:
+    """For panels too big for the plain MagicMock idiom: ControlsPanel and FileBrowser connect
+    to real signals and hand real models to Qt, which a bare mock can't satisfy."""
+
+    def __init__(self, repo=None):
+        from unittest.mock import MagicMock
+
+        from negpy.desktop.session import AppState
+
+        self._mock = MagicMock()
+        self.state = AppState()
+        self.session = self._mock.session
+        self.session.repo = repo if repo is not None else FakeRepo()
+        self.session.state = self.state
+        self.config_updated = self._mock.config_updated
+        self.image_updated = self._mock.image_updated
+        self.tool_sync_requested = self._mock.tool_sync_requested
+
+    def __getattr__(self, name):
+        return getattr(self._mock, name)
+
+
 @pytest.hookimpl(hookwrapper=True, trylast=True)
 def pytest_runtestloop(session):
     """Stop background threads before pytest-cov generates its coverage report.

--- a/tests/test_favourites_panel.py
+++ b/tests/test_favourites_panel.py
@@ -1,0 +1,190 @@
+import pytest
+
+from conftest import FakeController as _Controller, FakeRepo as _Repo
+from negpy.desktop.view.sidebar.controls_panel import ControlsPanel
+from negpy.desktop.view.sidebar.favourites import FavouritesSidebar, load_favourites
+from negpy.desktop.view.slider_shortcut_groups import SLIDER_GROUP_BY_ID
+from negpy.desktop.view.slider_targets import SLIDER_ATTRS, slider_widget_map
+from negpy.desktop.view.widgets.favourites_dialog import FavouritesDialog
+from negpy.desktop.view.widgets.sliders import CompactSlider, HueSlider, KelvinSlider, PowerWarpSlider, clone_slider
+
+
+@pytest.fixture(scope="module")
+def controls(qapp):
+    controller = _Controller(_Repo())
+    return ControlsPanel(controller)
+
+
+def test_widget_map_covers_every_shortcut_group(controls):
+    assert set(slider_widget_map(controls)) == set(SLIDER_GROUP_BY_ID)
+
+
+def test_every_favouritable_slider_resolves_and_is_clonable(controls):
+    """Guards drift in both directions: a renamed sidebar attribute breaks resolution, and a
+    slider switched to an unhandled class (e.g. PowerWarpSlider) makes clone_slider raise."""
+    widgets = slider_widget_map(controls)
+    for slider_id in SLIDER_ATTRS:
+        src = widgets[slider_id]()
+        clone = clone_slider(src)
+        assert clone.label.text() == src.label.text()
+
+
+def test_clone_round_trips_compact_slider_construction(qapp):
+    src = CompactSlider("Density", -2.0, 2.0, 0.25, step=0.05, precision=1000, has_neutral=True, unit=" EV", inverted=True)
+    clone = clone_slider(src)
+    assert (clone._min, clone._max, clone._default, clone._precision) == (-2.0, 2.0, 0.25, 1000)
+    assert clone.spin.singleStep() == pytest.approx(0.05)
+    assert clone.spin.suffix() == " EV"
+    assert clone.slider.objectName() == "neutral_slider"
+    assert clone.slider.invertedAppearance()
+
+
+def test_clone_round_trips_hue_and_kelvin(qapp):
+    hue = clone_slider(HueSlider("Shadow hue", 210.0))
+    assert isinstance(hue, HueSlider)
+    assert (hue._min, hue._max, hue._default) == (0.0, 360.0, 210.0)
+
+    kelvin = clone_slider(KelvinSlider("Temperature"))
+    assert isinstance(kelvin, KelvinSlider)
+    assert (kelvin._min, kelvin._max) == (3000.0, 12000.0)
+
+
+def test_clone_refuses_unhandled_class(qapp):
+    """A PowerWarpSlider flattened into a CompactSlider would keep its range but lose its
+    nonlinear travel — that must fail loudly, not ship a subtly wrong control."""
+    with pytest.raises(TypeError, match="PowerWarpSlider"):
+        clone_slider(PowerWarpSlider("Warp", 0.0, 4.0, 1.0, center=1.0))
+
+
+def test_mirror_value_drives_the_original(qapp):
+    src = CompactSlider("Chroma", 0.0, 2.0, 1.0)
+    live, committed = [], []
+    src.valueChanged.connect(live.append)
+    src.valueCommitted.connect(committed.append)
+
+    src.mirror_value(1.5, commit=False)
+    assert live == [1.5] and committed == []
+
+    src.mirror_value(1.75, commit=True)
+    assert live == [1.5, 1.75] and committed == [1.75]
+
+
+def test_mirror_commits_even_when_value_matches_a_previous_load(qapp):
+    """_rebase_commit=False is load-bearing: setValue's rebase would move the commit baseline
+    onto the new value and _on_committed would then see no change and stay silent."""
+    src = CompactSlider("Chroma", 0.0, 2.0, 1.0)
+    src.setValue(1.5)
+    committed = []
+    src.valueCommitted.connect(committed.append)
+    src.mirror_value(1.5, commit=True)
+    assert committed == []
+
+    src.mirror_value(1.6, commit=True)
+    assert committed == [1.6]
+
+
+def _favourites(controls, repo):
+    controls.controller.session.repo = repo
+    return FavouritesSidebar(controls.controller, controls)
+
+
+def test_panel_is_empty_by_default(controls, qapp):
+    panel = _favourites(controls, _Repo())
+    assert panel._mirrors == []
+    assert panel.empty_hint.isVisible() or not panel.isVisible()
+
+
+def test_panel_mirrors_stored_favourites_in_order(controls, qapp):
+    panel = _favourites(controls, _Repo(favourite_sliders=["saturation", "density"]))
+    labels = [clone.label.text() for clone, _ in panel._mirrors]
+    assert labels == [controls.lab_sidebar.saturation_slider.label.text(), controls.tone_sidebar.density_slider.label.text()]
+
+
+def test_moving_a_mirror_moves_the_original(controls, qapp):
+    panel = _favourites(controls, _Repo(favourite_sliders=["saturation"]))
+    clone, src = panel._mirrors[0]
+    committed = []
+    src.valueCommitted.connect(committed.append)
+
+    clone.mirror_value(1.4, commit=True)
+    assert committed == [1.4]
+    assert src.value() == pytest.approx(1.4)
+
+
+def test_sync_hides_a_mirror_only_when_the_original_is_explicitly_hidden(controls, qapp):
+    panel = _favourites(controls, _Repo(favourite_sliders=["saturation"]))
+    clone, src = panel._mirrors[0]
+
+    src.setVisible(False)
+    panel.sync_ui()
+    assert clone.isHidden()
+
+    src.setVisible(True)
+    panel.sync_ui()
+    assert not clone.isHidden()
+
+
+def test_load_drops_unknown_ids(qapp):
+    repo = _Repo(favourite_sliders=["density", "retired_slider", "saturation"])
+    assert load_favourites(repo) == ["density", "saturation"]
+
+
+def test_load_tolerates_missing_and_malformed_settings(qapp):
+    assert load_favourites(_Repo()) == []
+    assert load_favourites(_Repo(favourite_sliders="density")) == []
+
+
+def _dialog(qapp, selected):
+    choices = [("density", "Exposure", "Density"), ("grade", "Exposure", "Grade"), ("saturation", "Lab", "Chroma")]
+    return FavouritesDialog(None, choices, selected)
+
+
+def test_dialog_reorders_within_bounds(qapp):
+    dlg = _dialog(qapp, ["density", "grade", "saturation"])
+
+    dlg.chosen_list.setCurrentRow(2)
+    dlg._move_up()
+    assert dlg.selected_ids() == ["density", "saturation", "grade"]
+
+    dlg.chosen_list.setCurrentRow(0)
+    dlg._move_up()
+    assert dlg.selected_ids() == ["density", "saturation", "grade"]
+
+    dlg.chosen_list.setCurrentRow(2)
+    dlg._move_down()
+    assert dlg.selected_ids() == ["density", "saturation", "grade"]
+
+    dlg.chosen_list.setCurrentRow(0)
+    dlg._move_down()
+    assert dlg.selected_ids() == ["saturation", "density", "grade"]
+
+
+def test_dialog_ticking_appends_and_unticking_removes(qapp):
+    dlg = _dialog(qapp, ["grade"])
+    assert dlg.selected_ids() == ["grade"]
+
+    items = {dlg.available_list.item(i).data(256): dlg.available_list.item(i) for i in range(dlg.available_list.count())}
+    from PyQt6.QtCore import Qt
+
+    items["density"].setCheckState(Qt.CheckState.Checked)
+    assert dlg.selected_ids() == ["grade", "density"]
+
+    items["grade"].setCheckState(Qt.CheckState.Unchecked)
+    assert dlg.selected_ids() == ["density"]
+
+
+def test_dialog_remove_button_unticks_the_source_row(qapp):
+    from PyQt6.QtCore import Qt
+
+    dlg = _dialog(qapp, ["density", "grade"])
+    dlg.chosen_list.setCurrentRow(0)
+    dlg._remove_selected()
+
+    assert dlg.selected_ids() == ["grade"]
+    states = {dlg.available_list.item(i).data(256): dlg.available_list.item(i).checkState() for i in range(dlg.available_list.count())}
+    assert states["density"] == Qt.CheckState.Unchecked
+
+
+def test_dialog_drops_stored_ids_it_was_not_offered(qapp):
+    dlg = _dialog(qapp, ["density", "retired_slider"])
+    assert dlg.selected_ids() == ["density"]

--- a/tests/test_file_browser_toolbar.py
+++ b/tests/test_file_browser_toolbar.py
@@ -1,0 +1,67 @@
+import pytest
+from negpy.desktop.view.widgets.overflow_bar import OverflowBar
+
+from negpy.desktop.session import AssetListModel
+from negpy.desktop.view.sidebar.session_panel import SessionPanel
+
+from conftest import FakeController as _Controller, FakeRepo as _Repo
+
+
+@pytest.fixture
+def panel(qapp):
+    controller = _Controller(_Repo())
+    controller.session.asset_model = AssetListModel(controller.state)
+    panel = SessionPanel(controller)
+    panel.resize(300, 700)
+    panel.show()
+    qapp.processEvents()
+    return panel
+
+
+def _toolbar(panel) -> OverflowBar:
+    return panel.file_browser.findChild(OverflowBar)
+
+
+def test_toolbar_minimum_is_not_the_sum_of_its_buttons(panel):
+    """The regression this guards: a plain QHBoxLayout made the session panel unshrinkable
+    below every button laid end to end, so each new tool widened the panel for good."""
+    toolbar = _toolbar(panel)
+    assert toolbar.minimumSizeHint().width() < toolbar.sizeHint().width() / 2
+
+
+def test_toolbar_keeps_every_action(panel):
+    browser = panel.file_browser
+    toolbar = _toolbar(panel)
+    expected = [
+        browser.add_files_btn,
+        browser.add_folder_btn,
+        browser.unload_btn,
+        browser.hot_folder_btn,
+        browser.rgb_scan_btn,
+        browser.half_frame_btn,
+        browser.apply_btn,
+        browser.sheet_btn,
+        browser.sort_btn,
+    ]
+    assert toolbar.buttons == expected
+
+
+def test_narrowing_the_panel_raises_a_populated_overflow_menu(panel, qapp):
+    """QToolBar's native extension menu was tried first and came up empty: widgets added with
+    addWidget() become QWidgetActions its popup cannot host."""
+    toolbar = _toolbar(panel)
+    panel.resize(300, 700)
+    qapp.processEvents()
+    assert not toolbar.overflow_btn.isVisible()
+
+    panel.resize(200, 700)
+    qapp.processEvents()
+    assert toolbar.overflow_btn.isVisible()
+
+    labels = [action.text() for action in toolbar.build_overflow_menu().actions()]
+    assert labels, "overflow button with an empty menu"
+    assert "Sort" in labels
+
+
+def test_session_panel_shrinks_below_the_old_button_row_floor(panel):
+    assert panel.minimumSizeHint().width() < 268

--- a/tests/test_overflow_bar.py
+++ b/tests/test_overflow_bar.py
@@ -1,0 +1,145 @@
+import pytest
+from PyQt6.QtWidgets import QFrame, QPushButton, QToolButton
+
+from negpy.desktop.view.widgets.overflow_bar import OverflowBar
+
+
+@pytest.fixture
+def tabs(qapp):
+    bar = OverflowBar(tile=True, height=38, min_item=36)
+    for i in range(10):
+        bar.add_button(QPushButton(), f"Tab {i}")
+    bar.show()
+    return bar
+
+
+@pytest.fixture
+def toolbar(qapp):
+    bar = OverflowBar(height=28, spacing=4)
+    for i in range(6):
+        btn = QToolButton()
+        btn.setFixedWidth(24)
+        bar.add_button(btn, f"Action {i}")
+        if i == 2:
+            sep = QFrame()
+            sep.setFixedWidth(1)
+            bar.add_separator(sep)
+    bar.show()
+    return bar
+
+
+def _resize(qapp, bar, width):
+    bar.resize(width, bar._height)
+    qapp.processEvents()
+    return [i for i, btn in enumerate(bar.buttons) if not btn.isHidden()]
+
+
+def test_minimum_width_does_not_grow_with_the_button_count(qapp):
+    """The whole point: the floor used to be one button per item, so every button added to a
+    panel widened that panel permanently."""
+    small, large = OverflowBar(tile=True), OverflowBar(tile=True)
+    for i in range(3):
+        small.add_button(QPushButton(), f"B{i}")
+    for i in range(30):
+        large.add_button(QPushButton(), f"B{i}")
+    assert small.minimumSizeHint().width() == large.minimumSizeHint().width()
+
+
+def test_tiled_bar_shows_everything_when_wide_enough(qapp, tabs):
+    assert len(_resize(qapp, tabs, 10 * 36)) == 10
+    assert not tabs.overflow_btn.isVisible()
+
+
+def test_tiled_bar_spills_as_it_narrows(qapp, tabs):
+    wide = _resize(qapp, tabs, 360)
+    mid = _resize(qapp, tabs, 240)
+    narrow = _resize(qapp, tabs, 160)
+    assert len(wide) == 10 > len(mid) > len(narrow) >= 1
+    assert tabs.overflow_btn.isVisible()
+
+
+def test_tiled_bar_keeps_at_least_one_button_under_extreme_squeeze(qapp, tabs):
+    assert len(_resize(qapp, tabs, 1)) == 1
+
+
+def test_pinned_button_is_never_spilled(qapp, tabs):
+    """A tab strip that hides where you are is worse than one that truncates — the active tab
+    takes the last visible slot instead of falling into the menu."""
+    tabs.set_pinned(9)
+    visible = _resize(qapp, tabs, 120)
+    assert 9 in visible and visible[-1] == 9
+
+
+def test_tiled_buttons_fill_the_strip_without_gaps(qapp, tabs):
+    visible = _resize(qapp, tabs, 240)
+    edges = [(tabs.buttons[i].geometry().x(), tabs.buttons[i].geometry().right() + 1) for i in visible]
+    assert edges[0][0] == 0
+    assert all(left[1] == right[0] for left, right in zip(edges, edges[1:]))
+    assert edges[-1][1] + OverflowBar.OVERFLOW_W == tabs.width()
+
+
+def test_full_tiled_strip_uses_the_whole_width(qapp, tabs):
+    _resize(qapp, tabs, 400)
+    edges = [(b.geometry().x(), b.geometry().right() + 1) for b in tabs.buttons]
+    assert edges[0][0] == 0 and edges[-1][1] == tabs.width()
+
+
+def test_natural_bar_keeps_button_widths_and_packs_left(qapp, toolbar):
+    _resize(qapp, toolbar, 400)
+    assert not toolbar.overflow_btn.isVisible()
+    assert toolbar.buttons[0].geometry().x() == 0
+    assert all(btn.width() == 24 for btn in toolbar.buttons)
+
+
+def test_natural_bar_spills_the_tail_into_the_menu(qapp, toolbar):
+    visible = _resize(qapp, toolbar, 90)
+    assert len(visible) < 6
+    assert toolbar.overflow_btn.isVisible()
+    labels = [action.text() for action in toolbar.build_overflow_menu().actions()]
+    assert labels == [f"Action {i}" for i in range(len(visible), 6)]
+
+
+def test_separator_is_never_offered_in_the_menu(qapp, toolbar):
+    _resize(qapp, toolbar, 90)
+    assert all(action.text().startswith("Action") for action in toolbar.build_overflow_menu().actions())
+
+
+def test_a_trailing_separator_is_dropped_rather_than_left_dangling(qapp, toolbar):
+    """Cutting the row right after the separator would leave a hairline floating at the end."""
+    for width in range(60, 200, 2):
+        _resize(qapp, toolbar, width)
+        shown = [item for item, _label in toolbar._items if not item.isHidden()]
+        if shown:
+            assert not isinstance(shown[-1], QFrame), width
+
+
+def test_menu_entry_clicks_the_real_button(qapp, toolbar):
+    visible = _resize(qapp, toolbar, 90)
+    hidden_btn = toolbar.buttons[len(visible)]
+    fired = []
+    hidden_btn.clicked.connect(lambda *_: fired.append(1))
+
+    toolbar.build_overflow_menu().actions()[0].trigger()
+    assert fired == [1]
+
+
+def test_menu_mirrors_toggle_state(qapp, toolbar):
+    toolbar.buttons[5].setCheckable(True)
+    toolbar.buttons[5].setChecked(True)
+    _resize(qapp, toolbar, 90)
+
+    action = [a for a in toolbar.build_overflow_menu().actions() if a.text() == "Action 5"][0]
+    assert action.isCheckable() and action.isChecked()
+
+
+def test_overflow_button_stays_hidden_when_only_a_separator_would_spill(qapp):
+    bar = OverflowBar(height=28, spacing=0)
+    btn = QToolButton()
+    btn.setFixedWidth(24)
+    bar.add_button(btn, "Only")
+    sep = QFrame()
+    sep.setFixedWidth(1)
+    bar.add_separator(sep)
+    bar.show()
+    _resize(qapp, bar, 24)
+    assert not bar.overflow_btn.isVisible()


### PR DESCRIPTION
## Favourites panel

A new tab (star icon, `Ctrl+0`), empty until you fill it. **Edit Favourites** opens a two-pane picker: tick sliders on the left, order them with ↑/↓ on the right. The selection persists between sessions.

**Mirrors, not moves.** A `QWidget` has one parent, so re-parenting a slider into Favourites would tear it out of its home section. Each favourite is a second slider that forwards to the original, so every existing binding, mode-gate, channel-retarget and tooltip path keeps working untouched. Move one in either place and the other follows; favourite a Filtration slider and it hides itself in B&W along with its original.

**Why not the copy/paste picker's catalog.** `settings_catalog.CATALOG` describes *config fields*, not widgets — no range, no default, no link to a rendering control — and most of its rows (Crop, Rotation, Metadata, Export, combos) have no slider to show. Favourites are built from `SLIDER_GROUPS` instead, the one registry with a stable id, a human label and a live widget per entry.

Scope is those 43 sliders. Toggles and combos would need a per-control metadata registry extracted from 13 hand-written `_init_ui` methods — a deliberate separate job, not smuggled in here.

Side effect: the 86-lambda `slider_targets` dict inside `ShortcutManager._build_actions` collapses into one 43-entry registry that both the keyboard shortcuts and Favourites consume (~85 lines deleted, one registry instead of two).

## Side panels no longer pinned open by their button rows

Both panels' minimum width was their button row laid end to end, so **every button or tab added widened the panel permanently** — the Favourites tab alone would have pushed the controls panel from 324px to 360px.

| Panel | Before | After |
|---|---|---|
| Right / controls | 360px | **92px** |
| Left / session | 268px | **170px** |

Measured rather than assumed: the controls panel's floor was *entirely* the tab strip, since its pages are already wrapped in scroll areas that absorb their content — so one fix covered it.

`OverflowBar` places its buttons by hand (a `QHBoxLayout`'s minimum is the sum of its children's — precisely the floor being removed) and spills what doesn't fit into a `»` menu. It serves both shapes: equal-width tabs for the controls panel, natural widths with separators for the file browser toolbar.

**`QToolBar` was tried first** for the file browser and rejected: its native extension button appears at the right widths, but the menu is **empty** — widgets added with `addWidget()` become `QWidgetAction`s that Qt's extension popup cannot host. There is a regression test pinning that the menu is populated, not merely that the button shows.

Details worth knowing:
- The active tab is never spilled; it takes the last visible slot instead.
- Menu entries carry the button's icon, mirror its checked state, and click the real button.
- A separator is never offered in the menu, and is dropped rather than left dangling at the cut.
- The session panel's remaining floor is the search row; the filter field was allowed to shrink (it's the elastic one), while the regex toggle and thumbnail slider keep their designed widths.

## Notes

- `pythonpath = ["tests"]` added so test modules can share `FakeRepo` / `FakeController` from `conftest.py`.
- Two comments that my changes made stale were corrected (the file-browser toolbar rationale and the thumbnail-cell sizing note).
- `docs/USER_GUIDE.md`: new Favourites section, chapters renumbered, overflow documented for both panels. No `PIPELINE.md` change — no pixel math touched.

## Verification

`make all` green: **2869 passed**, 1 skipped, lint and types clean, nothing unrelated reformatted.

New tests cover: registry drift in both directions (every favouritable id resolves *and* is clonable), clone round-trips per slider class, `clone_slider` refusing an unhandled class rather than silently flattening a `PowerWarpSlider`'s nonlinear travel, mirror commit semantics, persistence with unknown-id dropping, picker reorder at list boundaries, and both `OverflowBar` modes including the populated-menu regression.