### PR TITLE
Camera scanning: fix the scan-window crash on Canon EOS and the white-light shutter (fixes #745, #746)

### DIFF
--- a/negpy/desktop/view/sidebar/scanlight.py
+++ b/negpy/desktop/view/sidebar/scanlight.py
@@ -1672,7 +1672,12 @@ class ScanlightSidebar(QWidget):
             shutter_r=shutter,
             shutter_g=shutter,
             shutter_b=shutter,
-            shutter_w=shutter,
+            # A white-light frame is not calibrated, so there is no baked exposure to force —
+            # its live-view steppers are the exposure control (see _refresh_preset_ui). Copying
+            # the RGB shutter here overwrote the operator's choice at capture time with a
+            # narrowband value: too long under white light, and rejected outright by a body
+            # whose shutter is dial-locked, which failed the capture (issue #746).
+            shutter_w="" if self._settings.white_mode else shutter,
             iso=iso,
             aperture=aperture,
             roll_name=self.roll_edit.text().strip() or "Roll001",

--- a/negpy/infrastructure/capture/gphoto.py
+++ b/negpy/infrastructure/capture/gphoto.py
@@ -288,6 +288,10 @@ class GphotoCamera:
         self._busy = threading.Event()
         # The post-shot event drain of the last successful still (see _finish_shot_async).
         self._post_shot: Optional[threading.Thread] = None
+        # Raised by a completed still, consumed by the preview loop before its next frame.
+        # A flag rather than the loop watching `_busy`: a capture can begin and end between
+        # two poll ticks, and a missed drain is what blocks the next preview on Fujifilm.
+        self._drain_owed = threading.Event()
         self._reset_body_state()
 
     def _reset_body_state(self) -> None:
@@ -298,6 +302,7 @@ class GphotoCamera:
         self._preview_broken = False
         self._drain_silence_ms = _DRAIN_SILENCE_MS
         self._drain_budget_s = _EVENT_DRAIN_S
+        self._drain_owed.clear()  # a fresh body owes nothing until it has taken a shot
         self._magnifier: Optional[_Magnifier] = None
         self._magnifier_ratios: Optional[tuple[str, str]] = None
         self._magnifier_off = ""
@@ -704,6 +709,7 @@ class GphotoCamera:
         except self._gp.GPhoto2Error as exc:
             raise GphotoError(f"capture failed: {exc}") from exc
         else:
+            self._drain_owed.set()  # the preview must clear this shot's stragglers before resuming
             self._finish_shot_async()
             drained_async = True
         finally:
@@ -815,23 +821,24 @@ class GphotoCamera:
     def _preview_loop(self) -> None:
         next_settings = 0.0
         failures = 0
-        # Drain before the first frame, after every still, and before every retry: Fujifilm
-        # queues post-shot events past the overlapped drain's quiet window, and events left
-        # unread block capture_preview until the camera is power-cycled (issue #658). Costs
-        # one empty wait_for_event on bodies with a clean queue.
-        drain_first = True
+        # Drain after a still, never before one: Fujifilm queues post-shot events past the
+        # overlapped drain's quiet window, and events left unread block capture_preview
+        # (issue #658). Draining with nothing pending is not merely wasteful — on a freshly
+        # opened Canon EOS, wait_for_event segfaults the process (issue #745), which no
+        # `except` can catch. `_drain_owed` is raised only by a completed still.
+        saw_capture = False
         while not self._stop.is_set():
             if self._busy.is_set():  # stand aside for a capture rather than race it for the lock
-                drain_first = True
                 self._stop.wait(0.02)
                 continue
             try:
                 with self._lock:
                     if self._camera is None:
                         return
-                    if drain_first:
+                    if self._drain_owed.is_set():
+                        self._drain_owed.clear()
+                        saw_capture = True
                         self._drain_events()
-                        drain_first = False
                     frame = self._camera.capture_preview()
                     data = bytes(memoryview(frame.get_data_and_size()))
                 self._publish_frame(data)
@@ -841,7 +848,8 @@ class GphotoCamera:
                     next_settings = time.monotonic() + _SETTINGS_INTERVAL_S
             except Exception as exc:  # noqa: BLE001 — a dropped frame must not kill the thread
                 failures += 1
-                drain_first = True  # a failed frame may be blocked by unread events — clear them before retrying
+                if saw_capture:
+                    self._drain_owed.set()  # unread events can block a retry, but only a capture leaves any
                 logger.warning("gphoto2 live view (%d/%d): %s", failures, _MAX_PREVIEW_FAILURES, exc)
                 if failures >= _MAX_PREVIEW_FAILURES:
                     # Repeated failures used to mean one thing — the body is gone — and the whole

--- a/tests/test_capture_gphoto.py
+++ b/tests/test_capture_gphoto.py
@@ -749,6 +749,24 @@ def test_fuji_gets_a_patient_event_drain(tmp_path):
     camera.close()
 
 
+def test_the_preview_never_drains_before_a_capture_has_happened(fake, tmp_path):
+    """Issue #745: on a freshly opened Canon EOS, wait_for_event with nothing pending
+    segfaults the process, and no `except` can catch that. Nothing but an actual still may
+    arm the preview loop's drain."""
+    import time
+
+    camera = GphotoCamera(gp_module=fake, jpeg_path=str(tmp_path / "lv.jpg"), settings_path=str(tmp_path / "lv.json"))
+    camera.start()
+    for _ in range(300):
+        if fake.previews >= 3:
+            break
+        time.sleep(0.01)
+
+    assert fake.previews >= 3  # the stream is genuinely running
+    assert fake.event_waits == []  # ...and never touched the event queue
+    camera.close()
+
+
 def test_preview_survives_a_still_that_leaves_late_events(fake, tmp_path):
     """Issue #658's core failure: events the body hands over only after a pause killed every
     capture_preview after the first still. The preview thread now drains before its first

--- a/tests/test_scanlight_sidebar.py
+++ b/tests/test_scanlight_sidebar.py
@@ -6,6 +6,7 @@ at app launch.
 """
 
 import sys
+from dataclasses import replace
 from unittest.mock import MagicMock
 
 import pytest
@@ -129,6 +130,25 @@ def test_builtin_white_preset_sets_white_mode():
     w._on_preset_selected(idx)
     assert w._settings.white_mode is True
     assert w._settings.white_process_mode == "auto"  # B&W/slide merged → NegPy autodetects
+
+
+def test_white_preset_does_not_inherit_the_rgb_shutter(tmp_path):
+    """Issue #746: a white-light frame has no baked exposure — its live-view steppers own it.
+    Carrying the previous RGB preset's shutter over forced a narrowband value onto the body,
+    overexposing the frame, and failed the capture outright on a dial-locked Fujifilm."""
+    w = _sidebar()
+    w._settings = replace(w._settings, shutter_r="1/20", shutter_w="1/20")  # as a calibrated RGB preset leaves it
+
+    idx = w.preset_combo.findData("White Light (B&W or Slide Film)")
+    w.preset_combo.setCurrentIndex(idx)
+    w._on_preset_selected(idx)
+
+    assert w._settings.white_mode is True
+    assert w._settings.shutter_w == ""  # nothing is forced; the camera keeps what the live view set
+
+    w.folder_edit.setText(str(tmp_path))
+    w._start_capture(retake=False)
+    assert w.controller.start_capture.call_args[0][0].shutter_w == ""
 
 
 def test_white_preset_hint_shows_then_clears():


### PR DESCRIPTION
Two independent camera-scanning bugs, kept in one PR to save review passes.

## The crash on opening the scan window, fixes #745

**This is a regression I introduced in #674 (shipped in 0.45.0), which matches the report exactly: 0.44.0 and earlier are fine.**

#674 made the preview thread drain the event queue before its *first* frame, to clear the post-shot stragglers that block live view on Fujifilm. On a freshly opened Canon EOS M6 that call segfaults the process: the reporter's traceback is `_drain_events` → `_preview_loop`, and the log shows the session opening and the capture target being set with no still ever taken. A SIGSEGV cannot be caught, so the only defence is not to make the call.

The drain is now armed **only by a completed still**, never at stream start.

Fixing that surfaced a second, real defect in the same code: the preview loop learned about captures by polling `_busy`, so a capture that began and ended between two poll ticks was missed entirely and its events were never drained. The initial `drain_first = True` had been masking that. The completed still now raises a flag the preview loop consumes, which is timing independent. A regression test asserts the stream runs without ever touching the event queue until a capture happens.

## White-light frames inherit the RGB shutter, fixes #746

`_update_settings_from_ui` copied the RGB shutter into `shutter_w` unconditionally, and `capture_white` forced it onto the body. But a white-light frame is not calibrated and has no baked exposure: its live-view steppers are the exposure control, exactly as `_refresh_preset_ui` documents ("they stay for white-light and camera-only modes").

So selecting a B&W or slide preset after an RGB one silently forced a narrowband shutter, which produced both symptoms in the report: far too long under white light, hence overexposed, and rejected outright by a Fujifilm whose shutter is dial-locked, which failed the capture with "camera rejected it or it did not settle".

White-light captures now force nothing and keep whatever the operator set in the live view. RGB triplets are untouched, they still assert their calibrated shutter per channel. The new test fails without the fix.

`make all` is green with and without the optional camera group; regression-tested on a Sony a7C II (live view, a scan, and live view surviving the capture). I have neither a Canon EOS nor a Fujifilm here, so confirmation from @plentia and @lamosadosa would be welcome.