### PR TITLE
Select first frame in filmstrip order on folder open, not discovery order

### DIFF
--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -1017,14 +1017,23 @@ class AppController(QObject):
             self.session.state.rendered_thumbnails.clear()
             self.session.add_files([], validated_info=valid_assets)
             self.generate_missing_thumbnails()
-            idx = next(
-                (
-                    i
-                    for i, f in enumerate(self.session.state.uploaded_files)
-                    if reselect_path in (f.get("path"), f.get("green_path"), f.get("blue_path"))
-                ),
-                0,
-            )
+            idx = None
+            if reselect_path:
+                # Guard on a set path: `None in (path, green_path, blue_path)` spuriously
+                # matches any non-RGB frame (its green/blue paths are absent → None).
+                idx = next(
+                    (
+                        i
+                        for i, f in enumerate(self.session.state.uploaded_files)
+                        if reselect_path in (f.get("path"), f.get("green_path"), f.get("blue_path"))
+                    ),
+                    None,
+                )
+            if idx is None:
+                # No prior frame to restore (a fresh folder open): land on the first frame
+                # in filmstrip (sorted/filtered) order, not discovery order.
+                ordered = self.session.asset_model.visible_actual_indices_ordered()
+                idx = ordered[0] if ordered else 0
             self.session.select_file(idx)
             self._start_next_asset_discovery()
             return
@@ -1037,7 +1046,12 @@ class AppController(QObject):
             if pending_scan and self._select_file_by_path(pending_scan):
                 selected_pending_scan = True
             elif auto_open and not self.state.current_file_path and len(self.session.state.uploaded_files) > first_new_idx:
-                self.session.select_file(first_new_idx)
+                # Select the first newly-loaded frame in filmstrip (sorted/filtered) order,
+                # not discovery order — otherwise the initial frame lands mid-strip.
+                new_indices = set(range(first_new_idx, len(self.session.state.uploaded_files)))
+                ordered = self.session.asset_model.visible_actual_indices_ordered()
+                target = next((i for i in ordered if i in new_indices), first_new_idx)
+                self.session.select_file(target)
         else:
             self.set_status("NO SUPPORTED ASSETS FOUND", 3000)
             self.status_progress_requested.emit(0, 0)

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1373,6 +1373,57 @@ class TestRgbScanModeReload(unittest.TestCase):
         self.assertEqual(state.uploaded_files, merged)
         self.mock_session_manager.select_file.assert_called_once_with(0)
 
+    def test_replace_fresh_open_selects_first_in_sorted_order(self):
+        # Library double-click loads via replace_existing=True with no frame to reselect;
+        # the fallback must land on the sorted-first frame, not discovery index 0.
+        state = self.mock_session_manager.state
+        state.uploaded_files = []
+
+        def add_files(_paths, validated_info=None):
+            state.uploaded_files.extend(validated_info or [])
+
+        self.mock_session_manager.add_files.side_effect = add_files
+        self.mock_session_manager.asset_model = MagicMock()
+        self.mock_session_manager.asset_model.visible_actual_indices_ordered.return_value = [1, 2, 0]
+        self.controller.generate_missing_thumbnails = MagicMock()
+        self.controller._replace_after_discovery = True
+        self.controller._reselect_after_discovery = None
+
+        discovered = [
+            {"name": "c", "path": "/c.dng", "hash": "h3"},
+            {"name": "a", "path": "/a.dng", "hash": "h1"},
+            {"name": "b", "path": "/b.dng", "hash": "h2"},
+        ]
+        self.controller._on_discovery_finished(discovered)
+
+        self.mock_session_manager.select_file.assert_called_once_with(1)
+
+    def test_auto_open_selects_first_in_sorted_order_not_discovery_order(self):
+        state = self.mock_session_manager.state
+        state.uploaded_files = []
+        state.current_file_path = None
+
+        def add_files(_paths, validated_info=None):
+            state.uploaded_files.extend(validated_info or [])
+
+        self.mock_session_manager.add_files.side_effect = add_files
+        self.mock_session_manager.asset_model = MagicMock()
+        self.controller.generate_missing_thumbnails = MagicMock()
+        self.controller._auto_open_after_discovery = True
+
+        # Discovery order c, a, b (indices 0,1,2); filmstrip sorts by name to a, b, c.
+        discovered = [
+            {"name": "c", "path": "/c.dng", "hash": "h3"},
+            {"name": "a", "path": "/a.dng", "hash": "h1"},
+            {"name": "b", "path": "/b.dng", "hash": "h2"},
+        ]
+        self.mock_session_manager.asset_model.visible_actual_indices_ordered.return_value = [1, 2, 0]
+
+        self.controller._on_discovery_finished(discovered)
+
+        # First in sorted order is "a" at actual index 1, not the first-discovered "c" at 0.
+        self.mock_session_manager.select_file.assert_called_once_with(1)
+
 
 class TestDiscoveryProgressPopup(unittest.TestCase):
     """Folder-load hashing drives the shared batch progress popup."""
@@ -1382,6 +1433,8 @@ class TestDiscoveryProgressPopup(unittest.TestCase):
         self.mock_session_manager.state = AppState()
         self.mock_session_manager.repo = MagicMock()
         self.mock_session_manager.repo.get_global_setting.return_value = False
+        self.mock_session_manager.asset_model = MagicMock()
+        self.mock_session_manager.asset_model.visible_actual_indices_ordered.return_value = []
 
         with (
             patch("negpy.desktop.controller.RenderWorker") as mock_rw_class,


### PR DESCRIPTION
Auto-open picked the first asset in discovery/directory-walk order, which lands mid-strip once the filmstrip sorts by name/date. Both open paths now select the first newly-loaded frame in sorted/filtered display order.

Also fixes a latent bug in the replace branch (library double-click): with no frame to reselect, `None in (path, green_path, blue_path)` spuriously matched any non-RGB frame, always pinning the selection to discovery index 0.

Fixes #742 