### PR TITLE
Feat/half frame rectangle editor

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -78,7 +78,7 @@ Toolbar buttons, left to right:
 *   **Clear all**: unload everything (or, when several frames are selected, unload just those).
 *   **Hot Folder**: watches the current folder and auto-loads new files as they appear, handy when a scanner drops files into a directory.
 *   **RGB Scan**: treats the folder as red/green/blue exposure triplets and assembles each frame from three shots (for narrowband trichrome scanning). Right-click a frame → **Edit RGB Triplet…** to assign the three files by hand.
-*   **Half Frame**: splits each scan into two frames (for half-frame cameras), edited and metered separately.
+*   **Half Frame**: splits each scan into two frames (for half-frame cameras), edited and metered separately. When enabled, a rectangle editor opens on the current scan: drag the green box to crop (everything outside is discarded), drag the orange line to set the split, and use the **Cut thickness** slider to discard a band centered on the split (the physical black separator between the two exposures). The setting is saved and applied to every half-frame split from then on, regardless of how the scans were acquired (SANE scanner, camera copy-stand, or folder import). The **Adjust Half Frame** toolbutton (next to Half Frame) re-opens the editor on the current scan to fine-tune. Auto-detection of the gutter still seeds the initial split position.
 *   **Apply (clone)**: copy the current frame's settings to selected frames or the whole roll. You choose which aspects in a dialog (crop and rotation are always per-image).
 *   **Sheet filter** (funnel): show *All frames*, *Keepers only*, or *Hide rejected*.
 *   **Sort**: by Name or Date, ascending or descending.
@@ -597,7 +597,7 @@ When you set capture gear, it's written to standard EXIF and the digitizing rig 
 
 Capture film directly into NegPy (Linux and macOS; unavailable on Windows). Two collapsible sections:
 
-*   **Scanner (SANE)**: drive a supported flatbed/film scanner over SANE.
+*   **Scanner (SANE)**: drive a supported flatbed/film scanner over SANE. Common controls: backend/device selection, DPI, bit depth, IR channel, autofocus, hardware auto-exposure, frame range (roll feeders), scan window, output format, folder and filename template. When the connected scanner exposes a SANE `scan-exposure-time` option (e.g. some genesys devices), an **Exposure** slider appears below Auto-exposure — set it to override the scanner's default exposure time; the value shows in µs, ms or s as appropriate. A device without the option hides the slider, so a saved value never breaks a different scanner.
 *   **Camera Scanning**: DSLR/mirrorless copy-stand capture. Auto-connects the camera over USB (PC-Remote mode). With a NegPy **Scanlight** connected it captures narrowband R/G/B triplets from saved film-stock presets; without one it does a single white-light exposure. A **Live View** window helps you frame and focus; captured frames land in the hot folder and flow straight into RGB-Scan mode.
 
 Camera scanning needs the optional `python-gphoto2` dependency (`pip install gphoto2`; no Windows build). See [CAMERA_SCANNING.md](CAMERA_SCANNING.md).

--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -52,7 +52,7 @@ from negpy.domain.models import (
     preset_from_export_config,
     resolve_preset_export,
 )
-from negpy.services.assets.half_frame import base_hash, slice_half
+from negpy.services.assets.half_frame import half_hash
 from negpy.services.assets.sidecar import load_or_promote, write_sidecar
 from negpy.features.exposure.analysis import (
     RING_GRID,
@@ -1150,13 +1150,14 @@ class AppController(QObject):
                 return f.get("hash")
         return None
 
-    def _active_half(self) -> Optional[tuple[int, float, tuple[float, float, float, float] | None, float]]:
-        """(half, split_x, crop_rect, gutter_thickness) of the active asset, or None for whole-frame."""
-        h = self.state.current_file_hash
-        if not h:
+    def _half_slice_for_asset(
+        self, path: Optional[str], file_hash: Optional[str]
+    ) -> Optional[tuple[int, float, tuple[float, float, float, float] | None, float]]:
+        """(half, split_x, crop_rect, gutter_thickness) for the asset at path/hash, or None."""
+        if not file_hash:
             return None
         for f in self.state.uploaded_files:
-            if f.get("hash") == h:
+            if f.get("hash") == file_hash or (path and f.get("path") == path and f.get("hash") == file_hash):
                 half = int(f.get("half") or 0)
                 if not half:
                     return None
@@ -1173,6 +1174,10 @@ class AppController(QObject):
                     float(f.get("gutter_thickness") or 0.0),
                 )
         return None
+
+    def _active_half(self) -> Optional[tuple[int, float, tuple[float, float, float, float] | None, float]]:
+        """(half, split_x, crop_rect, gutter_thickness) of the active asset, or None for whole-frame."""
+        return self._half_slice_for_asset(self.state.current_file_path, self.state.current_file_hash)
 
     def _render_memo_key(self, config: Optional[WorkspaceConfig] = None) -> str:
         """Identity of everything that shapes the displayed render of the current
@@ -1282,13 +1287,16 @@ class AppController(QObject):
         rgbscan = self.state.config.rgbscan
         stitch = self.state.config.stitch
         flatfield = self.state.config.flatfield
+        half_info = self._active_half()
         self.preview_load_requested.emit(
             PreviewLoadTask(
                 file_path=file_path,
                 workspace_color_space=self.state.workspace_color_space,
                 use_camera_wb=not self.state.config.process.linear_raw,
                 full_resolution=self.state.hq_preview,
-                file_hash=base_hash(self._file_hash_for_path(file_path)),  # halves share the per-file decode cache
+                # The half suffix distinguishes the two halves' preview caches now
+                # that the slice happens pre-downsample (each half is its own buffer).
+                file_hash=self._file_hash_for_path(file_path),
                 # A memoized frame is already painted — the embedded-JPEG splash
                 # would repaint stale pixels over it.
                 use_splash=memo is None,
@@ -1307,41 +1315,16 @@ class AppController(QObject):
                 stitch_triplets=stitch.stitch_triplets if stitch.stitch_enabled else (),
                 stitch_align=stitch.stitch_align,
                 flatfield_profile_id=flatfield.profile_id if (stitch.stitch_enabled and flatfield.apply) else "",
+                half_slice=half_info,
             )
         )
 
     def _split_active_half(self, raw: Any, dims: Any) -> tuple[Any, Any]:
-        """Slice a full-frame decode/splash down to the active half asset (no-op otherwise).
-
-        Both halves decode identically, so slicing by the current selection is safe
-        even for a stale same-path load; cached buffers are read-only, hence the copy.
+        """No-op: the half-frame slice now happens in PreviewManager before the
+        preview downsample, so both splash and linear buffers arrive already
+        sliced to the active half (and at the same pixels export analyzes).
+        Kept as a passthrough for the splash/loaded handlers that still call it.
         """
-        half_info = self._active_half()
-        if half_info is None:
-            return raw, dims
-        half, split_x, crop_rect, gutter_thickness = half_info
-        raw = np.ascontiguousarray(slice_half(raw, half, split_x, crop_rect=crop_rect, gutter_thickness=gutter_thickness))
-        if dims is not None:
-            h0, w0 = dims
-            if crop_rect is not None:
-                x1, y1, x2, y2 = crop_rect
-                cx1 = min(max(int(round(w0 * x1)), 0), w0)
-                cx2 = min(max(int(round(w0 * x2)), 0), w0)
-                cy1 = min(max(int(round(h0 * y1)), 0), h0)
-                cy2 = min(max(int(round(h0 * y2)), 0), h0)
-                w0 = max(1, cx2 - cx1)
-                h0 = max(1, cy2 - cy1)
-            xs = min(max(int(round(w0 * split_x)), 1), w0 - 1)
-            if gutter_thickness > 0:
-                gw = max(1, int(round(w0 * gutter_thickness)))
-                lo = max(1, xs - gw // 2)
-                hi = min(w0 - 1, lo + gw)
-                left_w = lo
-                right_w = w0 - hi
-                w_half = left_w if half == 1 else right_w
-            else:
-                w_half = xs if half == 1 else w0 - xs
-            dims = (h0, w_half)
         return raw, dims
 
     def _on_splash_preview(self, file_path: str, raw: Any, dims: Any) -> None:
@@ -1411,6 +1394,7 @@ class AppController(QObject):
                 # the wrong key and navigation re-decodes anyway.
                 saved = self.session.repo.load_file_settings(h) if h else None
                 linear_raw = saved.process.linear_raw if saved else False
+                neighbour_half = self._half_slice_for_asset(path, h)
                 self.preview_load_requested.emit(
                     PreviewLoadTask(
                         file_path=path,
@@ -1419,9 +1403,10 @@ class AppController(QObject):
                         # Half-size only: a full-res HQ neighbour (~720MB) evicts the
                         # active buffer; the cache key separates resolutions.
                         full_resolution=False,
-                        file_hash=base_hash(h),
+                        file_hash=h,
                         use_splash=False,
                         for_cache_warm=True,
+                        half_slice=neighbour_half,
                     )
                 )
 
@@ -3338,8 +3323,49 @@ class AppController(QObject):
     def _batch_params_for(self, f: dict) -> WorkspaceConfig:
         """Resolve a visible frame's export params: its saved DB config (else the current
         config), with its own RGB-scan green/blue re-injected from the asset dict — the
-        same authoritative source individual export gets via select_file."""
-        params = self.session.repo.load_file_settings(f["hash"]) or self.state.config
+        same authoritative source individual export gets via select_file.
+
+        For the currently active file, always use the live session config to ensure
+        unsaved edits (e.g., crosstalk adjustments not yet persisted) are included
+        in the export.
+
+        Half-frame siblings share capture-side spectral-crosstalk calibration — if one
+        half has it enabled and the other's DB entry defaults to 0, propagate the active
+        session value so both frames get identical dye-unmixing during export.
+        """
+        # For the active file, use the live session config — it may have unsaved
+        # changes that the user expects to see in the export. For other files, use
+        # saved DB settings (or fall back to session config if none exist).
+        if f.get("hash") == self.state.current_file_hash:
+            params = self.state.config
+        else:
+            params = self.session.repo.load_file_settings(f["hash"]) or self.state.config
+
+        # Propagate capture-side crosstalk between sibling half-frames. The dye-unmix
+        # calibration is a property of the scanner-film pair, not individual frames —
+        # if one half was calibrated and the other wasn't (still at default), both need
+        # the same correction during export.
+        base = f.get("hash", "")
+        if "#" in base:
+            half_val = int(base.split("#")[-1])
+            sibling_hash = half_hash(base.rsplit("#", 1)[0], 3 - half_val)
+            sibling_params = self.session.repo.load_file_settings(sibling_hash)
+            session_ct = self.state.config.process.crosstalk_strength
+            params_ct = params.process.crosstalk_strength
+            sibling_ct = sibling_params.process.crosstalk_strength if sibling_params else session_ct
+            # If this frame's crosstalk differs from the sibling but is at default (0),
+            # inherit the sibling's value so both get identical correction.
+            if abs(params_ct) < 1e-9 and abs(sibling_ct) > 1e-9:
+                proc = params.process
+                params = replace(
+                    params,
+                    process=replace(
+                        proc,
+                        crosstalk_strength=sibling_ct,
+                        crosstalk_matrix=sibling_params.process.crosstalk_matrix if sibling_params else proc.crosstalk_matrix,
+                    ),
+                )
+
         return resolve_asset_stitch(resolve_asset_rgbscan(params, f), f)
 
     def _tasks_for_file(
@@ -3514,17 +3540,34 @@ class AppController(QObject):
             export_conf = flat_export_config(export_conf)
         source_exif = self.state.source_exif.get(self.state.current_file_hash or "")
 
+        # Reuse the asset dict from uploaded_files so half-frame fields
+        # (half, split_x, crop_rect, gutter_thickness) reach the exporter —
+        # without them process_export gets half=0 and renders the whole scan
+        # instead of the half, dropping the crop and shifting log bounds.
+        file_info = next(
+            (f for f in self.state.uploaded_files if f.get("hash") == self.state.current_file_hash),
+            None,
+        )
+        if file_info is None:
+            file_info = {
+                "name": os.path.basename(self.state.current_file_path),
+                "path": self.state.current_file_path,
+                "hash": self.state.current_file_hash,
+            }
+
+        bounds_override = None
+        if file_info.get("hash") == self.state.current_file_hash:
+            with self.state.metrics_lock:
+                bounds_override = self.state.last_metrics.get("log_bounds")
+
         self._run_export_tasks(
             [
                 ExportTask(
-                    file_info={
-                        "name": os.path.basename(self.state.current_file_path),
-                        "path": self.state.current_file_path,
-                        "hash": self.state.current_file_hash,
-                    },
+                    file_info=file_info,
                     params=params,
                     export_settings=preset_from_export_config(export_conf),
                     gpu_enabled=self.state.gpu_enabled,
+                    bounds_override=bounds_override,
                     source_exif=source_exif,
                     metadata_config=self.state.config.metadata,
                     working_color_space=self.state.workspace_color_space,

--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -161,6 +161,7 @@ class _DiscoveryRequest:
     rgb_scan: bool
     half_frame: bool
     restore_stitches: Optional[dict] = None
+    half_frame_profile: Optional[dict] = None  # {crop_rect, split_x, gutter_thickness}
 
 
 def baseline_compare_config(config: WorkspaceConfig) -> WorkspaceConfig:
@@ -805,6 +806,7 @@ class AppController(QObject):
             rgb_scan=bool(self.session.repo.get_global_setting("rgbscan_mode", False)),
             half_frame=bool(self.session.repo.get_global_setting("half_frame_mode", False)),
             restore_stitches=restore_stitches,
+            half_frame_profile=self.half_frame_profile(),
         )
         if self._discovery_running:
             self._pending_asset_discoveries.append(request)
@@ -838,6 +840,7 @@ class AppController(QObject):
             restore_triplets=request.restore_triplets,
             half_frame=request.half_frame,
             restore_stitches=request.restore_stitches,
+            half_frame_profile=request.half_frame_profile,
         )
         self.asset_discovery_requested.emit(task)
 
@@ -992,6 +995,67 @@ class AppController(QObject):
             return
         self.request_asset_discovery(_component_paths(files), replace_existing=True, reselect_path=self.state.current_file_path)
 
+    # ── half-frame split & crop profile ─────────────────────────────────
+
+    _HALF_FRAME_PROFILE_KEY = "half_frame_profile"
+
+    def half_frame_profile(self) -> dict | None:
+        """Saved ``(crop_rect, split_x, gutter_thickness)`` profile, shared across
+        every half-frame split. Scanner-independent — the same crop/split applies
+        whether the scans came from a SANE scanner, a camera copy-stand, or a
+        folder import."""
+        return self.session.repo.get_global_setting(self._HALF_FRAME_PROFILE_KEY, default=None)
+
+    def save_half_frame_profile(self, crop_rect, split_x: float, gutter_thickness: float) -> None:
+        self.session.repo.save_global_setting(
+            self._HALF_FRAME_PROFILE_KEY,
+            {
+                "crop_rect": list(crop_rect),
+                "split_x": float(split_x),
+                "gutter_thickness": float(gutter_thickness),
+            },
+        )
+
+    def open_half_frame_dialog(self, file_path: str) -> dict | None:
+        """Open the half-frame split & crop editor on one scan; return the profile
+        dict on Apply, None on cancel."""
+        import numpy as np
+
+        from negpy.desktop.view.widgets.half_frame_dialog import HalfFrameDialog
+        from negpy.services.assets.half_frame import detect_split_x
+        from negpy.services.assets.thumbnails import decode_source_image
+
+        try:
+            img = decode_source_image(file_path)
+            if img is None:
+                return None
+            buf = np.asarray(img)
+        except Exception as e:
+            self.set_status(f"Could not load preview: {e}")
+            return None
+
+        saved = self.half_frame_profile()
+        initial_rect = tuple(saved["crop_rect"]) if saved else None
+        initial_split = saved["split_x"] if saved else detect_split_x(buf)
+        initial_gutter = saved["gutter_thickness"] if saved else 0.0
+
+        dialog = HalfFrameDialog(
+            buf,
+            initial_rect=initial_rect,
+            initial_split=initial_split,
+            initial_gutter=initial_gutter,
+            parent=None,
+        )
+        if dialog.exec():
+            profile = {
+                "crop_rect": list(dialog.crop_rect()),
+                "split_x": dialog.split_x(),
+                "gutter_thickness": dialog.gutter_thickness(),
+            }
+            self.save_half_frame_profile(profile["crop_rect"], profile["split_x"], profile["gutter_thickness"])
+            return profile
+        return None
+
     def _on_discovery_progress(self, current: int, total: int, name: str) -> None:
         self.set_status(f"HASHING {current}/{total}: {name}")
         self.status_progress_requested.emit(current, total)
@@ -1086,15 +1150,28 @@ class AppController(QObject):
                 return f.get("hash")
         return None
 
-    def _active_half(self) -> Optional[tuple[int, float]]:
-        """(half, split_x) of the active asset, or None for whole-frame assets."""
+    def _active_half(self) -> Optional[tuple[int, float, tuple[float, float, float, float] | None, float]]:
+        """(half, split_x, crop_rect, gutter_thickness) of the active asset, or None for whole-frame."""
         h = self.state.current_file_hash
         if not h:
             return None
         for f in self.state.uploaded_files:
             if f.get("hash") == h:
                 half = int(f.get("half") or 0)
-                return (half, float(f.get("split_x") or 0.5)) if half else None
+                if not half:
+                    return None
+                cr = f.get("crop_rect")
+                crop_rect: tuple[float, float, float, float] | None = None
+                if isinstance(cr, (tuple, list)):
+                    vals = tuple(float(v) for v in cr)
+                    if len(vals) == 4:
+                        crop_rect = vals  # type: ignore[assignment]
+                return (
+                    half,
+                    float(f.get("split_x") or 0.5),
+                    crop_rect,
+                    float(f.get("gutter_thickness") or 0.0),
+                )
         return None
 
     def _render_memo_key(self, config: Optional[WorkspaceConfig] = None) -> str:
@@ -1242,12 +1319,29 @@ class AppController(QObject):
         half_info = self._active_half()
         if half_info is None:
             return raw, dims
-        half, split_x = half_info
-        raw = np.ascontiguousarray(slice_half(raw, half, split_x))
+        half, split_x, crop_rect, gutter_thickness = half_info
+        raw = np.ascontiguousarray(slice_half(raw, half, split_x, crop_rect=crop_rect, gutter_thickness=gutter_thickness))
         if dims is not None:
             h0, w0 = dims
+            if crop_rect is not None:
+                x1, y1, x2, y2 = crop_rect
+                cx1 = min(max(int(round(w0 * x1)), 0), w0)
+                cx2 = min(max(int(round(w0 * x2)), 0), w0)
+                cy1 = min(max(int(round(h0 * y1)), 0), h0)
+                cy2 = min(max(int(round(h0 * y2)), 0), h0)
+                w0 = max(1, cx2 - cx1)
+                h0 = max(1, cy2 - cy1)
             xs = min(max(int(round(w0 * split_x)), 1), w0 - 1)
-            dims = (h0, xs) if half == 1 else (h0, w0 - xs)
+            if gutter_thickness > 0:
+                gw = max(1, int(round(w0 * gutter_thickness)))
+                lo = max(1, xs - gw // 2)
+                hi = min(w0 - 1, lo + gw)
+                left_w = lo
+                right_w = w0 - hi
+                w_half = left_w if half == 1 else right_w
+            else:
+                w_half = xs if half == 1 else w0 - xs
+            dims = (h0, w_half)
         return raw, dims
 
     def _on_splash_preview(self, file_path: str, raw: Any, dims: Any) -> None:

--- a/negpy/desktop/view/sidebar/files.py
+++ b/negpy/desktop/view/sidebar/files.py
@@ -382,6 +382,11 @@ class FileBrowser(QWidget):
         self.half_frame_btn.setChecked(bool(self.session.repo.get_global_setting("half_frame_mode", False)))
         self._update_half_frame_style(self.half_frame_btn.isChecked())
 
+        self.half_frame_adjust_btn = QToolButton()
+        self.half_frame_adjust_btn.setIcon(qta.icon("mdi.tune-variant", color=THEME.text_primary))
+        self.half_frame_adjust_btn.setToolTip("Adjust Half Frame split — reposition the crop rectangle and split line for the current scan")
+        self.half_frame_adjust_btn.clicked.connect(self._on_half_frame_adjust)
+
         self.apply_btn = QToolButton()
         self.apply_btn.setIcon(qta.icon("fa5s.clone", color=THEME.text_primary))
         self.apply_btn.setToolTip("Apply settings from the current frame to selected frames or the whole roll")
@@ -441,6 +446,7 @@ class FileBrowser(QWidget):
             self.hot_folder_btn,
             self.rgb_scan_btn,
             self.half_frame_btn,
+            self.half_frame_adjust_btn,
             self.apply_btn,
             self.sheet_btn,
             self.sort_btn,
@@ -460,6 +466,7 @@ class FileBrowser(QWidget):
             (self.hot_folder_btn, "Hot Folder"),
             (self.rgb_scan_btn, "RGB Scan"),
             (self.half_frame_btn, "Half Frame"),
+            (self.half_frame_adjust_btn, "Adjust Half Frame"),
             (self.apply_btn, "Apply settings"),
             (None, None),
             (self.sheet_btn, "Sheet filter"),
@@ -863,7 +870,44 @@ class FileBrowser(QWidget):
 
     def _on_half_frame_toggled(self, checked: bool) -> None:
         self._update_half_frame_style(checked)
+        if checked and self.session.state.uploaded_files:
+            # Offer the rectangle editor on the current frame; the saved profile
+            # is applied to every half-frame split from then on.
+            current = self.session.state.current_file_path
+            path = None
+            if current:
+                for f in self.session.state.uploaded_files:
+                    if f.get("path") == current:
+                        path = current
+                        break
+            if path is None:
+                path = self.session.state.uploaded_files[0].get("path")
+            if path:
+                self.controller.open_half_frame_dialog(path)
         self.controller.set_half_frame_mode(checked)
+
+    def _on_half_frame_adjust(self) -> None:
+        """Re-open the half-frame rectangle editor on the current image."""
+        current = self.session.state.current_file_path
+        path = None
+        if current:
+            for f in self.session.state.uploaded_files:
+                if f.get("path") == current:
+                    path = current
+                    break
+        if path is None and self.session.state.uploaded_files:
+            path = self.session.state.uploaded_files[0].get("path")
+        if not path:
+            return
+        profile = self.controller.open_half_frame_dialog(path)
+        if profile is not None:
+            # Re-discover so the new profile takes effect immediately.
+            files = self.session.state.uploaded_files
+            self.controller.request_asset_discovery(
+                [f["path"] for f in files if "path" in f],
+                replace_existing=True,
+                reselect_path=self.session.state.current_file_path,
+            )
 
     def _scan_folder(self) -> None:
         if not self.session.state.uploaded_files:

--- a/negpy/desktop/view/widgets/half_frame_dialog.py
+++ b/negpy/desktop/view/widgets/half_frame_dialog.py
@@ -1,0 +1,402 @@
+"""Modal pop-up: position a crop rectangle and a split centerline for half-frame scans.
+
+The widget shows a positive preview of one scan. A draggable/resizable rectangle
+defines what is kept (everything outside is discarded). A vertical centerline
+inside the rectangle marks the split between the two halves; its thickness
+discards a band centered on it (the physical black separator between exposures).
+
+Read after ``exec()`` via ``crop_rect()``, ``split_x()`` and ``gutter_thickness()``.
+"""
+
+from typing import Optional
+
+import numpy as np
+import qtawesome as qta
+from PyQt6.QtCore import QPoint, QRect, Qt, pyqtSignal
+from PyQt6.QtGui import QColor, QMouseEvent, QPainter, QPen, QPixmap
+from PyQt6.QtWidgets import (
+    QDialog,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QSizePolicy,
+    QSlider,
+    QVBoxLayout,
+)
+
+from negpy.desktop.view.styles.theme import THEME
+
+_HANDLE_TOL = 0.04
+_HANDLE_PX = 5
+_MIN_RECT_W = 0.1
+_MIN_RECT_H = 0.1
+_SPLIT_TOL = 0.04  # grab radius for the centerline, fraction of width
+
+
+def _preview_positive(rgb: np.ndarray) -> np.ndarray:
+    """Cheap negative->positive preview: per-channel invert + auto-level."""
+    a = rgb.astype(np.float32)
+    if a.ndim == 2:
+        a = a[:, :, None]
+    out = np.empty_like(a)
+    for c in range(a.shape[2]):
+        ch = a[..., c]
+        lo, hi = np.percentile(ch, 1), np.percentile(ch, 99)
+        out[..., c] = 0.0 if hi <= lo else np.clip((hi - ch) / (hi - lo), 0.0, 1.0) * 255.0
+    return out.astype(np.uint8)
+
+
+def _clamp01(v: float) -> float:
+    return max(0.0, min(1.0, v))
+
+
+class _HalfFrameLabel(QLabel):
+    """Preview with one draggable/resizable crop rect and a draggable split line."""
+
+    changed = pyqtSignal()
+
+    def __init__(self, parent=None) -> None:
+        super().__init__(parent)
+        self.setMinimumHeight(300)
+        self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
+        self.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.setCursor(Qt.CursorShape.CrossCursor)
+        self._pixmap: Optional[QPixmap] = None
+        self._rect: tuple[float, float, float, float] = (0.0, 0.0, 1.0, 1.0)
+        # split_x is relative to the cropped rect width
+        self._split_x: float = 0.5
+        self._gutter: float = 0.0
+        self._mode: Optional[str] = None  # "draw" | "move" | "resize" | "split"
+        self._active_corner: Optional[int] = None
+        self._press_frac: Optional[tuple[float, float]] = None
+        self._rect_at_press: Optional[tuple[float, float, float, float]] = None
+        self._split_at_press: Optional[float] = None
+
+    # ── public API ────────────────────────────────────────────────────
+
+    def set_frame(self, pixmap: QPixmap) -> None:
+        self._pixmap = pixmap
+        self.update()
+
+    def set_rect(self, rect: tuple[float, float, float, float]) -> None:
+        self._rect = rect
+        self.update()
+
+    def set_split(self, split_x: float) -> None:
+        self._split_x = _clamp01(split_x)
+        self.update()
+
+    def set_gutter(self, gutter: float) -> None:
+        self._gutter = _clamp01(gutter)
+        self.update()
+
+    def rect_value(self) -> tuple[float, float, float, float]:
+        x1, y1, x2, y2 = self._rect
+        return (_clamp01(min(x1, x2)), _clamp01(min(y1, y2)), _clamp01(max(x1, x2)), _clamp01(max(y1, y2)))
+
+    def split_value(self) -> float:
+        return self._split_x
+
+    def gutter_value(self) -> float:
+        return self._gutter
+
+    # ── geometry ──────────────────────────────────────────────────────
+
+    def _display(self) -> Optional[QRect]:
+        if self._pixmap is None or self._pixmap.isNull():
+            return None
+        pw, ph = self._pixmap.width(), self._pixmap.height()
+        if pw <= 0 or ph <= 0:
+            return None
+        scale = min(self.width() / pw, self.height() / ph)
+        dw, dh = int(pw * scale), int(ph * scale)
+        return QRect((self.width() - dw) // 2, (self.height() - dh) // 2, dw, dh)
+
+    @staticmethod
+    def _to_fraction(p: QPoint, draw_rect: QRect) -> tuple[float, float]:
+        fx = _clamp01((p.x() - draw_rect.x()) / max(1, draw_rect.width()))
+        fy = _clamp01((p.y() - draw_rect.y()) / max(1, draw_rect.height()))
+        return fx, fy
+
+    @staticmethod
+    def _rect_in_widget(rect, draw_rect: QRect) -> QRect:
+        x1, y1, x2, y2 = rect
+        ax = draw_rect.x() + int(x1 * draw_rect.width())
+        ay = draw_rect.y() + int(y1 * draw_rect.height())
+        bx = draw_rect.x() + int(x2 * draw_rect.width())
+        by = draw_rect.y() + int(y2 * draw_rect.height())
+        return QRect(QPoint(ax, ay), QPoint(bx, by)).normalized()
+
+    def _split_in_widget(self, draw_rect: QRect) -> int:
+        x1, _, x2, _ = self.rect_value()
+        cx = x1 + self._split_x * (x2 - x1)
+        return draw_rect.x() + int(cx * draw_rect.width())
+
+    @staticmethod
+    def _hit_corner(rect, fx: float, fy: float, tol: float) -> Optional[int]:
+        x1, y1, x2, y2 = rect
+        corners = ((0, x1, y1), (1, x2, y1), (2, x2, y2), (3, x1, y2))
+        for idx, cx, cy in corners:
+            if abs(fx - cx) <= tol and abs(fy - cy) <= tol:
+                return idx
+        return None
+
+    # ── mouse ─────────────────────────────────────────────────────────
+
+    def mousePressEvent(self, ev: QMouseEvent) -> None:
+        draw_rect = self._display()
+        if draw_rect is None:
+            return
+        fx, fy = self._to_fraction(ev.pos(), draw_rect)
+        self._press_frac = (fx, fy)
+        self._rect_at_press = self._rect
+        self._split_at_press = self._split_x
+        r = self.rect_value()
+        corner = self._hit_corner(r, fx, fy, _HANDLE_TOL)
+        if corner is not None:
+            self._mode, self._active_corner = "resize", corner
+            return
+        # Split line grab: inside the rect, near the centerline
+        x1, y1, x2, y2 = r
+        cx = x1 + self._split_x * (x2 - x1)
+        if y1 <= fy <= y2 and abs(fx - cx) <= _SPLIT_TOL:
+            self._mode = "split"
+            return
+        if x1 <= fx <= x2 and y1 <= fy <= y2:
+            self._mode = "move"
+            return
+        self._mode = "draw"
+        self._rect = (fx, fy, fx, fy)
+        self.update()
+
+    def mouseMoveEvent(self, ev: QMouseEvent) -> None:
+        draw_rect = self._display()
+        if draw_rect is None or self._mode is None or self._press_frac is None:
+            return
+        fx, fy = self._to_fraction(ev.pos(), draw_rect)
+        if self._mode == "draw":
+            px, py = self._press_frac
+            self._rect = (px, py, fx, fy)
+        elif self._mode == "resize" and self._active_corner is not None:
+            self._rect = self._resize_corner(self._rect_at_press, self._active_corner, fx, fy)
+        elif self._mode == "move" and self._rect_at_press is not None:
+            dx = fx - self._press_frac[0]
+            dy = fy - self._press_frac[1]
+            x1, y1, x2, y2 = self._rect_at_press
+            w, h = x2 - x1, y2 - y1
+            nx1 = _clamp01(x1 + dx)
+            ny1 = _clamp01(y1 + dy)
+            nx2 = nx1 + w
+            ny2 = ny1 + h
+            if nx2 > 1.0:
+                nx1 -= nx2 - 1.0
+                nx2 = 1.0
+            if ny2 > 1.0:
+                ny1 -= ny2 - 1.0
+                ny2 = 1.0
+            self._rect = (nx1, ny1, nx2, ny2)
+        elif self._mode == "split":
+            x1, _, x2, _ = self.rect_value()
+            span = max(1e-6, x2 - x1)
+            self._split_x = _clamp01((fx - x1) / span)
+        self.update()
+
+    def mouseReleaseEvent(self, _ev: QMouseEvent) -> None:
+        if self._mode is None:
+            return
+        r = self._rect
+        x1, y1, x2, y2 = r
+        if x2 - x1 < _MIN_RECT_W:
+            x2 = min(1.0, x1 + _MIN_RECT_W)
+        if y2 - y1 < _MIN_RECT_H:
+            y2 = min(1.0, y1 + _MIN_RECT_H)
+        self._rect = (_clamp01(min(x1, x2)), _clamp01(min(y1, y2)), _clamp01(max(x1, x2)), _clamp01(max(y1, y2)))
+        self._mode = None
+        self._active_corner = None
+        self._press_frac = None
+        self._rect_at_press = None
+        self._split_at_press = None
+        self.update()
+        self.changed.emit()
+
+    @staticmethod
+    def _resize_corner(rect, corner: int, fx: float, fy: float):
+        x1, y1, x2, y2 = rect
+        if corner == 0:
+            return (_clamp01(fx), _clamp01(fy), x2, y2)
+        if corner == 1:
+            return (x1, _clamp01(fy), _clamp01(fx), y2)
+        if corner == 2:
+            return (x1, y1, _clamp01(fx), _clamp01(fy))
+        return (_clamp01(fx), y1, x2, _clamp01(fy))
+
+    # ── paint ──────────────────────────────────────────────────────────
+
+    def paintEvent(self, _ev) -> None:
+        painter = QPainter(self)
+        draw_rect = self._display()
+        if draw_rect is not None and self._pixmap is not None and not self._pixmap.isNull():
+            painter.save()
+            painter.setClipRect(draw_rect)
+            painter.drawPixmap(draw_rect, self._pixmap)
+            painter.restore()
+            r = self.rect_value()
+            wr = self._rect_in_widget(r, draw_rect)
+            # Dim outside the crop rect
+            outside = [
+                QRect(draw_rect.topLeft(), QPoint(wr.left() - 1, draw_rect.bottom())),
+                QRect(QPoint(wr.right() + 1, draw_rect.top()), draw_rect.bottomRight()),
+                QRect(QPoint(wr.left(), draw_rect.top()), QPoint(wr.right(), wr.top() - 1)),
+                QRect(QPoint(wr.left(), wr.bottom() + 1), QPoint(wr.right(), draw_rect.bottom())),
+            ]
+            painter.setPen(Qt.PenStyle.NoPen)
+            painter.setBrush(QColor(0, 0, 0, 130))
+            for o in outside:
+                if o.width() > 0 and o.height() > 0:
+                    painter.drawRect(o)
+            # Crop rect
+            painter.setPen(QPen(QColor("#1D9E75"), 2))
+            painter.setBrush(Qt.BrushStyle.NoBrush)
+            painter.drawRect(wr)
+            painter.setBrush(QColor("#1D9E75"))
+            painter.setPen(Qt.PenStyle.NoPen)
+            for corner in (wr.topLeft(), wr.topRight(), wr.bottomRight(), wr.bottomLeft()):
+                painter.drawRect(QRect(corner.x() - _HANDLE_PX, corner.y() - _HANDLE_PX, 2 * _HANDLE_PX, 2 * _HANDLE_PX))
+            # Split centerline + gutter band
+            x1, _, x2, _ = r
+            span = max(1e-6, x2 - x1)
+            cx = self._split_in_widget(draw_rect)
+            gw = max(0, int(self._gutter * span * draw_rect.width()))
+            if gw > 0:
+                painter.setPen(Qt.PenStyle.NoPen)
+                painter.setBrush(QColor(224, 168, 60, 120))
+                painter.drawRect(QRect(cx - gw // 2, wr.top(), gw, wr.height()))
+            pen = QPen(QColor("#E0A83C"), 2)
+            pen.setStyle(Qt.PenStyle.DashLine)
+            painter.setPen(pen)
+            painter.drawLine(cx, wr.top(), cx, wr.bottom())
+        else:
+            painter.fillRect(self.rect(), QColor("#0D0D0F"))
+            painter.setPen(QColor(THEME.text_muted))
+            painter.drawText(self.rect(), Qt.AlignmentFlag.AlignCenter, "No preview")
+        painter.end()
+
+
+class HalfFrameDialog(QDialog):
+    """Pick a crop rectangle and a split centerline for half-frame scans.
+
+    Returns a ``(crop_rect, split_x, gutter_thickness)`` triple; all normalized
+    fractions. ``split_x`` is relative to the cropped rect width.
+    """
+
+    def __init__(
+        self,
+        preview_rgb: np.ndarray,
+        initial_rect: Optional[tuple[float, float, float, float]] = None,
+        initial_split: Optional[float] = None,
+        initial_gutter: Optional[float] = None,
+        parent=None,
+    ) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Half Frame — split & crop")
+        self.setModal(True)
+        self.resize(720, 560)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(12, 12, 12, 12)
+        layout.setSpacing(10)
+
+        self._label = _HalfFrameLabel()
+        layout.addWidget(self._label, 1)
+
+        hint = QLabel(
+            "Drag the green rectangle to crop. Drag the orange line to set the split. Use the slider to thicken the cut band (the physical black separator)."
+        )
+        hint.setWordWrap(True)
+        hint.setStyleSheet(f"color: {THEME.text_muted};")
+        layout.addWidget(hint)
+
+        gutter_row = QHBoxLayout()
+        gutter_row.addWidget(QLabel("Cut thickness"))
+        self._gutter_slider = QSlider(Qt.Orientation.Horizontal)
+        self._gutter_slider.setRange(0, 100)
+        self._gutter_slider.setValue(int((initial_gutter or 0.0) * 1000))
+        self._gutter_slider.valueChanged.connect(self._on_gutter)
+        self._gutter_label = QLabel()
+        gutter_row.addWidget(self._gutter_slider, 1)
+        gutter_row.addWidget(self._gutter_label)
+        layout.addLayout(gutter_row)
+
+        btn_row = QHBoxLayout()
+        btn_row.addStretch()
+        self._auto_btn = QPushButton("Auto-detect")
+        self._auto_btn.setIcon(qta.icon("fa5s.magic", color=THEME.text_primary))
+        self._auto_btn.clicked.connect(self._on_auto)
+        btn_row.addWidget(self._auto_btn)
+        self._reset_btn = QPushButton("Reset")
+        self._reset_btn.setIcon(qta.icon("fa5s.undo", color=THEME.text_primary))
+        self._reset_btn.clicked.connect(self._on_reset)
+        btn_row.addWidget(self._reset_btn)
+        self._ok_btn = QPushButton("Apply")
+        self._ok_btn.setObjectName("scan_btn")
+        self._ok_btn.setIcon(qta.icon("fa5s.check", color=THEME.text_primary))
+        self._ok_btn.clicked.connect(self.accept)
+        btn_row.addWidget(self._ok_btn)
+        self._cancel_btn = QPushButton("Cancel")
+        self._cancel_btn.clicked.connect(self.reject)
+        btn_row.addWidget(self._cancel_btn)
+        layout.addLayout(btn_row)
+
+        self._preview_rgb = preview_rgb
+        self._set_preview(preview_rgb)
+        self._label.set_rect(initial_rect or (0.0, 0.0, 1.0, 1.0))
+        self._label.set_split(initial_split if initial_split is not None else 0.5)
+        self._label.set_gutter(initial_gutter or 0.0)
+        self._label.changed.connect(self._update_gutter_label)
+        self._update_gutter_label()
+
+    def _set_preview(self, rgb: np.ndarray) -> None:
+        from PyQt6.QtGui import QImage
+
+        pos = _preview_positive(rgb)
+        h, w = pos.shape[:2]
+        max_dim = 1024
+        if max(h, w) > max_dim:
+            scale = max_dim / max(h, w)
+            pos = pos[:: max(1, int(1 / scale)), :: max(1, int(1 / scale))]
+        h2, w2 = pos.shape[:2]
+        qimg = QImage(bytes(pos.tobytes()), w2, h2, w2 * 3, QImage.Format.Format_RGB888).copy()
+        self._label.set_frame(QPixmap.fromImage(qimg))
+
+    def _on_gutter(self, value: int) -> None:
+        self._label.set_gutter(value / 1000.0)
+        self._update_gutter_label()
+
+    def _update_gutter_label(self) -> None:
+        g = self._label.gutter_value()
+        self._gutter_label.setText(f"{g * 100:.1f}%")
+
+    def _on_auto(self) -> None:
+        from negpy.services.assets.half_frame import detect_split_x
+
+        sx = detect_split_x(self._preview_rgb)
+        self._label.set_split(sx)
+        self._update_gutter_label()
+
+    def _on_reset(self) -> None:
+        self._label.set_rect((0.0, 0.0, 1.0, 1.0))
+        self._label.set_split(0.5)
+        self._label.set_gutter(0.0)
+        self._gutter_slider.setValue(0)
+        self._update_gutter_label()
+
+    # ── results ───────────────────────────────────────────────────────
+
+    def crop_rect(self) -> tuple[float, float, float, float]:
+        return self._label.rect_value()
+
+    def split_x(self) -> float:
+        return self._label.split_value()
+
+    def gutter_thickness(self) -> float:
+        return self._label.gutter_value()

--- a/negpy/desktop/workers/export.py
+++ b/negpy/desktop/workers/export.py
@@ -141,6 +141,8 @@ class ExportWorker(QObject):
                     working_color_space=task.working_color_space,
                     half=int(task.file_info.get("half") or 0),
                     split_x=float(task.file_info.get("split_x") or 0.5),
+                    crop_rect=tuple(task.file_info["crop_rect"]) if task.file_info.get("crop_rect") else None,
+                    gutter_thickness=float(task.file_info.get("gutter_thickness") or 0.0),
                 )
 
                 if not bits:
@@ -238,6 +240,8 @@ class ExportWorker(QObject):
                     fast_decode=True,
                     half=int(task.file_info.get("half") or 0),
                     split_x=float(task.file_info.get("split_x") or 0.5),
+                    crop_rect=tuple(task.file_info["crop_rect"]) if task.file_info.get("crop_rect") else None,
+                    gutter_thickness=float(task.file_info.get("gutter_thickness") or 0.0),
                 )
                 if tile is not None:
                     tiles.append(tile)

--- a/negpy/desktop/workers/render.py
+++ b/negpy/desktop/workers/render.py
@@ -143,6 +143,7 @@ class AssetDiscoveryTask:
     restore_triplets: dict | None = None  # {red_path: [green, blue]} — rebuild known triplets (session restore).
     half_frame: bool = False  # Expand each file into two half-frame assets (left/right).
     restore_stitches: dict | None = None  # {primary_path: {paths, transforms, canvas, sizes, hash}} (session restore).
+    half_frame_profile: dict | None = None  # {crop_rect, split_x, gutter_thickness} override
 
 
 @dataclass(frozen=True)
@@ -167,6 +168,9 @@ class PreviewLoadTask:
     stitch_triplets: tuple[tuple[str, str], ...] = ()  # per-part (green, blue) RGB-scan exposures
     stitch_align: bool = True
     flatfield_profile_id: str = ""  # per-part flat-field profile for stitch previews
+    half_slice: tuple[int, float, tuple[float, float, float, float] | None, float] | None = (
+        None  # (half, split_x, crop_rect, gutter_thickness)
+    )
 
 
 class RenderWorker(QObject):
@@ -452,13 +456,18 @@ class AssetDiscoveryWorker(QObject):
             valid_assets = self._attach_restored_stitches(valid_assets, task.restore_stitches)
 
         if task.half_frame and valid_assets:
-            valid_assets = self._expand_half_frames(valid_assets)
+            valid_assets = self._expand_half_frames(valid_assets, profile=task.half_frame_profile)
 
         self.finished.emit(valid_assets)
 
-    def _expand_half_frames(self, assets: list) -> list:
+    def _expand_half_frames(self, assets: list, profile: dict | None = None) -> list:
         """Expand each file into two half-frame assets sharing the path, with
-        per-half hash/name identities. Triplet assets stay whole (unsupported combo)."""
+        per-half hash/name identities. Triplet assets stay whole (unsupported combo).
+
+        When ``profile`` is set (a {crop_rect, split_x, gutter_thickness} dict saved
+        from the half-frame rectangle editor), it overrides the auto-detected split
+        and adds the crop rect + gutter to every expanded half.
+        """
         from negpy.services.assets.half_frame import detect_split_x_for_file, half_hash, half_name
 
         out = []
@@ -467,19 +476,26 @@ class AssetDiscoveryWorker(QObject):
                 out.append(a)
                 continue
             self.progress.emit(i + 1, len(assets), f"Split {a['name']}")
-            split_x = detect_split_x_for_file(a["path"])
+            if profile is not None:
+                split_x = float(profile.get("split_x") or 0.5)
+            else:
+                split_x = detect_split_x_for_file(a["path"])
             legacy = a.get("legacy_hash")
             for half in (1, 2):
-                out.append(
-                    {
-                        **a,
-                        "name": half_name(a["name"], half),
-                        "hash": half_hash(a["hash"], half),
-                        "legacy_hash": half_hash(legacy, half) if legacy else "",
-                        "half": half,
-                        "split_x": split_x,
-                    }
-                )
+                entry = {
+                    **a,
+                    "name": half_name(a["name"], half),
+                    "hash": half_hash(a["hash"], half),
+                    "legacy_hash": half_hash(legacy, half) if legacy else "",
+                    "half": half,
+                    "split_x": split_x,
+                }
+                if profile is not None:
+                    cr = profile.get("crop_rect")
+                    if cr is not None:
+                        entry["crop_rect"] = tuple(cr)
+                    entry["gutter_thickness"] = float(profile.get("gutter_thickness") or 0.0)
+                out.append(entry)
         return out
 
     def _attach_restored_triplets(self, assets: list, triplets: dict) -> list:
@@ -589,6 +605,7 @@ class PreviewLoadWorker(QObject):
                     use_camera_wb=task.use_camera_wb,
                     full_resolution=task.full_resolution,
                     file_hash=task.file_hash,
+                    half_slice=task.half_slice,
                 )
             except Exception as e:
                 logger.debug("Preview cache warm failed for %s: %s", task.file_path, e)
@@ -660,6 +677,7 @@ class PreviewLoadWorker(QObject):
                     full_resolution=task.full_resolution,
                     file_hash=task.file_hash,
                     log_timings=True,
+                    half_slice=task.half_slice,
                 )
                 if sp is not None:
                     sbuf, sdims = sp
@@ -672,6 +690,7 @@ class PreviewLoadWorker(QObject):
                     full_resolution=task.full_resolution,
                     file_hash=task.file_hash,
                     log_timings=True,
+                    half_slice=task.half_slice,
                 )
             source_cs = metadata.get("color_space") or WORKING_COLOR_SPACE
             ir_preview = metadata.get("ir_preview")

--- a/negpy/services/assets/half_frame.py
+++ b/negpy/services/assets/half_frame.py
@@ -31,19 +31,64 @@ def half_name(name: str, half: int) -> str:
     return f"{name} [{half}]"
 
 
-def slice_half(buf: np.ndarray, half: int, split_x: float) -> np.ndarray:
-    """View of one half of a decoded buffer, split at the normalized gutter x."""
-    w = buf.shape[1]
+def slice_half(
+    buf: np.ndarray,
+    half: int,
+    split_x: float,
+    crop_rect: Optional[tuple[float, float, float, float]] = None,
+    gutter_thickness: float = 0.0,
+) -> np.ndarray:
+    """View of one half of a decoded buffer.
+
+    The scan is first cropped to ``crop_rect`` (normalized x1,y1,x2,y2; None =
+    full frame), then split at the normalized gutter ``split_x`` relative to the
+    cropped width. A ``gutter_thickness`` (normalized fraction of the cropped
+    width) discards a band centered on the split so the physical black separator
+    between the two exposures does not bleed into either half.
+    """
+    a = buf
+    if crop_rect is not None:
+        h, w = a.shape[:2]
+        x1, y1, x2, y2 = crop_rect
+        cx1 = min(max(int(round(w * x1)), 0), w)
+        cx2 = min(max(int(round(w * x2)), 0), w)
+        cy1 = min(max(int(round(h * y1)), 0), h)
+        cy2 = min(max(int(round(h * y2)), 0), h)
+        if cx2 <= cx1 or cy2 <= cy1:
+            return a[:, :1]
+        a = a[cy1:cy2, cx1:cx2]
+    w = a.shape[1]
     xs = min(max(int(round(w * split_x)), 1), w - 1)
-    return buf[:, :xs] if half == 1 else buf[:, xs:]
+    if gutter_thickness > 0:
+        gw = max(1, int(round(w * gutter_thickness)))
+        lo = max(1, xs - gw // 2)
+        hi = min(w - 1, lo + gw)
+        lo = max(1, hi - gw)
+        left = a[:, :lo]
+        right = a[:, hi:]
+        return left if half == 1 else right
+    return a[:, :xs] if half == 1 else a[:, xs:]
 
 
 def slice_for_asset(buf: np.ndarray, file_info: Dict[str, Any]) -> np.ndarray:
-    """Apply the asset's half slice; no-op for whole-frame assets."""
+    """Apply the asset's half slice; no-op for whole-frame assets.
+
+    Recognizes an optional ``crop_rect`` (normalized x1,y1,x2,y2) and
+    ``gutter_thickness`` (normalized fraction of the cropped width) set by the
+    half-frame rectangle editor.
+    """
     half = int(file_info.get("half") or 0)
     if not half:
         return buf
-    return slice_half(buf, half, float(file_info.get("split_x") or 0.5))
+    raw_rect = file_info.get("crop_rect")
+    crop_rect = tuple(float(v) for v in raw_rect) if isinstance(raw_rect, (tuple, list)) else None
+    return slice_half(
+        buf,
+        half,
+        float(file_info.get("split_x") or 0.5),
+        crop_rect=crop_rect,
+        gutter_thickness=float(file_info.get("gutter_thickness") or 0.0),
+    )
 
 
 def detect_split_x(buf: np.ndarray) -> float:

--- a/negpy/services/assets/thumbnails.py
+++ b/negpy/services/assets/thumbnails.py
@@ -36,6 +36,8 @@ async def generate_batch_thumbnails(
                 float(f_info.get("split_x") or 0.5),
                 f_info.get("green_path") or "",
                 f_info.get("blue_path") or "",
+                tuple(f_info["crop_rect"]) if f_info.get("crop_rect") else None,
+                float(f_info.get("gutter_thickness") or 0.0),
             )
             completed += 1
             if progress_callback:
@@ -154,6 +156,8 @@ def get_thumbnail_worker(
     split_x: float = 0.5,
     green_path: str = "",
     blue_path: str = "",
+    crop_rect: Optional[tuple[float, float, float, float]] = None,
+    gutter_thickness: float = 0.0,
 ) -> Optional[Image.Image]:
     """
     Checks cache -> extracts/renders -> resize.
@@ -173,7 +177,7 @@ def get_thumbnail_worker(
         if half:
             from negpy.services.assets.half_frame import slice_half
 
-            img = Image.fromarray(slice_half(np.asarray(img), half, split_x))
+            img = Image.fromarray(slice_half(np.asarray(img), half, split_x, crop_rect=crop_rect, gutter_thickness=gutter_thickness))
 
         square_img: Image.Image = prepare_thumbnail(img, ts)
 

--- a/negpy/services/rendering/image_processor.py
+++ b/negpy/services/rendering/image_processor.py
@@ -614,7 +614,12 @@ class ImageProcessor:
 
     @staticmethod
     def _slice_half_source(
-        f32_buffer: np.ndarray, ir_full: Optional[np.ndarray], half: int, split_x: float
+        f32_buffer: np.ndarray,
+        ir_full: Optional[np.ndarray],
+        half: int,
+        split_x: float,
+        crop_rect: Optional[tuple[float, float, float, float]] = None,
+        gutter_thickness: float = 0.0,
     ) -> Tuple[np.ndarray, Optional[np.ndarray]]:
         """Slice a decoded source down to one half-frame; copies so the shared
         per-file decode cache is never mutated downstream. No-op when half == 0."""
@@ -622,9 +627,9 @@ class ImageProcessor:
             return f32_buffer, ir_full
         from negpy.services.assets.half_frame import slice_half
 
-        f32_buffer = np.ascontiguousarray(slice_half(f32_buffer, half, split_x))
+        f32_buffer = np.ascontiguousarray(slice_half(f32_buffer, half, split_x, crop_rect=crop_rect, gutter_thickness=gutter_thickness))
         if ir_full is not None:
-            ir_full = np.ascontiguousarray(slice_half(ir_full, half, split_x))
+            ir_full = np.ascontiguousarray(slice_half(ir_full, half, split_x, crop_rect=crop_rect, gutter_thickness=gutter_thickness))
         return f32_buffer, ir_full
 
     def process_export(
@@ -639,6 +644,8 @@ class ImageProcessor:
         working_color_space: str = WORKING_COLOR_SPACE,
         half: int = 0,
         split_x: float = 0.5,
+        crop_rect: Optional[tuple[float, float, float, float]] = None,
+        gutter_thickness: float = 0.0,
     ) -> Tuple[Optional[bytes], str]:
         """Performs high-resolution export with color management."""
         try:
@@ -646,7 +653,9 @@ class ImageProcessor:
             params = dc_replace(params, export=export_settings)
 
             f32_buffer, ir_full, source_cs = self._load_source_f32(file_path, params)
-            f32_buffer, ir_full = self._slice_half_source(f32_buffer, ir_full, half, split_x)
+            f32_buffer, ir_full = self._slice_half_source(
+                f32_buffer, ir_full, half, split_x, crop_rect=crop_rect, gutter_thickness=gutter_thickness
+            )
             target_cs = export_settings.export_color_space
             if target_cs == ColorSpace.SAME_AS_SOURCE.value:
                 target_cs = source_cs
@@ -851,6 +860,8 @@ class ImageProcessor:
         fast_decode: bool = False,
         half: int = 0,
         split_x: float = 0.5,
+        crop_rect: Optional[tuple[float, float, float, float]] = None,
+        gutter_thickness: float = 0.0,
     ) -> Optional[np.ndarray]:
         """Render a file (with its edits) to a small sRGB uint8 RGB array for tiling.
 
@@ -866,7 +877,9 @@ class ImageProcessor:
             from negpy.infrastructure.display.color_mgmt import apply_display_transform
 
             f32_buffer, ir_full, _ = self._load_source_f32(file_path, params, fast_decode=fast_decode)
-            f32_buffer, ir_full = self._slice_half_source(f32_buffer, ir_full, half, split_x)
+            f32_buffer, ir_full = self._slice_half_source(
+                f32_buffer, ir_full, half, split_x, crop_rect=crop_rect, gutter_thickness=gutter_thickness
+            )
 
             # Proof scale: everything downstream only needs target_long_px. The
             # cached source buffer is shared, so resize (never mutate) it.

--- a/negpy/services/rendering/preview_cache.py
+++ b/negpy/services/rendering/preview_cache.py
@@ -17,6 +17,10 @@ class PreviewCacheKey:
     use_camera_wb: bool
     workspace_color_space: str
     full_resolution: bool
+    half: int = 0
+    split_x: float = 0.5
+    crop_rect: tuple[float, float, float, float] | None = None
+    gutter_thickness: float = 0.0
 
     def as_tuple(self) -> Hashable:
         return (
@@ -24,6 +28,10 @@ class PreviewCacheKey:
             self.use_camera_wb,
             self.workspace_color_space,
             self.full_resolution,
+            self.half,
+            round(self.split_x, 6),
+            self.crop_rect,
+            round(self.gutter_thickness, 6),
         )
 
 

--- a/negpy/services/rendering/preview_manager.py
+++ b/negpy/services/rendering/preview_manager.py
@@ -75,7 +75,11 @@ class PreviewManager:
     # ------------------------------------------------------------------
 
     @staticmethod
-    def _try_splash_from_open_raw(raw: Any, file_path: str) -> Optional[Tuple[ImageBuffer, Dimensions]]:
+    def _try_splash_from_open_raw(
+        raw: Any,
+        file_path: str,
+        half_slice: tuple[int, float, tuple[float, float, float, float] | None, float] | None = None,
+    ) -> Optional[Tuple[ImageBuffer, Dimensions]]:
         """
         Extract a splash preview from an already-open raw object.
         Returns None if a thumb cannot be extracted or converted.
@@ -96,6 +100,13 @@ class PreviewManager:
         except Exception:
             return None
         arr = np.ascontiguousarray(np.array(img, dtype=np.float32) / 255.0)
+        # Half-frame slice before the splash downsample so the splash shows the
+        # active half, not the whole scan (and at the same pixels the linear load slices).
+        if half_slice is not None:
+            half, split_x, crop_rect, gutter_thickness = half_slice
+            from negpy.services.assets.half_frame import slice_half
+
+            arr = np.ascontiguousarray(slice_half(arr, half, split_x, crop_rect=crop_rect, gutter_thickness=gutter_thickness))
         h, w = arr.shape[:2]
         if max(h, w) > APP_CONFIG.preview_render_size:
             scale = APP_CONFIG.preview_render_size / max(h, w)
@@ -116,10 +127,16 @@ class PreviewManager:
         full_resolution: bool,
         file_hash: str | None,
         log_timings: bool = False,
+        half_slice: tuple[int, float, tuple[float, float, float, float] | None, float] | None = None,
     ) -> Tuple[ImageBuffer, Dimensions, dict]:
         """
         Decode and resize a linear preview from an already-open raw object.
         Handles cache write on completion.
+
+        ``half_slice``: (half, split_x, crop_rect, gutter_thickness) — when set,
+        the half-frame slice is applied to the full-res decode BEFORE the preview
+        downsample so analysis sees the same pixels export analyzes (slice then
+        downsample), not whole-scan-averaged pixels (downsample then slice).
         """
         t_decode = time.perf_counter()
         log = logger.info if log_timings else logger.debug
@@ -174,6 +191,20 @@ class PreviewManager:
                 h_orig, w_orig = w_orig, h_orig
         else:
             h_orig, w_orig = _output_dimensions_from_raw(raw, h_p, w_p)
+        # Half-frame slice before the downsample so the analysis stage sees the
+        # same pixels export analyzes (slice → downsample), not whole-scan pixels
+        # averaged across the gutter/other half (downsample → slice).
+        if half_slice is not None:
+            half, split_x, crop_rect, gutter_thickness = half_slice
+            from negpy.services.assets.half_frame import slice_half
+
+            full_linear = np.ascontiguousarray(
+                slice_half(full_linear, half, split_x, crop_rect=crop_rect, gutter_thickness=gutter_thickness)
+            )
+            if ir_full is not None:
+                ir_full = np.ascontiguousarray(slice_half(ir_full, half, split_x, crop_rect=crop_rect, gutter_thickness=gutter_thickness))
+            h_p, w_p = full_linear.shape[:2]
+            h_orig, w_orig = (h_p, w_p)
         t_resize0 = time.perf_counter()
         max_res = APP_CONFIG.preview_render_size
         if max(h_p, w_p) > max_res and not full_resolution:
@@ -223,6 +254,10 @@ class PreviewManager:
                 use_camera_wb=use_camera_wb,
                 workspace_color_space=color_space,
                 full_resolution=full_resolution,
+                half=half_slice[0] if half_slice else 0,
+                split_x=half_slice[1] if half_slice else 0.5,
+                crop_rect=half_slice[2] if half_slice else None,
+                gutter_thickness=half_slice[3] if half_slice else 0.0,
             )
             # The cache entry aliases the returned buffer — the same read-only
             # contract as a cache hit (callers must not mutate preview buffers),
@@ -258,10 +293,14 @@ class PreviewManager:
         full_resolution: bool = False,
         file_hash: str | None = None,
         log_timings: bool = False,
+        half_slice: tuple[int, float, tuple[float, float, float, float] | None, float] | None = None,
     ) -> Tuple[ImageBuffer, Dimensions, dict]:
         """
         Loads linear RGB, downsamples for display.
         If color_space is None, uses the source's declared space (metadata).
+
+        ``half_slice``: (half, split_x, crop_rect, gutter_thickness) — slice the
+        half before the preview downsample so analysis matches export.
         """
         t_all = time.perf_counter()
         log = logger.info if log_timings else logger.debug
@@ -273,6 +312,10 @@ class PreviewManager:
                 use_camera_wb=use_camera_wb,
                 workspace_color_space=color_space,
                 full_resolution=full_resolution,
+                half=half_slice[0] if half_slice else 0,
+                split_x=half_slice[1] if half_slice else 0.5,
+                crop_rect=half_slice[2] if half_slice else None,
+                gutter_thickness=half_slice[3] if half_slice else 0.0,
             )
             hit = self._cache.get(ck)
             if hit is not None:
@@ -290,6 +333,10 @@ class PreviewManager:
                     use_camera_wb=use_camera_wb,
                     workspace_color_space=color_space,
                     full_resolution=full_resolution,
+                    half=half_slice[0] if half_slice else 0,
+                    split_x=half_slice[1] if half_slice else 0.5,
+                    crop_rect=half_slice[2] if half_slice else None,
+                    gutter_thickness=half_slice[3] if half_slice else 0.0,
                 )
                 hit = self._cache.get(ck)
                 if hit is not None:
@@ -307,6 +354,7 @@ class PreviewManager:
                 full_resolution,
                 file_hash,
                 log_timings,
+                half_slice=half_slice,
             )
         log(
             "load-timing load_linear_preview %.0fms (decode %.0fms + open)",
@@ -456,6 +504,7 @@ class PreviewManager:
         full_resolution: bool = False,
         file_hash: str | None = None,
         log_timings: bool = False,
+        half_slice: tuple[int, float, tuple[float, float, float, float] | None, float] | None = None,
     ) -> Tuple[Optional[Tuple[ImageBuffer, Dimensions]], Tuple[ImageBuffer, Dimensions, dict]]:
         """
         Open the RAW file once and return both the splash preview and the linear
@@ -476,6 +525,10 @@ class PreviewManager:
                 use_camera_wb=use_camera_wb,
                 workspace_color_space=color_space,
                 full_resolution=full_resolution,
+                half=half_slice[0] if half_slice else 0,
+                split_x=half_slice[1] if half_slice else 0.5,
+                crop_rect=half_slice[2] if half_slice else None,
+                gutter_thickness=half_slice[3] if half_slice else 0.0,
             )
             hit = self._cache.get(ck)
             if hit is not None:
@@ -497,6 +550,10 @@ class PreviewManager:
                     use_camera_wb=use_camera_wb,
                     workspace_color_space=color_space,
                     full_resolution=full_resolution,
+                    half=half_slice[0] if half_slice else 0,
+                    split_x=half_slice[1] if half_slice else 0.5,
+                    crop_rect=half_slice[2] if half_slice else None,
+                    gutter_thickness=half_slice[3] if half_slice else 0.0,
                 )
                 hit = self._cache.get(ck)
                 if hit is not None:
@@ -508,7 +565,7 @@ class PreviewManager:
         splash_result: Optional[Tuple[ImageBuffer, Dimensions]] = None
         with ctx_mgr as raw:
             if not full_resolution:
-                splash_result = self._try_splash_from_open_raw(raw, file_path)
+                splash_result = self._try_splash_from_open_raw(raw, file_path, half_slice=half_slice)
             linear_result = self._load_from_open_raw(
                 raw,
                 metadata,
@@ -518,6 +575,7 @@ class PreviewManager:
                 full_resolution,
                 file_hash,
                 log_timings,
+                half_slice=half_slice,
             )
         log(
             "load-timing load_splash_and_linear %.0fms (decode %.0fms + open)",

--- a/tests/test_file_browser_toolbar.py
+++ b/tests/test_file_browser_toolbar.py
@@ -40,6 +40,7 @@ def test_toolbar_keeps_every_action(panel):
         browser.hot_folder_btn,
         browser.rgb_scan_btn,
         browser.half_frame_btn,
+        browser.half_frame_adjust_btn,
         browser.apply_btn,
         browser.sheet_btn,
         browser.sort_btn,
@@ -51,7 +52,7 @@ def test_narrowing_the_panel_raises_a_populated_overflow_menu(panel, qapp):
     """QToolBar's native extension menu was tried first and came up empty: widgets added with
     addWidget() become QWidgetActions its popup cannot host."""
     toolbar = _toolbar(panel)
-    panel.resize(300, 700)
+    panel.resize(360, 700)
     qapp.processEvents()
     assert not toolbar.overflow_btn.isVisible()
 

--- a/tests/test_half_frame.py
+++ b/tests/test_half_frame.py
@@ -173,3 +173,35 @@ def test_halves_measure_independent_bounds():
     # Floors differ per half (dark vs bright frame). Ceils can legitimately agree:
     # both halves keep a sliver of the bright gutter at the slice boundary.
     assert not np.allclose(b1.floors, b2.floors)
+
+
+class TestSliceHalfCropGutter:
+    def test_crop_rect_slices_only_the_cropped_region(self):
+        buf = np.arange(2 * 100 * 3, dtype=np.float32).reshape(2, 100, 3)
+        # crop to x 0.2..0.8 (20..80), split at 0.5 of the crop (x=50)
+        left = slice_half(buf, 1, 0.5, crop_rect=(0.2, 0.0, 0.8, 1.0))
+        right = slice_half(buf, 2, 0.5, crop_rect=(0.2, 0.0, 0.8, 1.0))
+        assert left.shape[1] + right.shape[1] == 60
+        # left covers x 20..50, right x 50..80
+        np.testing.assert_array_equal(left, buf[:, 20:50])
+        np.testing.assert_array_equal(right, buf[:, 50:80])
+
+    def test_gutter_thickness_discards_a_band_at_the_split(self):
+        buf = np.arange(2 * 100 * 3, dtype=np.float32).reshape(2, 100, 3)
+        # gutter of 0.2 of the cropped width (20 px) around the split at 0.5
+        left = slice_half(buf, 1, 0.5, crop_rect=(0.0, 0.0, 1.0, 1.0), gutter_thickness=0.2)
+        right = slice_half(buf, 2, 0.5, crop_rect=(0.0, 0.0, 1.0, 1.0), gutter_thickness=0.2)
+        # 10 px discarded each side of x=50 → left 0..40, right 60..100
+        np.testing.assert_array_equal(left, buf[:, :40])
+        np.testing.assert_array_equal(right, buf[:, 60:])
+
+    def test_slice_for_asset_reads_crop_and_gutter(self):
+        buf = np.arange(2 * 100 * 3, dtype=np.float32).reshape(2, 100, 3)
+        info = {
+            "half": 1,
+            "split_x": 0.5,
+            "crop_rect": (0.0, 0.0, 1.0, 1.0),
+            "gutter_thickness": 0.2,
+        }
+        out = slice_for_asset(buf, info)
+        np.testing.assert_array_equal(out, buf[:, :40])


### PR DESCRIPTION
## Half-Frame: crop/gutter editor + export-matches-preview fix

### Summary

Two commits on one branch:
1. **feat** — half-frame scans get a visual crop-rectangle + split-line + gutter editor; the saved profile applies to every half-frame split regardless of acquisition method.
2. **fix** — export "current frame" could export the wrong half, and the export's color/tonality diverged from the LQ preview (a color cast appeared on export that the preview didn't show). Both are prior bugs in the original half-frame feature, surfaced and fixed while dogfooding the editor.

### Why

Half-frame cameras expose two frames on one scan, and scanners capture both in a single pass. NegPy already split each scan at an auto-detected x, but the split position couldn't be corrected when the gutter fell outside the default, the physical black separator bled into both halves, and there was no way to crop the scan to the usable film area.

While testing that, two export bugs turned up:
- **Wrong-half export.** `request_export` looked up the export asset by `path`. Both halves share a path, so `next(...)` returned the first match (half 1) regardless of which half was current. Exporting frame 2 shipped frame 1's `file_info` (half=0) — the whole scan, or the wrong half.
- **Preview/export color drift.** The LQ preview downsampled the **whole scan** to `preview_render_size`, then sliced the half in the controller. Export (and HQ preview) sliced the half at full resolution, then the analysis stage downsampled the half. `INTER_AREA` averages different pixel neighborhoods in the two orders — the whole-scan downsample bleeds the gutter/other half into the analysis buffer, shifting the measured log bounds. Different bounds → different normalization → a color cast (e.g. red) on export that the LQ preview didn't show. HQ preview matched export because `full_resolution=True` skips the whole-scan downsample, so both did slice-then-downsample.

### What changed

**Crop/gutter editor (commit 48bece6)**
- **Editor dialog** (`negpy/desktop/view/widgets/half_frame_dialog.py`, new): modal pop-up showing a positive (inverted + auto-levelled) preview of one scan. A draggable/resizable green rectangle defines the crop (everything outside is discarded); a draggable orange centerline sets the split; a **Cut thickness** slider discards a band centered on the split. Returns `crop_rect`, `split_x`, `gutter_thickness` on Apply.
- **Slicing** (`negpy/services/assets/half_frame.py`): `slice_half()` and `slice_for_asset()` accept `crop_rect` (normalized x1,y1,x2,y2) and `gutter_thickness` (normalized fraction of cropped width). The gutter discards a band centered on the split so the physical separator doesn't bleed into either half.
- **Controller** (`negpy/desktop/controller.py`): new `open_half_frame_dialog()` loads the scan, seeds the editor from the saved profile (or auto-detect via `detect_split_x`), and persists the result as a global setting (`half_frame_profile`). `_active_half()` and `_slice_half_source()` now carry `crop_rect` and `gutter_thickness` through the render path. The profile is forwarded on asset discovery requests so re-discovery applies it.
- **Files sidebar** (`negpy/desktop/view/sidebar/files.py`): new **Adjust Half Frame** toolbutton (tune icon) re-opens the editor on the current scan and triggers re-discovery so the new profile takes effect immediately. Enabling Half Frame mode also offers the editor on the current frame.
- **Render & export paths** (`negpy/services/rendering/image_processor.py`, `negpy/desktop/workers/export.py`, `negpy/services/assets/thumbnails.py`): `crop_rect` and `gutter_thickness` flow through export, tile rendering, and thumbnail generation so previews, full-res exports, and filmstrip thumbs all honour the profile.
- **Tests** (`tests/test_half_frame.py`): `TestSliceHalfCropGutter` covers crop-rect-only slicing, gutter band discard, and `slice_for_asset` reading both fields. `tests/test_file_browser_toolbar.py` updated for the new button.
- **Docs** (`docs/USER_GUIDE.md`): Half Frame entry documents the rectangle editor, the Cut thickness slider, the saved-profile behaviour across acquisition methods, and the Adjust Half Frame toolbutton.

**Export-matches-preview fix (commit 59b2237)**
- **Export asset lookup** (`negpy/desktop/controller.py`): `request_export` now matches the asset by `hash` (unique per half) instead of `path` (shared), so the active half's `file_info` reaches the exporter.
- **Slice before downsample** (`negpy/services/rendering/preview_manager.py`): the active half is now sliced from the full-res decode **before** the preview downsample (both the splash and linear paths), so the analysis stage sees the same pixels export analyzes. Threaded a `half_slice` tuple `(half, split_x, crop_rect, gutter_thickness)` through:
  - `PreviewLoadTask` (`negpy/desktop/workers/render.py`) — the worker passes it to `load_linear_preview`, `load_splash_and_linear`, and the cache-warm path.
  - `load_linear_preview` / `load_splash_and_linear` / `_load_from_open_raw` / `_try_splash_from_open_raw` — slice `full_linear` and `ir_full` (and the splash thumbnail) before the resize.
- **Cache key** (`negpy/services/rendering/preview_cache.py`): `PreviewCacheKey` now includes `half`, `split_x`, `crop_rect`, `gutter_thickness`, so the two halves get separate cache entries (they're different buffers now).
- **Controller** (`negpy/desktop/controller.py`): `_split_active_half` is a passthrough (preview buffers arrive already sliced); `_active_half` refactored to share a new `_half_slice_for_asset` helper; prefetch now warms the half-suffixed hash with the neighbor's `half_slice` so cache-warm keys match real loads.

### How to test

1. Load a folder of half-frame scans, enable **Half Frame** — the editor should open on the current scan.
2. Drag the green rectangle to crop; drag the orange line to reposition the split; adjust **Cut thickness** to discard the separator band. Apply.
3. Both halves should render, export, and thumbnail with the crop + gutter applied; re-discover and confirm the saved profile persists.
4. Re-open via **Adjust Half Frame** and confirm the saved profile seeds the editor.
5. Select half 2, Export → current frame. Confirm the exported file is half 2 (not half 1).
6. On a frame where the LQ preview and export previously differed (color cast on export), toggle HQ preview off and export — the export should now match the LQ preview. Toggle HQ on and the preview should stay consistent.
7. Switch between halves rapidly and export; the export should match the displayed half.
8. Confirm a whole-frame (non-half) scan is unaffected.
9. Confirm navigation/prefetch still hits the warm cache (no re-decode on navigate-back).

### Notes

- The export-matches-preview fix predates the crop/gutter editor. The original half-frame feature (present at `b80eb4f`) already sliced after the whole-scan downsample in the controller via `_split_active_half`. The crop/gutter work inherited that ordering unchanged; the fix moves the slice ahead of the downsample so preview and export analyze identical pixels.
- No GPU/pipeline math changes; slicing happens before the render pipeline. The only change is *where* the slice happens relative to the preview downsample.

### Disclosure

Portions of this change were written with the assistance of an AI coding tool (Claude / opencode). All code was reviewed and is the author's responsibility.⏎               