### PR TITLE
Fix GPU test-strip / ring-around preview by stripping alpha before RGB888 display

### DIFF
--- a/negpy/desktop/workers/render.py
+++ b/negpy/desktop/workers/render.py
@@ -297,6 +297,9 @@ class RenderWorker(QObject):
                 )
                 if isinstance(result, GPUTexture):
                     result = result.readback()
+                # GPU readback is rgba32float; ImageConverter.to_qimage assumes RGB888 (w*3).
+                if isinstance(result, np.ndarray) and result.ndim == 3 and result.shape[2] >= 4:
+                    result = np.ascontiguousarray(result[:, :, :3])
                 tiles.append(result)
                 if content_rect is None:
                     content_rect = metrics.get("content_rect")

--- a/tests/test_test_strip_controller.py
+++ b/tests/test_test_strip_controller.py
@@ -93,6 +93,44 @@ class TestStripWorker(unittest.TestCase):
 
         self.assertEqual(leaked, [])
 
+    def test_gpu_rgba_readback_is_stripped_to_rgb(self):
+        """GPUTexture.readback is HxWx4; mosaics must be HxWx3 for RGB888 display."""
+        with patch("negpy.desktop.workers.render.ImageProcessor") as MockIP:
+            from negpy.desktop.workers.render import RenderWorker, TestStripTask
+            from negpy.infrastructure.gpu.resources import GPUTexture
+
+            rgba = np.zeros((8, 8, 4), np.float32)
+            rgba[:, :, :3] = 0.5
+            rgba[:, :, 3] = 1.0
+            tex = object.__new__(GPUTexture)
+            tex.readback = lambda: rgba  # type: ignore[method-assign]
+
+            MockIP.return_value.run_pipeline.side_effect = lambda *a, **k: (
+                tex,
+                {"content_rect": (0, 0, 8, 8)},
+            )
+            worker = RenderWorker()
+            done: list = []
+            worker.strip_finished.connect(lambda m, r: done.append((m, r)))
+
+            worker.build_strip(
+                TestStripTask(
+                    buffer=np.zeros((8, 8, 3), np.float32),
+                    config=WorkspaceConfig(),
+                    source_hash="f1",
+                    preview_size=512.0,
+                    overrides=tuple(strip_overrides()),
+                    grid=STRIP_GRID,
+                    gpu_enabled=True,
+                )
+            )
+
+        mosaics, _ = done[0]
+        self.assertEqual(len(mosaics), 4)
+        for mosaic in mosaics:
+            self.assertEqual(mosaic.shape, (8, 8, 3))
+            self.assertTrue(np.allclose(mosaic, 0.5))
+
 
 class TestStripLifecycle(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary
- Fix corrupted GPU test-strip and colour ring-around previews (mesh / RGB streaks) caused by feeding `rgba32float` readbacks into `ImageConverter.to_qimage`, which assumes RGB888 with stride `w * 3`.
- Strip alpha to RGB after GPU readback in `RenderWorker.build_strip`, matching the main canvas / thumbnail paths.
- Add a regression test that mocks an HxWx4 GPU readback and asserts mosaics are HxWx3.

## Test plan
- [x] GPU on → open a scan → Exposure test strip looks correct (no mesh / rainbow streaks)
- [x] GPU on → Filtration colour ring-around looks correct
- [x] GPU off → both proofs still look correct (CPU path unchanged)
- [x] Click a strip / ring patch and confirm the committed settings match the chosen cell
- [x] Test on multiple pc setups to check if it works with different setups (previously this worked fine on my laptop, but not my desktop)
 
Fixes #698