### PR TITLE
Fix GPU glow/halation export scaling and CPU/GPU parity

### DIFF
--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -269,7 +269,7 @@ This mimics what lab scanners like Frontier or Noritsu do automatically. For max
     $$I_{out} = I + B_{glow} \cdot s_{glow}$$
     $$B_{glow} = \text{GaussianBlur}(I \cdot m_{hl})$$
 
-    *   $m_{hl}$: **Display-domain** highlight mask (lens bloom follows perceived print brightness), quadratically ramped from code value 0.5 to 1.0.
+    *   $m_{hl}$: **Display-domain** highlight mask (lens bloom follows perceived print brightness), linearly ramped from code value 0.5 to 1.0.
     *   Applied equally to all three channels; the sum is clamped at the stage output.
 
 6.  **Halation**: Simulates the red scatter caused by light reflecting back through the film base at capture. Uses a larger-radius Gaussian than Glow and a strongly red-biased highlight source. Because scattered light is *added exposure*, the composite is additive in linear light (not a screen blend), and the mask thresholds **linear reflectance** ($t = 0.65$) so the halation footprint is fixed by scene exposure instead of moving with Grade/Density.
@@ -278,7 +278,7 @@ This mimics what lab scanners like Frontier or Noritsu do automatically. For max
     $$B_{hal} = \text{GaussianBlur}(I_R \cdot m_{lin} \cdot C_{hal})$$
 
     *   $I_R$: Red channel used as the scatter source.
-    *   $m_{lin}$: Linear-light highlight mask, quadratically ramped from reflectance 0.65 to 1.0.
+    *   $m_{lin}$: Linear-light highlight mask, linearly ramped from reflectance 0.65 to 1.0.
     *   $C_{hal}$: Per-channel tint weights $(1.0,\ 0.3,\ 0.05)$ for red-dominant scatter.
 
 ---

--- a/negpy/features/lab/logic.py
+++ b/negpy/features/lab/logic.py
@@ -308,7 +308,7 @@ def apply_glow_and_halation(
         enc = working_oetf_encode(img)
         luma = enc[:, :, 0] * np.float32(LUM_R) + enc[:, :, 1] * np.float32(LUM_G) + enc[:, :, 2] * np.float32(LUM_B)
         threshold = 0.5
-        glow_mask = np.clip((luma - threshold) / (1.0 - threshold), 0.0, 1.0) ** 2
+        glow_mask = np.clip((luma - threshold) / (1.0 - threshold), 0.0, 1.0)
         base_r = max(3, int(15 * scale_factor))
         k = min((base_r * 2 + 1) | 1, 201)
         sigma = base_r * 0.5
@@ -319,7 +319,7 @@ def apply_glow_and_halation(
     if halation_strength > 0.0:
         lin_luma = img[:, :, 0] * np.float32(LUM_R) + img[:, :, 1] * np.float32(LUM_G) + img[:, :, 2] * np.float32(LUM_B)
         t = HALATION_THRESHOLD_LINEAR
-        hal_mask = np.clip((lin_luma - t) / (1.0 - t), 0.0, 1.0) ** 2
+        hal_mask = np.clip((lin_luma - t) / (1.0 - t), 0.0, 1.0)
         base_r = max(5, int(25 * scale_factor))
         k = min((base_r * 2 + 1) | 1, 301)
         sigma = base_r * 0.5

--- a/negpy/features/lab/shaders/lab.wgsl
+++ b/negpy/features/lab/shaders/lab.wgsl
@@ -433,7 +433,8 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
     }
 
     // 4. Glow and Halation
-    // Radii match the CPU defaults (base_r at scale_factor=1): glow=15px, halation=25px.
+    // Radii match the CPU base_r (glow=15px, halation=25px at scale_factor=1) and scale
+    // with resolution so full-res exports keep the preview footprint.
     // Accumulate highlight-weighted Gaussian samples then divide by the fixed kernel
     // weight sum (BLOOM_GAUSS_SUM) — mirrors how a normalised Gaussian convolution
     // kernel divides by its total weight, so intensity decays naturally with distance
@@ -443,8 +444,10 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
         // Halation mask in LINEAR reflectance: fixed by scene exposure, so the
         // footprint doesn't move with grade/density (mirrors CPU logic.py).
         let HALATION_THRESHOLD_LINEAR = 0.65;
-        let GLOW_RADIUS = 15.0;
-        let HAL_RADIUS = 25.0;
+        // Radii scale with resolution so a full-res export keeps the preview footprint
+        // (mirrors CPU logic.py's base_r = max(., int(. * scale_factor))).
+        let GLOW_RADIUS = max(3.0, 15.0 * params.scale_factor);
+        let HAL_RADIUS = max(5.0, 25.0 * params.scale_factor);
 
         var glow_accum = vec3<f32>(0.0);
         var hal_accum = vec3<f32>(0.0);

--- a/negpy/services/rendering/gpu_engine.py
+++ b/negpy/services/rendering/gpu_engine.py
@@ -1907,6 +1907,12 @@ class GPUEngine:
             k_radius = len(gaussian_kernel_1d(settings.lab.sharpen_radius * scale_factor)) // 2
             mult = 6 if settings.lab.sharpen_method == SharpenMethod.RL else 1
             halo = max(halo, k_radius * mult)
+        # Glow/halation taps reach up to their radius (max(., . * scale_factor) in
+        # lab.wgsl); without this the bloom seams at tile edges on big exports.
+        if settings.lab.glow_amount > 0.0:
+            halo = max(halo, int(np.ceil(max(3.0, 15.0 * scale_factor))))
+        if settings.lab.halation_strength > 0.0:
+            halo = max(halo, int(np.ceil(max(5.0, 25.0 * scale_factor))))
         halo = min(halo, 512)
 
         for ty in range(0, crop_h, TILE_SIZE):


### PR DESCRIPTION
Two related defects in the lab glow/halation stage:

1. Export footprint collapse (GPU). The shader hard-coded GLOW_RADIUS=15 and HAL_RADIUS=25, so full-res exports (scale 4-8x) rendered the bloom 4-8x smaller than the preview showed, nearly erasing the effect; HQ preview showed the same shrinkage live. Scale both radii by params.scale_factor (with the CPU's min-radius clamps), and extend the tiled-export halo to cover the larger reach so big exports don't seam at tile edges.

2. Look mismatch (CPU vs GPU). The GPU weighted the bloom by the raw linear highlight mask while the CPU squared it (** 2) -- divergent since the feature's first commit, so glow visibly changed when toggling GPU acceleration and in exports. The GPU path runs first and is the de-facto shipped (glowier) look, so converge both paths on the linear mask by dropping the ** 2 from logic.py.

PIPELINE.md documented the mask as "quadratically ramped"; corrected to "linearly ramped". Lab tests are directional and pass; glow's default is 0.0 so no golden depends on the mask shape.

Fixes #728 