### PR TITLE
fix: Linear Output batch config leak and XMP metadata

### DIFF
--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -3362,12 +3362,10 @@ class AppController(QObject):
             return
 
         exported = 0
-        cfg = self.state.config
-        geometry = cfg.geometry
         expansion = self.state.linear_expansion
-        rgbscan = cfg.rgbscan
-        stitch = cfg.stitch if cfg.stitch.stitch_enabled else None
         for f in supported:
+            params = self._batch_params_for(f)
+            stitch = params.stitch if params.stitch.stitch_enabled else None
             stem = os.path.splitext(os.path.basename(f["path"]))[0]
             out_path = os.path.join(export_path, f"{stem}_linear.tiff")
             counter = 2
@@ -3378,12 +3376,12 @@ class AppController(QObject):
                 export_linear_output(
                     f["path"],
                     out_path,
-                    geometry=geometry,
+                    geometry=params.geometry,
                     expansion=expansion,
-                    rgbscan=rgbscan,
+                    rgbscan=params.rgbscan,
                     stitch=stitch,
-                    flatfield=cfg.flatfield,
-                    process=cfg.process,
+                    flatfield=params.flatfield,
+                    process=params.process,
                     apply_wb=self.state.linear_apply_wb,
                     apply_flatfield=self.state.linear_apply_flatfield,
                     apply_sensor=self.state.linear_apply_sensor,

--- a/negpy/services/export/linear_output.py
+++ b/negpy/services/export/linear_output.py
@@ -451,9 +451,21 @@ def _normalize_wb_rgb(wb: tuple[float, float, float, float]) -> tuple[float, flo
     return (wb[0] / g, 1.0, wb[2] / g)
 
 
-def _build_xmp(source_path: str, wb: _CameraWB) -> bytes:
-    r, g, b = _normalize_wb_rgb(wb.as_shot)
+def _build_xmp(source_path: str, wb: _CameraWB, title: str = "", wb_applied: bool = False) -> bytes:
     raw_name = os.path.basename(source_path)
+    title_block = ""
+    if title:
+        title_block = f"  <dc:title>\n   <rdf:Alt>\n    <rdf:li xml:lang='x-default'>{title}</rdf:li>\n   </rdf:Alt>\n  </dc:title>\n"
+    desc_block = ""
+    if not wb_applied:
+        r, g, b = _normalize_wb_rgb(wb.as_shot)
+        desc_block = (
+            "  <dc:description>\n"
+            "   <rdf:Alt>\n"
+            f"    <rdf:li xml:lang='x-default'>RAW-WB: {r:.6f} {g:.6f} {b:.6f}</rdf:li>\n"
+            "   </rdf:Alt>\n"
+            "  </dc:description>\n"
+        )
     xmp = (
         "<?xpacket begin='﻿' id='W5M0MpCehiHzreSzNTczkc9d'?>\n"
         "<x:xmpmeta xmlns:x='adobe:ns:meta/'>\n"
@@ -464,11 +476,8 @@ def _build_xmp(source_path: str, wb: _CameraWB) -> bytes:
         " </rdf:Description>\n"
         " <rdf:Description rdf:about=''\n"
         "  xmlns:dc='http://purl.org/dc/elements/1.1/'>\n"
-        "  <dc:description>\n"
-        "   <rdf:Alt>\n"
-        f"    <rdf:li xml:lang='x-default'>RAW-WB: {r:.6f} {g:.6f} {b:.6f}</rdf:li>\n"
-        "   </rdf:Alt>\n"
-        "  </dc:description>\n"
+        f"{title_block}"
+        f"{desc_block}"
         " </rdf:Description>\n"
         "</rdf:RDF>\n"
         "</x:xmpmeta>\n"
@@ -546,7 +555,7 @@ def _write_tiff(
 
     extratags: list[tuple] = []
     if camera_wb is not None and source_path is not None:
-        xmp_bytes = _build_xmp(source_path, camera_wb)
+        xmp_bytes = _build_xmp(source_path, camera_wb, title=description, wb_applied=wb_applied)
         extratags.append((700, 1, len(xmp_bytes), xmp_bytes, True))
 
     if source_meta is not None:


### PR DESCRIPTION
## Summary
- **Batch export per-file config**: Linear Output batch export was using the current frame's rgbscan, stitch, flatfield, and process config for every file. Now loads each file's own config via `_batch_params_for()`, matching the print export pattern. Expansion and correction toggles remain session-level.
- **XMP dc:title**: adds the full description string as `dc:title` so Bridge (and other XMP-aware tools) shows it instead of just the `RAW-WB:` line from `dc:description`
- **Drop RAW-WB when WB is applied**: when white balance has been baked into the pixels, the `RAW-WB:` gains are omitted from `dc:description` to prevent double-correction by downstream tools like ColorPerfect

## Test plan
- [x] Batch-exported a mix of Pakon, DNG, and camera RAW (including stitch) — each got its own config, no leaking
- [x] Verified XMP tags: `dc:title` present on camera RAW exports, `RAW-WB` absent when WB applied, present when not
