### PR TITLE
Disable LibRaw adjust_maximum_thr in _decode_sensor_rgb (?)

### DIFF
--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -1156,6 +1156,13 @@ class AppController(QObject):
         if self.state.current_file_path:
             self.load_file(self.state.current_file_path, preserve_zoom=True)
 
+    def toggle_fix_adjust_maximum(self, enabled: bool) -> None:
+        self.state.fix_adjust_maximum = enabled
+        self.render_worker.processor.fix_adjust_maximum = enabled
+        self.preview_service.fix_adjust_maximum = enabled
+        if self.state.current_file_path:
+            self.load_file(self.state.current_file_path, preserve_zoom=True)
+
     def handle_canvas_clicked(self, nx: float, ny: float) -> None:
         if self.state.active_tool == ToolMode.WB_PICK:
             self._handle_wb_pick(nx, ny)

--- a/negpy/desktop/session.py
+++ b/negpy/desktop/session.py
@@ -153,6 +153,9 @@ class AppState:
     # Transient: preview is currently peeking the flat render (not persisted).
     flat_peek: bool = False
 
+    # Temporary A/B toggle: when True, _decode_sensor_rgb uses adjust_maximum_thr=0.0.
+    fix_adjust_maximum: bool = True
+
     @property
     def local_hidden_masks(self) -> set:
         """The current file's hidden-mask indices (empty = all shown). Returns a fresh,

--- a/negpy/desktop/view/sidebar/process.py
+++ b/negpy/desktop/view/sidebar/process.py
@@ -107,6 +107,15 @@ class ProcessSidebar(BaseSidebar):
         raw_row.addWidget(self.lock_bounds_btn, 1)
         self.layout.addLayout(raw_row)
 
+        self.fix_amt_btn = self._small_toggle(
+            "mdi6.ab-testing",
+            "Fix WL",
+            self.state.fix_adjust_maximum,
+            "A/B: pin RAW white level to camera max (disable rawpy adjust_maximum_thr). "
+            "ON = fixed white level, OFF = legacy 75% threshold. Triggers re-decode.",
+        )
+        self.layout.addWidget(self.fix_amt_btn)
+
         buf_row = QHBoxLayout()
         self.analysis_buffer_slider = CompactSlider("Analysis Buffer", 0.0, 0.25, conf.analysis_buffer)
         self.analysis_region_btn = self._tool_toggle(
@@ -230,6 +239,7 @@ class ProcessSidebar(BaseSidebar):
         self.lock_bounds_btn.toggled.connect(self._on_lock_bounds_toggled)
         self.linear_raw_btn.toggled.connect(self._on_linear_raw_toggled)
         self.narrowband_scan_btn.toggled.connect(self._on_narrowband_scan_toggled)
+        self.fix_amt_btn.toggled.connect(lambda c: self.controller.toggle_fix_adjust_maximum(c))
 
         self.analysis_buffer_slider.valueChanged.connect(lambda v: self._on_buffer_changed(v, persist=False))
         self.analysis_buffer_slider.valueCommitted.connect(lambda v: self._on_buffer_changed(v, persist=True))
@@ -445,6 +455,7 @@ class ProcessSidebar(BaseSidebar):
             self.lock_bounds_btn.setChecked(conf.lock_bounds)
             self.linear_raw_btn.setChecked(conf.linear_raw)
             self.narrowband_scan_btn.setChecked(conf.narrowband_scan)
+            self.fix_amt_btn.setChecked(self.state.fix_adjust_maximum)
 
             profiles = CrosstalkProfiles.list_profiles()
             if profiles != [self.crosstalk_combo.itemText(i) for i in range(self.crosstalk_combo.count())]:
@@ -489,6 +500,7 @@ class ProcessSidebar(BaseSidebar):
             self.lock_bounds_btn,
             self.linear_raw_btn,
             self.narrowband_scan_btn,
+            self.fix_amt_btn,
             self.ch_global_btn,
             self.ch_r_btn,
             self.ch_g_btn,

--- a/negpy/services/rendering/image_processor.py
+++ b/negpy/services/rendering/image_processor.py
@@ -444,6 +444,7 @@ class ImageProcessor:
                 output_color=rawpy.ColorSpace.raw,
                 demosaic_algorithm=algo,
                 user_flip=0,
+                adjust_maximum_thr=0.0,
                 **post_kw,
             )
             rgb = ensure_rgb(rgb)

--- a/negpy/services/rendering/image_processor.py
+++ b/negpy/services/rendering/image_processor.py
@@ -111,6 +111,9 @@ class ImageProcessor:
         self.engine_cpu = DarkroomEngine()
         self.engine_gpu: Optional[GPUEngine] = None
 
+        # Temporary A/B flag: when True, use adjust_maximum_thr=0.0 in _decode_sensor_rgb.
+        self.fix_adjust_maximum: bool = True
+
         # Last decoded full-res source (decode+flatfield) — skips re-decode on repeat export.
         # One entry only (full-res buffers are large); treated read-only downstream.
         self._source_cache_key: Optional[tuple] = None
@@ -435,6 +438,7 @@ class ImageProcessor:
             algo = get_best_demosaic_algorithm(raw)
             user_wb = [1, 1, 1, 1] if linear_raw else None
             post_kw: Dict[str, Any] = {"half_size": True} if fast and _use_half_size_decode(raw, linear_raw) else {}
+            amt_kw = {"adjust_maximum_thr": 0.0} if self.fix_adjust_maximum else {}
             rgb = raw.postprocess(
                 gamma=(1, 1),
                 no_auto_bright=True,
@@ -444,7 +448,7 @@ class ImageProcessor:
                 output_color=rawpy.ColorSpace.raw,
                 demosaic_algorithm=algo,
                 user_flip=0,
-                adjust_maximum_thr=0.0,
+                **amt_kw,
                 **post_kw,
             )
             rgb = ensure_rgb(rgb)

--- a/negpy/services/rendering/preview_manager.py
+++ b/negpy/services/rendering/preview_manager.py
@@ -68,6 +68,8 @@ class PreviewManager:
 
     def __init__(self) -> None:
         self._cache = PreviewBufferCache(APP_CONFIG)
+        # Temporary A/B flag: when True, use adjust_maximum_thr=0.0 in postprocess.
+        self.fix_adjust_maximum: bool = True
 
     # ------------------------------------------------------------------
     # Internal helpers — operate on an already-open raw object so that
@@ -142,6 +144,7 @@ class PreviewManager:
         user_wb = None if use_camera_wb else [1, 1, 1, 1]
 
         t_pp = time.perf_counter()
+        amt_kw = {"adjust_maximum_thr": 0.0} if self.fix_adjust_maximum else {}
         rgb = raw.postprocess(
             gamma=(1, 1),
             no_auto_bright=True,
@@ -151,6 +154,7 @@ class PreviewManager:
             output_color=rawpy.ColorSpace.raw,
             demosaic_algorithm=demosaic,
             user_flip=0,
+            **amt_kw,
             **post_kw,
         )
         log("load-timing decode.postprocess %.0fms (fast=%s) %s", (time.perf_counter() - t_pp) * 1000, use_fast, file_path)
@@ -327,6 +331,7 @@ class PreviewManager:
                     demosaic = rawpy.DemosaicAlgorithm.LINEAR
                     # half_size casts X-Trans channel ratios (skews detection); Bayer is fine.
                     post_kw = {} if is_xtrans(raw) else {"half_size": True}
+                amt_kw2 = {"adjust_maximum_thr": 0.0} if self.fix_adjust_maximum else {}
                 rgb = raw.postprocess(
                     gamma=(1, 1),
                     no_auto_bright=True,
@@ -336,6 +341,7 @@ class PreviewManager:
                     output_color=rawpy.ColorSpace.raw,
                     demosaic_algorithm=demosaic,
                     user_flip=0,
+                    **amt_kw2,
                     **post_kw,
                 )
             return uint16_to_float32(ensure_rgb(rgb))


### PR DESCRIPTION

## Summary
`_decode_sensor_rgb` uses LibRaw's default `adjust_maximum_thr=0.75`, which silently substitutes the camera's nominal white level with the frame's own brightest pixel when it exceeds 75% of the stated maximum. This makes the scaling reference image-dependent — a bright specular in one frame shifts the decode of the entire tonal range relative to a frame without one.

Setting `adjust_maximum_thr=0.0` pins the reference to the camera's fixed white level. The calibration path (`raw_demosaic.py`) already carries this fix with documentation explaining the rationale; the main pipeline is the remaining gap.

## Why this matters
When `adjust_maximum_thr` is left at the default, LibRaw picks a different white-level reference per frame based on that frame's content. This means two frames from the same roll, shot with the same camera, can decode to different absolute values for the same scene luminance — the decode is no longer a fixed function of the sensor data.

This has knock-on effects across NegPy:
- **Batch normalization drifts.** The floor/ceiling analysis assumes all frames in a roll share the same decode scaling. A single bright frame that triggers the substitution will have its tonal range compressed relative to the others, skewing the batch statistics.
- **A/B consistency breaks.** Switching between two frames that were decoded with different effective white levels introduces a tonal shift that has nothing to do with exposure or scene content.
- **Roll-level operations become scene-dependent.** Crosstalk correction, flatfield, and white-balance normalization all assume the input is scaled to a fixed reference. A per-frame rescale means these corrections are applied to data that isn't on the same footing.
- **Non-deterministic re-decode.** Reopening the same file after editing a bright region (e.g. cropping out a specular) can change whether the threshold triggers, producing a different decode from the same source.

The calibration path (`raw_demosaic.py`) already documents this and uses `0.0`. The threshold exists in LibRaw to handle sensors where the nominal white level in the EXIF is too conservative, but for NegPy's use case — scanning film negatives where the densest part of the negative (brightest in the capture) rarely approaches sensor clip — the substitution does more harm than good.

## Why draft
This changes the decode for every camera RAW file. The calibration path already uses `0.0`, so there's precedent — but if the default was left at `0.75` deliberately in the main pipeline, this PR should be rejected. Opening as draft for discussion.

## Test plan
- `make all` passes (one pre-existing unrelated failure in `test_overflow_bar`)
- No logic change beyond adding the one kwarg


---
Testing the A/B toggle:

There's a "Fix WL" button in the Process panel (below Linear RAW / Narrowband / Lock). ON = fixed white level, OFF = legacy behavior.

Toggle it with a camera RAW file loaded and compare. Note: the file's brightest pixel must exceed 75% of the camera's nominal white level for there to be any visible difference — below that threshold both modes produce identical output.

---