### PR TITLE
Keep the session panel stacked when its sections are collapsed (fixes #754)

### DIFF
--- a/negpy/desktop/view/sidebar/files.py
+++ b/negpy/desktop/view/sidebar/files.py
@@ -549,6 +549,9 @@ class FileBrowser(QWidget):
 
         layout.addWidget(self.library_section)
         layout.addWidget(self.frames_section)
+        # Absorbs the surplus when every section is collapsed — otherwise Qt spreads it
+        # into the gaps between the rows above. Stretch 0 leaves an open section its share.
+        layout.addStretch(0)
         self._rebalance_sections()
 
         # Applied after list_view exists — the filter prunes selection against the view.

--- a/tests/test_session_panel.py
+++ b/tests/test_session_panel.py
@@ -71,6 +71,19 @@ def test_a_collapsed_section_keeps_only_its_header(panel):
     assert browser.layout().stretch(browser.layout().indexOf(browser.frames_section)) > 0
 
 
+def test_collapsing_both_sections_keeps_the_panel_top_aligned(panel, qapp):
+    """With nothing expanded the leftover height must not spread into the gaps (#754)."""
+    browser = panel.file_browser
+    browser.library_section.toggle_button.setChecked(False)
+    browser.frames_section.toggle_button.setChecked(False)
+
+    browser.resize(300, 900)
+    browser.show()
+    qapp.processEvents()
+
+    assert browser.frames_section.y() < 200  # ~115 stacked, ~707 spread
+
+
 def test_expanding_a_section_gives_it_back_a_share(panel):
     browser = panel.file_browser
     browser.frames_section.toggle_button.setChecked(False)


### PR DESCRIPTION
Collapsing the Film Strip spread the left panel's contents — logo, toolbar, filter row, section header — evenly down the whole dock instead of leaving them stacked at the top ([#754](https://github.com/marcinz606/NegPy/issues/754)).

`_rebalance_sections` pins a collapsed section to its header height and gives it stretch 0. That is deliberate, but it left `FileBrowser`'s layout with no item able to grow: the toolbar and filter rows are fixed height, and both sections are capped. With every section shut, Qt falls back to spreading the surplus into the gaps between rows.

A trailing `addStretch(0)` absorbs it. Stretch 0 rather than 1, so an expanded section still takes the whole surplus — expanded geometry is unchanged (the 40/60 split and the single-section case measure identically before and after).

Easiest to hit before a library exists: the Library section stays hidden until it has roots, so the Film Strip is the only section there is to collapse. Both-collapsed had the same fault.

`test_collapsing_both_sections_keeps_the_panel_top_aligned` covers it on realized geometry — the existing tests only assert stretch factors, which were already correct. Confirmed it fails without the fix (section at y≈707 in a 900px panel, y≈115 with it).

The issue's second remark — no Library dropdown — is that hidden-until-roots behaviour, answered in the thread. No change here.