### PR TITLE
Fix bulk operations stamping active frame's edit onto frames without saved edits

### DIFF
--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -2429,7 +2429,7 @@ class AppController(QObject):
         """
         self._end_batch("normalization")
         for f_info in self.state.uploaded_files:
-            p = self.session.repo.load_file_settings(f_info["hash"]) or replace(self.state.config)
+            p = self.session.repo.load_file_settings(f_info["hash"]) or self.session.config_for_asset(f_info)
             new_process = replace(
                 p.process,
                 use_luma_average=True,
@@ -2480,7 +2480,7 @@ class AppController(QObject):
         if data:
             locked_floors, locked_ceils = data
             for f_info in self.state.uploaded_files:
-                p = self.session.repo.load_file_settings(f_info["hash"]) or replace(self.state.config)
+                p = self.session.repo.load_file_settings(f_info["hash"]) or self.session.config_for_asset(f_info)
                 new_process = replace(
                     p.process,
                     use_luma_average=True,
@@ -3213,6 +3213,7 @@ class AppController(QObject):
         flush = self.flush_export_settings
         if flush is not None:
             flush()
+
     def request_linear_output_export(self, files: list[dict] | None = None) -> None:
         """Export decoded linear buffers as untagged 16-bit TIFFs to the export folder."""
         from negpy.services.export.linear_output import export_linear_output, is_linear_output_supported

--- a/negpy/desktop/session.py
+++ b/negpy/desktop/session.py
@@ -869,7 +869,7 @@ class DesktopSessionManager(QObject):
             if idx == self.state.selected_file_idx or not (0 <= idx < len(self.state.uploaded_files)):
                 continue
             target_hash = self.state.uploaded_files[idx]["hash"]
-            target_config = self.repo.load_file_settings(target_hash) or WorkspaceConfig()
+            target_config = self.repo.load_file_settings(target_hash) or self.config_for_asset(self.state.uploaded_files[idx])
             target_path = self.state.uploaded_files[idx]["path"]
             synced = apply_selected_fields(source_config, target_config, rows)
             if src_bounds is not None:
@@ -919,7 +919,7 @@ class DesktopSessionManager(QObject):
                 count += 1
                 continue
             target_hash = self.state.uploaded_files[idx]["hash"]
-            target_config = self.repo.load_file_settings(target_hash) or WorkspaceConfig()
+            target_config = self.repo.load_file_settings(target_hash) or self.config_for_asset(self.state.uploaded_files[idx])
             synced = apply_selected_fields(source, target_config, rows)
             self.push_external_history(target_hash, target_config, synced)
             self.repo.save_file_settings(target_hash, synced, file_path=self.state.uploaded_files[idx]["path"])

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -95,6 +95,36 @@ class TestAppController(unittest.TestCase):
         self.controller._on_preview_loaded("/tmp/a.dng", None, (0, 0), "", None, "")
         self.assertNotIn("decode_failed", state.uploaded_files[0])
 
+    def test_normalization_finished_uses_hydrated_base_not_active_edit(self):
+        """P0-5 Variant A: a frame with no saved edits must take its per-asset hydrated
+        config as the write base, never the active frame's crop/heals/local sections."""
+        from negpy.domain.models import GeometryConfig, RetouchConfig
+
+        state = self.mock_session_manager.state
+        state.uploaded_files = [
+            {"name": "a.dng", "path": "/tmp/a.dng", "hash": "hash1"},
+            {"name": "b.dng", "path": "/tmp/b.dng", "hash": "hash2"},
+        ]
+        state.current_file_hash = "hash1"
+        state.config = replace(
+            WorkspaceConfig(),
+            geometry=GeometryConfig(manual_crop_rect=(0.1, 0.1, 0.9, 0.9)),
+            retouch=RetouchConfig(manual_dust_spots=[(0.5, 0.5, 3)]),
+        )
+        self.mock_session_manager.repo.load_file_settings.return_value = None
+        self.mock_session_manager.config_for_asset.return_value = WorkspaceConfig()
+
+        with patch.object(self.controller, "_end_batch"), patch.object(self.controller, "request_render"):
+            self.controller._on_normalization_finished((0.0, 0.0, 0.0), (1.0, 1.0, 1.0))
+
+        saved = {c.args[0]: c.args[1] for c in self.mock_session_manager.repo.save_file_settings.call_args_list}
+        self.assertIn("hash2", saved)
+        self.assertIsNone(saved["hash2"].geometry.manual_crop_rect)
+        self.assertEqual(saved["hash2"].retouch.manual_dust_spots, [])
+        # Baseline still broadcast onto the fresh frame.
+        self.assertTrue(saved["hash2"].process.use_luma_average)
+        self.mock_session_manager.config_for_asset.assert_any_call(state.uploaded_files[1])
+
     def test_clear_roll_baseline_resets_axes(self):
         state = self.mock_session_manager.state
         state.config = replace(
@@ -1140,6 +1170,7 @@ class TestPresetExportSelected(unittest.TestCase):
 
     def test_batch_normalization_records_history_for_other_files(self):
         self.mock_session_manager.repo.load_file_settings.return_value = None
+        self.mock_session_manager.config_for_asset.return_value = WorkspaceConfig()
         self.controller._on_normalization_finished((0.1, 0.1, 0.1), (0.9, 0.9, 0.9))
 
         pushed = {c.args[0] for c in self.mock_session_manager.push_external_history.call_args_list}

--- a/tests/test_desktop_session.py
+++ b/tests/test_desktop_session.py
@@ -515,6 +515,33 @@ class TestDesktopSessionSync(unittest.TestCase):
         args, _ = self.mock_repo.save_file_settings.call_args
         self.assertEqual(args[1].geometry.autocrop_offset, 0)
 
+    def test_sync_fresh_target_keeps_sticky_workflow_not_bare_defaults(self):
+        """P0-5 Variant B: a target frame with no saved edits must fall back to the
+        sticky-aware hydrated config, not bare WorkspaceConfig(), so syncing one field
+        doesn't silently reset its scan/process-mode to dataclass defaults."""
+        sticky = {
+            "last_export_config": {},
+            "last_process_mode": "E-6",
+            "last_narrowband_scan": True,
+        }
+        self.mock_repo.get_global_setting.side_effect = lambda key, default=None: sticky.get(key, default)
+        self.mock_repo.load_file_settings.return_value = None  # fresh target, no DB row
+
+        self.session.state.selected_file_idx = 0
+        self.session.state.current_file_hash = "hash1"
+        self.session.state.config = replace(WorkspaceConfig(), exposure=replace(WorkspaceConfig().exposure, density=1.5))
+
+        self.session.update_selection([0, 1])
+        with patch("negpy.desktop.session.load_or_promote", return_value=None):
+            self.session.sync_selected_settings([_row("Print Density")])
+
+        args, _ = self.mock_repo.save_file_settings.call_args
+        saved = args[1]
+        self.assertEqual(saved.exposure.density, 1.5)  # the one synced field
+        # Sticky workflow settings survive because the base was config_for_asset, not defaults.
+        self.assertTrue(saved.process.narrowband_scan)
+        self.assertEqual(saved.process.process_mode, "E-6")
+
     def test_sync_selected_settings_empty_is_noop(self):
         self.session.state.selected_file_idx = 0
         self.session.state.current_file_hash = "hash1"


### PR DESCRIPTION
Three bulk paths disagreed about the base config for a frame that has no DB row yet. Batch Analysis and roll application (controller._on_normalization_finished, apply_normalization_roll) fell back to the active frame's *entire* edit — manual crop, heal strokes, dodge/burn, toning, retouch — and saved it onto every untouched frame; heal strokes are source-normalized to a different image, so they rendered as arbitrary smudges. Sync and preset application (session.sync_selected_settings, apply_preset_fields) fell back to bare WorkspaceConfig(), discarding the sticky workflow settings (scan/process mode/WB) a fresh frame gets on open, so a synced frame decoded wrong and skipped autodetect.

All four now fall back to the hydrated per-asset config (config_for_asset): saved frames keep their own settings, fresh frames get defaults plus sticky workflow preferences. The normalization paths still overlay only the process bounds onto that base, never the current frame's geometry/retouch/local sections.

Fixes #730 