### PR TITLE
Fix neighbor prefetch to warm frames in filmstrip (display) order

### DIFF
--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -1109,7 +1109,10 @@ class AppController(QObject):
                 return
             idx = self.state.selected_file_idx
             files = self.state.uploaded_files
-            for path, h in neighbor_paths_and_hashes(files, idx):
+            if idx < 0 or not files:
+                return
+            display_order = self.session.asset_model.visible_actual_indices_ordered()
+            for path, h in neighbor_paths_and_hashes(files, display_order, idx):
                 # Match the cache key load_file will use for this neighbour: its own saved
                 # linear_raw, not the current file's. Otherwise the warm buffer lands under
                 # the wrong key and navigation re-decodes anyway.

--- a/negpy/desktop/prefetch_logic.py
+++ b/negpy/desktop/prefetch_logic.py
@@ -3,23 +3,30 @@ from __future__ import annotations
 from typing import List, Optional, Tuple
 
 
-def neighbor_indices(n_files: int, current_index: int) -> List[int]:
+def display_neighbor_indices(display_order: List[int], current_index: int) -> List[int]:
     """
-    Returns actual list indices for previous and next file, in-bounds.
+    Actual indices of the prev/next files in filmstrip (display) order.
+
+    `display_order` is the display-ordered list of actual indices
+    (AssetListModel.visible_actual_indices_ordered); `current_index` is an actual
+    index. Mirrors next_file/prev_file so prefetch warms exactly the frames
+    navigation lands on, not the raw uploaded_files (discovery-order) neighbours.
     """
-    if n_files <= 0 or current_index < 0 or current_index >= n_files:
+    try:
+        pos = display_order.index(current_index)
+    except ValueError:
         return []
     out: List[int] = []
-    if current_index > 0:
-        out.append(current_index - 1)
-    if current_index + 1 < n_files:
-        out.append(current_index + 1)
+    if pos > 0:
+        out.append(display_order[pos - 1])
+    if pos + 1 < len(display_order):
+        out.append(display_order[pos + 1])
     return out
 
 
-def neighbor_paths_and_hashes(files: List[dict], current_index: int) -> List[Tuple[str, Optional[str]]]:
+def neighbor_paths_and_hashes(files: List[dict], display_order: List[int], current_index: int) -> List[Tuple[str, Optional[str]]]:
     """
-    (path, hash) for prev/next neighbors; hash may be None.
+    (path, hash) for the prev/next neighbours in display order; hash may be None.
     """
-    ni = neighbor_indices(len(files), current_index)
+    ni = display_neighbor_indices(display_order, current_index)
     return [(files[i]["path"], files[i].get("hash")) for i in ni]

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -64,6 +64,23 @@ class TestAppController(unittest.TestCase):
         mock_slot.assert_called_once_with(1.0)
         self.assertFalse(self.controller.state.hq_preview)
 
+    def test_prefetch_neighbors_no_selection_is_noop(self):
+        """With no current selection the scheduled prefetch must fire harmlessly:
+        no load requested, and crucially no exception out of the QTimer slot (PyQt6
+        aborts the process on one). Regression: it used to reach the asset model
+        before checking for an empty state."""
+        from PyQt6.QtTest import QTest
+
+        self.controller.state.uploaded_files = []
+        self.controller.state.selected_file_idx = -1
+        mock_slot = MagicMock()
+        self.controller.preview_load_requested.connect(mock_slot)
+
+        self.controller._schedule_prefetch_neighbors()
+        QTest.qWait(120)  # let the 50ms singleShot fire
+
+        mock_slot.assert_not_called()
+
     def test_decode_failure_badges_file_and_success_clears_it(self):
         self.mock_session_manager.asset_model = MagicMock()
         state = self.mock_session_manager.state

--- a/tests/test_prefetch_logic.py
+++ b/tests/test_prefetch_logic.py
@@ -1,12 +1,27 @@
 from __future__ import annotations
 
-from negpy.desktop.prefetch_logic import neighbor_indices, neighbor_paths_and_hashes
+from negpy.desktop.prefetch_logic import display_neighbor_indices, neighbor_paths_and_hashes
 
 
-def test_neighbor_indices() -> None:
-    assert neighbor_indices(3, 0) == [1]
-    assert neighbor_indices(3, 1) == [0, 2]
-    assert neighbor_indices(1, 0) == []
+def test_display_neighbor_indices_identity_order() -> None:
+    # Display order matches actual order: neighbours are current ± 1.
+    assert display_neighbor_indices([0, 1, 2], 0) == [1]
+    assert display_neighbor_indices([0, 1, 2], 1) == [0, 2]
+    assert display_neighbor_indices([0], 0) == []
+
+
+def test_display_neighbor_indices_sorted_order() -> None:
+    # Discovery order [0,1,2] shown sorted as [2,0,1]: navigating from actual 0
+    # lands on 2 (prev) and 1 (next), not the raw-order 1 (and nothing before).
+    display = [2, 0, 1]
+    assert display_neighbor_indices(display, 0) == [2, 1]  # middle of the strip
+    assert display_neighbor_indices(display, 2) == [0]  # first shown: next only
+    assert display_neighbor_indices(display, 1) == [0]  # last shown: prev only
+
+
+def test_display_neighbor_indices_filtered_out_current() -> None:
+    # Current file not in the display order (filtered out): no neighbours.
+    assert display_neighbor_indices([0, 2], 1) == []
 
 
 def test_neighbor_paths_and_hashes() -> None:
@@ -15,5 +30,6 @@ def test_neighbor_paths_and_hashes() -> None:
         {"path": "/b", "hash": "hb"},
         {"path": "/c", "hash": "hc"},
     ]
-    assert neighbor_paths_and_hashes(files, 0) == [("/b", "hb")]
-    assert set(neighbor_paths_and_hashes(files, 1)) == {("/a", "ha"), ("/c", "hc")}
+    # Sorted display order [/c, /a, /b]; from actual 0 (/a): prev /c, next /b.
+    assert neighbor_paths_and_hashes(files, [2, 0, 1], 0) == [("/c", "hc"), ("/b", "hb")]
+    assert set(neighbor_paths_and_hashes(files, [0, 1, 2], 1)) == {("/a", "ha"), ("/c", "hc")}


### PR DESCRIPTION
next_file/prev_file navigate the sorted/filtered display order (AssetListModel), but the decode-prefetch computed neighbours as current ± 1 in raw uploaded_files (discovery) order. Whenever those differ — the common case: discovery order rarely matches the name sort, and any date sort or filter guarantees a mismatch — prefetch warmed frames the user never moved to, so every adjacent navigation still hit a cold decode (and wasted a decode plus a PreviewBufferCache slot).

Compute neighbors from the display-ordered actual indices (visible_actual_indices_ordered), mirroring next_file/prev_file exactly, so the warmed decode is the frame arrow-key navigation actually lands on.

Also bail out of the scheduled prefetch when there is no current selection, before touching the asset model. The QTimer.singleShot slot can fire with an empty/torn-down state; PyQt6 aborts the process on any exception that escapes a slot, so an unguarded asset-model access there takes the whole app (and the test suite) down with a SIGABRT.

Fixes #709 