### PR TITLE
Pieusb integration

### DIFF
--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -289,7 +289,7 @@ class AppController(QObject):
     scan_backend_requested = pyqtSignal(str)
     scan_requested = pyqtSignal(ScanRequest)
     scan_devices_ready = pyqtSignal(list)
-    scan_progress = pyqtSignal(float)
+    scan_progress = pyqtSignal(float, str) # progress, phase name
     scan_finished = pyqtSignal(str)
     scan_error = pyqtSignal(str)
     scan_started = pyqtSignal()

--- a/negpy/desktop/view/sidebar/right_panel.py
+++ b/negpy/desktop/view/sidebar/right_panel.py
@@ -1,4 +1,3 @@
-import sys
 from typing import Any, Dict
 
 import numpy as np

--- a/negpy/desktop/view/sidebar/right_panel.py
+++ b/negpy/desktop/view/sidebar/right_panel.py
@@ -101,9 +101,6 @@ class RightPanel(QWidget):
 
         from negpy.desktop.view.sidebar.scan import ScanSidebar, _ScanUnsupportedPlaceholder
 
-        # if sys.platform == "win32":
-        #     self.scan_sidebar = _ScanUnsupportedPlaceholder()
-        # else:
         self.scan_sidebar = ScanSidebar(self.controller)
 
         from negpy.desktop.view.sidebar.scanlight import ScanlightSidebar

--- a/negpy/desktop/view/sidebar/right_panel.py
+++ b/negpy/desktop/view/sidebar/right_panel.py
@@ -101,10 +101,10 @@ class RightPanel(QWidget):
 
         from negpy.desktop.view.sidebar.scan import ScanSidebar, _ScanUnsupportedPlaceholder
 
-        if sys.platform == "win32":
-            self.scan_sidebar = _ScanUnsupportedPlaceholder()
-        else:
-            self.scan_sidebar = ScanSidebar(self.controller)
+        # if sys.platform == "win32":
+        #     self.scan_sidebar = _ScanUnsupportedPlaceholder()
+        # else:
+        self.scan_sidebar = ScanSidebar(self.controller)
 
         from negpy.desktop.view.sidebar.scanlight import ScanlightSidebar
 

--- a/negpy/desktop/view/sidebar/right_panel.py
+++ b/negpy/desktop/view/sidebar/right_panel.py
@@ -99,7 +99,7 @@ class RightPanel(QWidget):
         self.metadata_sidebar = MetadataSidebar(self.controller)
         self.history_panel = HistoryPanel(self.controller)
 
-        from negpy.desktop.view.sidebar.scan import ScanSidebar, _ScanUnsupportedPlaceholder
+        from negpy.desktop.view.sidebar.scan import ScanSidebar
 
         self.scan_sidebar = ScanSidebar(self.controller)
 

--- a/negpy/desktop/view/sidebar/scan.py
+++ b/negpy/desktop/view/sidebar/scan.py
@@ -260,7 +260,7 @@ class ScanSidebar(QWidget):
         self.depth_combo.currentTextChanged.connect(lambda: self._update_settings_from_ui())
         self.ir_check.toggled.connect(lambda: self._update_settings_from_ui())
         self.autofocus_check.toggled.connect(lambda: self._update_settings_from_ui())
-        self.ae_check.toggled.connect(lambda: self._update_settings_from_ui())
+        self.ae_check.toggled.connect(lambda: self._on_ae_toggled())
         self.exposure_slider.valueChanged.connect(self._on_exposure_changed)
         self.frame_from_spin.valueChanged.connect(self._on_frame_from_changed)
         self.frame_to_spin.valueChanged.connect(self._on_frame_to_changed)
@@ -492,6 +492,10 @@ class ScanSidebar(QWidget):
         self.ae_check.blockSignals(False)
         self.frame_from_spin.blockSignals(False)
         self.frame_to_spin.blockSignals(False)
+
+    def _on_ae_toggled(self) -> None:
+        self.exposure_slider.setEnabled(not self.ae_check.isChecked()) 
+        self._update_settings_from_ui()
 
     def _on_exposure_changed(self, _value: int) -> None:
         self._update_exposure_value_label()

--- a/negpy/desktop/view/sidebar/scan.py
+++ b/negpy/desktop/view/sidebar/scan.py
@@ -378,6 +378,8 @@ class ScanSidebar(QWidget):
         self.eject_btn.setVisible(caps.can_eject)
         self.eject_btn.setEnabled(caps.can_eject and not self._scanning)
         self.frame_label.setText(f"Frame: {caps.max_area_mm[0]:.0f} × {caps.max_area_mm[1]:.0f} mm")
+        self.autofocus_check.setChecked(caps.autofocus)
+        self.autofocus_check.setVisible(caps.autofocus)
 
         # If no film sources, show banner
         if not caps.sources:

--- a/negpy/desktop/view/sidebar/scan.py
+++ b/negpy/desktop/view/sidebar/scan.py
@@ -660,9 +660,10 @@ class ScanSidebar(QWidget):
             self.set_scanning(False)
             self.status_label.setText(f"Scanner busy: {e}")
 
-    @pyqtSlot(float)
-    def _on_scan_progress(self, progress: float) -> None:
+    @pyqtSlot(float, str)
+    def _on_scan_progress(self, progress: float, phase_name: str = 'Scanning') -> None:
         self.progress_bar.setVisible(True)
+        self.progress_bar.setFormat(f"{phase_name}… %p%")
         self.progress_bar.setValue(int(progress * 100))
 
     @pyqtSlot(str)

--- a/negpy/desktop/view/sidebar/scan.py
+++ b/negpy/desktop/view/sidebar/scan.py
@@ -245,6 +245,7 @@ class ScanSidebar(QWidget):
         self.pattern_edit.setText(self._settings.filename_pattern)
         self.autofocus_check.setChecked(self._settings.autofocus)
         self.ae_check.setChecked(self._settings.auto_exposure)
+        self.exposure_slider.setEnabled(not self._settings.auto_exposure)
 
     def _connect_signals(self) -> None:
         self.refresh_btn.clicked.connect(self._on_refresh)

--- a/negpy/desktop/workers/scan_worker.py
+++ b/negpy/desktop/workers/scan_worker.py
@@ -53,7 +53,7 @@ class ScanWorker(QObject):
     """Background worker for scanner operations. Mirrors RenderWorker pattern."""
 
     devices_ready = pyqtSignal(list)  # list[ScannerDevice]
-    progress = pyqtSignal(float)  # 0.0..1.0
+    progress = pyqtSignal(float, str)  # 0.0..1.0, phase name
     finished = pyqtSignal(str)  # output rgb file path
     frame_done = pyqtSignal(int, str)  # batch: frame number, rgb file path
     batch_finished = pyqtSignal(list)  # batch: all written rgb paths (also on stop/error)

--- a/negpy/desktop/workers/scan_worker.py
+++ b/negpy/desktop/workers/scan_worker.py
@@ -128,7 +128,9 @@ class ScanWorker(QObject):
                     result = service.run_scan(
                         device_id=req.device_id,
                         params=req.params,
-                        progress=self.progress.emit,
+                        # A one-phase backend calls progress(fraction), which a
+                        # two-argument signal's emit rejects on its own.
+                        progress=lambda fraction, phase="Scanning": self.progress.emit(fraction, phase),
                         cancel=self._cancel_event,
                     )
                 except Exception as error:
@@ -204,8 +206,8 @@ class ScanWorker(QObject):
                 frame_params = dataclasses.replace(req.params, frame=frame, window=window, frame_offset_mm=offset)
                 base = index / total
 
-                def _progress(fraction: float, _base: float = base) -> None:
-                    self.progress.emit(_base + min(1.0, max(0.0, fraction)) / total)
+                def _progress(fraction: float, phase: str = "Scanning", _base: float = base) -> None:
+                    self.progress.emit(_base + min(1.0, max(0.0, fraction)) / total, phase)
 
                 try:
                     result = service.run_scan(req.device_id, frame_params, _progress, self._cancel_event)

--- a/negpy/infrastructure/scanners/base.py
+++ b/negpy/infrastructure/scanners/base.py
@@ -57,7 +57,7 @@ class ScannerSession(Protocol):
     def scan(
         self,
         params: ScanParams,
-        progress: Callable[[float], None],
+        progress: Callable[[float, str], None],
         cancel: threading.Event,
     ) -> ScanResult: ...
     def eject(self) -> bool: ...
@@ -75,6 +75,11 @@ class ScannerBackend(Protocol):
       scanner with no selectable source must still populate it or it never appears.
     - `scan` raises `TransientScanError` for retryable transport failures and a plain
       exception for everything else — that choice is the backend's alone.
+    - `scan` reports progress as `progress(fraction)`, or `progress(fraction, phase)`
+      when it has more than one phase to distinguish. The fraction is relative to
+      the phase, not the scan, so a backend reporting several rewinds to 0.0 at each
+      one and the label is what makes that legible. A caller supplying `progress`
+      must therefore accept the phase as optional, defaulting it to "Scanning".
     - `eject` returns False for a device with no eject action; it raises only when a
       present eject genuinely fails.
     - The constructor raises `ScannerUnavailable` when the driver is missing, with an
@@ -90,7 +95,7 @@ class ScannerBackend(Protocol):
         self,
         device_id: str,
         params: ScanParams,
-        progress: Callable[[float], None],
+        progress: Callable[[float, str], None],
         cancel: threading.Event,
     ) -> ScanResult: ...
     def open_session(self, device_id: str) -> ScannerSession: ...

--- a/negpy/infrastructure/scanners/base.py
+++ b/negpy/infrastructure/scanners/base.py
@@ -28,6 +28,7 @@ class ScannerCapabilities:
     supported_depths: tuple[int, ...]
     sources: tuple[ScanMode, ...]
     max_area_mm: tuple[float, float]  # (width, height)
+    autofocus: bool = True
     auto_exposure: bool = False
     adapter_frame_capacity: int | None = None  # transport capacity bound, not an exposure count
     adapter_frame_control: bool = False

--- a/negpy/infrastructure/scanners/per_frame_roll.py
+++ b/negpy/infrastructure/scanners/per_frame_roll.py
@@ -57,7 +57,7 @@ class PerFrameRollSession:
                 frame=slot,
             )
             try:
-                result = self._backend.scan(self._device.id, params, lambda _fraction: None, cancel)
+                result = self._backend.scan(self._device.id, params, lambda _fraction, _phase="": None, cancel)
             except Exception as error:
                 if cancel.is_set():
                     return

--- a/negpy/infrastructure/scanners/pieusb_backend.py
+++ b/negpy/infrastructure/scanners/pieusb_backend.py
@@ -1,6 +1,13 @@
-from negpy.infrastructure.scanners.base import ScannerDevice, ScannerSession, ScannerUnavailable
-from negpy.infrastructure.scanners.params import ScanParams
+from negpy.infrastructure.scanners.base import (
+    ScannerDevice,
+    ScannerSession,
+    ScannerUnavailable,
+    ScannerCapabilities
+)
+from negpy.infrastructure.scanners.params import ScanParams, ScanMode
 from negpy.infrastructure.scanners.result import ScanResult
+
+from pieusb.types import DeviceInfo
 
 from collections.abc import Callable
 
@@ -36,12 +43,41 @@ class PieusbBackend:
             raise ScannerUnavailable('Could not import module pieusb')
         self._pieusb = pieusb
         self._devices_cache: list[ScannerDevice] | None = None
+        self._devices_map: dict[str, DeviceInfo] = {}
 
     def list_devices(self) -> list[ScannerDevice]:
-        return []
+        if self._devices_cache is not None:
+            return self._devices_cache
+
+        return self.refresh_devices()
     
     def refresh_devices(self) -> list[ScannerDevice]:
-        return []
+        self._devices_cache = []
+        self._devices_map = {}
+        devices = self._pieusb.get_devices()
+        for dev in devices:
+            native_res = dev.inquiry.max_resolution_x
+            max_w = dev.inquiry.max_scan_w / native_res * 25.4
+            max_h = dev.inquiry.max_scan_h / native_res * 25.4
+            caps = ScannerCapabilities(
+                ir_channel=self._pieusb.types.Filter.INFRARED in dev.inquiry.filters,
+                supported_dpi=(300, 500, 1000, 2500, 5000, 10000),
+                supported_depths=(8, 16),
+                sources=(ScanMode.POSITIVE),
+                max_area_mm=(max_w, max_h),
+                auto_exposure=True
+            )
+            device_str = f'pieusb:{dev.dev.bus}:{dev.dev.address}'
+            self._devices_map[device_str] = dev.dev
+            self._devices_cache.append(ScannerDevice(
+                id='something',
+                vendor=dev.inquiry.vendor,
+                model=dev.inquiry.model_str,
+                capabilities=caps
+            ))
+
+        return self._devices_cache
+
 
     def scan(
         self,

--- a/negpy/infrastructure/scanners/pieusb_backend.py
+++ b/negpy/infrastructure/scanners/pieusb_backend.py
@@ -23,7 +23,7 @@ def _require_pieusb() -> None:
     try:
         import pieusb
     except ImportError:
-        raise ScannerUnavailable('pieusb not importable.') from None
+        raise ScannerUnavailable('pieusb not importable. Install: uv sync --group pieusb') from None
 
 class PieusbSession:
     device_id: str
@@ -78,7 +78,8 @@ class PieusbBackend:
                 supported_depths=supported_depths,
                 sources=(ScanMode.POSITIVE,),
                 max_area_mm=(max_w, max_h),
-                auto_exposure=True
+                auto_exposure=True,
+                autofocus=False
             )
             device_str = f'pieusb:{dev.dev.bus}:{dev.dev.address}'
             self._devices_map[device_str] = dev

--- a/negpy/infrastructure/scanners/pieusb_backend.py
+++ b/negpy/infrastructure/scanners/pieusb_backend.py
@@ -169,6 +169,7 @@ class PieusbBackend:
                 max_area_mm=(max_w, max_h),
                 auto_exposure=True,
                 autofocus=False,
+                exposure_time_us=(dev.inquiry.minimum_exposure, dev.inquiry.maximum_exposure),
             )
             device_str = f"pieusb:{dev.dev.bus}:{dev.dev.address}"
             self._devices_map[device_str] = dev
@@ -201,6 +202,10 @@ class PieusbBackend:
             s.color_depth = params.depth
             s.resolution = params.dpi
             s.auto_exp = params.auto_exposure
+            if not params.auto_exposure and params.exposure_time_us is not None:
+                s.exp_time_r = params.exposure_time_us
+                s.exp_time_g = params.exposure_time_us
+                s.exp_time_b = params.exposure_time_us
 
             if params.window is not None:
                 tl_x, tl_y, br_x, br_y = params.window

--- a/negpy/infrastructure/scanners/pieusb_backend.py
+++ b/negpy/infrastructure/scanners/pieusb_backend.py
@@ -4,18 +4,16 @@ from typing import TYPE_CHECKING
 
 
 from negpy.infrastructure.scanners.base import (
+    ScannerCapabilities,
     ScannerDevice,
     ScannerSession,
     ScannerUnavailable,
-    ScannerCapabilities,
-    TransientScanError
 )
 from negpy.infrastructure.scanners.params import ScanParams, ScanMode
 from negpy.infrastructure.scanners.result import ScanResult
 
 if TYPE_CHECKING:
     from pieusb.types import DeviceInfo
-    from pieusb.scanner import Scanner
 
 from collections.abc import Callable
 
@@ -42,7 +40,7 @@ class PieusbSession:
     def scan(
         self,
         params: ScanParams,
-        progress: Callable[[float], None],
+        progress: Callable[[float, str], None],
         cancel: threading.Event,
     ) -> ScanResult:
         raise NotImplementedError("PieusbSession is a stub; use PieusbBackend.scan")
@@ -111,10 +109,6 @@ class PieusbBackend:
         cancel: threading.Event,
     ) -> ScanResult:
         from pieusb.scanner import Scanner
-
-        from pieusb.exceptions import WarmingUp, DeviceNotReady
-
-        from pieusb.types import ScanPhase
 
         if cancel.is_set():
             raise Exception("Scan was cancelled")

--- a/negpy/infrastructure/scanners/pieusb_backend.py
+++ b/negpy/infrastructure/scanners/pieusb_backend.py
@@ -1,0 +1,62 @@
+from negpy.infrastructure.scanners.base import ScannerDevice, ScannerSession, ScannerUnavailable
+from negpy.infrastructure.scanners.params import ScanParams
+from negpy.infrastructure.scanners.result import ScanResult
+
+from collections.abc import Callable
+
+import numpy
+import threading
+
+class PieusbSession:
+    device_id: str
+
+    def __init__(self) -> None:
+        pass
+    
+    def scan(
+        self,
+        params: ScanParams,
+        progress: Callable[[float], None],
+        cancel: threading.Event,
+    ) -> ScanResult: ...
+    def eject(self) -> bool:
+        return False
+    def close(self) -> None:
+        pass
+    def __enter__(self) -> "ScannerSession":
+        return self
+    def __exit__(self, *exc: object) -> None:
+        pass
+
+class PieusbBackend:
+    def __init__(self) -> None:
+        try:
+            import pieusb
+        except ImportError:
+            raise ScannerUnavailable('Could not import module pieusb')
+        self._pieusb = pieusb
+        self._devices_cache: list[ScannerDevice] | None = None
+
+    def list_devices(self) -> list[ScannerDevice]:
+        return []
+    
+    def refresh_devices(self) -> list[ScannerDevice]:
+        return []
+
+    def scan(
+        self,
+        device_id: str,
+        params: ScanParams,
+        progress: Callable[[float], None],
+        cancel: threading.Event,
+    ) -> ScanResult:
+        return ScanResult(
+            rgb=numpy.array([]),
+            ir=numpy.array([]),
+            dpi=0,
+            device_model='Unknown'
+        )
+    def open_session(self, device_id: str) -> ScannerSession:
+        return PieusbSession()
+    def eject(self, device_id: str) -> bool:
+        return False

--- a/negpy/infrastructure/scanners/pieusb_backend.py
+++ b/negpy/infrastructure/scanners/pieusb_backend.py
@@ -2,7 +2,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from negpy.infrastructure.scanners.base import ScannerDevice, ScannerSession, ScannerUnavailable, ScannerCapabilities
+
+from negpy.infrastructure.scanners.base import (
+    ScannerDevice,
+    ScannerSession,
+    ScannerUnavailable,
+    ScannerCapabilities,
+    TransientScanError
+)
 from negpy.infrastructure.scanners.params import ScanParams, ScanMode
 from negpy.infrastructure.scanners.result import ScanResult
 
@@ -28,8 +35,9 @@ def _require_pieusb() -> None:
 class PieusbSession:
     device_id: str
 
-    def __init__(self, info: DeviceInfo) -> None:
-        self.dev = Scanner(info)
+
+    def __init__(self, backend: PieusbBackend) -> None:
+        raise NotImplementedError('PieusbSession not yet implemented')
 
     def scan(
         self,
@@ -99,10 +107,13 @@ class PieusbBackend:
         self,
         device_id: str,
         params: ScanParams,
-        progress: Callable[[float], None],
+        progress: Callable[[float, str], None],
         cancel: threading.Event,
     ) -> ScanResult:
         from pieusb.scanner import Scanner
+
+        from pieusb.exceptions import WarmingUp, DeviceNotReady
+
         from pieusb.types import ScanPhase
 
         if cancel.is_set():
@@ -132,29 +143,21 @@ class PieusbBackend:
                 s.br_y = int(br_y)
 
             result = None
-
-            # Auto exposure meters from a preview pass, which is a full scan and
-            # reports its own 0..100%. Compress it into the head of the bar so
-            # the caller still sees one monotonic sweep instead of two. The
-            # share is a guess at relative cost: the preview runs at the
-            # device's preview resolution, so it is short next to the real scan
-            # but not free, since it pays warm-up and calibration again.
-            metering_share = 0.1 if params.auto_exposure else 0.0
+            scan_error = None
 
             def on_update(update):
-                scanned, total = update.scanned_lines, update.total_lines
-                if scanned is None or not total:
-                    return
-                fraction = scanned / total
-                if update.phase == ScanPhase.METERING:
-                    progress(fraction * metering_share)
-                else:
-                    progress(metering_share + fraction * (1.0 - metering_share))
+                progress(update.progress, update.phase)
 
             def on_complete(scan_result):
-                nonlocal result
-                result = ScanResult(rgb=scan_result.rgb, ir=scan_result.ir, dpi=params.dpi, device_model=dev.inquiry.model_str)
-
+                nonlocal result, scan_error
+                scan_error = scan_result.error
+                result = ScanResult(
+                    rgb=scan_result.rgb,
+                    ir=scan_result.ir,
+                    dpi=params.dpi,
+                    device_model=dev.inquiry.model_str
+                )
+            
             s.scan(on_update, on_complete)
 
             while not s.wait(0.2):
@@ -162,8 +165,8 @@ class PieusbBackend:
                     s.cancel()
                     raise Exception("Scan was cancelled")
 
-            if result is None:
-                raise Exception("Error while assembling the scan result")
+            if result is None or result.rgb is None:
+                raise Exception('Error while assembling the scan result')
 
             return result
 

--- a/negpy/infrastructure/scanners/pieusb_backend.py
+++ b/negpy/infrastructure/scanners/pieusb_backend.py
@@ -8,6 +8,7 @@ from negpy.infrastructure.scanners.base import (
     ScannerDevice,
     ScannerSession,
     ScannerUnavailable,
+    TransientScanError,
 )
 from negpy.infrastructure.scanners.params import ScanParams, ScanMode
 from negpy.infrastructure.scanners.result import ScanResult
@@ -17,7 +18,17 @@ if TYPE_CHECKING:
 
 from collections.abc import Callable
 
+import errno
 import threading
+
+# libusb failures worth another attempt: a fresh `with Scanner(dev)` re-claims the
+# interface, which clears a stall or a busy handle. pyusb maps these from
+# LIBUSB_ERROR_BUSY/TIMEOUT/PIPE (usb.backend.libusb1._libusb_errno).
+_RETRYABLE_USB_ERRNOS = frozenset({errno.EBUSY, errno.ETIMEDOUT, errno.EPIPE})
+
+# ...and the ones a retry cannot help, because _devices_map still holds the
+# vanished device and every attempt would reuse a dead handle.
+_GONE_USB_ERRNOS = frozenset({errno.ENODEV, errno.ENOENT})
 
 
 def _require_pieusb() -> None:
@@ -28,6 +39,71 @@ def _require_pieusb() -> None:
         import pieusb  # noqa: F401
     except ImportError:
         raise ScannerUnavailable("pieusb not importable. Install: uv sync --group pieusb") from None
+
+
+def _as_scan_error(exc: BaseException, params: ScanParams) -> Exception:
+    """Re-type a failed scan so ScannerService can decide on type alone.
+
+    `TransientScanError` earns a retry (ScannerService gives it three attempts
+    with a settle delay); anything else fails fast with a message the sidebar
+    shows verbatim, so each one has to say what the user can do about it.
+
+    pieusb reports failures by exception type, unlike SANE's message markers in
+    `sane_backend._as_scan_error` — with one exception, noted below. Note that
+    pyusb's USBError is NOT wrapped by pieusb's transport layer, so it arrives
+    raw and must be handled here.
+    """
+    import usb.core
+    from pieusb.exceptions import (
+        CheckCondition,
+        DeviceNotReady,
+        PieusbError,
+        Timeout,
+        TransportError,
+        WarmingUp,
+    )
+
+    # --- retryable ---------------------------------------------------------
+    if isinstance(exc, (TransportError, Timeout)):
+        # TransportError already reset the transport before raising, so the
+        # device is deliberately left in a state a fresh open can use.
+        return TransientScanError(f"Scanner transport failure: {exc}")
+    if isinstance(exc, WarmingUp):
+        # Retryable by nature, but pieusb has already waited out its own budget
+        # (~150s at START SCAN), so each further attempt costs that again. The
+        # WARMING_UP phase reaches the progress bar, so the wait is at least visible.
+        return TransientScanError(f"Scanner lamp is still warming up: {exc}")
+    if isinstance(exc, usb.core.USBError) and getattr(exc, "errno", None) in _RETRYABLE_USB_ERRNOS:
+        return TransientScanError(f"USB error during the scan: {exc}")
+
+    # --- fatal, most specific first ----------------------------------------
+    if isinstance(exc, usb.core.USBError):
+        if getattr(exc, "errno", None) in _GONE_USB_ERRNOS:
+            return RuntimeError(f"Lost contact with the scanner mid-scan; refresh the device list and try again ({exc})")
+        # No errno, or one not worth a claim either way: say what happened and
+        # stop, rather than guessing at a cause the message cannot support.
+        return RuntimeError(f"USB error during the scan: {exc}")
+    if isinstance(exc, MemoryError):
+        return RuntimeError(
+            f"Not enough memory to hold a {params.dpi} dpi {params.depth}-bit scan"
+            f"{' with infrared' if params.capture_ir else ''}. Lower the resolution, "
+            f"scan 8-bit, or select a smaller area."
+        )
+    if isinstance(exc, DeviceNotReady):
+        # WarmingUp, its one retryable subclass, was taken above.
+        return RuntimeError(f"The scanner is not ready to scan — check the holder and the cover ({exc})")
+    if isinstance(exc, CheckCondition):
+        # str() carries the sense key/code/qualifier, which is the only thing that
+        # makes an unrecognised refusal diagnosable after the fact.
+        return RuntimeError(f"The scanner refused a command: {exc}")
+    if isinstance(exc, PieusbError):
+        # The one message match, because pieusb has no distinct type for it and it
+        # is the likeliest failure with a user action attached. Worth an upstream
+        # exception type; until then, matching beats showing raw geometry.
+        if "empty image" in str(exc):
+            return RuntimeError("The scanner reported an empty image — check that film is loaded and the area is in range")
+        return RuntimeError(f"Scan failed: {exc}")
+    return RuntimeError(f"Scan failed: {exc}")
 
 
 class PieusbSession:
@@ -139,20 +215,22 @@ class PieusbBackend:
 
             result = None
             scan_error = None
+            scan_cancelled = False
 
             def on_update(update):
                 progress(update.progress, update.phase)
 
             def on_complete(scan_result):
-                nonlocal result, scan_error
+                nonlocal result, scan_error, scan_cancelled
                 scan_error = scan_result.error
+                scan_cancelled = scan_result.cancelled
                 result = ScanResult(
                     rgb=scan_result.rgb,
                     ir=scan_result.ir,
                     dpi=params.dpi,
                     device_model=dev.inquiry.model_str
                 )
-            
+
             s.scan(on_update, on_complete)
 
             done = False
@@ -162,8 +240,21 @@ class PieusbBackend:
                     raise Exception("Scan was cancelled")
                 done = s.wait(0.2)
 
-            if result is None or result.rgb is None:
-                raise Exception('Error while assembling the scan result')
+            # A pieusb scan reports exactly one outcome, and the three below are
+            # not interchangeable: only `error` may be retried, and a cancelled
+            # scan is not a failure at all.
+            if scan_cancelled:
+                # The worker noticed the cancel at a chunk boundary and stopped the
+                # device itself, so the poll above saw it finish rather than cancel.
+                raise Exception("Scan was cancelled")
+            if scan_error is not None:
+                raise _as_scan_error(scan_error, params) from scan_error
+            if result is None:
+                # on_complete never ran: the worker thread died on something that
+                # is not an Exception, so the device state is unknown, not failed.
+                raise RuntimeError("The scan worker did not report an outcome")
+            if result.rgb is None:
+                raise RuntimeError("The scan completed but returned no image data")
 
             return result
 

--- a/negpy/infrastructure/scanners/pieusb_backend.py
+++ b/negpy/infrastructure/scanners/pieusb_backend.py
@@ -75,9 +75,10 @@ class PieusbBackend:
         from pieusb import get_devices
         from pieusb.types import Filter
 
-        self._devices_cache = []
-        self._devices_map = {}
+        self._devices_cache = None
         devices = get_devices()
+        self._devices_map = {}
+        self._devices_cache = []
         for dev in devices:
             native_res = dev.inquiry.max_resolution_x
             max_w = dev.inquiry.max_scan_w / native_res * 25.4
@@ -154,10 +155,12 @@ class PieusbBackend:
             
             s.scan(on_update, on_complete)
 
-            while not s.wait(0.2):
+            done = False
+            while not done:
                 if cancel.is_set():
                     s.cancel()
                     raise Exception("Scan was cancelled")
+                done = s.wait(0.2)
 
             if result is None or result.rgb is None:
                 raise Exception('Error while assembling the scan result')

--- a/negpy/infrastructure/scanners/pieusb_backend.py
+++ b/negpy/infrastructure/scanners/pieusb_backend.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from negpy.infrastructure.scanners.base import (
     ScannerDevice,
     ScannerSession,
@@ -7,13 +11,19 @@ from negpy.infrastructure.scanners.base import (
 from negpy.infrastructure.scanners.params import ScanParams, ScanMode
 from negpy.infrastructure.scanners.result import ScanResult
 
-from pieusb.types import DeviceInfo
-from pieusb.scanner import Scanner
+if TYPE_CHECKING:
+    from pieusb.types import DeviceInfo
+    from pieusb.scanner import Scanner
 
 from collections.abc import Callable
 
-import numpy
 import threading
+
+def _require_pieusb() -> None:
+    try:
+        import pieusb
+    except ImportError:
+        raise ScannerUnavailable('pieusb not importable.') from None
 
 class PieusbSession:
     device_id: str
@@ -30,7 +40,7 @@ class PieusbSession:
     def eject(self) -> bool:
         return False
     def close(self) -> None:
-        self.dev.dev.close()
+        self.dev.close()
     def __enter__(self) -> "ScannerSession":
         return self
     def __exit__(self, *exc: object) -> None:
@@ -38,11 +48,8 @@ class PieusbSession:
 
 class PieusbBackend:
     def __init__(self) -> None:
-        try:
-            import pieusb
-        except ImportError:
-            raise ScannerUnavailable('Could not import module pieusb')
-        self._pieusb = pieusb
+        _require_pieusb()
+
         self._devices_cache: list[ScannerDevice] | None = None
         self._devices_map: dict[str, DeviceInfo] = {}
 
@@ -53,32 +60,36 @@ class PieusbBackend:
         return self.refresh_devices()
     
     def refresh_devices(self) -> list[ScannerDevice]:
+        from pieusb import get_devices
+        from pieusb.types import Filter
+
         self._devices_cache = []
         self._devices_map = {}
-        devices = self._pieusb.get_devices()
+        devices = get_devices()
         for dev in devices:
             native_res = dev.inquiry.max_resolution_x
             max_w = dev.inquiry.max_scan_w / native_res * 25.4
             max_h = dev.inquiry.max_scan_h / native_res * 25.4
+            supported_dpi = tuple([int(native_res / d) for d in [1, 2, 4, 5, 8, 10, 20]])
+            supported_depths = tuple([d for d in [8, 16] if d in dev.inquiry.color_depths])
             caps = ScannerCapabilities(
-                ir_channel=self._pieusb.types.Filter.INFRARED in dev.inquiry.filters,
-                supported_dpi=(300, 500, 1000, 2500, 5000, 10000),
-                supported_depths=(8, 16),
-                sources=(ScanMode.POSITIVE),
+                ir_channel=Filter.INFRARED in dev.inquiry.filters,
+                supported_dpi=supported_dpi,
+                supported_depths=supported_depths,
+                sources=(ScanMode.POSITIVE,),
                 max_area_mm=(max_w, max_h),
                 auto_exposure=True
             )
             device_str = f'pieusb:{dev.dev.bus}:{dev.dev.address}'
-            self._devices_map[device_str] = dev.dev
+            self._devices_map[device_str] = dev
             self._devices_cache.append(ScannerDevice(
-                id='something',
+                id=device_str,
                 vendor=dev.inquiry.vendor,
                 model=dev.inquiry.model_str,
                 capabilities=caps
             ))
 
         return self._devices_cache
-
 
     def scan(
         self,
@@ -87,15 +98,66 @@ class PieusbBackend:
         progress: Callable[[float], None],
         cancel: threading.Event,
     ) -> ScanResult:
-        return ScanResult(
-            rgb=numpy.array([]),
-            ir=numpy.array([]),
-            dpi=0,
-            device_model='Unknown'
-        )
+        from pieusb.scanner import Scanner
+
+        if cancel.is_set():
+            raise Exception('Scan was cancelled')
+
+        dev = self._devices_map[device_id]
+
+        with Scanner(dev) as s:
+
+            if params.capture_ir:
+                s.mode = 'rgbi'
+            else:
+                s.mode = 'rgb'
+
+            s.color_depth = params.depth
+            s.resolution = params.dpi
+            s.auto_exp = params.auto_exposure
+
+            if params.window is not None:
+                tl_x, tl_y, br_x, br_y = params.window
+                tl_x *= dev.inquiry.max_scan_w
+                br_x *= dev.inquiry.max_scan_w
+                tl_y *= dev.inquiry.max_scan_h
+                br_y *= dev.inquiry.max_scan_h
+                s.tl_x = int(tl_x)
+                s.tl_y = int(tl_y)
+                s.br_x = int(br_x)
+                s.br_y = int(br_y)
+
+            result = None
+
+            def on_update(update):
+                scanned, total = update.scanned_lines, update.total_lines
+                if scanned is not None and total:
+                    progress(scanned / total)
+
+            def on_complete(scan_result):
+                nonlocal result
+                result = ScanResult(
+                    rgb=scan_result.rgb,
+                    ir=scan_result.ir,
+                    dpi=params.dpi,
+                    device_model=dev.inquiry.model_str
+                )
+
+            s.scan(on_update, on_complete)
+
+            while not s.wait(0.2):
+                if cancel.is_set():
+                    s.cancel()
+                    raise Exception('Scan was cancelled')
+
+            if result is None:
+                raise Exception('Error while assembling the scan result')
+
+            return result
+
 
     def open_session(self, device_id: str) -> ScannerSession:
-        return PieusbSession(self._devices_map[device_id])
+        raise NotImplementedError('open_session not yet implemented in PieusbBackend')
 
     def eject(self, device_id: str) -> bool:
         return False

--- a/negpy/infrastructure/scanners/pieusb_backend.py
+++ b/negpy/infrastructure/scanners/pieusb_backend.py
@@ -2,12 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from negpy.infrastructure.scanners.base import (
-    ScannerDevice,
-    ScannerSession,
-    ScannerUnavailable,
-    ScannerCapabilities
-)
+from negpy.infrastructure.scanners.base import ScannerDevice, ScannerSession, ScannerUnavailable, ScannerCapabilities
 from negpy.infrastructure.scanners.params import ScanParams, ScanMode
 from negpy.infrastructure.scanners.result import ScanResult
 
@@ -19,32 +14,43 @@ from collections.abc import Callable
 
 import threading
 
+
 def _require_pieusb() -> None:
     try:
-        import pieusb
+        # An actual import, not find_spec: a resolvable spec still fails to load
+        # if pyusb or libusb_package's bundled library is missing or ABI-broken,
+        # which is the failure this is here to catch.
+        import pieusb  # noqa: F401
     except ImportError:
-        raise ScannerUnavailable('pieusb not importable. Install: uv sync --group pieusb') from None
+        raise ScannerUnavailable("pieusb not importable. Install: uv sync --group pieusb") from None
+
 
 class PieusbSession:
     device_id: str
 
     def __init__(self, info: DeviceInfo) -> None:
         self.dev = Scanner(info)
-    
+
     def scan(
         self,
         params: ScanParams,
         progress: Callable[[float], None],
         cancel: threading.Event,
-    ) -> ScanResult: ...
+    ) -> ScanResult:
+        raise NotImplementedError("PieusbSession is a stub; use PieusbBackend.scan")
+
     def eject(self) -> bool:
         return False
+
     def close(self) -> None:
         self.dev.close()
+
     def __enter__(self) -> "ScannerSession":
         return self
+
     def __exit__(self, *exc: object) -> None:
         self.close()
+
 
 class PieusbBackend:
     def __init__(self) -> None:
@@ -58,7 +64,7 @@ class PieusbBackend:
             return self._devices_cache
 
         return self.refresh_devices()
-    
+
     def refresh_devices(self) -> list[ScannerDevice]:
         from pieusb import get_devices
         from pieusb.types import Filter
@@ -79,16 +85,13 @@ class PieusbBackend:
                 sources=(ScanMode.POSITIVE,),
                 max_area_mm=(max_w, max_h),
                 auto_exposure=True,
-                autofocus=False
+                autofocus=False,
             )
-            device_str = f'pieusb:{dev.dev.bus}:{dev.dev.address}'
+            device_str = f"pieusb:{dev.dev.bus}:{dev.dev.address}"
             self._devices_map[device_str] = dev
-            self._devices_cache.append(ScannerDevice(
-                id=device_str,
-                vendor=dev.inquiry.vendor,
-                model=dev.inquiry.model_str,
-                capabilities=caps
-            ))
+            self._devices_cache.append(
+                ScannerDevice(id=device_str, vendor=dev.inquiry.vendor, model=dev.inquiry.model_str, capabilities=caps)
+            )
 
         return self._devices_cache
 
@@ -100,18 +103,18 @@ class PieusbBackend:
         cancel: threading.Event,
     ) -> ScanResult:
         from pieusb.scanner import Scanner
+        from pieusb.types import ScanPhase
 
         if cancel.is_set():
-            raise Exception('Scan was cancelled')
+            raise Exception("Scan was cancelled")
 
         dev = self._devices_map[device_id]
 
         with Scanner(dev) as s:
-
             if params.capture_ir:
-                s.mode = 'rgbi'
+                s.mode = "rgbi"
             else:
-                s.mode = 'rgb'
+                s.mode = "rgb"
 
             s.color_depth = params.depth
             s.resolution = params.dpi
@@ -130,35 +133,42 @@ class PieusbBackend:
 
             result = None
 
+            # Auto exposure meters from a preview pass, which is a full scan and
+            # reports its own 0..100%. Compress it into the head of the bar so
+            # the caller still sees one monotonic sweep instead of two. The
+            # share is a guess at relative cost: the preview runs at the
+            # device's preview resolution, so it is short next to the real scan
+            # but not free, since it pays warm-up and calibration again.
+            metering_share = 0.1 if params.auto_exposure else 0.0
+
             def on_update(update):
                 scanned, total = update.scanned_lines, update.total_lines
-                if scanned is not None and total:
-                    progress(scanned / total)
+                if scanned is None or not total:
+                    return
+                fraction = scanned / total
+                if update.phase == ScanPhase.METERING:
+                    progress(fraction * metering_share)
+                else:
+                    progress(metering_share + fraction * (1.0 - metering_share))
 
             def on_complete(scan_result):
                 nonlocal result
-                result = ScanResult(
-                    rgb=scan_result.rgb,
-                    ir=scan_result.ir,
-                    dpi=params.dpi,
-                    device_model=dev.inquiry.model_str
-                )
+                result = ScanResult(rgb=scan_result.rgb, ir=scan_result.ir, dpi=params.dpi, device_model=dev.inquiry.model_str)
 
             s.scan(on_update, on_complete)
 
             while not s.wait(0.2):
                 if cancel.is_set():
                     s.cancel()
-                    raise Exception('Scan was cancelled')
+                    raise Exception("Scan was cancelled")
 
             if result is None:
-                raise Exception('Error while assembling the scan result')
+                raise Exception("Error while assembling the scan result")
 
             return result
 
-
     def open_session(self, device_id: str) -> ScannerSession:
-        raise NotImplementedError('open_session not yet implemented in PieusbBackend')
+        raise NotImplementedError("open_session not yet implemented in PieusbBackend")
 
     def eject(self, device_id: str) -> bool:
         return False

--- a/negpy/infrastructure/scanners/pieusb_backend.py
+++ b/negpy/infrastructure/scanners/pieusb_backend.py
@@ -169,7 +169,7 @@ class PieusbBackend:
                 max_area_mm=(max_w, max_h),
                 auto_exposure=True,
                 autofocus=False,
-                exposure_time_us=(dev.inquiry.minimum_exposure, dev.inquiry.maximum_exposure),
+                exposure_time_us=(4100, 65518), # Empirical findings, not really matching reality, either
             )
             device_str = f"pieusb:{dev.dev.bus}:{dev.dev.address}"
             self._devices_map[device_str] = dev
@@ -203,9 +203,10 @@ class PieusbBackend:
             s.resolution = params.dpi
             s.auto_exp = params.auto_exposure
             if not params.auto_exposure and params.exposure_time_us is not None:
-                s.exp_time_r = params.exposure_time_us
-                s.exp_time_g = params.exposure_time_us
-                s.exp_time_b = params.exposure_time_us
+                rel = int(100 * params.exposure_time_us / 4100)
+                s.exp_rel_r = rel
+                s.exp_rel_g = rel
+                s.exp_rel_b = rel
 
             if params.window is not None:
                 tl_x, tl_y, br_x, br_y = params.window

--- a/negpy/infrastructure/scanners/pieusb_backend.py
+++ b/negpy/infrastructure/scanners/pieusb_backend.py
@@ -8,6 +8,7 @@ from negpy.infrastructure.scanners.params import ScanParams, ScanMode
 from negpy.infrastructure.scanners.result import ScanResult
 
 from pieusb.types import DeviceInfo
+from pieusb.scanner import Scanner
 
 from collections.abc import Callable
 
@@ -17,8 +18,8 @@ import threading
 class PieusbSession:
     device_id: str
 
-    def __init__(self) -> None:
-        pass
+    def __init__(self, info: DeviceInfo) -> None:
+        self.dev = Scanner(info)
     
     def scan(
         self,
@@ -29,11 +30,11 @@ class PieusbSession:
     def eject(self) -> bool:
         return False
     def close(self) -> None:
-        pass
+        self.dev.dev.close()
     def __enter__(self) -> "ScannerSession":
         return self
     def __exit__(self, *exc: object) -> None:
-        pass
+        self.close()
 
 class PieusbBackend:
     def __init__(self) -> None:
@@ -92,7 +93,9 @@ class PieusbBackend:
             dpi=0,
             device_model='Unknown'
         )
+
     def open_session(self, device_id: str) -> ScannerSession:
-        return PieusbSession()
+        return PieusbSession(self._devices_map[device_id])
+
     def eject(self, device_id: str) -> bool:
         return False

--- a/negpy/infrastructure/scanners/registry.py
+++ b/negpy/infrastructure/scanners/registry.py
@@ -8,10 +8,12 @@ def _make_sane() -> ScannerBackend:
 
     return SaneBackend()
 
+
 def _make_pieusb() -> ScannerBackend:
     from negpy.infrastructure.scanners.pieusb_backend import PieusbBackend
 
     return PieusbBackend()
+
 
 DEFAULT_BACKEND_ID = "sane"
 

--- a/negpy/infrastructure/scanners/registry.py
+++ b/negpy/infrastructure/scanners/registry.py
@@ -8,6 +8,10 @@ def _make_sane() -> ScannerBackend:
 
     return SaneBackend()
 
+def _make_pieusb() -> ScannerBackend:
+    from negpy.infrastructure.scanners.pieusb_backend import PieusbBackend
+
+    return PieusbBackend()
 
 DEFAULT_BACKEND_ID = "sane"
 
@@ -15,6 +19,7 @@ DEFAULT_BACKEND_ID = "sane"
 # Adding a backend is one entry here plus its implementation module.
 BACKENDS: dict[str, tuple[str, Callable[[], ScannerBackend]]] = {
     "sane": ("SANE", _make_sane),
+    "pieusb": ("PIEUSB", _make_pieusb),
 }
 
 

--- a/negpy/infrastructure/scanners/sane_backend.py
+++ b/negpy/infrastructure/scanners/sane_backend.py
@@ -726,10 +726,16 @@ class SaneSession:
     def scan(
         self,
         params: ScanParams,
-        progress: Callable[[float], None],
+        progress: Callable[..., None],
         cancel: threading.Event,
     ) -> ScanResult:
-        """Scan one frame on the held handle. Blocks until complete or cancelled."""
+        """Scan one frame on the held handle. Blocks until complete or cancelled.
+
+        `progress` is `...` rather than `[[float], None]` because SANE reports one
+        phase and so calls `progress(fraction)`, while ScannerSession declares the
+        `(fraction, phase)` form callers must accept; only `...` is assignable to
+        both. See ScannerBackend's progress obligation.
+        """
         if self.closed:
             raise RuntimeError(f"Scanner session for {self.device_id} is closed")
         return self._backend._scan_on_device(self._dev, self.device_id, params, progress, cancel)
@@ -931,7 +937,7 @@ class SaneBackend:
         self,
         device_id: str,
         params: ScanParams,
-        progress: Callable[[float], None],
+        progress: Callable[..., None],
         cancel: threading.Event,
     ) -> ScanResult:
         """Execute a one-shot scan via SANE (open, scan, close). Blocks until complete or cancelled."""
@@ -962,7 +968,7 @@ class SaneBackend:
         dev,
         device_id: str,
         params: ScanParams,
-        progress: Callable[[float], None],
+        progress: Callable[..., None],
         cancel: threading.Event,
     ) -> ScanResult:
         """Scan one frame on an already-open handle. sane_cancel()s the frame when

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "qtawesome==1.4.2",
     "wgpu==0.31.1",
     "pyserial>=3.5",
+    "pieusb",
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",
@@ -103,3 +104,6 @@ exclude = [
 
 [tool.coverage.run]
 source = ["negpy"]
+
+[tool.uv.sources]
+pieusb = { path = "../sw/pieusb", editable = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ camera = [
     "gphoto2>=2.5 ; sys_platform != 'win32'",
 ]
 pieusb = [
-    "pieusb>=0.3.1",
+    "pieusb>=0.3.2",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ camera = [
     "gphoto2>=2.5 ; sys_platform != 'win32'",
 ]
 pieusb = [
-    "pieusb>=0.2.0",
+    "pieusb>=0.3.1",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ dependencies = [
     "qtawesome==1.4.2",
     "wgpu==0.31.1",
     "pyserial>=3.5",
-    "pieusb",
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",
@@ -55,6 +54,9 @@ camera = [
     # Tethered camera scanning. libgphoto2 has no Windows build, so the wheels — and the
     # Camera Scanning tab with them — are macOS and Linux only.
     "gphoto2>=2.5 ; sys_platform != 'win32'",
+]
+pieusb = [
+    "pieusb>=0.2.0",
 ]
 
 [project.urls]
@@ -104,6 +106,3 @@ exclude = [
 
 [tool.coverage.run]
 source = ["negpy"]
-
-[tool.uv.sources]
-pieusb = { path = "../sw/pieusb", editable = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ camera = [
     "gphoto2>=2.5 ; sys_platform != 'win32'",
 ]
 pieusb = [
-    "pieusb>=0.3.2",
+    "pieusb>=0.3.7",
 ]
 
 [project.urls]

--- a/tests/scanners/test_pieusb_autoexposure.py
+++ b/tests/scanners/test_pieusb_autoexposure.py
@@ -1,0 +1,392 @@
+"""Parity tests for pieusb's auto-exposure against the SANE backend it ports.
+
+The reference is sane-backends' pieusb: getGain/getGainSetting
+(pieusb_specific.c:2420, 2440), updateGain2 (2528), the dg derivation in
+sanei_pieusb_set_gain_offset's "from preview" branch (1912) and the 1%/99% loop
+in sanei_pieusb_analyze_preview (2394). The expected numbers below are the C's,
+not this implementation's.
+"""
+
+import numpy
+import pytest
+
+pieusb_calibration = pytest.importorskip("pieusb.calibration")
+
+GAINS = pieusb_calibration.GAINS
+gain_increase = pieusb_calibration.gain_increase
+get_gain = pieusb_calibration.get_gain
+get_gain_setting = pieusb_calibration.get_gain_setting
+percentile_bounds = pieusb_calibration.percentile_bounds
+update_gain = pieusb_calibration.update_gain
+
+
+def test_gain_table_matches_the_firmware_values():
+    assert len(GAINS) == 13
+    assert GAINS[0] == 1.000
+    assert GAINS[12] == 4.627
+
+
+@pytest.mark.parametrize(
+    "setting,expected",
+    [
+        (0, 1.000),
+        (5, 1.075),
+        (19, 1.3398),  # the default gain
+        (30, 1.653),
+        (59, 4.4292),  # last setting before the extrapolated branch
+        (60, 4.627),
+        (63, 5.2204),  # extrapolated past the table
+    ],
+)
+def test_get_gain_interpolates_the_table(setting, expected):
+    assert get_gain(setting) == pytest.approx(expected, abs=1e-4)
+
+
+def test_get_gain_clamps_below_zero():
+    assert get_gain(-5) == GAINS[0]
+
+
+def test_get_gain_setting_inverts_get_gain():
+    # 60-62 are excluded: getGain extrapolates from (setting - 55) while
+    # getGainSetting's matching branch starts at 60, so the C's own pair does not
+    # round-trip there. Reproducing that skew is deliberate.
+    for setting in list(range(60)) + [63]:
+        assert get_gain_setting(get_gain(setting)) == setting
+
+
+def test_get_gain_setting_is_bounded():
+    assert get_gain_setting(0.5) == 0
+    assert get_gain_setting(1.0) == 0
+    assert get_gain_setting(1000.0) == 63
+
+
+def test_update_gain_splits_the_boost_between_gain_and_exposure():
+    # Defaults (gain 19, exposure 2937) with the maximum dg the C allows.
+    assert update_gain(19, 2937, 3.0) == (43, 5087)
+
+
+@pytest.mark.parametrize("dg", [0.5, 1.0, 1.5, 2.0, 2.5, 3.0])
+def test_update_gain_delivers_exactly_dg(dg):
+    """Gain takes sqrt(dg); exposure takes whatever quantisation left over."""
+    setting, exposure = update_gain(19, 2937, dg)
+    achieved = (get_gain(setting) / get_gain(19)) * (exposure / 2937)
+    assert achieved == pytest.approx(dg, rel=2e-3)
+
+
+def test_update_gain_can_reduce():
+    setting, exposure = update_gain(40, 2937, 0.5)
+    assert setting < 40
+    assert exposure < 2937
+
+
+def test_gain_increase_takes_the_smallest_channel_ratio():
+    # Green saturates lowest, so green sets the ceiling for all three.
+    dg = gain_increase((100, 200, 100), (58981, 52428, 58981))
+    expected = (52428 / 65536) / (200 / 256)
+    assert dg == pytest.approx(expected)
+
+
+def test_gain_increase_is_capped_at_three():
+    assert gain_increase((5, 5, 5), (58981, 52428, 58981)) == 3.00
+
+
+def test_gain_increase_can_ask_to_pull_back():
+    # A preview already brighter than the saturation reference wants dg < 1.
+    assert gain_increase((250, 250, 250), (32768, 32768, 32768)) < 1.0
+
+
+def test_gain_increase_skips_empty_channels():
+    dg = gain_increase((0, 200, 0), (58981, 52428, 58981))
+    assert dg == pytest.approx((52428 / 65536) / (200 / 256))
+
+
+def test_gain_increase_is_a_noop_when_nothing_was_measured():
+    assert gain_increase((0, 0, 0), (58981, 52428, 58981)) == 1.0
+
+
+def test_percentile_bounds_shifts_16_bit_into_256_bins():
+    # 40000 >> 8 = 156, and the bound is the last bin still under 99% (see
+    # test_percentile_bounds_is_the_last_bin_below_the_threshold), so 155.
+    plane = numpy.full((10, 10), 40000, dtype="<u2")
+    _lower, upper = percentile_bounds(plane)
+    assert upper == (40000 >> 8) - 1
+
+
+def test_percentile_bounds_bins_8_bit_directly():
+    # Divergence from the C, which would shift 8-bit samples into bin 0.
+    plane = numpy.full((10, 10), 200, dtype="u1")
+    _lower, upper = percentile_bounds(plane)
+    assert upper == 199
+
+
+def test_percentile_bounds_ignores_the_top_one_percent():
+    # 0.5% specular highlights at full scale must not drag the bound up to 255.
+    plane = numpy.zeros(1000, dtype="<u2").reshape(10, 100)
+    plane[:] = 10 * 256
+    plane.ravel()[:5] = 65535
+    _lower, upper = percentile_bounds(plane)
+    assert upper == 9
+
+
+def _metering_scanner(mode="rgb", preview_plane_value=10 * 256, planes=3, cancelled=False):
+    """A Scanner with just enough state for _meter_from_preview, no USB."""
+    scanner_mod = pytest.importorskip("pieusb.scanner")
+    from pieusb.option import generate_options
+    from pieusb.types import ScanResult
+
+    inquiry = _fake_inquiry()
+    scanner = object.__new__(scanner_mod.Scanner)
+    scanner.info = _FakeInfo(inquiry)
+    scanner.params = generate_options(inquiry)
+    scanner.params["mode"].value = mode
+    scanner._get_gain_offset = lambda: {"saturation_level": (58981, 52428, 58981)}
+
+    seen = {}
+
+    def fake_scan_pass(started, emit):
+        # Capture the options as the preview pass would see them. Stubs
+        # _scan_pass, the sequence both passes share, not _run_scan, which is the
+        # orchestrator that calls _meter_from_preview in the first place —
+        # stubbing that would remove the code under test.
+        seen["resolution"] = scanner.params["resolution"].value
+        seen["sharpen"] = scanner.params["sharpen"].value
+        seen["emit"] = emit
+        rgb = numpy.full((8, 8, planes), preview_plane_value, dtype="<u2")
+        return ScanResult(rgb=None if cancelled else rgb, cancelled=cancelled)
+
+    scanner._scan_pass = fake_scan_pass
+    return scanner, seen
+
+
+class _FakeInfo:
+    def __init__(self, inquiry):
+        self.inquiry = inquiry
+
+
+def _fake_inquiry():
+    import dataclasses
+
+    from pieusb.inquiry import Filter, InquiryResponse
+
+    values = {f.name: 0 for f in dataclasses.fields(InquiryResponse)}
+    values.update(
+        filters=(Filter.RED, Filter.GREEN, Filter.BLUE),
+        color_depths=(8, 16),
+        color_formats=(),
+        image_formats=(),
+        scan_capabilities=(),
+        optional_devices=(),
+        max_resolution_x=10000,
+        max_resolution_y=10000,
+        max_scan_w=5000,
+        max_scan_h=5000,
+        minimum_exposure=100,
+        maximum_exposure=1000,
+        preview_scan_resolution=225,
+        model_str="fake",
+        vendor="v",
+        revision="",
+        production="",
+        timestamp="",
+        signature="",
+        slide_transport=False,
+    )
+    return InquiryResponse(**values)
+
+
+def test_metering_pass_runs_at_the_preview_resolution_with_quality_options_off():
+    scanner, seen = _metering_scanner()
+    scanner.params["resolution"].value = 3600
+    scanner.params["sharpen"].value = True
+
+    assert scanner._meter_from_preview(0.0) is None
+
+    assert seen["resolution"] == 225
+    assert seen["sharpen"] is False
+    # ...and the caller's own settings are back afterwards.
+    assert scanner.params["resolution"].value == 3600
+    assert scanner.params["sharpen"].value is True
+
+
+def test_metering_pass_reports_its_progress_as_metering():
+    """The pass is a full scan, so its updates must not read as the real one's."""
+    from pieusb.types import ScanPhase, UpdateData
+
+    scanner, seen = _metering_scanner()
+    reported = []
+    scanner.on_update = reported.append
+
+    scanner._meter_from_preview(0.0)
+
+    seen["emit"](UpdateData(phase=ScanPhase.SCANNING, progress=0.5))
+    assert reported == [UpdateData(phase=ScanPhase.METERING, progress=0.5)]
+
+
+def test_metering_rewrites_gain_and_exposure_for_all_three_channels():
+    scanner, _ = _metering_scanner()
+    scanner._meter_from_preview(0.0)
+
+    for suffix in ("r", "g", "b"):
+        assert scanner.params[f"gain_{suffix}"].value != 19
+        assert scanner.params[f"exp_time_{suffix}"].value != 2937
+    # Infrared is never metered, matching updateGain2's 0..2 loop.
+    assert scanner.params["gain_i"].value == 19
+    assert scanner.params["exp_time_i"].value == 2937
+
+
+def test_metering_applies_one_uniform_factor_to_every_channel():
+    scanner, _ = _metering_scanner()
+    scanner._meter_from_preview(0.0)
+
+    gains = {scanner.params[f"gain_{s}"].value for s in ("r", "g", "b")}
+    assert len(gains) == 1, "per-channel gains would rebalance the colour"
+
+
+def test_metering_a_gray_pass_only_touches_the_green_channel():
+    scanner, _ = _metering_scanner(mode="gray", planes=1)
+    scanner._meter_from_preview(0.0)
+
+    assert scanner.params["gain_g"].value != 19
+    assert scanner.params["gain_r"].value == 19
+    assert scanner.params["gain_b"].value == 19
+
+
+def test_a_cancelled_metering_pass_is_returned_instead_of_scanning():
+    scanner, _ = _metering_scanner(cancelled=True)
+    result = scanner._meter_from_preview(0.0)
+
+    assert result is not None and result.cancelled
+    assert scanner.params["gain_r"].value == 19
+
+
+def test_metering_leaves_settings_alone_when_the_preview_is_black():
+    scanner, _ = _metering_scanner(preview_plane_value=0)
+    assert scanner._meter_from_preview(0.0) is None
+    assert scanner.params["gain_r"].value == 19
+    assert scanner.params["exp_time_r"].value == 2937
+
+
+class _RecordingDevice:
+    """Captures every set_options() write instead of talking to USB."""
+
+    def __init__(self):
+        self.writes = []
+
+    def command(self, code, out_data=None, cdb_length=0):
+        self.writes.append(out_data)
+        return b""
+
+
+def _sent_payloads(table):
+    """set_options()'s writes, keyed by the write code in their first 2 bytes."""
+    import struct
+
+    from pieusb.option import set_options
+
+    dev = _RecordingDevice()
+    set_options(dev, table)
+    grouped = {}
+    for payload in dev.writes:
+        code = struct.unpack_from("<H", payload, 0)[0]
+        grouped.setdefault(code, []).append(payload)
+    return grouped
+
+
+def _relative_exposures(grouped):
+    import struct
+
+    from pieusb.transport import SCSI_EXPOSURE
+
+    return [struct.unpack_from("<H", p, 6)[0] for p in grouped[SCSI_EXPOSURE]]
+
+
+def test_relative_and_absolute_exposure_are_separate_options():
+    from pieusb.option import generate_options
+
+    table = generate_options(_fake_inquiry())
+    # Both exist, with the two defaults SANE uses for the two commands.
+    assert [table[f"exp_rel_{c}"].value for c in "rgb"] == [100, 100, 100]
+    assert [table[f"exp_time_{c}"].value for c in "rgbi"] == [2937] * 4
+    # Relative exposure has no infrared entry: the C struct holds three colours.
+    with pytest.raises(KeyError):
+        table["exp_rel_i"]
+
+
+def test_relative_exposure_reaches_only_the_scsi_exposure_write():
+    from pieusb.option import generate_options
+
+    table = generate_options(_fake_inquiry())
+    table["exp_rel_r"].value = 55
+    table["exp_rel_g"].value = 60
+    table["exp_rel_b"].value = 65
+
+    grouped = _sent_payloads(table)
+    assert _relative_exposures(grouped) == [55, 60, 65]
+
+
+def test_absolute_exposure_does_not_leak_into_the_relative_write():
+    """The conflation regression: one option used to feed both commands."""
+    from pieusb.option import generate_options
+
+    table = generate_options(_fake_inquiry())
+    for channel in "rgb":
+        table[f"exp_time_{channel}"].value = 5087
+
+    # Moving the absolute time leaves the relative write at its 100% default.
+    assert _relative_exposures(_sent_payloads(table)) == [100, 100, 100]
+
+
+def test_absolute_exposure_reaches_the_gain_offset_payload():
+    import struct
+
+    from pieusb.option import generate_options, set_options
+
+    table = generate_options(_fake_inquiry())
+    table["exp_time_r"].value = 5000
+    table["exp_time_g"].value = 5001
+    table["exp_time_b"].value = 5002
+    table["exp_time_i"].value = 5003
+
+    dev = _RecordingDevice()
+    set_options(dev, table)
+
+    # The gain/offset payload is the only 29-byte write. R/G/B exposure times
+    # lead it; infrared's sits at byte 18, after the 12 offset/gain/light bytes.
+    payload = next(p for p in dev.writes if len(p) == 29)
+    assert struct.unpack_from("<3H", payload, 0) == (5000, 5001, 5002)
+    assert struct.unpack_from("<H", payload, 18)[0] == 5003
+
+
+def test_moving_the_relative_exposure_warns(caplog):
+    from pieusb.option import generate_options
+
+    table = generate_options(_fake_inquiry())
+    table["mode"].value = "rgb"
+    with caplog.at_level("WARNING"):
+        table.validate()
+    assert not [r for r in caplog.records if "relative exposure" in r.message]
+
+    table["exp_rel_g"].value = 120
+    caplog.clear()
+    with caplog.at_level("WARNING"):
+        table.validate()
+    warning = next(r for r in caplog.records if "relative exposure" in r.message)
+    assert "exp_rel_g=120" in warning.message
+    assert "exp_time_" in warning.message
+
+
+def test_metering_never_touches_the_relative_exposure():
+    scanner, _ = _metering_scanner()
+    scanner._meter_from_preview(0.0)
+
+    assert [scanner.params[f"exp_rel_{c}"].value for c in "rgb"] == [100, 100, 100]
+
+
+def test_percentile_bounds_is_the_last_bin_below_the_threshold():
+    # 99% of the pixels sit in bin 10 and 1% in bin 200. The cumulative share is
+    # already >= 0.99 at bin 10, so the C's loop stops before it: bound 9, not 10.
+    plane = numpy.zeros((100, 100), dtype="<u2")
+    plane[:] = 10 * 256
+    plane.ravel()[:100] = 200 * 256
+    _lower, upper = percentile_bounds(plane)
+    assert upper == 9

--- a/tests/scanners/test_pieusb_backend.py
+++ b/tests/scanners/test_pieusb_backend.py
@@ -1,0 +1,222 @@
+"""How PieusbBackend reports a scan's outcome.
+
+The split that matters is ScannerService's: `TransientScanError` earns three
+attempts, anything else fails fast, and a cancelled scan is neither. pieusb
+reports by exception type, so these assert on type rather than on message text.
+"""
+
+import threading
+
+import numpy as np
+import pytest
+
+from negpy.infrastructure.scanners.base import TransientScanError
+from negpy.infrastructure.scanners.params import ScanParams
+
+pytest.importorskip("pieusb")
+
+from negpy.infrastructure.scanners import pieusb_backend  # noqa: E402
+from negpy.infrastructure.scanners.pieusb_backend import PieusbBackend, _as_scan_error  # noqa: E402
+
+_PARAMS = ScanParams(dpi=5000, depth=16, capture_ir=True)
+
+
+def _pieusb_exc(name: str, *args):
+    import pieusb.exceptions as exceptions
+
+    return getattr(exceptions, name)(*args)
+
+
+# ── classification ────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        pytest.param(_pieusb_exc("TransportError", "USB status 0x08"), id="transport"),
+        pytest.param(_pieusb_exc("Timeout", "command 0x08 timed out"), id="timeout"),
+        pytest.param(_pieusb_exc("WarmingUp", "still warming up"), id="warming-up"),
+    ],
+)
+def test_transport_trouble_is_typed_transient(exc: Exception) -> None:
+    assert isinstance(_as_scan_error(exc, _PARAMS), TransientScanError)
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        pytest.param(_pieusb_exc("DeviceNotReady", "not ready"), id="not-ready"),
+        pytest.param(_pieusb_exc("CheckCondition", 0x05, 0x20, 0x00), id="check-condition"),
+        pytest.param(_pieusb_exc("PieusbError", "GET SHADING PARMS returned no entries"), id="protocol"),
+        pytest.param(_pieusb_exc("ParamError", "sharpen and fast_infrared are exclusive"), id="bad-options"),
+        pytest.param(MemoryError(), id="out-of-memory"),
+        pytest.param(ValueError("Invalid value provided to option 'resolution'"), id="unexpected"),
+    ],
+)
+def test_real_errors_fail_fast(exc: BaseException) -> None:
+    """A retry would cost another full scan and end the same way."""
+    reported = _as_scan_error(exc, _PARAMS)
+    assert isinstance(reported, Exception)
+    assert not isinstance(reported, TransientScanError)
+
+
+def test_a_stalled_interface_is_transient_but_a_vanished_device_is_not() -> None:
+    """Both are USBError, which pieusb's transport does not wrap — errno decides.
+
+    A retry re-opens the device, which clears a stall; it cannot help once the
+    device is gone, because _devices_map still holds the dead handle.
+    """
+    import errno
+
+    import usb.core
+
+    # pyusb's third argument is the errno; the second is libusb's own code.
+    stalled = usb.core.USBError("Resource busy", -6, errno.EBUSY)
+    vanished = usb.core.USBError("No such device", -4, errno.ENODEV)
+
+    assert isinstance(_as_scan_error(stalled, _PARAMS), TransientScanError)
+    vanished_report = _as_scan_error(vanished, _PARAMS)
+    assert not isinstance(vanished_report, TransientScanError)
+    assert "refresh" in str(vanished_report)
+
+
+def test_a_usb_error_without_an_errno_makes_no_claim_about_the_cause() -> None:
+    """pieusb raises some USBErrors with no errno; the message must not overreach."""
+    import usb.core
+
+    reported = _as_scan_error(usb.core.USBError("something went wrong"), _PARAMS)
+
+    assert not isinstance(reported, TransientScanError)
+    assert "refresh" not in str(reported)
+    assert "something went wrong" in str(reported)
+
+
+def test_the_sense_data_survives_into_the_message() -> None:
+    """An unrecognised refusal is only diagnosable from its sense triple."""
+    reported = _as_scan_error(_pieusb_exc("CheckCondition", 0x05, 0x20, 0x00), _PARAMS)
+    assert "0x05" in str(reported) and "0x20" in str(reported)
+
+
+def test_out_of_memory_names_what_to_change() -> None:
+    """MemoryError alone tells the user nothing they can act on."""
+    reported = _as_scan_error(MemoryError(), _PARAMS)
+    assert "5000" in str(reported) and "16" in str(reported)
+
+
+def test_an_empty_image_is_reported_as_missing_film() -> None:
+    exc = _pieusb_exc("PieusbError", "GET PARAMETERS reported an empty image (0x0)")
+    assert "film" in str(_as_scan_error(exc, _PARAMS)).lower()
+
+
+# ── outcome triage ────────────────────────────────────────────────────────
+
+
+class _FakeScanner:
+    """Enough Scanner for PieusbBackend.scan: options are plain attributes."""
+
+    def __init__(self, outcome) -> None:
+        self._outcome = outcome
+
+    def __enter__(self) -> "_FakeScanner":
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        return None
+
+    def scan(self, on_update, on_complete) -> None:
+        from pieusb.types import ScanPhase, UpdateData
+
+        on_update(UpdateData(phase=ScanPhase.SCANNING, progress=0.5))
+        if self._outcome is not None:
+            on_complete(self._outcome)
+
+    def wait(self, timeout=None) -> bool:
+        return True
+
+    def cancel(self) -> None:
+        return None
+
+
+class _FakeInquiry:
+    max_scan_w = 10000
+    max_scan_h = 10000
+    model_str = "ProScan 10T"
+
+
+class _FakeInfo:
+    inquiry = _FakeInquiry()
+
+
+def _backend_with(monkeypatch: pytest.MonkeyPatch, outcome) -> PieusbBackend:
+    monkeypatch.setattr("pieusb.scanner.Scanner", lambda info: _FakeScanner(outcome))
+    monkeypatch.setattr(pieusb_backend, "_require_pieusb", lambda: None)
+    backend = PieusbBackend()
+    backend._devices_map = {"pieusb:1:2": _FakeInfo()}  # type: ignore[dict-item]
+    return backend
+
+
+def _scan(backend: PieusbBackend, progress=None):
+    return backend.scan("pieusb:1:2", _PARAMS, progress or (lambda *_: None), threading.Event())
+
+
+def _pieusb_result(**kwargs):
+    from pieusb.types import ScanResult
+
+    return ScanResult(**kwargs)
+
+
+def test_a_clean_scan_returns_the_image(monkeypatch: pytest.MonkeyPatch) -> None:
+    rgb = np.ones((4, 3, 3), dtype=np.uint16)
+    backend = _backend_with(monkeypatch, _pieusb_result(rgb=rgb, width=3, height=4))
+    seen: list[tuple[float, str]] = []
+
+    result = _scan(backend, progress=lambda fraction, phase: seen.append((fraction, phase)))
+
+    assert result.rgb.shape == (4, 3, 3)
+    assert result.dpi == _PARAMS.dpi
+    assert result.device_model == "ProScan 10T"
+    assert seen == [(0.5, "Scanning")]
+
+
+def test_a_transient_failure_reaches_the_caller_typed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without this the service cannot retry: the type is its only signal."""
+    error = _pieusb_exc("TransportError", "USB status 0x08")
+    backend = _backend_with(monkeypatch, _pieusb_result(rgb=None, error=error))
+
+    with pytest.raises(TransientScanError) as excinfo:
+        _scan(backend)
+    assert excinfo.value.__cause__ is error  # the traceback survives for the log
+
+
+def test_a_real_failure_is_not_retried(monkeypatch: pytest.MonkeyPatch) -> None:
+    error = _pieusb_exc("CheckCondition", 0x05, 0x20, 0x00)
+    backend = _backend_with(monkeypatch, _pieusb_result(rgb=None, error=error))
+
+    with pytest.raises(Exception) as excinfo:
+        _scan(backend)
+    assert not isinstance(excinfo.value, TransientScanError)
+    assert excinfo.value.__cause__ is error
+
+
+def test_a_scan_cancelled_by_the_worker_reports_cancellation(monkeypatch: pytest.MonkeyPatch) -> None:
+    """pieusb stops at a chunk boundary, so the poll sees it finish, not cancel."""
+    backend = _backend_with(monkeypatch, _pieusb_result(rgb=None, cancelled=True))
+
+    with pytest.raises(Exception, match="[Cc]ancel") as excinfo:
+        _scan(backend)
+    assert not isinstance(excinfo.value, TransientScanError)
+
+
+def test_a_missing_outcome_is_not_disguised_as_a_failed_scan(monkeypatch: pytest.MonkeyPatch) -> None:
+    """on_complete never ran, so the device state is unknown rather than failed."""
+    backend = _backend_with(monkeypatch, None)
+
+    with pytest.raises(RuntimeError, match="did not report an outcome"):
+        _scan(backend)
+
+
+def test_an_empty_result_without_an_error_is_still_a_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    backend = _backend_with(monkeypatch, _pieusb_result(rgb=None))
+
+    with pytest.raises(RuntimeError, match="no image data"):
+        _scan(backend)

--- a/tests/test_scan_sidebar.py
+++ b/tests/test_scan_sidebar.py
@@ -81,7 +81,7 @@ class _FakeRepo:
 
 class _FakeController(QObject):
     scan_devices_ready = pyqtSignal(list)
-    scan_progress = pyqtSignal(float)
+    scan_progress = pyqtSignal(float, str)  # progress, phase name
     scan_finished = pyqtSignal(str)
     scan_error = pyqtSignal(str)
     scan_cancelled = pyqtSignal()

--- a/tests/test_scan_worker.py
+++ b/tests/test_scan_worker.py
@@ -210,6 +210,29 @@ def test_scan_worker_reports_eject_failure() -> None:
     assert errors == ["transport refused"]
 
 
+def test_progress_without_a_phase_is_reported_as_scanning() -> None:
+    """A backend with one phase calls progress(fraction); the signal needs both.
+
+    SANE does exactly this, so passing `self.progress.emit` straight to the
+    backend would raise on every update.
+    """
+
+    class _ProgressService(_ScanService):
+        def run_scan(self, *, device_id, params, progress, cancel):
+            progress(0.25)  # no phase — the SANE shape
+            progress(0.5, "Calibrating")  # a backend that names its phases
+            return object()
+
+    worker = ScanWorker()
+    worker._service = _ProgressService()  # type: ignore[assignment]
+    seen: list[tuple[float, str]] = []
+    worker.progress.connect(lambda fraction, phase: seen.append((fraction, phase)))
+
+    worker.run_scan(_scan_request())
+
+    assert seen == [(0.25, "Scanning"), (0.5, "Calibrating")]
+
+
 def test_scan_worker_emits_cancelled_when_acquisition_returns_after_cancel() -> None:
     worker = ScanWorker()
     service = _ScanService(cancel_during_acquisition=True)

--- a/uv.lock
+++ b/uv.lock
@@ -497,7 +497,6 @@ wheels = [
 
 [[package]]
 name = "pieusb"
-version = "0.1.0"
 source = { editable = "../sw/pieusb" }
 dependencies = [
     { name = "libusb-package" },

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.13"
 
 [[package]]
@@ -327,7 +327,6 @@ dependencies = [
     { name = "numba" },
     { name = "numpy" },
     { name = "opencv-python-headless" },
-    { name = "pieusb" },
     { name = "piexif" },
     { name = "pillow" },
     { name = "pyqt6" },
@@ -350,6 +349,9 @@ dev = [
     { name = "ruff" },
     { name = "ty" },
 ]
+pieusb = [
+    { name = "pieusb" },
+]
 scanner = [
     { name = "python-sane" },
 ]
@@ -362,7 +364,6 @@ requires-dist = [
     { name = "numba", specifier = "==0.65.1" },
     { name = "numpy", specifier = "==2.4.4" },
     { name = "opencv-python-headless", specifier = "==4.13.0.92" },
-    { name = "pieusb", editable = "../sw/pieusb" },
     { name = "piexif", specifier = "==1.1.3" },
     { name = "pillow", specifier = "==12.2.0" },
     { name = "pyqt6", specifier = "==6.11.0" },
@@ -383,6 +384,7 @@ dev = [
     { name = "ruff", specifier = "==0.14.10" },
     { name = "ty", specifier = ">=0.0.26" },
 ]
+pieusb = [{ name = "pieusb", specifier = ">=0.2.0" }]
 scanner = [{ name = "python-sane", specifier = ">=2.9" }]
 
 [[package]]
@@ -497,18 +499,16 @@ wheels = [
 
 [[package]]
 name = "pieusb"
-source = { editable = "../sw/pieusb" }
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "libusb-package" },
     { name = "numpy" },
     { name = "pyusb" },
 ]
-
-[package.metadata]
-requires-dist = [
-    { name = "libusb-package", specifier = ">=1.0.30.0" },
-    { name = "numpy", specifier = ">=2.4.4" },
-    { name = "pyusb", specifier = ">=1.3.1" },
+sdist = { url = "https://files.pythonhosted.org/packages/93/82/304cf642c52036c175956bc5200575502326c4577ec194915addc491f714/pieusb-0.2.0.tar.gz", hash = "sha256:e1427061e648ab4fa4695edcb368185fbf0f42f6af2de4d97e46b1e4fd542e45", size = 48692, upload-time = "2026-07-29T12:36:33.004Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/3f/779deeb48275b8e4a9bcfca53ca04e595775babfb06b913d17d981f6f817/pieusb-0.2.0-py3-none-any.whl", hash = "sha256:924877549b704c1dae1f15249eb238b19876b4e39fed5c754f599a1634b13005", size = 39120, upload-time = "2026-07-29T12:36:31.844Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.13"
 
 [[package]]
@@ -384,7 +384,7 @@ dev = [
     { name = "ruff", specifier = "==0.14.10" },
     { name = "ty", specifier = ">=0.0.26" },
 ]
-pieusb = [{ name = "pieusb", specifier = ">=0.2.0" }]
+pieusb = [{ name = "pieusb", specifier = ">=0.3.1" }]
 scanner = [{ name = "python-sane", specifier = ">=2.9" }]
 
 [[package]]
@@ -499,16 +499,16 @@ wheels = [
 
 [[package]]
 name = "pieusb"
-version = "0.2.0"
+version = "0.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "libusb-package" },
     { name = "numpy" },
     { name = "pyusb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/93/82/304cf642c52036c175956bc5200575502326c4577ec194915addc491f714/pieusb-0.2.0.tar.gz", hash = "sha256:e1427061e648ab4fa4695edcb368185fbf0f42f6af2de4d97e46b1e4fd542e45", size = 48692, upload-time = "2026-07-29T12:36:33.004Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d1/9b/ee42e79d755b3958abf91afa0509d7300db4e22d07c2ee7402c1c4dc86f3/pieusb-0.3.1.tar.gz", hash = "sha256:321dffc408dc6cea3e455711fd62a30c8e802dea64be29d331d0cbeec86b0c9a", size = 60545, upload-time = "2026-08-03T08:25:34.243Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/3f/779deeb48275b8e4a9bcfca53ca04e595775babfb06b913d17d981f6f817/pieusb-0.2.0-py3-none-any.whl", hash = "sha256:924877549b704c1dae1f15249eb238b19876b4e39fed5c754f599a1634b13005", size = 39120, upload-time = "2026-07-29T12:36:31.844Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/cb/908173a7acb17f4f0a52ba3d70febf9aaf188eccbb158ba7d13bff23b289/pieusb-0.3.1-py3-none-any.whl", hash = "sha256:7444461f143f14860a55eb0044963635dd1e7e6f8500ee30c57b24a161a6a9b8", size = 49716, upload-time = "2026-08-03T08:25:32.647Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -384,7 +384,7 @@ dev = [
     { name = "ruff", specifier = "==0.14.10" },
     { name = "ty", specifier = ">=0.0.26" },
 ]
-pieusb = [{ name = "pieusb", specifier = ">=0.3.1" }]
+pieusb = [{ name = "pieusb", specifier = ">=0.3.2" }]
 scanner = [{ name = "python-sane", specifier = ">=2.9" }]
 
 [[package]]
@@ -499,16 +499,16 @@ wheels = [
 
 [[package]]
 name = "pieusb"
-version = "0.3.1"
+version = "0.3.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "libusb-package" },
     { name = "numpy" },
     { name = "pyusb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/9b/ee42e79d755b3958abf91afa0509d7300db4e22d07c2ee7402c1c4dc86f3/pieusb-0.3.1.tar.gz", hash = "sha256:321dffc408dc6cea3e455711fd62a30c8e802dea64be29d331d0cbeec86b0c9a", size = 60545, upload-time = "2026-08-03T08:25:34.243Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/1e/70da3b080b141201deabf3353716ea4c8e645444248d230bbcc1127066f3/pieusb-0.3.2.tar.gz", hash = "sha256:aa71bc9b04cb28537e8881086fae35e6fad070621e261d1a59c10a985257ab0d", size = 60581, upload-time = "2026-08-03T12:37:46.188Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0f/cb/908173a7acb17f4f0a52ba3d70febf9aaf188eccbb158ba7d13bff23b289/pieusb-0.3.1-py3-none-any.whl", hash = "sha256:7444461f143f14860a55eb0044963635dd1e7e6f8500ee30c57b24a161a6a9b8", size = 49716, upload-time = "2026-08-03T08:25:32.647Z" },
+    { url = "https://files.pythonhosted.org/packages/15/c0/7196dee7f3337595b37f45a2788c69681d98fd39e12aef07a4aaf3810e24/pieusb-0.3.2-py3-none-any.whl", hash = "sha256:74c1fba821177e69d8900a3a67379bd597cbb98b7368955f494863f632012511", size = 49761, upload-time = "2026-08-03T12:37:45.106Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.13"
 
 [[package]]
@@ -186,6 +186,15 @@ wheels = [
 ]
 
 [[package]]
+name = "importlib-resources"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/06/b56dfa750b44e86157093bc8fca0ab81dccbf5260510de4eaf1cb69b5b99/importlib_resources-7.1.0.tar.gz", hash = "sha256:0722d4c6212489c530f2a145a34c0a7a3b4721bc96a15fada5930e2a0b760708", size = 44985, upload-time = "2026-04-12T16:36:09.232Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/db/55a262f3606bebcae07cc14095338471ad7c0bbcaa37707e6f0ee49725b7/importlib_resources-7.1.0-py3-none-any.whl", hash = "sha256:1bd7b48b4088eddb2cd16382150bb515af0bd2c70128194392725f82ad2c96a1", size = 37232, upload-time = "2026-04-12T16:36:08.219Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -204,6 +213,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "libusb-package"
+version = "1.0.30.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-resources" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/a8/8b3d5dae7340880d556f9f866874b9674b2e3a22fee1e2b96f1ab0feae36/libusb_package-1.0.30.0-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:2b98784bac3bedda7e95bb5039dd0eded84b02f36110e4d5d607375366c61090", size = 69516, upload-time = "2026-06-30T07:41:02.451Z" },
+    { url = "https://files.pythonhosted.org/packages/52/6f/26de4e9f858ab50e87931f0be268f3c1bbfce33e8584add60da857632142/libusb_package-1.0.30.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:4ad25f8d254bbbdd234446d5580b24d62d59bb0e690d8090457dac347f044437", size = 65700, upload-time = "2026-06-30T07:41:03.557Z" },
+    { url = "https://files.pythonhosted.org/packages/11/12/9ba8fa91dc95b1cbfa4a68207d4048b08b900fd3686fa72b99846608de01/libusb_package-1.0.30.0-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c71b5f8c65b286425c02c7d624eee1fd7f08bfb1dfa492ddc20e27f06fee3829", size = 76166, upload-time = "2026-06-30T07:41:04.462Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/e1/a7c83535749332825f02d6693868f8ee9ae99c4104e60a483773bb652c0e/libusb_package-1.0.30.0-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f502ad5a0527b8c0431de817662325c88a1bba2cc334173665b04ad168d7b6d3", size = 76159, upload-time = "2026-06-30T07:41:05.543Z" },
+    { url = "https://files.pythonhosted.org/packages/de/56/a1fb1726fc96a8ee3bd0e04e5e505500f022dd310dd348ecebf5cdae7a60/libusb_package-1.0.30.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7a2a1c82f6ef85d9920cbe2898aa6927d4c487744ef9f20b0d7d6d95705095bb", size = 77162, upload-time = "2026-06-30T07:41:06.581Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/03/264cefc51275ecb047194c4973bc40b3b278566a64bbe6e74f86bf1e0afc/libusb_package-1.0.30.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:2ee5ef8ac6f08402b4e8334f7404850316bdd26037c9a97f2a7456ee9a5d1550", size = 76676, upload-time = "2026-06-30T07:41:07.505Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/95/d166eeefe0d9dd5833d5724a97b023ec380c3a2d364040ec0485fd57703c/libusb_package-1.0.30.0-py3-none-win32.whl", hash = "sha256:79728146e1f01e525786900b2ccd8298a8eca53cd94b37fb0885e56aa6f9d60a", size = 78769, upload-time = "2026-06-30T07:41:08.432Z" },
+    { url = "https://files.pythonhosted.org/packages/60/4a/ff49bd77f33af05ca26fee29d601beb1e19ca791bb86efece82a3833885c/libusb_package-1.0.30.0-py3-none-win_amd64.whl", hash = "sha256:90808da724c8939a333d931d0c7226372ca5fefd98e2f2f3ef79fd918aa37522", size = 90711, upload-time = "2026-06-30T07:41:09.318Z" },
 ]
 
 [[package]]
@@ -300,6 +327,7 @@ dependencies = [
     { name = "numba" },
     { name = "numpy" },
     { name = "opencv-python-headless" },
+    { name = "pieusb" },
     { name = "piexif" },
     { name = "pillow" },
     { name = "pyqt6" },
@@ -334,6 +362,7 @@ requires-dist = [
     { name = "numba", specifier = "==0.65.1" },
     { name = "numpy", specifier = "==2.4.4" },
     { name = "opencv-python-headless", specifier = "==4.13.0.92" },
+    { name = "pieusb", editable = "../sw/pieusb" },
     { name = "piexif", specifier = "==1.1.3" },
     { name = "pillow", specifier = "==12.2.0" },
     { name = "pyqt6", specifier = "==6.11.0" },
@@ -464,6 +493,23 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/03/4f/2750f7f6f025a1507cd3b7218691671eecfd0bbebebe8b39aa0fe1d360b8/pefile-2024.8.26.tar.gz", hash = "sha256:3ff6c5d8b43e8c37bb6e6dd5085658d658a7a0bdcd20b6a07b1fcfc1c4e9d632", size = 76008, upload-time = "2024-08-26T20:58:38.155Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/16/12b82f791c7f50ddec566873d5bdd245baa1491bac11d15ffb98aecc8f8b/pefile-2024.8.26-py3-none-any.whl", hash = "sha256:76f8b485dcd3b1bb8166f1128d395fa3d87af26360c2358fb75b80019b957c6f", size = 74766, upload-time = "2024-08-26T21:01:02.632Z" },
+]
+
+[[package]]
+name = "pieusb"
+version = "0.1.0"
+source = { editable = "../sw/pieusb" }
+dependencies = [
+    { name = "libusb-package" },
+    { name = "numpy" },
+    { name = "pyusb" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "libusb-package", specifier = ">=1.0.30.0" },
+    { name = "numpy", specifier = ">=2.4.4" },
+    { name = "pyusb", specifier = ">=1.3.1" },
 ]
 
 [[package]]
@@ -724,6 +770,15 @@ name = "python-sane"
 version = "2.9.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/45/e9/e8baff69fc2347606c547201204d4b4843c7ad8ecb9164eceee42016eff6/python_sane-2.9.2.tar.gz", hash = "sha256:50ab8e0b033cececad26c7231a7254f80ad8fe9ec6b5c25add2493d7e2a07bbe", size = 22513, upload-time = "2025-07-21T21:20:21.735Z" }
+
+[[package]]
+name = "pyusb"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/6b/ce3727395e52b7b76dfcf0c665e37d223b680b9becc60710d4bc08b7b7cb/pyusb-1.3.1.tar.gz", hash = "sha256:3af070b607467c1c164f49d5b0caabe8ac78dbed9298d703a8dbf9df4052d17e", size = 77281, upload-time = "2025-01-08T23:45:01.866Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/28/b8/27e6312e86408a44fe16bd28ee12dd98608b39f7e7e57884a24e8f29b573/pyusb-1.3.1-py3-none-any.whl", hash = "sha256:bf9b754557af4717fe80c2b07cc2b923a9151f5c08d17bdb5345dac09d6a0430", size = 58465, upload-time = "2025-01-08T23:45:00.029Z" },
+]
 
 [[package]]
 name = "pywin32-ctypes"

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.13"
 
 [[package]]
@@ -384,7 +384,7 @@ dev = [
     { name = "ruff", specifier = "==0.14.10" },
     { name = "ty", specifier = ">=0.0.26" },
 ]
-pieusb = [{ name = "pieusb", specifier = ">=0.3.2" }]
+pieusb = [{ name = "pieusb", specifier = ">=0.3.7" }]
 scanner = [{ name = "python-sane", specifier = ">=2.9" }]
 
 [[package]]
@@ -499,16 +499,16 @@ wheels = [
 
 [[package]]
 name = "pieusb"
-version = "0.3.2"
+version = "0.3.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "libusb-package" },
     { name = "numpy" },
     { name = "pyusb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d5/1e/70da3b080b141201deabf3353716ea4c8e645444248d230bbcc1127066f3/pieusb-0.3.2.tar.gz", hash = "sha256:aa71bc9b04cb28537e8881086fae35e6fad070621e261d1a59c10a985257ab0d", size = 60581, upload-time = "2026-08-03T12:37:46.188Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/67/dd6caa659bb2a35014c80cd3f6e53c185721732c8a650e0c3bbc034decef/pieusb-0.3.7.tar.gz", hash = "sha256:d32eb76eb8ec8259b1941e35baa93639668d068627888ae90f7c0f08954cb879", size = 81048, upload-time = "2026-08-11T20:36:32.328Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/15/c0/7196dee7f3337595b37f45a2788c69681d98fd39e12aef07a4aaf3810e24/pieusb-0.3.2-py3-none-any.whl", hash = "sha256:74c1fba821177e69d8900a3a67379bd597cbb98b7368955f494863f632012511", size = 49761, upload-time = "2026-08-03T12:37:45.106Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/46/8ae130175f50a753b2b013ea62edf009fc0717ee084883a0cfc60fadaa11/pieusb-0.3.7-py3-none-any.whl", hash = "sha256:4c0a0501406dedc7d36d37b1373cc7ec43250c4cc46d7f3688f01ae0cdbf36ca", size = 46272, upload-time = "2026-08-11T20:36:31.149Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Add a second scanner backend: pieusb (direct USB)

Adds `PieusbBackend` alongside `SaneBackend`, driving Reflecta / Pacific Image
film scanners over raw USB through the [pieusb](https://pypi.org/project/pieusb/)
library instead of SANE. It is the first non-SANE backend, so a few
transport-neutral seams had to grow to fit it.

Requires `pieusb>=0.3.7`, added as an optional dependency group (`uv sync --group pieusb`).

## What works

- **Enumeration**: `pieusb:{bus}:{address}` device ids; capabilities derived
  from INQUIRY
- **Scanning**: `ScanParams` maps onto pieusb's attribute-style options
  (`mode`, `color_depth`, `resolution`, `auto_exp`, and the normalised window
  scaled into device units).
- **Hardware auto-exposure**: runs a preview scan and adjusts scan parameter. It will calculate the exposure per-channel, which will produce a balanced scan, with the orange mask already compensated for.
- **The Scan tab now appears on Windows.** It was replaced by
  `_ScanUnsupportedPlaceholder` there because python-sane has no Windows build;
  pieusb is pyusb + a bundled libusb, so that gate is gone.

## Progress reporting gained a phase

The bar used to move only during the read. A pieusb scan has distinguishable
phases (configuring, warming up, calibrating, metering, scanning,
post-processing), and with auto-exposure it runs the whole sequence twice, so a
single fraction was misleading. When the phase name is not provided, it defaults to "Scanning"

`ScanWorker.progress` / `AppController.scan_progress` are now
`pyqtSignal(float, str)` and the bar renders `"Calibrating… 42%"`. The backend
contract in `base.py`:

Consequences worth knowing when reviewing:

- The fraction is **per-phase**, so a multi-phase bar rewinds between phases.
  That is intentional; the label is what carries the meaning.
- SANE's behaviour is unchanged — it reports one phase and still calls
  `progress(fraction)`. Three of its signatures widened to `Callable[..., None]`
  so `SaneSession` still satisfies the `ScannerSession` protocol while its
  one-argument calls stay valid; no call sites or logic touched.
- Consumers of `progress` default the phase (`ScanWorker`'s emit wrapper, its
  batch closure, `PerFrameRollSession`'s discard lambda).

## Autofocus is now a capability

Added autofocus support in the scanner capabilities dataclass, as some Reflecta scanners don't support it. It will hide the checkbox and set it to unchecked if this function is not supprorted.

## Other things to note

- **`PieusbSession` is a stub** — `open_session` raises `NotImplementedError`.
  Nothing in `negpy/` calls it: single scans, `run_batch` frames and
  `PerFrameRollSession` preview slots all go through `backend.scan`.
- No USB permission / driver diagnosis at enumeration (a missing udev rule or a
  vendor-driver-bound device on Windows currently just looks like "no devices").
- `tests/scanners/test_backend_contract.py` still runs against SANE only; adding
  pieusb needs a fake pieusb module and a Scanner double.
- `frame` and `frame_offset_mm` are accepted and ignored.

## Risks / what to check before merging

- **Hardware coverage is one unit** (ProScan 10T)
- The SANE backend is touched (three annotations, no logic) and `base.py`'s
  protocol changed, so the shared paths deserve a look even though SANE's
  behaviour is unchanged.
