### PR TITLE
Work prints: named versions of a frame that survive the undo stack

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -26,7 +26,7 @@ The right-hand tabs are arranged in the order you actually work, which mirrors t
 | **Colour** | palette | Lab · Toning | Chroma, sharpening, effects, split/chemical toning |
 | **Finish** | brush | Retouch · Finishing | Dust removal, vignette, border, carrier |
 | **Favourites** | star | Your chosen sliders | Quick access to the controls you use most |
-| **History** | clock | Edit history | Step back through every change |
+| **History** | clock | Work prints · Edit history | Keep named versions, step back through every change |
 | **Export** | file | Export settings | Format, size, colour, batch output |
 | **Metadata** | tags | Archival metadata | Original camera/lens/film details |
 | **Scan** | camera | Scanner · Camera Scanning | Capture film directly (Linux/macOS) |
@@ -498,6 +498,22 @@ switch and a scroll. Empty until you fill it.
 ---
 
 ## 10. History tab
+
+Two lists: the versions you chose to keep, above the running record of every change.
+
+### Work prints
+
+A **work print** is a named version of this frame — the darkroom habit of keeping the prints you made on the way to the final one, so you can go back to the third attempt after deciding the fifth went too far.
+
+*   **Save work print** (**Ctrl+Shift+S**) keeps the current edit under a name; NegPy offers *Work print 1*, *Work print 2* and so on. Saving over an existing name asks first.
+*   **Click** one to make it live. That counts as an edit, so **Ctrl+Z** puts back what was on screen before — you cannot lose your place by looking at an old version.
+*   **Right-click** → **Export this version…**, **Rename…** or **Delete**.
+
+Work prints differ from history steps in the way that matters: they are **never pruned and never thrown away by a later edit**. The undo history keeps the last 100 steps and drops the branch above you when you edit after stepping back; a work print survives both. The list only appears once you've saved one.
+
+They belong to the frame, not to your presets — a preset is a look you apply to other images, a work print is one version of this print. Both live in NegPy's database; work prints are not written to `.negpy` sidecars.
+
+### Edit history
 
 A scrollable list of every edit step (last 100 kept), newest on top; the current step is bold.
 

--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -3303,6 +3303,11 @@ class AppController(QObject):
         self.session.jump_to_step(index)
         self.request_export()
 
+    def export_work_print(self, name: str) -> None:
+        """Make a named version live, then export it through the normal export path."""
+        self.session.load_work_print(name)
+        self.request_export()
+
     def _flush_export_ui(self) -> None:
         """Push pending Export-panel edits into state before any export path reads config."""
         flush = self.flush_export_settings

--- a/negpy/desktop/session.py
+++ b/negpy/desktop/session.py
@@ -994,6 +994,12 @@ class DesktopSessionManager(QObject):
         """
         Updates global config and optionally saves to disk.
         """
+        # A step identical to the live config renders as a dead "· —" row in the History
+        # panel and costs a redo branch — reloading the same work print, resetting an
+        # already-default panel or pasting identical settings all land here.
+        if persist and record_history and config == self.state.config:
+            record_history = False
+
         if persist and record_history and self.state.current_file_hash:
             # If editing after an undo, drop the now-orphaned future branch
             if self.state.undo_index < self.state.max_history_index:

--- a/negpy/desktop/session.py
+++ b/negpy/desktop/session.py
@@ -405,6 +405,7 @@ class DesktopSessionManager(QObject):
     state_changed = pyqtSignal()
     files_changed = pyqtSignal()  # File list additions only — does not trigger sidebar sync
     history_changed = pyqtSignal()  # Emitted when undo/redo/persist happens
+    work_prints_changed = pyqtSignal()  # A named version was saved, renamed or deleted
     settings_saved = pyqtSignal()
     active_file_changing = pyqtSignal()  # Outgoing file about to be replaced — last chance to snapshot it
     settings_copied = pyqtSignal()
@@ -1072,6 +1073,49 @@ class DesktopSessionManager(QObject):
                 self._config_dirty = True
                 self.state_changed.emit()
                 self.history_changed.emit()
+
+    def work_prints(self) -> List[str]:
+        """This frame's named versions, newest first."""
+        if not self.state.current_file_hash:
+            return []
+        return self.repo.list_work_prints(self.state.current_file_hash)
+
+    def next_work_print_name(self) -> str:
+        """Default name offered for the next save: the first free `Work print N`."""
+        taken = set(self.work_prints())
+        n = 1
+        while f"Work print {n}" in taken:
+            n += 1
+        return f"Work print {n}"
+
+    def save_work_print(self, name: str) -> None:
+        """Keep the live edit under `name`. Unlike a history step this is never pruned
+        and never truncated by a later edit."""
+        if not (self.state.current_file_hash and name):
+            return
+        self.repo.save_work_print(self.state.current_file_hash, name, self.state.config)
+        self.work_prints_changed.emit()
+
+    def load_work_print(self, name: str) -> None:
+        """Make a named version live. Committed through update_config, so it lands on the
+        undo stack and a plain Ctrl+Z puts back what was on screen before."""
+        if not self.state.current_file_hash:
+            return
+        config = self.repo.load_work_print(self.state.current_file_hash, name)
+        if config is not None:
+            self.update_config(config, persist=True)
+
+    def rename_work_print(self, name: str, new_name: str) -> None:
+        if not (self.state.current_file_hash and new_name) or new_name == name:
+            return
+        self.repo.rename_work_print(self.state.current_file_hash, name, new_name)
+        self.work_prints_changed.emit()
+
+    def delete_work_print(self, name: str) -> None:
+        if not self.state.current_file_hash:
+            return
+        self.repo.delete_work_print(self.state.current_file_hash, name)
+        self.work_prints_changed.emit()
 
     def jump_to_step(self, index: int) -> None:
         """Load an arbitrary history step (random-access undo/redo)."""

--- a/negpy/desktop/view/keyboard_shortcuts.py
+++ b/negpy/desktop/view/keyboard_shortcuts.py
@@ -139,6 +139,7 @@ class ShortcutManager:
             "copy": controller.session.copy_settings,
             "copy_with_bounds": controller.session.copy_settings_with_bounds,
             "paste": lambda: open_paste_dialog(self.window, controller),
+            "save_work_print": self.window.right_panel.history_panel.save_work_print,
             "undo": lambda: _context_undo(controller),
             "redo": controller.session.redo,
             "show_shortcuts": lambda: _show_shortcuts(self.window),

--- a/negpy/desktop/view/shortcut_registry.py
+++ b/negpy/desktop/view/shortcut_registry.py
@@ -156,6 +156,7 @@ REGISTRY: dict[str, ShortcutEntry] = {
     "copy": ShortcutEntry("Ctrl+C", "Copy settings", "Actions"),
     "copy_with_bounds": ShortcutEntry("Ctrl+Shift+C", "Copy settings (with bounds)", "Actions"),
     "paste": ShortcutEntry("Ctrl+V", "Paste settings", "Actions"),
+    "save_work_print": ShortcutEntry("Ctrl+Shift+S", "Save the current edit as a named work print", "Actions"),
     "undo": ShortcutEntry("Ctrl+Z", "Undo", "Actions"),
     "redo": ShortcutEntry("Ctrl+Y", "Redo", "Actions"),
     "show_shortcuts": ShortcutEntry("?", "Show shortcuts", "Help"),

--- a/negpy/desktop/view/sidebar/history.py
+++ b/negpy/desktop/view/sidebar/history.py
@@ -1,20 +1,40 @@
 from PyQt6.QtCore import Qt
 from PyQt6.QtGui import QFont
-from PyQt6.QtWidgets import QListWidget, QListWidgetItem, QMenu
+from PyQt6.QtWidgets import QInputDialog, QListWidget, QListWidgetItem, QMenu, QMessageBox, QPushButton
 
+from negpy.desktop.view.shortcut_registry import tooltip_with_shortcut
 from negpy.desktop.view.sidebar.base import BaseSidebar
 from negpy.desktop.view.styles.templates import section_subheader
 from negpy.desktop.view.styles.theme import THEME
 
 _INDEX_ROLE = Qt.ItemDataRole.UserRole
 
+_WORK_PRINT_TOOLTIP = (
+    "Named versions of this frame — the printer's work prints. Unlike the edit history they "
+    "are never pruned and never dropped by a later edit. Click one to make it live (undoable); "
+    "right-click to export, rename or delete it."
+)
+
 
 class HistoryPanel(BaseSidebar):
-    """Scrollable list of edit-history steps; click to jump, right-click to export."""
+    """Work prints (named versions, kept) above the edit-history steps (pruned)."""
 
     SIDE_MARGIN = THEME.space_xl
 
     def _init_ui(self) -> None:
+        self.work_print_header = section_subheader("WORK PRINTS")
+        self.layout.addWidget(self.work_print_header)
+
+        self.work_prints = QListWidget()
+        self.work_prints.setToolTip(_WORK_PRINT_TOOLTIP)
+        self.work_prints.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
+        self.work_prints.setMaximumHeight(120)
+        self.layout.addWidget(self.work_prints, 0)
+
+        self.save_btn = QPushButton("Save work print")
+        self.save_btn.setToolTip(tooltip_with_shortcut("Keep the current edit as a named version", "save_work_print"))
+        self.layout.addWidget(self.save_btn)
+
         self.layout.addWidget(section_subheader("EDIT HISTORY"))
 
         self.list = QListWidget()
@@ -27,10 +47,23 @@ class HistoryPanel(BaseSidebar):
     def _connect_signals(self) -> None:
         self.list.itemClicked.connect(self._on_item_clicked)
         self.list.customContextMenuRequested.connect(self._on_context_menu)
+        self.work_prints.itemClicked.connect(lambda item: self.controller.session.load_work_print(item.text()))
+        self.work_prints.customContextMenuRequested.connect(self._on_work_print_menu)
+        self.save_btn.clicked.connect(self.save_work_print)
         self.controller.session.history_changed.connect(self.refresh)
+        self.controller.session.work_prints_changed.connect(self.refresh)
         self.controller.session.file_selected.connect(lambda _: self.refresh())
 
     def refresh(self) -> None:
+        session = self.controller.session
+        names = session.work_prints()
+        self.work_prints.clear()
+        self.work_prints.addItems(names)
+        # An empty list is a strip of dead space in a panel most people use for undo.
+        self.work_prints.setVisible(bool(names))
+        self.work_print_header.setVisible(bool(names))
+        self.save_btn.setEnabled(bool(self.controller.state.current_file_hash))
+
         self.list.clear()
         for row in reversed(self.controller.history_steps()):  # newest on top
             item = QListWidgetItem(row["label"])
@@ -41,6 +74,20 @@ class HistoryPanel(BaseSidebar):
                 item.setFont(font)
                 self.list.setCurrentItem(item)
             self.list.addItem(item)
+
+    def save_work_print(self) -> None:
+        session = self.controller.session
+        if not self.controller.state.current_file_hash:
+            return
+        name, ok = QInputDialog.getText(self, "Save work print", "Name:", text=session.next_work_print_name())
+        name = name.strip()
+        if not (ok and name):
+            return
+        if name in session.work_prints():
+            replace = QMessageBox.question(self, "Replace work print", f"“{name}” already exists. Replace it?")
+            if replace != QMessageBox.StandardButton.Yes:
+                return
+        session.save_work_print(name)
 
     def _on_item_clicked(self, item: QListWidgetItem) -> None:
         self.controller.jump_to_history_step(item.data(_INDEX_ROLE))
@@ -53,3 +100,22 @@ class HistoryPanel(BaseSidebar):
         export_action = menu.addAction("Export this version…")
         if menu.exec(self.list.mapToGlobal(pos)) is export_action:
             self.controller.export_history_step(item.data(_INDEX_ROLE))
+
+    def _on_work_print_menu(self, pos) -> None:
+        item = self.work_prints.itemAt(pos)
+        if item is None:
+            return
+        name = item.text()
+        menu = QMenu(self)
+        export_action = menu.addAction("Export this version…")
+        rename_action = menu.addAction("Rename…")
+        delete_action = menu.addAction("Delete")
+        chosen = menu.exec(self.work_prints.mapToGlobal(pos))
+        if chosen is export_action:
+            self.controller.export_work_print(name)
+        elif chosen is rename_action:
+            new_name, ok = QInputDialog.getText(self, "Rename work print", "Name:", text=name)
+            if ok:
+                self.controller.session.rename_work_print(name, new_name.strip())
+        elif chosen is delete_action:
+            self.controller.session.delete_work_print(name)

--- a/negpy/desktop/view/widgets/database_dialog.py
+++ b/negpy/desktop/view/widgets/database_dialog.py
@@ -20,6 +20,7 @@ from negpy.desktop.view.styles.theme import THEME
 _EDIT_ROWS = (
     ("file_settings", "Saved edits (images)"),
     ("edit_history", "Undo-history steps"),
+    ("work_prints", "Work prints"),
     ("file_marks", "Keep / reject marks"),
 )
 _TOOLING_ROWS = (
@@ -178,7 +179,7 @@ class DatabaseDialog(QDialog):
         self._update_enabled(stats)
 
     def _update_enabled(self, stats: dict) -> None:
-        edits = stats.get("file_settings", 0) + stats.get("edit_history", 0) + stats.get("file_marks", 0)
+        edits = sum(stats.get(k, 0) for k in ("file_settings", "edit_history", "work_prints", "file_marks"))
         total = edits + sum(stats.get(k, 0) for k in ("normalization_rolls", "export_presets", "app_preferences"))
         self.clear_edits_btn.setEnabled(edits > 0)
         self.reset_all_btn.setEnabled(total > 0)

--- a/negpy/infrastructure/storage/repository.py
+++ b/negpy/infrastructure/storage/repository.py
@@ -1,6 +1,7 @@
 import sqlite3
 import json
 import os
+import time
 from contextlib import contextmanager
 from typing import Any, List, Optional
 from negpy.domain.models import ExportPreset, WorkspaceConfig
@@ -61,6 +62,19 @@ class StorageRepository(IRepository):
                     step_index INTEGER,
                     settings_json TEXT,
                     PRIMARY KEY (file_hash, step_index)
+                )
+            """)
+
+            # Named versions of one frame's edit. Deliberately not a column on
+            # edit_history: an edit after stepping back truncates the future branch, so a
+            # named step would be deleted by the very thing it is meant to survive.
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS work_prints (
+                    file_hash TEXT,
+                    name TEXT,
+                    created_at REAL,
+                    settings_json TEXT,
+                    PRIMARY KEY (file_hash, name)
                 )
             """)
 
@@ -254,7 +268,44 @@ class StorageRepository(IRepository):
             )
             conn.execute("DELETE FROM file_settings WHERE file_hash = ?", (old_hash,))
             conn.execute("UPDATE OR REPLACE edit_history SET file_hash = ? WHERE file_hash = ?", (new_hash, old_hash))
+            conn.execute("UPDATE OR REPLACE work_prints SET file_hash = ? WHERE file_hash = ?", (new_hash, old_hash))
             conn.execute("UPDATE OR REPLACE file_marks SET file_hash = ? WHERE file_hash = ?", (new_hash, old_hash))
+
+    def save_work_print(self, file_hash: str, name: str, settings: WorkspaceConfig) -> None:
+        """Store (or replace) a named version of this frame's edit."""
+        with self._connect(self.edits_db_path) as conn:
+            conn.execute(
+                "INSERT OR REPLACE INTO work_prints (file_hash, name, created_at, settings_json) VALUES (?, ?, ?, ?)",
+                (file_hash, name, time.time(), json.dumps(settings.to_dict(), default=str)),
+            )
+
+    def list_work_prints(self, file_hash: str) -> List[str]:
+        """This frame's work-print names, newest first."""
+        with self._connect(self.edits_db_path) as conn:
+            cursor = conn.execute(
+                "SELECT name FROM work_prints WHERE file_hash = ? ORDER BY created_at DESC, rowid DESC",
+                (file_hash,),
+            )
+            return [str(row[0]) for row in cursor.fetchall()]
+
+    def load_work_print(self, file_hash: str, name: str) -> Optional[WorkspaceConfig]:
+        with self._connect(self.edits_db_path) as conn:
+            row = conn.execute(
+                "SELECT settings_json FROM work_prints WHERE file_hash = ? AND name = ?",
+                (file_hash, name),
+            ).fetchone()
+        return WorkspaceConfig.from_flat_dict(json.loads(row[0])) if row else None
+
+    def rename_work_print(self, file_hash: str, name: str, new_name: str) -> None:
+        with self._connect(self.edits_db_path) as conn:
+            conn.execute(
+                "UPDATE OR REPLACE work_prints SET name = ? WHERE file_hash = ? AND name = ?",
+                (new_name, file_hash, name),
+            )
+
+    def delete_work_print(self, file_hash: str, name: str) -> None:
+        with self._connect(self.edits_db_path) as conn:
+            conn.execute("DELETE FROM work_prints WHERE file_hash = ? AND name = ?", (file_hash, name))
 
     def save_history_step(self, file_hash: str, index: int, settings: WorkspaceConfig) -> None:
         with self._connect(self.edits_db_path) as conn:
@@ -403,6 +454,7 @@ class StorageRepository(IRepository):
         with self._connect(self.edits_db_path) as conn:
             file_settings = self._count(conn, "file_settings")
             edit_history = self._count(conn, "edit_history")
+            work_prints = self._count(conn, "work_prints")
             file_marks = self._count(conn, "file_marks")
             normalization_rolls = self._count(conn, "normalization_rolls")
 
@@ -416,6 +468,7 @@ class StorageRepository(IRepository):
         return {
             "file_settings": file_settings,
             "edit_history": edit_history,
+            "work_prints": work_prints,
             "file_marks": file_marks,
             "normalization_rolls": normalization_rolls,
             "export_presets": export_presets,
@@ -441,12 +494,12 @@ class StorageRepository(IRepository):
             conn.execute("VACUUM")
 
     def clear_saved_edits(self) -> None:
-        """Drop per-image looks: saved edits, their undo history, and keep/reject
-        marks. Rig calibration (normalization rolls), export presets, and app
+        """Drop per-image looks: saved edits, their undo history, work prints, and
+        keep/reject marks. Rig calibration (normalization rolls), export presets, and app
         preferences are left intact — so a reloaded image starts from defaults
         without losing the user's tooling. Flat-field profiles live in the file
         store (APP_CONFIG.flatfield_dir), not here, so they are untouched too."""
-        self._wipe(self.edits_db_path, ["file_settings", "edit_history", "file_marks"])
+        self._wipe(self.edits_db_path, ["file_settings", "edit_history", "work_prints", "file_marks"])
 
     def reset_everything(self) -> None:
         """Full clean slate: every table in both databases. Export presets, rig
@@ -456,6 +509,6 @@ class StorageRepository(IRepository):
         disk, not in these databases, so they survive — as with a fresh install."""
         self._wipe(
             self.edits_db_path,
-            ["file_settings", "edit_history", "file_marks", "normalization_rolls"],
+            ["file_settings", "edit_history", "work_prints", "file_marks", "normalization_rolls"],
         )
         self._wipe(self.settings_db_path, ["global_settings"])

--- a/tests/test_history_panel.py
+++ b/tests/test_history_panel.py
@@ -81,6 +81,18 @@ class TestJumpToStep(unittest.TestCase):
         self.session.jump_to_step(2)
         self.assertEqual(self.session.state.config, self.cfg_b)
 
+    def test_persisting_an_unchanged_config_records_no_step(self):
+        """A step whose config equals the one before it renders as a dead '· —' row."""
+        self.session.update_config(self.cfg_b, persist=True)
+        self.assertEqual(self.session.state.undo_index, 2)
+        self.assertEqual(self.session.state.max_history_index, 2)
+
+    def test_persisting_an_unchanged_config_keeps_the_redo_branch(self):
+        self.session.jump_to_step(1)
+        self.session.update_config(self.session.state.config, persist=True)
+        self.assertEqual(self.session.state.max_history_index, 2)
+        self.assertIn(2, [i for i, _ in self.repo.load_all_history("h")])
+
     def test_edit_after_jump_truncates_future(self):
         self.session.jump_to_step(0)
         self.session.update_config(_exposure_variant(), persist=True)

--- a/tests/test_work_prints.py
+++ b/tests/test_work_prints.py
@@ -1,0 +1,132 @@
+import tempfile
+import unittest
+from dataclasses import replace
+
+from negpy.desktop.session import DesktopSessionManager
+from negpy.domain.models import WorkspaceConfig
+from negpy.infrastructure.storage.repository import StorageRepository
+
+
+def _variant(density: float) -> WorkspaceConfig:
+    base = WorkspaceConfig()
+    return replace(base, exposure=replace(base.exposure, density=density))
+
+
+class TestWorkPrintStore(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.repo = StorageRepository(f"{self._tmp.name}/edits.db", f"{self._tmp.name}/settings.db")
+        self.repo.initialize()
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_round_trip(self):
+        cfg = _variant(1.4)
+        self.repo.save_work_print("h", "Work print 1", cfg)
+        self.assertEqual(self.repo.list_work_prints("h"), ["Work print 1"])
+        self.assertEqual(self.repo.load_work_print("h", "Work print 1"), cfg)
+
+    def test_listed_newest_first(self):
+        self.repo.save_work_print("h", "first", _variant(1.0))
+        self.repo.save_work_print("h", "second", _variant(1.1))
+        self.assertEqual(self.repo.list_work_prints("h"), ["second", "first"])
+
+    def test_scoped_to_the_frame(self):
+        self.repo.save_work_print("h", "mine", _variant(1.0))
+        self.assertEqual(self.repo.list_work_prints("other"), [])
+        self.assertIsNone(self.repo.load_work_print("other", "mine"))
+
+    def test_same_name_replaces(self):
+        self.repo.save_work_print("h", "one", _variant(1.0))
+        self.repo.save_work_print("h", "one", _variant(1.9))
+        self.assertEqual(self.repo.list_work_prints("h"), ["one"])
+        self.assertEqual(self.repo.load_work_print("h", "one").exposure.density, 1.9)
+
+    def test_rename_keeps_the_settings(self):
+        cfg = _variant(1.4)
+        self.repo.save_work_print("h", "old", cfg)
+        self.repo.rename_work_print("h", "old", "new")
+        self.assertEqual(self.repo.list_work_prints("h"), ["new"])
+        self.assertEqual(self.repo.load_work_print("h", "new"), cfg)
+
+    def test_delete(self):
+        self.repo.save_work_print("h", "one", _variant(1.0))
+        self.repo.delete_work_print("h", "one")
+        self.assertEqual(self.repo.list_work_prints("h"), [])
+
+    def test_missing_name_loads_none(self):
+        self.assertIsNone(self.repo.load_work_print("h", "nothing"))
+
+    def test_rehome_carries_work_prints_to_the_new_hash(self):
+        self.repo.save_file_settings("old", _variant(1.0), file_path="/frame.raw")
+        self.repo.save_work_print("old", "one", _variant(1.4))
+        self.repo.rehome_file_settings("old", "new", "/frame.raw")
+        self.assertEqual(self.repo.list_work_prints("new"), ["one"])
+        self.assertEqual(self.repo.list_work_prints("old"), [])
+
+    def test_clearing_saved_edits_drops_work_prints(self):
+        self.repo.save_work_print("h", "one", _variant(1.0))
+        self.repo.clear_saved_edits()
+        self.assertEqual(self.repo.list_work_prints("h"), [])
+
+    def test_reset_everything_drops_work_prints(self):
+        self.repo.save_work_print("h", "one", _variant(1.0))
+        self.repo.reset_everything()
+        self.assertEqual(self.repo.list_work_prints("h"), [])
+
+    def test_counted_in_the_database_stats(self):
+        self.repo.save_work_print("h", "one", _variant(1.0))
+        self.assertEqual(self.repo.database_stats()["work_prints"], 1)
+
+    def test_survives_history_pruning(self):
+        """The whole point: an undo stack that rolls over must not take versions with it."""
+        self.repo.save_work_print("h", "kept", _variant(1.4))
+        for i in range(20):
+            self.repo.save_history_step("h", i, _variant(1.0 + i / 100.0))
+        self.repo.prune_history("h", max_steps=10)
+        self.repo.truncate_history_above("h", 2)
+        self.assertEqual(self.repo.list_work_prints("h"), ["kept"])
+
+
+class TestWorkPrintController(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.repo = StorageRepository(f"{self._tmp.name}/edits.db", f"{self._tmp.name}/settings.db")
+        self.repo.initialize()
+        self.session = DesktopSessionManager(self.repo)
+        self.session.state.current_file_hash = "h"
+        self.session.state.config = _variant(1.4)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_saving_names_the_next_work_print(self):
+        self.assertEqual(self.session.next_work_print_name(), "Work print 1")
+        self.session.save_work_print("Work print 1")
+        self.assertEqual(self.session.next_work_print_name(), "Work print 2")
+
+    def test_saving_stores_the_live_edit(self):
+        self.session.save_work_print("wp")
+        self.assertEqual(self.repo.load_work_print("h", "wp"), _variant(1.4))
+
+    def test_loading_a_work_print_is_undoable(self):
+        self.session.save_work_print("wp")
+        self.session.update_config(_variant(0.6), persist=True)
+        self.session.load_work_print("wp")
+        self.assertEqual(self.session.state.config, _variant(1.4))
+        self.session.undo()
+        self.assertEqual(self.session.state.config, _variant(0.6))
+
+    def test_loading_a_missing_work_print_changes_nothing(self):
+        self.session.load_work_print("nothing")
+        self.assertEqual(self.session.state.config, _variant(1.4))
+
+    def test_no_frame_no_work_prints(self):
+        self.session.state.current_file_hash = ""
+        self.session.save_work_print("wp")
+        self.assertEqual(self.session.work_prints(), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_work_prints.py
+++ b/tests/test_work_prints.py
@@ -118,6 +118,14 @@ class TestWorkPrintController(unittest.TestCase):
         self.session.undo()
         self.assertEqual(self.session.state.config, _variant(0.6))
 
+    def test_clicking_an_unchanged_work_print_adds_no_history_step(self):
+        self.session.save_work_print("wp")
+        index = self.session.state.undo_index
+        self.session.load_work_print("wp")
+        self.session.load_work_print("wp")
+        self.assertEqual(self.session.state.undo_index, index)
+        self.assertEqual(self.session.state.max_history_index, index)
+
     def test_loading_a_missing_work_print_changes_nothing(self):
         self.session.load_work_print("nothing")
         self.assertEqual(self.session.state.config, _variant(1.4))


### PR DESCRIPTION
## What

A **work print** is a named version of one frame's edit — the darkroom habit of keeping the prints you made on the way to the final one, so you can go back to the third attempt after deciding the fifth went too far. Master-printer workflow descriptions are consistent about this: several work prints get made and kept, and the recipe is written down.

NegPy's history is an unnamed 100-deep undo stack that prunes, so a version could not be kept, compared or re-exported by name.

In the History tab, above the edit history:

* **Save work print** (**Ctrl+Shift+S**) keeps the live edit under a name, offering *Work print 1*, *2*, … Saving over an existing name asks first.
* **Click** one to make it live; **right-click** → Export this version… / Rename… / Delete.
* The list only appears once you have saved one.

## Why a separate table, not a name column on `edit_history`

The obvious version — name a history step, exempt named steps from pruning — is a trap, and worth spelling out because it looks cheaper:

`update_config` calls `truncate_history_above` whenever you edit after stepping back. Jump to work print 1, nudge a slider, and work print 2 is deleted as an "orphaned future branch" — the name would be destroyed by the very thing it is meant to survive. Exempting named rows there instead strands them above `max_history_index`, and `history_steps` iterates `range(max_history_index + 1)`, so the panel could not show them.

A `work_prints (file_hash, name, created_at, settings_json)` table sits outside that bookkeeping entirely: nothing to exempt, no undo semantics to bend. Storage follows the `normalization_rolls` pattern in the same file, and loading goes through `update_config`, so **loading a work print is itself undoable** for free.

Per-frame, so the DB is the right home; `services/assets/presets.py` (JSON files, library-wide looks) stays separate — a preset list polluted with "frame 12 work print 2" is useless. Not mirrored to `.negpy` sidecars.

## The easy-to-miss sites

`rehome_file_settings` (so a superseded content hash carries its work prints — this is what makes `hash_migration.py` need no change), `database_stats` + the Manage Database row, and both wipe lists (`clear_saved_edits`, `reset_everything`).

## Verification

`make all` green (3256 tests). 17 new tests cover the store, the rehome, both wipes, survival of `prune_history`/`truncate_history_above`, and that loading is undoable.

End to end through the real `MainWindow` History panel on a real scan, 21 checks: the list stays hidden until there is one, both entries list newest-first, both survive 103 edits past the prune horizon *and* a truncating edit after stepping back, loading restores its density and Ctrl+Z puts back what was on screen, rename keeps the settings, the panel follows every change, `Ctrl+Shift+S` is bound with no other action claiming it, and Clear saved edits drops them.