### PR TITLE
feat: icon-only Reset in Filtration panel

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -242,7 +242,7 @@ Colour timing, like the dichroic filters on an enlarger head. A **Global / Shado
 
 *   **Pick WB** (eyedropper): click a pixel that should be neutral grey; NegPy solves the CMY filtration to make it neutral in the selected region.
 *   **Roll Lock**: re-aims each newly opened frame's temperature to the current target (its own tint preserved), a per-region lock for consistent warmth across a roll.
-*   **Reset**: return the selected region's temperature and CMY to neutral.
+*   **Reset** (undo-arrow icon): return the selected region's temperature and CMY to neutral.
 *   **Temperature**: a warm↔cool lever driving the region's magenta/yellow pair (cyan stays put, as in a real darkroom).
 *   **Cyan / Magenta / Yellow** (-1 to 1): the three filtration axes, Cyan↔Red, Magenta↔Green and Yellow↔Blue.
 *   **Cast Removal** (0.0 to 1.0): neutralizes the residual colour cast a negative leaves in the print, balancing each layer so greys stay neutral from deep shadows through highlights (C-41). Applied strength scales with how many clean near-neutrals the frame has. Default ~0.5; 0 turns it off.

--- a/negpy/desktop/view/sidebar/colour.py
+++ b/negpy/desktop/view/sidebar/colour.py
@@ -1,11 +1,9 @@
-import qtawesome as qta
-from PyQt6.QtWidgets import QButtonGroup, QHBoxLayout, QPushButton
+from PyQt6.QtWidgets import QButtonGroup, QHBoxLayout
 
 from negpy.desktop.session import ToolMode
 from negpy.desktop.view.shortcut_registry import tooltip_with_shortcut
 from negpy.desktop.view.sidebar.base import BaseSidebar
 from negpy.desktop.view.styles.templates import wrap_tooltip
-from negpy.desktop.view.styles.theme import THEME
 from negpy.desktop.view.widgets.sliders import CompactSlider, KelvinSlider
 from negpy.features.exposure.logic import kelvin_to_wb, wb_to_kelvin
 
@@ -58,16 +56,17 @@ class ColourSidebar(BaseSidebar):
             "(its own tint preserved); committing the slider while locked updates the target. "
             "Each region (Global/Shadows/Highlights) holds its own lock.",
         )
-        self.region_reset_btn = QPushButton(" Reset")
-        self.region_reset_btn.setIcon(qta.icon("fa5s.undo", color=THEME.text_primary, color_disabled=THEME.text_muted))
-        self.region_reset_btn.setToolTip("Reset the selected region's white balance — Temperature and Cyan/Magenta/Yellow back to neutral")
+        self.region_reset_btn = self._icon_action(
+            "fa5s.undo",
+            "Reset the selected region's white balance — Temperature and Cyan/Magenta/Yellow back to neutral",
+        )
         self.ring_btn = self._tool_toggle("mdi.target", "", self._ring_tooltip())
         self.ring_btn.setFixedWidth(36)
 
         tools_row = QHBoxLayout()
         tools_row.addWidget(self.pick_wb_btn, 1)
         tools_row.addWidget(self.temp_lock_btn, 1)
-        tools_row.addWidget(self.region_reset_btn, 1)
+        tools_row.addWidget(self.region_reset_btn)
         tools_row.addWidget(self.ring_btn)
         self.layout.addLayout(tools_row)
 


### PR DESCRIPTION
Filtration's **Reset** was the only labelled one-shot action in a row of toggles, so its row didn't line up with Tone's.

Now it uses `_icon_action("fa5s.undo", …)` — same idiom as Set Targets / Test Strip / Ring-Around: labelled toggles (Pick WB, Roll Lock) stretch, fixed-width 36px icon buttons sit flush at the end. Tooltip unchanged, behaviour unchanged.

USER_GUIDE notes the icon.

`make all` green.