### PR TITLE
Fix Export Sidecars stamping active frame's edit onto unedited frames

### DIFF
--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -3575,7 +3575,7 @@ class AppController(QObject):
         written = 0
         for f in files:
             half = int(f.get("half") or 0)
-            params = load_or_promote(repo, f["hash"], f["path"], half=half) or self.state.config
+            params = load_or_promote(repo, f["hash"], f["path"], half=half) or self.session.config_for_asset(f)
             try:
                 write_sidecar(f["path"], params, half=half)
                 written += 1

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -139,6 +139,30 @@ class TestAppController(unittest.TestCase):
         self.assertTrue(saved["hash2"].process.use_luma_average)
         self.mock_session_manager.config_for_asset.assert_any_call(state.uploaded_files[1])
 
+    def test_write_edit_sidecars_uses_hydrated_base_not_active_edit(self):
+        """A frame with no saved edit must get its own hydrated config written to its
+        sidecar, never the active frame's edit (which load_or_promote would later promote
+        into that file's persistent DB row)."""
+        from negpy.domain.models import GeometryConfig
+
+        state = self.mock_session_manager.state
+        state.config = replace(state.config, geometry=GeometryConfig(manual_crop_rect=(0.1, 0.1, 0.9, 0.9)))
+        hydrated = WorkspaceConfig()
+        self.mock_session_manager.config_for_asset.return_value = hydrated
+        frame = {"name": "b.dng", "path": "/tmp/b.dng", "hash": "hash2"}
+
+        with (
+            patch("negpy.desktop.controller.load_or_promote", return_value=None),
+            patch("negpy.desktop.controller.write_sidecar") as mock_write,
+        ):
+            written = self.controller._write_edit_sidecars([frame])
+
+        self.assertEqual(written, 1)
+        self.mock_session_manager.config_for_asset.assert_called_once_with(frame)
+        params = mock_write.call_args.args[1]
+        self.assertIs(params, hydrated)
+        self.assertIsNone(params.geometry.manual_crop_rect)
+
     def test_clear_roll_baseline_resets_axes(self):
         state = self.mock_session_manager.state
         state.config = replace(


### PR DESCRIPTION
_write_edit_sidecars fell back to self.state.config — the active frame's entire edit — for any frame with no saved edit. load_or_promote later promotes that .negpy sidecar into the DB, so an untouched frame acquired another frame's look as its persistent edit on any future session.

Fall back to the hydrated per-asset config (config_for_asset) instead: saved frames keep their own settings, fresh frames get defaults plus sticky workflow preferences. Same fix class as the bulk-normalization and sync base-config paths.

Fixes #734 