### PR TITLE
perf(preview): cut the preview drag frame 135ms -> 12ms, and the HQ drag frame 5.6s -> 11ms

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -38,9 +38,11 @@ parts rather than rewriting.
 
 - **No Xvfb installed?** `QT_QPA_PLATFORM=offscreen` works, but every widget
   grab (`window.canvas.grab()`, `window.grab()`) comes back black — take pixel
-  evidence from `controller.state.last_metrics["base_positive"]` instead
-  (readback via `main_window._display_buffer_for_canvas`; it's the exact
-  buffer `_on_image_updated` would hand the canvas). wgpu compute runs fine
+  evidence from `controller.state.last_metrics["base_positive"]` instead; it's
+  the exact buffer `_on_image_updated` hands the canvas. Call `.readback()` on
+  it when soft proof is off, where it is still a `GPUTexture` (the canvas hands
+  those straight to the display shader; only the CPU overlay branch in
+  `ImageCanvas.update_buffer` copies to the host). wgpu compute runs fine
   offscreen.
 - A driver-side `controller.load_file(path)` does not populate
   `state.uploaded_files`, so `_on_image_updated` early-returns and the canvas

--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -2467,7 +2467,7 @@ class AppController(QObject):
         self.config_updated.emit()
         self.request_render()
 
-    def update_selected_local_mask(self, **changes) -> None:
+    def update_selected_local_mask(self, persist: bool = True, readback_metrics: bool = True, **changes) -> None:
         local = self.state.config.local
         idx = self.state.local_selected_mask
         if not (0 <= idx < len(local.masks)):
@@ -2475,8 +2475,8 @@ class AppController(QObject):
         masks = list(local.masks)
         masks[idx] = replace(masks[idx], **changes)
         new_local = replace(local, masks=tuple(masks))
-        self.session.update_config(replace(self.state.config, local=new_local), persist=True)
-        self.request_render()
+        self.session.update_config(replace(self.state.config, local=new_local), persist=persist)
+        self.request_render(readback_metrics=readback_metrics)
 
     def _handle_wb_pick(self, nx: float, ny: float) -> None:
         """

--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -78,7 +78,7 @@ from negpy.features.local.models import LocalAdjustmentsConfig
 from negpy.features.process.models import ProcessConfig, ProcessMode, invalidate_local_bounds, scan_setup_values
 from negpy.services.assets.thumbnails import asset_thumbnail_key
 from negpy.kernel.system.paths import get_resource_path
-from negpy.features.retouch.logic import fallback_source_offset, select_source_offset
+from negpy.features.retouch.logic import downsample_ir, fallback_source_offset, select_source_offset
 from negpy.features.retouch.models import HEAL_SIZE_REF, RetouchConfig
 from negpy.features.toning.models import ToningConfig
 from negpy.infrastructure.display.color_spaces import ColorSpaceRegistry
@@ -124,6 +124,20 @@ def _interactive_proxy(raw: Optional[Any]) -> Optional[Any]:
     scale = APP_CONFIG.preview_render_size / float(long_edge)
     w, h = max(1, round(raw.shape[1] * scale)), max(1, round(raw.shape[0] * scale))
     return cv2.resize(raw, (w, h), interpolation=cv2.INTER_AREA)
+
+
+def _interactive_ir_proxy(ir: Optional[Any], proxy: Optional[Any]) -> Optional[Any]:
+    """IR plane matched to ``proxy``'s shape, or None when no proxy is in use.
+
+    Routed through ``downsample_ir`` rather than a plain resize: a defect is a
+    *minimum* in IR transmittance and INTER_AREA averages sub-pixel minima away.
+    """
+    if proxy is None or not isinstance(ir, np.ndarray):
+        return None
+    h, w = proxy.shape[:2]
+    if ir.shape[:2] == (h, w):
+        return ir
+    return downsample_ir(ir, max(h, w), dims=(w, h))
 
 
 def _capture_import_key(path: str) -> str:
@@ -1394,6 +1408,7 @@ class AppController(QObject):
         self.state.preview_raw = raw
         self.state.preview_proxy = _interactive_proxy(raw)
         self.state.preview_ir = ir_preview
+        self.state.preview_ir_proxy = _interactive_ir_proxy(ir_preview, self.state.preview_proxy)
         self.state.has_ir = ir_preview is not None
         if not self.state.has_ir and self.state.dust_overlay_mode == "ir":
             self.state.dust_overlay_mode = "off"
@@ -3145,10 +3160,9 @@ class AppController(QObject):
         soft-proof toggle is on; the output profile only applies with the toggle.
         """
         proofing = self.state.soft_proof_enabled
-        narrowband = self.state.config.process.narrowband_scan
-        if not (proofing or narrowband):
+        if not (proofing or self.state.config.process.narrowband_scan):
             return None
-        icc_input = self.effective_input_icc() if (proofing or narrowband) else None
+        icc_input = self.effective_input_icc()
         icc_output = self.effective_output_icc() if proofing else None
         if not (icc_input or icc_output):
             return None
@@ -3235,8 +3249,11 @@ class AppController(QObject):
         # frames render against the proxy so the main thread never handles an HQ frame
         # while the gesture is live; the release re-renders at full resolution.
         interactive = not readback_metrics
+        ir_buffer = self.state.preview_ir
         if interactive and self.state.preview_proxy is not None:
             preview_raw = self.state.preview_proxy
+            # The IR plane must follow the image it is read against.
+            ir_buffer = self.state.preview_ir_proxy
 
         target_size = float(APP_CONFIG.preview_render_size)
         if self.state.hq_preview:
@@ -3245,8 +3262,11 @@ class AppController(QObject):
         crop_preview_full = self.state.active_tool in (ToolMode.CROP_MANUAL, ToolMode.ANALYSIS_DRAW)
         # Only a plain render of the saved edit is reproducible on navigate-back;
         # overrides (compare/flat peek), splash and tool previews are not memoized.
+        # Not interactive either: a proxy frame under the full-resolution config's key
+        # would have navigate-back paint the low-res stand-in (CPU fallback publishes a
+        # host array, which is what the memo stores).
         memo_key = ""
-        if config_override is None and not ephemeral and not crop_preview_full:
+        if config_override is None and not ephemeral and not crop_preview_full and not interactive:
             memo_key = self._render_memo_key()
 
         task = RenderTask(
@@ -3256,7 +3276,7 @@ class AppController(QObject):
             preview_size=target_size,
             gpu_enabled=self.state.gpu_enabled,
             readback_metrics=readback_metrics,
-            ir_buffer=self.state.preview_ir,
+            ir_buffer=ir_buffer,
             crop_preview_full=crop_preview_full,
             ephemeral=ephemeral,
             memo_key=memo_key,

--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -3,6 +3,7 @@ import time
 from dataclasses import dataclass, fields, replace
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
+import cv2
 import numpy as np
 from PyQt6.QtCore import Q_ARG, QMetaObject, QObject, Qt, QThread, QTimer, pyqtSignal
 from PyQt6.QtGui import QIcon, QPixmap
@@ -106,6 +107,23 @@ class _PendingCaptureImport:
     detect_mode: bool = False
     capture_roll: str = ""
     capture_frame: Optional[int] = None
+
+
+def _interactive_proxy(raw: Optional[Any]) -> Optional[Any]:
+    """Preview-resolution stand-in for an HQ buffer, or None when one is not needed.
+
+    Everything a frame costs downstream — the pipeline, the canvas present, any
+    readback — scales with this buffer, so dragging against the HQ original makes the
+    main thread pay 60Mpx per gesture step. Built once per load, not per frame.
+    """
+    if not isinstance(raw, np.ndarray) or raw.ndim < 2:
+        return None
+    long_edge = max(raw.shape[:2])
+    if long_edge <= APP_CONFIG.preview_render_size:
+        return None
+    scale = APP_CONFIG.preview_render_size / float(long_edge)
+    w, h = max(1, round(raw.shape[1] * scale)), max(1, round(raw.shape[0] * scale))
+    return cv2.resize(raw, (w, h), interpolation=cv2.INTER_AREA)
 
 
 def _capture_import_key(path: str) -> str:
@@ -1374,6 +1392,7 @@ class AppController(QObject):
         if ir_preview is not None:
             ir_preview, _ = self._split_active_half(ir_preview, None)
         self.state.preview_raw = raw
+        self.state.preview_proxy = _interactive_proxy(raw)
         self.state.preview_ir = ir_preview
         self.state.has_ir = ir_preview is not None
         if not self.state.has_ir and self.state.dust_overlay_mode == "ir":
@@ -3212,6 +3231,13 @@ class AppController(QObject):
         if preview_raw is None:
             return
 
+        # readback_metrics is the settle marker: a drag asks for no metrics. Interactive
+        # frames render against the proxy so the main thread never handles an HQ frame
+        # while the gesture is live; the release re-renders at full resolution.
+        interactive = not readback_metrics
+        if interactive and self.state.preview_proxy is not None:
+            preview_raw = self.state.preview_proxy
+
         target_size = float(APP_CONFIG.preview_render_size)
         if self.state.hq_preview:
             target_size = float(max(preview_raw.shape[:2]))
@@ -3235,6 +3261,7 @@ class AppController(QObject):
             ephemeral=ephemeral,
             memo_key=memo_key,
             compare=self.state.compare_mode,
+            interactive=interactive,
         )
 
         if self._is_rendering:
@@ -4043,8 +4070,13 @@ class AppController(QObject):
             self._first_render_t0 = None
 
         # Config is replaced wholesale on every edit, so identity detects any change.
+        # Never mid-gesture: the filmstrip only has to be right once the drag settles,
+        # and refreshing it there puts a full-frame copy on the UI thread's critical path.
         should_update_thumb = (
-            self._pending_render_task is None and not metrics.get("ephemeral") and self.state.config is not self._thumb_config
+            self._pending_render_task is None
+            and not metrics.get("ephemeral")
+            and not metrics.get("interactive")
+            and self.state.config is not self._thumb_config
         )
 
         with self.state.metrics_lock:
@@ -4091,8 +4123,10 @@ class AppController(QObject):
         self.metrics_available.emit(metrics)
 
         # Don't persist bounds from an ephemeral (splash) render or a render of a different
-        # file (late metric after a fast switch) — they aren't this frame's bounds.
-        if metrics.get("ephemeral"):
+        # file (late metric after a fast switch) — they aren't this frame's bounds. Nor
+        # from a mid-gesture frame: persisting writes settings and rebuilds the history
+        # panel on the UI thread, and it renders against the proxy anyway.
+        if metrics.get("ephemeral") or metrics.get("interactive"):
             return
         src = metrics.get("source_hash")
         if src is not None and src != self.state.current_file_hash:

--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -662,7 +662,7 @@ class AppController(QObject):
         self.poll_light_temp_requested.connect(self.capture_worker.poll_light_temp)
         self.capture_worker.light_temp_polled.connect(self.light_temp_polled.emit)
 
-        self.session.active_file_changing.connect(lambda: self._update_thumbnail_from_state(force_readback=True))
+        self.session.active_file_changing.connect(self._update_thumbnail_from_state)
         self.session.session_emptied.connect(self._render_memo.clear)
         self.session.session_emptied.connect(self._strip_memo.clear)
         self.session.file_selected.connect(self._on_file_selected_load)
@@ -1290,6 +1290,7 @@ class AppController(QObject):
         # densitometer's probe sources so hover readouts go quiet until the next render.
         self.state.last_metrics.pop("normalized_log", None)
         self.state.last_metrics.pop("base_positive", None)
+        self.state.last_metrics.pop("thumbnail_source", None)
 
         if memo is not None:
             with self.state.metrics_lock:
@@ -2295,7 +2296,7 @@ class AppController(QObject):
     def save_current_edits(self) -> None:
         if self.state.current_file_hash:
             self.session.update_config(self.state.config, persist=True)
-            self._update_thumbnail_from_state(force_readback=True)
+            self._update_thumbnail_from_state()
 
     def clear_retouch(self) -> None:
         from negpy.desktop.view.confirm import confirm_clear_heals
@@ -3277,6 +3278,8 @@ class AppController(QObject):
             memo_key=memo_key,
             compare=self.state.compare_mode,
             interactive=interactive,
+            # Mirrors should_update_thumb, minus its pending-task check.
+            wants_thumbnail=(not interactive and not ephemeral and config_override is None and self.state.config is not self._thumb_config),
         )
 
         if self._is_rendering:
@@ -4118,7 +4121,7 @@ class AppController(QObject):
         if should_update_thumb:
             self._thumb_config = self.state.config
             # persist=False: refresh in-memory only; disk JPEG written on switch/save/export.
-            self._update_thumbnail_from_state(force_readback=True, persist=False)
+            self._update_thumbnail_from_state(persist=False)
 
         if self._pending_render_task:
             task = self._pending_render_task
@@ -4189,9 +4192,9 @@ class AppController(QObject):
         owner = self._active_batch if self._active_batch in ("export", "contact_sheet") else "export"
         self._end_batch(owner)
         self.export_finished.emit(elapsed, self._export_failures)
-        self._update_thumbnail_from_state(force_readback=True)
+        self._update_thumbnail_from_state()
 
-    def _update_thumbnail_from_state(self, force_readback: bool = False, persist: bool = True) -> None:
+    def _update_thumbnail_from_state(self, persist: bool = True) -> None:
         if not self.state.current_file_path or not self.state.current_file_hash:
             return
         idx = self.state.selected_file_idx
@@ -4201,8 +4204,8 @@ class AppController(QObject):
             metrics = dict(self.state.last_metrics)
         buffer = metrics.get("base_positive")
 
-        # The render worker supplies host pixels; reading the texture back here would
-        # put a full-frame copy on the UI thread.
+        # The render worker supplies host pixels; reading back here would put a
+        # full-frame copy on the UI thread.
         if isinstance(buffer, GPUTexture):
             buffer = metrics.get("thumbnail_source")
 

--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -208,6 +208,9 @@ class AppController(QObject):
     metrics_available = pyqtSignal(dict)
     loading_started = pyqtSignal()
     load_failed = pyqtSignal()
+    # The GPU engine is about to free its texture pool: anything holding a render
+    # texture (the canvas samples one directly) must drop it first.
+    gpu_textures_released = pyqtSignal()
     export_progress = pyqtSignal(int, int, str)
     export_finished = pyqtSignal(float, int)
     render_requested = pyqtSignal(RenderTask)
@@ -1250,10 +1253,14 @@ class AppController(QObject):
             self.loading_started.emit()
         self._thumb_config = None
 
+        # The canvas samples the render texture directly, so it has to let go before
+        # the pool is freed or the next draw references destroyed memory.
+        self.gpu_textures_released.emit()
         self._render_cleanup_requested.emit()
         # The cleanup destroys the GPU textures last_metrics still points at; drop the
-        # densitometer's probe source so hover readouts go quiet until the next render.
+        # densitometer's probe sources so hover readouts go quiet until the next render.
         self.state.last_metrics.pop("normalized_log", None)
+        self.state.last_metrics.pop("base_positive", None)
 
         if memo is not None:
             with self.state.metrics_lock:
@@ -4143,20 +4150,15 @@ class AppController(QObject):
         idx = self.state.selected_file_idx
         if not (0 <= idx < len(self.state.uploaded_files)):
             return
-        asset_name = self.state.uploaded_files[idx]["name"]
-
         with self.state.metrics_lock:
             metrics = dict(self.state.last_metrics)
         buffer = metrics.get("base_positive")
 
+        # Never read a render texture back here: this is the UI thread, and at HQ that
+        # copy is ~976MB / ~700ms — long enough to freeze a slider drag. The render
+        # worker attaches a host copy on settle frames instead.
         if isinstance(buffer, GPUTexture):
-            t0 = time.perf_counter()
-            buffer = buffer.readback()
-            logger.info(
-                "thumb-refresh readback %.1fms %s",
-                (time.perf_counter() - t0) * 1000,
-                asset_name,
-            )
+            buffer = metrics.get("thumbnail_source")
 
         if buffer is not None and not isinstance(buffer, np.ndarray):
             buffer = metrics.get("analysis_buffer")

--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -110,11 +110,10 @@ class _PendingCaptureImport:
 
 
 def _interactive_proxy(raw: Optional[Any]) -> Optional[Any]:
-    """Preview-resolution stand-in for an HQ buffer, or None when one is not needed.
+    """Preview-resolution stand-in for an HQ buffer; None when one is not needed.
 
-    Everything a frame costs downstream — the pipeline, the canvas present, any
-    readback — scales with this buffer, so dragging against the HQ original makes the
-    main thread pay 60Mpx per gesture step. Built once per load, not per frame.
+    Every downstream cost scales with this buffer, so interactive frames render
+    against it rather than the full-resolution original.
     """
     if not isinstance(raw, np.ndarray) or raw.ndim < 2:
         return None
@@ -129,8 +128,8 @@ def _interactive_proxy(raw: Optional[Any]) -> Optional[Any]:
 def _interactive_ir_proxy(ir: Optional[Any], proxy: Optional[Any]) -> Optional[Any]:
     """IR plane matched to ``proxy``'s shape, or None when no proxy is in use.
 
-    Routed through ``downsample_ir`` rather than a plain resize: a defect is a
-    *minimum* in IR transmittance and INTER_AREA averages sub-pixel minima away.
+    Not a plain resize: a defect is a *minimum* in IR transmittance, which area
+    averaging removes.
     """
     if proxy is None or not isinstance(ir, np.ndarray):
         return None
@@ -240,8 +239,8 @@ class AppController(QObject):
     metrics_available = pyqtSignal(dict)
     loading_started = pyqtSignal()
     load_failed = pyqtSignal()
-    # The GPU engine is about to free its texture pool: anything holding a render
-    # texture (the canvas samples one directly) must drop it first.
+    # Emitted before the GPU engine frees its texture pool; the canvas samples a
+    # pooled texture directly and must drop it first.
     gpu_textures_released = pyqtSignal()
     export_progress = pyqtSignal(int, int, str)
     export_finished = pyqtSignal(float, int)
@@ -1285,8 +1284,6 @@ class AppController(QObject):
             self.loading_started.emit()
         self._thumb_config = None
 
-        # The canvas samples the render texture directly, so it has to let go before
-        # the pool is freed or the next draw references destroyed memory.
         self.gpu_textures_released.emit()
         self._render_cleanup_requested.emit()
         # The cleanup destroys the GPU textures last_metrics still points at; drop the
@@ -3245,9 +3242,8 @@ class AppController(QObject):
         if preview_raw is None:
             return
 
-        # readback_metrics is the settle marker: a drag asks for no metrics. Interactive
-        # frames render against the proxy so the main thread never handles an HQ frame
-        # while the gesture is live; the release re-renders at full resolution.
+        # A drag asks for no metrics; the release does. Interactive frames go through
+        # the proxy, so full resolution is reached only once the gesture settles.
         interactive = not readback_metrics
         ir_buffer = self.state.preview_ir
         if interactive and self.state.preview_proxy is not None:
@@ -3262,9 +3258,8 @@ class AppController(QObject):
         crop_preview_full = self.state.active_tool in (ToolMode.CROP_MANUAL, ToolMode.ANALYSIS_DRAW)
         # Only a plain render of the saved edit is reproducible on navigate-back;
         # overrides (compare/flat peek), splash and tool previews are not memoized.
-        # Not interactive either: a proxy frame under the full-resolution config's key
-        # would have navigate-back paint the low-res stand-in (CPU fallback publishes a
-        # host array, which is what the memo stores).
+        # Interactive frames are excluded: a proxy render filed under the full-resolution
+        # config's key would be painted back as if it were the real one.
         memo_key = ""
         if config_override is None and not ephemeral and not crop_preview_full and not interactive:
             memo_key = self._render_memo_key()
@@ -4090,8 +4085,7 @@ class AppController(QObject):
             self._first_render_t0 = None
 
         # Config is replaced wholesale on every edit, so identity detects any change.
-        # Never mid-gesture: the filmstrip only has to be right once the drag settles,
-        # and refreshing it there puts a full-frame copy on the UI thread's critical path.
+        # Not mid-gesture: the filmstrip only has to be right once the drag settles.
         should_update_thumb = (
             self._pending_render_task is None
             and not metrics.get("ephemeral")
@@ -4144,8 +4138,7 @@ class AppController(QObject):
 
         # Don't persist bounds from an ephemeral (splash) render or a render of a different
         # file (late metric after a fast switch) — they aren't this frame's bounds. Nor
-        # from a mid-gesture frame: persisting writes settings and rebuilds the history
-        # panel on the UI thread, and it renders against the proxy anyway.
+        # from a mid-gesture frame, which measured the proxy rather than the real buffer.
         if metrics.get("ephemeral") or metrics.get("interactive"):
             return
         src = metrics.get("source_hash")
@@ -4208,9 +4201,8 @@ class AppController(QObject):
             metrics = dict(self.state.last_metrics)
         buffer = metrics.get("base_positive")
 
-        # Never read a render texture back here: this is the UI thread, and at HQ that
-        # copy is ~976MB / ~700ms — long enough to freeze a slider drag. The render
-        # worker attaches a host copy on settle frames instead.
+        # The render worker supplies host pixels; reading the texture back here would
+        # put a full-frame copy on the UI thread.
         if isinstance(buffer, GPUTexture):
             buffer = metrics.get("thumbnail_source")
 

--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -1797,8 +1797,6 @@ class AppController(QObject):
             self.on_strip_finished(cached["mosaics"], cached["content_rect"], from_cache=True)
             return
 
-        proofing = self.state.soft_proof_enabled
-        icc_input = self.effective_input_icc() if (proofing or self.state.config.process.narrowband_scan) else None
         self.state.test_strip_kind = kind
         self.state.test_strip_pending = True
         self.test_strip_changed.emit(False)
@@ -1815,12 +1813,8 @@ class AppController(QObject):
                 preview_size=float(APP_CONFIG.preview_render_size),
                 overrides=tuple(overrides),
                 grid=grid,
-                icc_input_path=icc_input,
-                icc_output_path=self.effective_output_icc() if proofing else None,
-                color_space=self.state.workspace_color_space,
                 gpu_enabled=self.state.gpu_enabled,
                 ir_buffer=self.state.preview_ir,
-                monitor_icc_bytes=self.state.monitor_icc_bytes,
             )
         )
 
@@ -3103,23 +3097,36 @@ class AppController(QObject):
             return get_resource_path("icc/RGBScan.icc")
         return None
 
-    def display_transform_params(self, splash: bool = False) -> tuple[str, Optional[bytes]]:
-        """Source space + monitor profile to hand the display transform for the
-        current render, as ``(color_space, monitor_icc_bytes)``.
+    def display_transform_params(self, splash: bool = False) -> tuple[str, Optional[bytes], Optional[tuple]]:
+        """Everything the display transform needs for the current render, as
+        ``(color_space, monitor_icc_bytes, proof)``.
 
         Single source of truth for every consumer of a rendered buffer — the canvas
-        and the filmstrip thumbnail must agree, or the same frame shows two different
-        colours. With a proof active the render worker already baked
-        source→output→monitor into the buffer, so the transform has to be a no-op
-        (sRGB→sRGB, no monitor profile); treating that buffer as working-space instead
-        re-applies the working→sRGB conversion and blows the saturation out. ``splash``
-        marks the embedded camera thumbnail, which is already sRGB.
+        shader, the CPU overlay and the filmstrip thumbnail must agree, or the same
+        frame shows two different colours. Renders arrive in the working space; a
+        proof is *not* baked into them, it is folded into the display LUT here (see
+        ``get_display_lut``), which is what lets a GPU texture go to the shader
+        untouched. ``splash`` marks the embedded camera thumbnail, already sRGB.
         """
         if splash:
-            return ColorSpace.SRGB.value, self.state.monitor_icc_bytes
-        if self.proof_active():
-            return ColorSpace.SRGB.value, None
-        return self.state.workspace_color_space, self.state.monitor_icc_bytes
+            return ColorSpace.SRGB.value, self.state.monitor_icc_bytes, None
+        return self.state.workspace_color_space, self.state.monitor_icc_bytes, self.proof_profiles()
+
+    def proof_profiles(self) -> Optional[tuple]:
+        """``(input_icc, output_icc)`` for the preview proof, or None when off.
+
+        Narrowband Scan supplies an implicit *input* profile whether or not the
+        soft-proof toggle is on; the output profile only applies with the toggle.
+        """
+        proofing = self.state.soft_proof_enabled
+        narrowband = self.state.config.process.narrowband_scan
+        if not (proofing or narrowband):
+            return None
+        icc_input = self.effective_input_icc() if (proofing or narrowband) else None
+        icc_output = self.effective_output_icc() if proofing else None
+        if not (icc_input or icc_output):
+            return None
+        return icc_input, icc_output
 
     def proof_active(self) -> bool:
         """True when the preview should soft-proof: the toggle is on and an input or
@@ -3202,14 +3209,6 @@ class AppController(QObject):
         if self.state.hq_preview:
             target_size = float(max(preview_raw.shape[:2]))
 
-        # Soft-proof gating: Output/Input ICC only touch the preview when the toggle is
-        # on; otherwise the preview is the edit shown on the monitor (export unaffected).
-        # Narrowband Scan supplies an implicit input profile regardless of the toggle.
-        proofing = self.state.soft_proof_enabled
-        narrowband = self.state.config.process.narrowband_scan
-        icc_input = self.effective_input_icc() if (proofing or narrowband) else None
-        effective_output = self.effective_output_icc() if proofing else None
-
         crop_preview_full = self.state.active_tool in (ToolMode.CROP_MANUAL, ToolMode.ANALYSIS_DRAW)
         # Only a plain render of the saved edit is reproducible on navigate-back;
         # overrides (compare/flat peek), splash and tool previews are not memoized.
@@ -3222,13 +3221,9 @@ class AppController(QObject):
             config=config_override if config_override is not None else self.state.config,
             source_hash=self.state.current_file_hash or "preview",
             preview_size=target_size,
-            icc_input_path=icc_input,
-            icc_output_path=effective_output,
-            color_space=self.state.workspace_color_space,
             gpu_enabled=self.state.gpu_enabled,
             readback_metrics=readback_metrics,
             ir_buffer=self.state.preview_ir,
-            monitor_icc_bytes=self.state.monitor_icc_bytes,
             crop_preview_full=crop_preview_full,
             ephemeral=ephemeral,
             memo_key=memo_key,
@@ -4170,7 +4165,7 @@ class AppController(QObject):
 
         # Same transform the canvas used for this buffer, so the filmstrip and the
         # canvas can't disagree about the frame's colour.
-        display_cs, monitor_bytes = self.display_transform_params(splash=bool(metrics.get("splash")))
+        display_cs, monitor_bytes, proof = self.display_transform_params(splash=bool(metrics.get("splash")))
         # The asset's own key, so the batch (source) path re-serves this rendered positive
         # instead of the uninverted source merge it would decode itself.
         self.thumbnail_update_requested.emit(
@@ -4179,6 +4174,7 @@ class AppController(QObject):
                 buffer=buffer,
                 color_space=display_cs,
                 monitor_icc_bytes=monitor_bytes,
+                proof=proof,
                 persist=persist,
             )
         )

--- a/negpy/desktop/converters.py
+++ b/negpy/desktop/converters.py
@@ -13,18 +13,24 @@ class ImageConverter:
     """
 
     @staticmethod
-    def to_qimage(buffer: np.ndarray, color_space: str = WORKING_COLOR_SPACE, monitor_icc_bytes: Optional[bytes] = None) -> QImage:
+    def to_qimage(
+        buffer: np.ndarray,
+        color_space: str = WORKING_COLOR_SPACE,
+        monitor_icc_bytes: Optional[bytes] = None,
+        proof: Optional[tuple] = None,
+    ) -> QImage:
         """
         Safely converts a NumPy float32 or uint8 buffer to a QImage.
         Performs a deep copy to prevent memory corruption (harsh noise).
 
         ``color_space`` is the working space of ``buffer``; it is color-managed to
         the monitor's display profile (``monitor_icc_bytes``, or sRGB when None) so
-        the preview matches a color-managed view of the export.
+        the preview matches a color-managed view of the export. ``proof`` is the
+        soft-proof profile pair when one is active, folded into the same transform.
         """
         # 1. Color-manage working space → display profile, then quantize to uint8
         if buffer.dtype == np.float32:
-            buffer = apply_display_transform(buffer, color_space, monitor_icc_bytes)
+            buffer = apply_display_transform(buffer, color_space, monitor_icc_bytes, proof)
             u8_buffer = float_to_uint8(buffer)
         else:
             u8_buffer = buffer

--- a/negpy/desktop/session.py
+++ b/negpy/desktop/session.py
@@ -69,6 +69,9 @@ class AppState:
     # buffer is used again the moment the gesture settles. None when not needed.
     preview_proxy: Optional[Any] = None
     preview_ir: Optional[Any] = None  # downsampled IR float32 [0,1] (H,W); None if source has no IR
+    # IR plane matched to preview_proxy. The pipeline reads the IR against the image it
+    # is given, so proxying one without the other silently mis-corrects the dust.
+    preview_ir_proxy: Optional[Any] = None
     has_ir: bool = False
     ir_degenerate: bool = False  # IR plane carries image content (B&W/Kodachrome) → IR restore disabled
     original_res: tuple[int, int] = (0, 0)

--- a/negpy/desktop/session.py
+++ b/negpy/desktop/session.py
@@ -64,6 +64,10 @@ class AppState:
     last_metrics: Dict[str, Any] = field(default_factory=dict)
     metrics_lock: threading.Lock = field(default_factory=threading.Lock, init=False, compare=False, repr=False)
     preview_raw: Optional[Any] = None
+    # Preview-resolution stand-in for preview_raw while HQ is on. Interactive frames
+    # render against this so a drag costs the same as it does without HQ; the full
+    # buffer is used again the moment the gesture settles. None when not needed.
+    preview_proxy: Optional[Any] = None
     preview_ir: Optional[Any] = None  # downsampled IR float32 [0,1] (H,W); None if source has no IR
     has_ir: bool = False
     ir_degenerate: bool = False  # IR plane carries image content (B&W/Kodachrome) → IR restore disabled

--- a/negpy/desktop/session.py
+++ b/negpy/desktop/session.py
@@ -64,13 +64,12 @@ class AppState:
     last_metrics: Dict[str, Any] = field(default_factory=dict)
     metrics_lock: threading.Lock = field(default_factory=threading.Lock, init=False, compare=False, repr=False)
     preview_raw: Optional[Any] = None
-    # Preview-resolution stand-in for preview_raw while HQ is on. Interactive frames
-    # render against this so a drag costs the same as it does without HQ; the full
-    # buffer is used again the moment the gesture settles. None when not needed.
+    # Preview-resolution stand-in for preview_raw while HQ is on; interactive frames
+    # render against it. None when preview_raw is already small enough.
     preview_proxy: Optional[Any] = None
     preview_ir: Optional[Any] = None  # downsampled IR float32 [0,1] (H,W); None if source has no IR
-    # IR plane matched to preview_proxy. The pipeline reads the IR against the image it
-    # is given, so proxying one without the other silently mis-corrects the dust.
+    # IR plane matched to preview_proxy. The pipeline reads the IR against whichever
+    # image it is given, and a mismatched pair mis-corrects silently.
     preview_ir_proxy: Optional[Any] = None
     has_ir: bool = False
     ir_degenerate: bool = False  # IR plane carries image content (B&W/Kodachrome) → IR restore disabled

--- a/negpy/desktop/view/canvas/gpu_widget.py
+++ b/negpy/desktop/view/canvas/gpu_widget.py
@@ -45,6 +45,12 @@ class GPUCanvasWidget(QWidget):
         self.lut_view: Optional[Any] = None
         self.lut_sampler: Optional[Any] = None
         self._monitor_icc_bytes: Optional[bytes] = None
+        self._working_color_space: str = WORKING_COLOR_SPACE
+        self._proof: Optional[tuple] = None
+        # Identity of the LUT currently uploaded, so a settled frame re-uploads nothing.
+        self._lut_key: Optional[tuple] = None
+        # Grid size of that LUT — the proof LUT is finer than the plain display one.
+        self._lut_n: int = DEFAULT_LUT_SIZE
 
         self.zoom: float = 1.0
         self.pan_x: float = 0.0
@@ -105,46 +111,69 @@ class GPUCanvasWidget(QWidget):
         self._monitor_icc_bytes = monitor_icc_bytes
         if self.device is not None:
             self._upload_display_lut()
+            self._lut_key = (self._working_color_space, monitor_icc_bytes, self._proof)
             self.canvas.request_draw(self._draw_frame)
+
+    def set_display_transform(self, working_color_space: str, monitor_icc_bytes: Optional[bytes], proof: Optional[tuple]) -> None:
+        """Point the shader at the LUT for the current display state.
+
+        ``proof`` folds the preview soft proof into the same LUT, so a rendered
+        texture reaches the screen without ever coming back to the host.
+        """
+        key = (working_color_space, monitor_icc_bytes, proof)
+        if key == self._lut_key:
+            return
+        self._lut_key = key
+        self._working_color_space = working_color_space
+        self._monitor_icc_bytes = monitor_icc_bytes
+        self._proof = proof
+        if self.device is not None:
+            self._upload_display_lut()
 
     def _upload_display_lut(self) -> None:
         """Build and upload the working-space → display-profile 3D LUT used at
         display time.
 
         The destination is the monitor profile (`self._monitor_icc_bytes`, or sRGB
-        when None). On any failure an identity LUT is uploaded so the binding always
-        exists and display is a pass-through.
+        when None), with the soft proof folded in when one is active. On any failure
+        an identity LUT is uploaded so the binding always exists and display is a
+        pass-through.
+
+        Stored as rgba16float, not rgba8unorm: the proof LUT is built to beat the
+        8-bit round-trip it replaced, and quantizing it back to 8 bits here would
+        give that away. f16 is filterable in core WebGPU; f32 is not.
         """
-        n = DEFAULT_LUT_SIZE
         try:
-            lut = get_display_lut(WORKING_COLOR_SPACE, self._monitor_icc_bytes)
+            lut = get_display_lut(self._working_color_space, self._monitor_icc_bytes, self._proof)
         except Exception as e:
             logger.warning("Display LUT build failed, using identity: %s", e)
             lut = None
 
         if lut is None:
             # Identity ramp: texel value == its normalized coordinate.
+            n = DEFAULT_LUT_SIZE
             axis = np.linspace(0.0, 1.0, n, dtype=np.float32)
             r, g, b = np.meshgrid(axis, axis, axis, indexing="ij")
             lut = np.stack((r, g, b), axis=-1).astype(np.float32)
+        n = lut.shape[0]
+        self._lut_n = n
 
         # Reorder to (b, g, r, c) so the fastest data axis (r) maps to texture width.
         arr = np.ascontiguousarray(lut.transpose(2, 1, 0, 3))
-        rgba = np.empty((n, n, n, 4), dtype=np.uint8)
-        rgba[..., :3] = np.clip(arr * 255.0 + 0.5, 0, 255).astype(np.uint8)
-        rgba[..., 3] = 255
+        rgba = np.ones((n, n, n, 4), dtype=np.float16)
+        rgba[..., :3] = arr.astype(np.float16)
         rgba = np.ascontiguousarray(rgba)
 
         lut_tex = self.device.create_texture(
             size=(n, n, n),
             dimension=wgpu.TextureDimension.d3,
-            format=wgpu.TextureFormat.rgba8unorm,
+            format=wgpu.TextureFormat.rgba16float,
             usage=wgpu.TextureUsage.TEXTURE_BINDING | wgpu.TextureUsage.COPY_DST,
         )
         self.device.queue.write_texture(
             {"texture": lut_tex},
             rgba,
-            {"bytes_per_row": n * 4, "rows_per_image": n},
+            {"bytes_per_row": n * 8, "rows_per_image": n},
             (n, n, n),
         )
         self.lut_view = lut_tex.create_view(dimension=wgpu.TextureViewDimension.d3)
@@ -241,12 +270,11 @@ class GPUCanvasWidget(QWidget):
         @group(0) @binding(2) var lut_tex: texture_3d<f32>;
         @group(0) @binding(3) var lut_samp: sampler;
 
-        // Working-space → display-profile LUT size (must match DEFAULT_LUT_SIZE).
-        const LUT_N: f32 = 33.0;
-
-        fn lut_coord(v: f32) -> f32 {
+        // Working-space → display-profile LUT grid size, uploaded per LUT: the soft
+        // proof uses a finer grid than the plain display transform.
+        fn lut_coord(v: f32, n: f32) -> f32 {
             // Map a [0,1] value to the texture coord at the matching texel center.
-            return (0.5 + clamp(v, 0.0, 1.0) * (LUT_N - 1.0)) / LUT_N;
+            return (0.5 + clamp(v, 0.0, 1.0) * (n - 1.0)) / n;
         }
 
         fn cubic(v: f32) -> f32 {
@@ -287,7 +315,8 @@ class GPUCanvasWidget(QWidget):
         @fragment
         fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
             let col = textureSampleBicubic(in.uv);
-            let coord = vec3<f32>(lut_coord(col.r), lut_coord(col.g), lut_coord(col.b));
+            let n = params.transform.w;
+            let coord = vec3<f32>(lut_coord(col.r, n), lut_coord(col.g, n), lut_coord(col.b, n));
             let mapped = textureSampleLevel(lut_tex, lut_samp, coord, 0.0).rgb;
             return vec4<f32>(mapped, col.a);
         }
@@ -391,7 +420,7 @@ class GPUCanvasWidget(QWidget):
                     self.zoom,
                     self.pan_x,
                     self.pan_y,
-                    0.0,  # padding
+                    float(self._lut_n),
                 ),
             )
 

--- a/negpy/desktop/view/canvas/gpu_widget.py
+++ b/negpy/desktop/view/canvas/gpu_widget.py
@@ -49,7 +49,7 @@ class GPUCanvasWidget(QWidget):
         self._proof: Optional[tuple] = None
         # Identity of the LUT currently uploaded, so a settled frame re-uploads nothing.
         self._lut_key: Optional[tuple] = None
-        # Grid size of that LUT — the proof LUT is finer than the plain display one.
+        # Grid size of that LUT; the proof and display LUTs do not share one.
         self._lut_n: int = DEFAULT_LUT_SIZE
 
         self.zoom: float = 1.0
@@ -139,9 +139,8 @@ class GPUCanvasWidget(QWidget):
         an identity LUT is uploaded so the binding always exists and display is a
         pass-through.
 
-        Stored as rgba16float, not rgba8unorm: the proof LUT is built to beat the
-        8-bit round-trip it replaced, and quantizing it back to 8 bits here would
-        give that away. f16 is filterable in core WebGPU; f32 is not.
+        Stored as rgba16float: 8-bit texels would quantize the proof away, and f32 is
+        not filterable in core WebGPU.
         """
         try:
             lut = get_display_lut(self._working_color_space, self._monitor_icc_bytes, self._proof)
@@ -289,9 +288,8 @@ class GPUCanvasWidget(QWidget):
             return 0.0;
         }
 
-        // Minifying: bicubic reads a 4x4 window of a much denser grid, so it is no
-        // more correct than bilinear and costs 4x the taps — at HQ (61Mpx source,
-        // fit zoom) that is 45ms a present on the UI thread against 6.5ms here.
+        // Minification path. Bicubic reads a 4x4 window of a much denser grid, so it
+        // is no more correct than bilinear there and costs four times the taps.
         fn textureSampleBilinear(uv: vec2<f32>) -> vec4<f32> {
             let dims = textureDimensions(tex);
             let fdims = vec2<f32>(f32(dims.x), f32(dims.y));
@@ -337,9 +335,8 @@ class GPUCanvasWidget(QWidget):
 
         @fragment
         fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
-            // filt.x >= 1 means one screen pixel covers at most one image pixel, i.e.
-            // we are magnifying — the only regime where the extra taps buy anything.
-            // Must be if/else: assigning bilinear first and overwriting would run both.
+            // filt.x >= 1 = magnifying, the only regime the extra taps buy anything.
+            // Must be if/else: assigning one then overwriting runs both.
             var col: vec4<f32>;
             if (params.filt.x >= 1.0) {
                 col = textureSampleBicubic(in.uv);

--- a/negpy/desktop/view/canvas/gpu_widget.py
+++ b/negpy/desktop/view/canvas/gpu_widget.py
@@ -92,8 +92,8 @@ class GPUCanvasWidget(QWidget):
         self.format = self.context.get_preferred_format(adapter).replace("-srgb", "")
         self._configure_context()
 
-        # Uniform buffer now needs 32 bytes (2 * vec4<f32>)
-        self.uniform_buffer = self.device.create_buffer(size=32, usage=wgpu.BufferUsage.UNIFORM | wgpu.BufferUsage.COPY_DST)
+        # Uniform buffer: 3 * vec4<f32>
+        self.uniform_buffer = self.device.create_buffer(size=48, usage=wgpu.BufferUsage.UNIFORM | wgpu.BufferUsage.COPY_DST)
         self._upload_display_lut()
         self._create_render_pipeline(self.format)
 
@@ -227,7 +227,8 @@ class GPUCanvasWidget(QWidget):
         shader_source = """
         struct RenderUniforms {
             rect: vec4<f32>,
-            transform: vec4<f32> // x: zoom, y: pan_x, z: pan_y
+            transform: vec4<f32>, // x: zoom, y: pan_x, z: pan_y, w: LUT grid size
+            filt: vec4<f32>       // x: image pixels per screen pixel
         };
         @group(0) @binding(1) var<uniform> params: RenderUniforms;
 
@@ -288,6 +289,28 @@ class GPUCanvasWidget(QWidget):
             return 0.0;
         }
 
+        // Minifying: bicubic reads a 4x4 window of a much denser grid, so it is no
+        // more correct than bilinear and costs 4x the taps — at HQ (61Mpx source,
+        // fit zoom) that is 45ms a present on the UI thread against 6.5ms here.
+        fn textureSampleBilinear(uv: vec2<f32>) -> vec4<f32> {
+            let dims = textureDimensions(tex);
+            let fdims = vec2<f32>(f32(dims.x), f32(dims.y));
+            let pixel = uv * fdims - 0.5;
+            let ipos = floor(pixel);
+            let fpos = fract(pixel);
+
+            var col = vec4<f32>(0.0);
+            for (var y = 0; y <= 1; y++) {
+                for (var x = 0; x <= 1; x++) {
+                    let coord = clamp(vec2<i32>(ipos + vec2<f32>(f32(x), f32(y))), vec2<i32>(0), vec2<i32>(dims) - 1);
+                    let wx = select(1.0 - fpos.x, fpos.x, x == 1);
+                    let wy = select(1.0 - fpos.y, fpos.y, y == 1);
+                    col += textureLoad(tex, coord, 0) * (wx * wy);
+                }
+            }
+            return col;
+        }
+
         fn textureSampleBicubic(uv: vec2<f32>) -> vec4<f32> {
             let dims = textureDimensions(tex);
             let fdims = vec2<f32>(f32(dims.x), f32(dims.y));
@@ -314,7 +337,15 @@ class GPUCanvasWidget(QWidget):
 
         @fragment
         fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
-            let col = textureSampleBicubic(in.uv);
+            // filt.x >= 1 means one screen pixel covers at most one image pixel, i.e.
+            // we are magnifying — the only regime where the extra taps buy anything.
+            // Must be if/else: assigning bilinear first and overwriting would run both.
+            var col: vec4<f32>;
+            if (params.filt.x >= 1.0) {
+                col = textureSampleBicubic(in.uv);
+            } else {
+                col = textureSampleBilinear(in.uv);
+            }
             let n = params.transform.w;
             let coord = vec3<f32>(lut_coord(col.r, n), lut_coord(col.g, n), lut_coord(col.b, n));
             let mapped = textureSampleLevel(lut_tex, lut_samp, coord, 0.0).rgb;
@@ -337,7 +368,7 @@ class GPUCanvasWidget(QWidget):
                     "visibility": wgpu.ShaderStage.VERTEX | wgpu.ShaderStage.FRAGMENT,
                     "buffer": {
                         "type": wgpu.BufferBindingType.uniform,
-                        "min_binding_size": 32,
+                        "min_binding_size": 48,
                     },
                 },
                 {
@@ -412,7 +443,7 @@ class GPUCanvasWidget(QWidget):
                 self.uniform_buffer,
                 0,
                 struct.pack(
-                    "ffffffff",
+                    "ffffffffffff",
                     (nx / ww) * 2.0 - 1.0,
                     1.0 - (ny / wh) * 2.0,
                     (nw / ww) * 2.0,
@@ -421,6 +452,11 @@ class GPUCanvasWidget(QWidget):
                     self.pan_x,
                     self.pan_y,
                     float(self._lut_n),
+                    # Screen pixels per image pixel: r fits the image, zoom scales it.
+                    r * self.zoom,
+                    0.0,
+                    0.0,
+                    0.0,
                 ),
             )
 
@@ -433,7 +469,7 @@ class GPUCanvasWidget(QWidget):
                         "resource": {
                             "buffer": self.uniform_buffer,
                             "offset": 0,
-                            "size": 32,
+                            "size": 48,
                         },
                     },
                     {"binding": 2, "resource": self.lut_view},

--- a/negpy/desktop/view/canvas/overlay.py
+++ b/negpy/desktop/view/canvas/overlay.py
@@ -1,3 +1,4 @@
+import logging
 import math
 import os
 import sys
@@ -39,6 +40,8 @@ from negpy.features.local.models import MaskShape
 from negpy.features.retouch.models import HEAL_SIZE_REF
 from negpy.services.view.coordinate_mapping import CoordinateMapping
 from negpy.services.view.printing_notes import mask_notes, recipe_lines
+
+logger = logging.getLogger(__name__)
 
 _LASSO_SNAP_PX = 12.0
 _CROP_HANDLE_PX = 10.0
@@ -257,10 +260,11 @@ class CanvasOverlay(QWidget):
         self._wash_cache: Dict[int, Tuple[tuple, QImage]] = {}
 
         # The rendered frame as NumPy, for the instruments that measure pixels (zone grid,
-        # grain loupe). main_window reads a GPU texture back before the canvas sees it, so
-        # this is populated on both engines. No id()-keyed cache — update_buffer invalidates
-        # unconditionally, so it can't go stale.
+        # grain loupe, notes sheet). The GPU path hands over a texture instead, read back
+        # only when one of those asks — a per-frame readback would undo the point of it.
         self._display_buffer: Optional[np.ndarray] = None
+        self._gpu_texture: Optional[Any] = None
+        self._host_qimage_cache: Optional[Tuple[tuple, QImage]] = None
         self._zone_cells: Optional[np.ndarray] = None
         self._zone_labels: List[Tuple[int, int, int]] = []
 
@@ -443,9 +447,12 @@ class CanvasOverlay(QWidget):
         gpu_size: Optional[Tuple[int, int]] = None,
         monitor_icc_bytes: Optional[bytes] = None,
         proof: Optional[tuple] = None,
+        gpu_texture: Optional[Any] = None,
     ) -> None:
         self._content_rect = content_rect
         self._display_buffer = buffer if isinstance(buffer, np.ndarray) else None
+        self._gpu_texture = gpu_texture
+        self._host_qimage_cache = None
         self._zone_cells = None  # rebuilt lazily on the next zones paint
         # Kept so a strip mosaic gets the same display transform as this buffer did.
         self._display_cs = color_space
@@ -465,6 +472,38 @@ class CanvasOverlay(QWidget):
 
         self._recalc_view_rect()
         self.update()
+
+    def drop_gpu_texture(self) -> None:
+        """Forget the displayed texture before the engine frees its pool."""
+        self._gpu_texture = None
+
+    def _host_buffer(self) -> Optional[np.ndarray]:
+        """The displayed frame as NumPy, in working space. Reads the GPU texture back on
+        first ask and holds it until the next frame replaces it."""
+        if self._display_buffer is None and self._gpu_texture is not None:
+            try:
+                rb = self._gpu_texture.readback()
+            except Exception:
+                logger.exception("Failed to read back the GPU frame for a canvas instrument")
+                self._gpu_texture = None
+                return None
+            self._display_buffer = np.ascontiguousarray(rb[:, :, :3]) if rb.ndim == 3 and rb.shape[2] >= 3 else rb
+        return self._display_buffer
+
+    def _host_qimage(self) -> Optional[QImage]:
+        """The displayed frame under its own display transform. `_qimage` already is one
+        on the CPU path; the GPU path draws from the texture, so build it here."""
+        if self._qimage is not None:
+            return self._qimage
+        buf = self._host_buffer()
+        if buf is None:
+            return None
+        key = (id(buf), self._display_cs, self._proof)
+        if self._host_qimage_cache is not None and self._host_qimage_cache[0] == key:
+            return self._host_qimage_cache[1]
+        img = ImageConverter.to_qimage(buf, self._display_cs, self._monitor_icc_bytes, self._proof)
+        self._host_qimage_cache = (key, img)
+        return img
 
     def resizeEvent(self, event) -> None:
         super().resizeEvent(event)
@@ -812,7 +851,7 @@ class CanvasOverlay(QWidget):
         instead of reflowing under the cursor while panning; zoom deep enough and you're
         inside one cell. Rebuild from the visible sub-rect if that ever matters."""
         if self._zone_cells is None:
-            src = self._display_buffer
+            src = self._host_buffer()
             if src is None:
                 return
             if self._content_rect is not None:
@@ -902,16 +941,15 @@ class CanvasOverlay(QWidget):
         """The darkroom grain magnifier: a circular window at the cursor showing the frame's own
         pixels at `_LOUPE_MAG`, with an acutance figure so sharpness is a number.
 
-        Samples `_qimage` — the image the canvas already blitted, so it is display-transformed
-        exactly once. Re-running ImageConverter here would double-proof it: under a soft proof
-        the worker has already baked the transform and `_display_cs` is sRGB.
+        Samples the frame under the canvas's own display transform, applied exactly once —
+        a second pass would double-proof it.
 
         ponytail: magnifies whatever the canvas holds — a 1600 px frame off a half-size demosaic
         unless HQ preview is on — so the acutance figure is comparative below HQ, not absolute,
         and the badge says which. A true 1:1-of-scan loupe needs a full-res ROI render path;
         RenderTask renders whole frames only.
         """
-        img = self._qimage
+        img = self._host_qimage()
         if img is None:
             return
         rect = self._content_view_rect()
@@ -948,10 +986,11 @@ class CanvasOverlay(QWidget):
         painter.drawEllipse(dest)
 
         acutance = 0.0
-        if self._display_buffer is not None:
+        host = self._host_buffer()
+        if host is not None:
             x0, y0 = int(src.x()), int(src.y())
             x1, y1 = int(src.right()), int(src.bottom())
-            acutance = loupe_acutance(self._display_buffer[y0:y1, x0:x1])
+            acutance = loupe_acutance(host[y0:y1, x0:x1])
         label = f"acutance {acutance:.1f} · {'full res' if self.state.hq_preview else 'preview res'}"
 
         badge = QRectF(dest.center().x() - 96.0, dest.bottom() + 6.0, 192.0, _LOUPE_BADGE_H)
@@ -1689,14 +1728,15 @@ class CanvasOverlay(QWidget):
     def printing_notes_sheet(self) -> Optional[QImage]:
         """The exportable notes sheet: the frame the canvas rendered, the map baked on
         it, and the recipe in a band below. None when there is nothing to annotate."""
-        if self._qimage is None:
+        img = self._host_qimage()
+        if img is None:
             return None
         with self.state.metrics_lock:
             uv_grid = self.state.last_metrics.get("uv_grid")
         if uv_grid is None and self.state.config.local.masks:
             return None
         return notes_sheet(
-            self._qimage, self._content_rect, self.state.config.local, uv_grid, self._recipe_lines(), self.state.config.exposure.grade
+            img, self._content_rect, self.state.config.local, uv_grid, self._recipe_lines(), self.state.config.exposure.grade
         )
 
     def _draw_local_handles(self, painter: QPainter, shape: MaskShape, ctrl_pts: List[QPointF], color: QColor) -> None:

--- a/negpy/desktop/view/canvas/overlay.py
+++ b/negpy/desktop/view/canvas/overlay.py
@@ -290,6 +290,7 @@ class CanvasOverlay(QWidget):
 
         self._display_cs: str = ""
         self._monitor_icc_bytes: Optional[bytes] = None
+        self._proof: Optional[tuple] = None
 
         self._buffer_overlay_ratio: float = 0.0
         self._buffer_overlay_visible: bool = False
@@ -441,6 +442,7 @@ class CanvasOverlay(QWidget):
         content_rect: Optional[Tuple[int, int, int, int]] = None,
         gpu_size: Optional[Tuple[int, int]] = None,
         monitor_icc_bytes: Optional[bytes] = None,
+        proof: Optional[tuple] = None,
     ) -> None:
         self._content_rect = content_rect
         self._display_buffer = buffer if isinstance(buffer, np.ndarray) else None
@@ -448,8 +450,9 @@ class CanvasOverlay(QWidget):
         # Kept so a strip mosaic gets the same display transform as this buffer did.
         self._display_cs = color_space
         self._monitor_icc_bytes = monitor_icc_bytes
+        self._proof = proof
         if buffer is not None:
-            self._qimage = ImageConverter.to_qimage(buffer, color_space, monitor_icc_bytes)
+            self._qimage = ImageConverter.to_qimage(buffer, color_space, monitor_icc_bytes, proof)
             self._current_size = (self._qimage.width(), self._qimage.height())
         else:
             self._qimage = None
@@ -978,10 +981,10 @@ class CanvasOverlay(QWidget):
         mosaic = self.state.test_strip_mosaic
         if mosaic is None:
             return None
-        key = (id(mosaic), self._display_cs)
+        key = (id(mosaic), self._display_cs, self._proof)
         if self._strip_cache is not None and self._strip_cache[0] == key:
             return self._strip_cache[1]
-        img = ImageConverter.to_qimage(mosaic, self._display_cs, self._monitor_icc_bytes)
+        img = ImageConverter.to_qimage(mosaic, self._display_cs, self._monitor_icc_bytes, self._proof)
         self._strip_cache = (key, img)
         return img
 

--- a/negpy/desktop/view/canvas/widget.py
+++ b/negpy/desktop/view/canvas/widget.py
@@ -335,6 +335,7 @@ class ImageCanvas(QWidget):
         """
         self._last_buffer = None
         self.gpu_widget.clear()
+        self.overlay.drop_gpu_texture()
 
     def content_rect(self) -> Optional[Tuple[int, int, int, int]]:
         """Image content rect (off_x, off_y, w, h) inside the displayed buffer; None = no borders."""
@@ -573,7 +574,9 @@ class ImageCanvas(QWidget):
             self.gpu_widget.show()
             self.gpu_widget.set_display_transform(color_space, monitor_icc_bytes, proof)
             self.gpu_widget.update_texture(buffer)
-            self.overlay.update_buffer(None, color_space, content_rect, gpu_size=(buffer.width, buffer.height), proof=proof)
+            self.overlay.update_buffer(
+                None, color_space, content_rect, gpu_size=(buffer.width, buffer.height), proof=proof, gpu_texture=buffer
+            )
             self.overlay.show()
             self.overlay.raise_()
             self.overlay.update()

--- a/negpy/desktop/view/canvas/widget.py
+++ b/negpy/desktop/view/canvas/widget.py
@@ -328,10 +328,10 @@ class ImageCanvas(QWidget):
         self.overlay.update_buffer(None, "sRGB", None)
 
     def release_gpu_texture(self) -> None:
-        """Drop the displayed texture because the engine is about to destroy its pool.
+        """Drop the displayed texture before the engine frees its pool.
 
         The canvas samples pooled stage textures directly, so a frame drawn after the
-        pool is freed fails validation. Zoom/pan survive — only the pixels go.
+        pool is freed fails validation. Zoom and pan survive.
         """
         self._last_buffer = None
         self.gpu_widget.clear()
@@ -579,8 +579,7 @@ class ImageCanvas(QWidget):
             self.overlay.update()
         else:
             self.gpu_widget.hide()
-            # Only the CPU overlay needs pixels on the host, so the readback lives here
-            # rather than on the way in — the GPU branch above never pays it.
+            # Only the CPU overlay needs host pixels; the GPU branch above never does.
             if isinstance(buffer, GPUTexture):
                 try:
                     readback = buffer.readback()

--- a/negpy/desktop/view/canvas/widget.py
+++ b/negpy/desktop/view/canvas/widget.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING, Any, Optional, Tuple
 import math
 import sys
+import numpy as np
 from PyQt6.QtWidgets import QStackedLayout, QMenu, QWidget, QPinchGesture, QGestureEvent
 from PyQt6.QtGui import QCursor, QMouseEvent, QNativeGestureEvent, QPainter, QColor, QWheelEvent
 from PyQt6.QtCore import QEvent, pyqtSignal, Qt, QPointF
@@ -568,6 +569,15 @@ class ImageCanvas(QWidget):
             self.overlay.update()
         else:
             self.gpu_widget.hide()
+            # Only the CPU overlay needs pixels on the host, so the readback lives here
+            # rather than on the way in — the GPU branch above never pays it.
+            if isinstance(buffer, GPUTexture):
+                try:
+                    readback = buffer.readback()
+                    buffer = np.ascontiguousarray(readback[:, :, :3]) if readback.ndim == 3 and readback.shape[2] >= 3 else readback
+                except Exception:
+                    logger.exception("Failed to read back GPU preview for canvas display")
+                    return
             self.overlay.update_buffer(buffer, color_space, content_rect, monitor_icc_bytes=monitor_icc_bytes)
             self.overlay.show()
             self.overlay.raise_()

--- a/negpy/desktop/view/canvas/widget.py
+++ b/negpy/desktop/view/canvas/widget.py
@@ -327,6 +327,15 @@ class ImageCanvas(QWidget):
         self.gpu_widget.clear()
         self.overlay.update_buffer(None, "sRGB", None)
 
+    def release_gpu_texture(self) -> None:
+        """Drop the displayed texture because the engine is about to destroy its pool.
+
+        The canvas samples pooled stage textures directly, so a frame drawn after the
+        pool is freed fails validation. Zoom/pan survive — only the pixels go.
+        """
+        self._last_buffer = None
+        self.gpu_widget.clear()
+
     def content_rect(self) -> Optional[Tuple[int, int, int, int]]:
         """Image content rect (off_x, off_y, w, h) inside the displayed buffer; None = no borders."""
         return self.overlay._content_rect

--- a/negpy/desktop/view/canvas/widget.py
+++ b/negpy/desktop/view/canvas/widget.py
@@ -551,19 +551,20 @@ class ImageCanvas(QWidget):
         color_space: str,
         content_rect: Optional[Tuple[int, int, int, int]] = None,
         monitor_icc_bytes: Optional[bytes] = None,
+        proof: Optional[tuple] = None,
     ) -> None:
         """
         Switches between CPU and GPU rendering paths.
 
-        ``monitor_icc_bytes`` drives the CPU display transform (working→monitor); it
-        must be None when ``buffer`` is already in display space (e.g. a baked soft
-        proof) to avoid a double conversion. The GPU path manages its own display LUT.
+        ``monitor_icc_bytes`` and ``proof`` describe the working→display transform for
+        this buffer; both paths apply the identical LUT, the GPU one in its shader.
         """
         self._last_buffer = buffer
         if self.state.gpu_enabled and isinstance(buffer, GPUTexture):
             self.gpu_widget.show()
+            self.gpu_widget.set_display_transform(color_space, monitor_icc_bytes, proof)
             self.gpu_widget.update_texture(buffer)
-            self.overlay.update_buffer(None, color_space, content_rect, gpu_size=(buffer.width, buffer.height))
+            self.overlay.update_buffer(None, color_space, content_rect, gpu_size=(buffer.width, buffer.height), proof=proof)
             self.overlay.show()
             self.overlay.raise_()
             self.overlay.update()
@@ -578,7 +579,7 @@ class ImageCanvas(QWidget):
                 except Exception:
                     logger.exception("Failed to read back GPU preview for canvas display")
                     return
-            self.overlay.update_buffer(buffer, color_space, content_rect, monitor_icc_bytes=monitor_icc_bytes)
+            self.overlay.update_buffer(buffer, color_space, content_rect, monitor_icc_bytes=monitor_icc_bytes, proof=proof)
             self.overlay.show()
             self.overlay.raise_()
         self._raise_floating_widgets()

--- a/negpy/desktop/view/main_window.py
+++ b/negpy/desktop/view/main_window.py
@@ -75,21 +75,6 @@ def _read_screen_icc(screen: object) -> Optional[bytes]:
     return data
 
 
-def _display_buffer_for_canvas(buffer: object) -> object:
-    if isinstance(buffer, GPUTexture):
-        try:
-            readback = buffer.readback()
-        except Exception:
-            logger.exception("Failed to read back GPU preview for canvas display")
-            return buffer
-
-        if isinstance(readback, np.ndarray) and readback.ndim == 3 and readback.shape[2] >= 3:
-            return np.ascontiguousarray(readback[:, :, :3])
-        return readback
-
-    return buffer
-
-
 class _EmptyStateOverlay(QWidget):
     """Shown on top of the canvas when no image is loaded.
 
@@ -541,7 +526,10 @@ class MainWindow(QMainWindow):
             logger.warning("Render completed but 'base_positive' not found in metrics")
             return
 
-        buffer = _display_buffer_for_canvas(metrics["base_positive"])
+        # A GPU texture goes to the canvas as-is: the GPU display path samples it and
+        # applies the working→display LUT in its shader. Reading it back here forced
+        # every frame through the CPU converter instead.
+        buffer = metrics["base_positive"]
         content_rect = metrics.get("content_rect")
 
         if isinstance(buffer, np.ndarray) and not self.state.gpu_enabled:

--- a/negpy/desktop/view/main_window.py
+++ b/negpy/desktop/view/main_window.py
@@ -412,6 +412,7 @@ class MainWindow(QMainWindow):
         self.controller.image_updated.connect(self._on_image_updated)
         self.controller.preview_loaded.connect(self._refresh_image_info)
         self.controller.loading_started.connect(self._on_loading_started)
+        self.controller.gpu_textures_released.connect(self.canvas.release_gpu_texture)
         self.controller.image_updated.connect(self.loading_overlay.stop)
         self.controller.load_failed.connect(self._on_load_failed)
         self.controller.zoom_changed.connect(self._on_zoom_info_changed)

--- a/negpy/desktop/view/main_window.py
+++ b/negpy/desktop/view/main_window.py
@@ -559,8 +559,8 @@ class MainWindow(QMainWindow):
 
         # Shared with the filmstrip thumbnail so the same frame can't render two
         # different colours in the two places (see display_transform_params).
-        display_cs, monitor_bytes = self.controller.display_transform_params(splash=bool(metrics.get("splash")))
-        self.canvas.update_buffer(buffer, display_cs, content_rect=content_rect, monitor_icc_bytes=monitor_bytes)
+        display_cs, monitor_bytes, proof = self.controller.display_transform_params(splash=bool(metrics.get("splash")))
+        self.canvas.update_buffer(buffer, display_cs, content_rect=content_rect, monitor_icc_bytes=monitor_bytes, proof=proof)
 
     def _refresh_image_info(self) -> None:
         """Updates the canvas HUD corner pills."""

--- a/negpy/desktop/view/main_window.py
+++ b/negpy/desktop/view/main_window.py
@@ -527,9 +527,8 @@ class MainWindow(QMainWindow):
             logger.warning("Render completed but 'base_positive' not found in metrics")
             return
 
-        # A GPU texture goes to the canvas as-is: the GPU display path samples it and
-        # applies the working→display LUT in its shader. Reading it back here forced
-        # every frame through the CPU converter instead.
+        # Passed on as-is: the GPU display path samples the texture and applies the
+        # working→display LUT in its shader.
         buffer = metrics["base_positive"]
         content_rect = metrics.get("content_rect")
 

--- a/negpy/desktop/view/sidebar/local.py
+++ b/negpy/desktop/view/sidebar/local.py
@@ -115,9 +115,8 @@ class LocalSidebar(BaseSidebar):
     def _connect_signals(self) -> None:
         for btn, mode in self._tool_modes().items():
             btn.toggled.connect(lambda checked, m=mode: self._on_draw_toggled(checked, m))
-        # Drag steps render only; the commit writes history and settings — the same
-        # split every other sidebar uses. Persisting per step wrote a history row and
-        # rebuilt the history panel on every mouse-move.
+        # Drag steps render only; the commit writes history and settings, as in every
+        # other sidebar.
         for slider, field in (
             (self.burn_slider, "stops"),
             (self.feather_slider, "feather"),

--- a/negpy/desktop/view/sidebar/local.py
+++ b/negpy/desktop/view/sidebar/local.py
@@ -115,9 +115,18 @@ class LocalSidebar(BaseSidebar):
     def _connect_signals(self) -> None:
         for btn, mode in self._tool_modes().items():
             btn.toggled.connect(lambda checked, m=mode: self._on_draw_toggled(checked, m))
-        self.burn_slider.valueChanged.connect(lambda v: self.controller.update_selected_local_mask(stops=float(v)))
-        self.feather_slider.valueChanged.connect(lambda v: self.controller.update_selected_local_mask(feather=float(v)))
-        self.grade_slider.valueChanged.connect(lambda v: self.controller.update_selected_local_mask(grade=float(v)))
+        # Drag steps render only; the commit writes history and settings — the same
+        # split every other sidebar uses. Persisting per step wrote a history row and
+        # rebuilt the history panel on every mouse-move.
+        for slider, field in (
+            (self.burn_slider, "stops"),
+            (self.feather_slider, "feather"),
+            (self.grade_slider, "grade"),
+        ):
+            slider.valueChanged.connect(
+                lambda v, f=field: self.controller.update_selected_local_mask(persist=False, readback_metrics=False, **{f: float(v)})
+            )
+            slider.valueCommitted.connect(lambda v, f=field: self.controller.update_selected_local_mask(**{f: float(v)}))
         self.invert_btn.toggled.connect(lambda v: self.controller.update_selected_local_mask(invert=bool(v)))
 
     def _tool_modes(self) -> dict:

--- a/negpy/desktop/view/sidebar/right_panel.py
+++ b/negpy/desktop/view/sidebar/right_panel.py
@@ -354,9 +354,8 @@ class RightPanel(QWidget):
         if source is None:
             source = metrics.get("analysis_buffer")
         if source is None:
-            # base_positive is a GPU texture on the GPU path; binning it here would mean
-            # a full readback on the UI thread. Drag frames carry no histogram (they ask
-            # for none), so keep the last one rather than blanking the chart.
+            # A GPU texture cannot be binned here without a full readback on the UI
+            # thread, so keep the last histogram rather than blanking the chart.
             candidate = metrics.get("base_positive")
             source = candidate if isinstance(candidate, np.ndarray) else None
         if source is None:
@@ -381,9 +380,7 @@ class RightPanel(QWidget):
 
     def _update_analysis(self) -> None:
         metrics = self.controller.session.state.last_metrics
-        # Mid-gesture frames carry no metrics to read anyway, and rebuilding the curve,
-        # step wedge and zone strip on the UI thread is what makes a slider handle stutter.
-        # The settle frame refreshes all of it.
+        # Mid-gesture frames carry no metrics; the settle frame refreshes all of this.
         if metrics.get("interactive"):
             return
 

--- a/negpy/desktop/view/sidebar/right_panel.py
+++ b/negpy/desktop/view/sidebar/right_panel.py
@@ -381,6 +381,11 @@ class RightPanel(QWidget):
 
     def _update_analysis(self) -> None:
         metrics = self.controller.session.state.last_metrics
+        # Mid-gesture frames carry no metrics to read anyway, and rebuilding the curve,
+        # step wedge and zone strip on the UI thread is what makes a slider handle stutter.
+        # The settle frame refreshes all of it.
+        if metrics.get("interactive"):
+            return
 
         self._update_histograms(metrics)
         # Measured zones read through the current config, so they track every render.

--- a/negpy/desktop/view/sidebar/right_panel.py
+++ b/negpy/desktop/view/sidebar/right_panel.py
@@ -1,6 +1,7 @@
 import sys
 from typing import Any, Dict
 
+import numpy as np
 import qtawesome as qta
 from PyQt6.QtCore import Qt, QSize
 from PyQt6.QtWidgets import (
@@ -353,7 +354,13 @@ class RightPanel(QWidget):
         if source is None:
             source = metrics.get("analysis_buffer")
         if source is None:
-            source = metrics.get("base_positive")
+            # base_positive is a GPU texture on the GPU path; binning it here would mean
+            # a full readback on the UI thread. Drag frames carry no histogram (they ask
+            # for none), so keep the last one rather than blanking the chart.
+            candidate = metrics.get("base_positive")
+            source = candidate if isinstance(candidate, np.ndarray) else None
+        if source is None:
+            return
         bins = output_histogram(source)
 
         self.curve_widget.set_output_histogram(bins)

--- a/negpy/desktop/view/sidebar/right_panel.py
+++ b/negpy/desktop/view/sidebar/right_panel.py
@@ -426,6 +426,6 @@ class RightPanel(QWidget):
         from negpy.features.exposure.logic import print_curve, print_curve_output
 
         enc = print_curve_output(print_curve(config, slope, pivot, process_mode), wedge_vals())
-        display_cs, monitor_bytes = self.controller.display_transform_params()
+        display_cs, monitor_bytes, proof = self.controller.display_transform_params()
         self.step_wedge.setVisible(True)
-        self.step_wedge.update_data(enc, wedge_step_density(metrics.get("norm_density_range")), display_cs, monitor_bytes)
+        self.step_wedge.update_data(enc, wedge_step_density(metrics.get("norm_density_range")), display_cs, monitor_bytes, proof)

--- a/negpy/desktop/view/widgets/charts.py
+++ b/negpy/desktop/view/widgets/charts.py
@@ -739,11 +739,11 @@ class StepWedgeWidget(QWidget):
         self._step_d: float = 0.0
         self._colors: list = []
 
-    def update_data(self, enc: Any, step_density: float, color_space: str, monitor_icc_bytes: Any = None) -> None:
+    def update_data(self, enc: Any, step_density: float, color_space: str, monitor_icc_bytes: Any = None, proof: Any = None) -> None:
         """`enc` is the 21 display-encoded patch values. The patches go through the same
-        display transform the canvas used, so wedge and frame can't disagree; under a proof
-        `color_space` is already sRGB and the transform a no-op, because the render worker
-        baked the proof into the buffer and proofing it twice blows the saturation out.
+        display transform the canvas used — including the soft proof, which rides the
+        display LUT rather than being baked into the buffer — so wedge and frame can't
+        disagree.
         """
         from negpy.desktop.converters import ImageConverter
 
@@ -753,7 +753,7 @@ class StepWedgeWidget(QWidget):
             self._colors = []
         else:
             buf = np.repeat(np.clip(self._enc, 0.0, 1.0).reshape(1, -1, 1), 3, axis=2)
-            img = ImageConverter.to_qimage(buf, color_space, monitor_icc_bytes)
+            img = ImageConverter.to_qimage(buf, color_space, monitor_icc_bytes, proof)
             self._colors = [img.pixelColor(i, 0) for i in range(img.width())]
         self.update()
 

--- a/negpy/desktop/view/widgets/sliders.py
+++ b/negpy/desktop/view/widgets/sliders.py
@@ -18,8 +18,11 @@ from negpy.desktop.view.styles.templates import EditedDot, slider_label_qss, sli
 # text_secondary, not text_muted: #555 on the #161616 tooltip background is ~2.4:1.
 _RESET_HINT = f'<div style="color:{THEME.text_secondary};">Double-click to reset</div>'
 
-# Quiet period after the last slider step before a render is asked for.
-_EMIT_INTERVAL_MS = 100
+# Quiet period after the last slider step before a render is asked for. Was 100ms
+# while a drag frame could cost a full HQ render; interactive frames now render
+# against a preview-resolution proxy (see AppController._interactive_proxy), so the
+# preview can follow the handle much sooner without putting work on the UI thread.
+_EMIT_INTERVAL_MS = 33
 
 
 class _NoScrollSlider(QSlider):

--- a/negpy/desktop/view/widgets/sliders.py
+++ b/negpy/desktop/view/widgets/sliders.py
@@ -1,5 +1,4 @@
 import math
-import time
 from typing import Optional
 
 from PyQt6.QtWidgets import (
@@ -19,8 +18,8 @@ from negpy.desktop.view.styles.templates import EditedDot, slider_label_qss, sli
 # text_secondary, not text_muted: #555 on the #161616 tooltip background is ~2.4:1.
 _RESET_HINT = f'<div style="color:{THEME.text_secondary};">Double-click to reset</div>'
 
-# Shortest gap between two valueChanged emissions during a drag (~30/s).
-_EMIT_INTERVAL_MS = 33
+# Quiet period after the last slider step before a render is asked for.
+_EMIT_INTERVAL_MS = 100
 
 
 class _NoScrollSlider(QSlider):
@@ -154,13 +153,10 @@ class BaseSlider(QWidget):
         self.spin.setRange(min_val, max_val)
         self.spin.setValue(default_val)
 
-        # Emit throttle — leading edge plus a guaranteed trailing frame (see
-        # _schedule_emit). A preview frame costs single-digit ms, so a drag can feed
-        # the renderer continuously instead of waiting for the user to pause.
+        # Trailing debounce — see _schedule_emit for why it stays trailing.
         self.timer = QTimer()
         self.timer.setSingleShot(True)
         self.timer.setInterval(_EMIT_INTERVAL_MS)
-        self._last_emit_ms = 0.0
 
         self._connect_base_signals()
 
@@ -217,20 +213,17 @@ class BaseSlider(QWidget):
         self._schedule_emit()
 
     def _schedule_emit(self) -> None:
-        """Emit at once when the window is open, else arm one trailing frame.
+        """Trailing debounce: the handle must never wait on a render.
 
-        The timer is armed only when idle — restarting it on every step is a pure
-        trailing debounce, which emits nothing at all until the drag pauses.
+        A leading edge plus a max-wait was tried and reverted. Emitting mid-drag drags
+        the whole per-render UI fan-out along with the handle — repaint, sidebar
+        resync, analysis panel, canvas present — and at HQ preview that is enough to
+        make the handle visibly lag the mouse. Dispatching only once the drag pauses
+        keeps the slider decoupled from rendering, which is the behaviour to beat.
         """
-        elapsed = time.monotonic() * 1000.0 - self._last_emit_ms
-        if elapsed >= _EMIT_INTERVAL_MS:
-            self.timer.stop()
-            self._emit_value()
-        elif not self.timer.isActive():
-            self.timer.start(max(1, int(_EMIT_INTERVAL_MS - elapsed)))
+        self.timer.start(_EMIT_INTERVAL_MS)
 
     def _emit_value(self) -> None:
-        self._last_emit_ms = time.monotonic() * 1000.0
         self.valueChanged.emit(self.spin.value())
 
     def setValue(self, value: float, _rebase_commit: bool = True) -> None:

--- a/negpy/desktop/view/widgets/sliders.py
+++ b/negpy/desktop/view/widgets/sliders.py
@@ -1,4 +1,5 @@
 import math
+import time
 from typing import Optional
 
 from PyQt6.QtWidgets import (
@@ -17,6 +18,9 @@ from negpy.desktop.view.styles.templates import EditedDot, slider_label_qss, sli
 
 # text_secondary, not text_muted: #555 on the #161616 tooltip background is ~2.4:1.
 _RESET_HINT = f'<div style="color:{THEME.text_secondary};">Double-click to reset</div>'
+
+# Shortest gap between two valueChanged emissions during a drag (~30/s).
+_EMIT_INTERVAL_MS = 33
 
 
 class _NoScrollSlider(QSlider):
@@ -150,10 +154,13 @@ class BaseSlider(QWidget):
         self.spin.setRange(min_val, max_val)
         self.spin.setValue(default_val)
 
-        # Debounce timer
+        # Emit throttle — leading edge plus a guaranteed trailing frame (see
+        # _schedule_emit). A preview frame costs single-digit ms, so a drag can feed
+        # the renderer continuously instead of waiting for the user to pause.
         self.timer = QTimer()
         self.timer.setSingleShot(True)
-        self.timer.setInterval(100)
+        self.timer.setInterval(_EMIT_INTERVAL_MS)
+        self._last_emit_ms = 0.0
 
         self._connect_base_signals()
 
@@ -172,10 +179,18 @@ class BaseSlider(QWidget):
         self.slider.sliderReleased.connect(self.dragEnded.emit)
 
     def _on_committed(self) -> None:
+        # Stop the trailing frame: the commit below renders the same value, and letting
+        # the timer fire afterwards costs a second identical round trip.
+        pending = self.timer.isActive()
+        self.timer.stop()
         current_val = self.spin.value()
         if current_val != self._last_committed_value:
             self._last_committed_value = current_val
             self.valueCommitted.emit(current_val)
+        elif pending:
+            # Dragged away and back: no commit fires, so that trailing frame is the
+            # only thing that would put the preview back on the committed value.
+            self._emit_value()
 
     def _to_int(self, value: float) -> int:
         """Value -> slider int; subclasses override the pair for nonlinear
@@ -193,15 +208,29 @@ class BaseSlider(QWidget):
         self.spin.blockSignals(True)
         self.spin.setValue(f_val)
         self.spin.blockSignals(False)
-        self.timer.start()
+        self._schedule_emit()
 
     def _on_spin_changed(self, value: float) -> None:
         self.slider.blockSignals(True)
         self.slider.setValue(self._to_int(value))
         self.slider.blockSignals(False)
-        self.timer.start()
+        self._schedule_emit()
+
+    def _schedule_emit(self) -> None:
+        """Emit at once when the window is open, else arm one trailing frame.
+
+        The timer is armed only when idle — restarting it on every step is a pure
+        trailing debounce, which emits nothing at all until the drag pauses.
+        """
+        elapsed = time.monotonic() * 1000.0 - self._last_emit_ms
+        if elapsed >= _EMIT_INTERVAL_MS:
+            self.timer.stop()
+            self._emit_value()
+        elif not self.timer.isActive():
+            self.timer.start(max(1, int(_EMIT_INTERVAL_MS - elapsed)))
 
     def _emit_value(self) -> None:
+        self._last_emit_ms = time.monotonic() * 1000.0
         self.valueChanged.emit(self.spin.value())
 
     def setValue(self, value: float, _rebase_commit: bool = True) -> None:
@@ -434,8 +463,8 @@ class CompactSlider(BaseSlider):
                     sensitivity *= 10.0
                 new_val = max(self._min, min(self._max, self._scrub_start_val + dx * sensitivity))
                 self.setValue(new_val, _rebase_commit=False)
-                # debounce like groove drags; a direct emit renders per mouse-move
-                self.timer.start()
+                # throttle like groove drags; a direct emit renders per mouse-move
+                self._schedule_emit()
                 return True
             if et == QEvent.Type.MouseButtonRelease and self._scrub_active:
                 self._scrub_active = False

--- a/negpy/desktop/view/widgets/sliders.py
+++ b/negpy/desktop/view/widgets/sliders.py
@@ -18,10 +18,7 @@ from negpy.desktop.view.styles.templates import EditedDot, slider_label_qss, sli
 # text_secondary, not text_muted: #555 on the #161616 tooltip background is ~2.4:1.
 _RESET_HINT = f'<div style="color:{THEME.text_secondary};">Double-click to reset</div>'
 
-# Quiet period after the last slider step before a render is asked for. Was 100ms
-# while a drag frame could cost a full HQ render; interactive frames now render
-# against a preview-resolution proxy (see AppController._interactive_proxy), so the
-# preview can follow the handle much sooner without putting work on the UI thread.
+# Quiet period after the last slider step before a render is asked for.
 _EMIT_INTERVAL_MS = 33
 
 
@@ -178,8 +175,7 @@ class BaseSlider(QWidget):
         self.slider.sliderReleased.connect(self.dragEnded.emit)
 
     def _on_committed(self) -> None:
-        # Stop the trailing frame: the commit below renders the same value, and letting
-        # the timer fire afterwards costs a second identical round trip.
+        # The commit below renders this value; a trailing frame would repeat it.
         pending = self.timer.isActive()
         self.timer.stop()
         current_val = self.spin.value()
@@ -218,11 +214,8 @@ class BaseSlider(QWidget):
     def _schedule_emit(self) -> None:
         """Trailing debounce: the handle must never wait on a render.
 
-        A leading edge plus a max-wait was tried and reverted. Emitting mid-drag drags
-        the whole per-render UI fan-out along with the handle — repaint, sidebar
-        resync, analysis panel, canvas present — and at HQ preview that is enough to
-        make the handle visibly lag the mouse. Dispatching only once the drag pauses
-        keeps the slider decoupled from rendering, which is the behaviour to beat.
+        Emitting mid-drag pulls the whole per-render UI fan-out onto the handle's own
+        thread. A leading edge was tried here and reverted for that reason.
         """
         self.timer.start(_EMIT_INTERVAL_MS)
 

--- a/negpy/desktop/workers/render.py
+++ b/negpy/desktop/workers/render.py
@@ -222,6 +222,14 @@ class RenderWorker(QObject):
             # canvas shader without a readback and every consumer of this buffer sees
             # the same unproofed print.
 
+            # The filmstrip thumbnail needs host pixels. This is the only thread that
+            # can take them safely — the engine recycles its stage textures on the next
+            # frame — and the only place that keeps the copy off the UI thread, where at
+            # HQ it is ~976MB and freezes the slider for ~700ms. Settle frames only, so
+            # a drag never pays it.
+            if task.readback_metrics and isinstance(result, GPUTexture):
+                metrics["thumbnail_source"] = np.ascontiguousarray(result.readback()[:, :, :3])
+
             # Ensure ground truth is stored in metrics for view consumption
             metrics["base_positive"] = result
             # Render identity, so the controller can reject stale/ephemeral bounds writeback.

--- a/negpy/desktop/workers/render.py
+++ b/negpy/desktop/workers/render.py
@@ -222,12 +222,13 @@ class RenderWorker(QObject):
             # canvas shader without a readback and every consumer of this buffer sees
             # the same unproofed print.
 
-            # The filmstrip thumbnail needs host pixels. This is the only thread that
-            # can take them safely — the engine recycles its stage textures on the next
-            # frame — and the only place that keeps the copy off the UI thread, where at
-            # HQ it is ~976MB and freezes the slider for ~700ms. Settle frames only, so
-            # a drag never pays it.
-            if task.readback_metrics and isinstance(result, GPUTexture):
+            # Host pixels for the filmstrip thumbnail. This is the only thread that can
+            # take them safely — the engine recycles its stage textures on the next
+            # frame. Settle frames only, and never from an HQ render: that copy is
+            # ~976MB and ~700ms of device time to produce a 256px thumbnail that a
+            # preview-sized render already produced identically.
+            wants_thumb = task.readback_metrics and task.preview_size <= APP_CONFIG.preview_render_size
+            if wants_thumb and isinstance(result, GPUTexture):
                 metrics["thumbnail_source"] = np.ascontiguousarray(result.readback()[:, :, :3])
 
             # Ensure ground truth is stored in metrics for view consumption

--- a/negpy/desktop/workers/render.py
+++ b/negpy/desktop/workers/render.py
@@ -45,6 +45,9 @@ class RenderTask:
     # These pixels are the before/after baseline, not the edit. Echoed in metrics so
     # the BEFORE badge tracks what is painted, not the pending toggle.
     compare: bool = False
+    # A frame produced while a gesture is live. Echoed in metrics so the UI thread can
+    # skip everything that only has to be right once the gesture settles.
+    interactive: bool = False
 
 
 @dataclass(frozen=True)
@@ -238,6 +241,7 @@ class RenderWorker(QObject):
             metrics["ephemeral"] = task.ephemeral
             metrics["memo_key"] = task.memo_key
             metrics["compare"] = task.compare
+            metrics["interactive"] = task.interactive
 
             self.finished.emit(result, metrics)
             self.metrics_updated.emit(metrics)

--- a/negpy/desktop/workers/render.py
+++ b/negpy/desktop/workers/render.py
@@ -15,7 +15,6 @@ from negpy.features.process.sensor import apply_sensor_correction, effective_sen
 from negpy.features.rgbscan.models import is_rgb_triplet
 from negpy.features.geometry.processor import GeometryProcessor
 from negpy.infrastructure.display.color_spaces import WORKING_COLOR_SPACE
-from negpy.infrastructure.display.icc_lut import apply_lut_f32
 from negpy.infrastructure.gpu.resources import GPUTexture
 from negpy.kernel.system.config import APP_CONFIG, DEFAULT_WORKSPACE_CONFIG
 from negpy.kernel.system.logging import get_logger
@@ -32,15 +31,9 @@ class RenderTask:
     config: WorkspaceConfig
     source_hash: str
     preview_size: float
-    icc_input_path: Optional[str] = None
-    icc_output_path: Optional[str] = None
-    color_space: str = "Adobe RGB"
     gpu_enabled: bool = True
     readback_metrics: bool = True
     ir_buffer: Optional[np.ndarray] = None
-    # Monitor ICC profile bytes (detected on the UI thread); soft proof is shown on
-    # this display. None = sRGB display.
-    monitor_icc_bytes: Optional[bytes] = None
     # True while the crop tool is active: show the full uncropped frame instead of
     # the final crop.
     crop_preview_full: bool = False
@@ -66,12 +59,8 @@ class TestStripTask:
     preview_size: float
     overrides: tuple
     grid: tuple
-    icc_input_path: Optional[str] = None
-    icc_output_path: Optional[str] = None
-    color_space: str = "Adobe RGB"
     gpu_enabled: bool = True
     ir_buffer: Optional[np.ndarray] = None
-    monitor_icc_bytes: Optional[bytes] = None
 
 
 @dataclass(frozen=True)
@@ -81,9 +70,10 @@ class ThumbnailUpdateTask:
     file_hash: str  # asset_thumbnail_key — the filmstrip and the disk cache share it
     buffer: np.ndarray
     # Display-transform inputs, from AppController.display_transform_params — must be
-    # the same pair the canvas used for this buffer or the thumbnail's colour drifts.
+    # the same triple the canvas used for this buffer or the thumbnail's colour drifts.
     color_space: str = WORKING_COLOR_SPACE
     monitor_icc_bytes: Optional[bytes] = None
+    proof: Optional[tuple] = None
     persist: bool = True  # False = in-memory filmstrip only, skip the disk JPEG encode.
 
 
@@ -223,20 +213,14 @@ class RenderWorker(QObject):
                 crop_preview_full=task.crop_preview_full,
             )
 
-            soft_proof = task.icc_input_path or task.icc_output_path
-
-            # CPU renders have no in-shader histogram; bin the float output here,
-            # before soft-proofing quantizes it to 8/16-bit (comb artifacts).
+            # CPU renders have no in-shader histogram; bin the float output here.
             if task.readback_metrics and "histogram_raw" not in metrics and isinstance(result, np.ndarray):
                 metrics["histogram_raw"] = output_histogram(result)
 
-            if soft_proof and isinstance(result, GPUTexture):
-                result = result.readback()
-
-            if soft_proof and isinstance(result, np.ndarray):
-                result = self._soft_proof(
-                    result, task.config, task.color_space, task.icc_input_path, task.icc_output_path, task.monitor_icc_bytes
-                )
+            # The soft proof is not baked here: it rides the display LUT
+            # (AppController.display_transform_params), so a GPU texture reaches the
+            # canvas shader without a readback and every consumer of this buffer sees
+            # the same unproofed print.
 
             # Ensure ground truth is stored in metrics for view consumption
             metrics["base_positive"] = result
@@ -252,39 +236,6 @@ class RenderWorker(QObject):
         except Exception as e:
             logger.exception("Render pipeline failed")
             self.error.emit(str(e))
-
-    def _soft_proof(
-        self,
-        result: np.ndarray,
-        config: WorkspaceConfig,
-        color_space: str,
-        icc_input_path: Optional[str],
-        icc_output_path: Optional[str],
-        monitor_icc_bytes: Optional[bytes],
-    ) -> np.ndarray:
-        """Bake source→output→monitor into the buffer; the display transform is then a
-        no-op (see AppController.display_transform_params).
-
-        The proof rides a cached 3D LUT — rebuilding the littleCMS transform per frame
-        cost ~56ms of every preview. The LUT is built from the same transform, so a
-        fallback to the per-pixel path only happens if the build itself failed.
-        """
-        lut = self._processor.soft_proof_lut(color_space, icc_input_path, icc_output_path, monitor_icc_bytes)
-        if lut is not None and result.dtype == np.float32 and result.ndim == 3 and result.shape[2] >= 3:
-            # A GPU readback carries an alpha lane; apply_lut_f32 wants contiguous RGB.
-            # The canvas dropped that lane itself before, so this moves a copy rather
-            # than adding one.
-            return apply_lut_f32(np.ascontiguousarray(result[:, :, :3]), lut)
-
-        pil_proof = self._processor.soft_proof_preview(
-            self._processor.buffer_to_pil(result, config),
-            color_space,
-            icc_input_path,
-            icc_output_path,
-            monitor_icc_bytes,
-        )
-        arr = np.array(pil_proof)
-        return arr.astype(np.float32) / (65535.0 if arr.dtype == np.uint16 else 255.0)
 
     @pyqtSlot(TestStripTask)
     def build_strip(self, task: TestStripTask) -> None:
@@ -324,13 +275,8 @@ class RenderWorker(QObject):
             # One mosaic per quarter-turn while the tiles are still in hand: a rotated ladder needs
             # a different slice of each render. Peak memory is unchanged, the tiles dominate.
             mosaics = tuple(strip_mosaic(rotate_grid(tiles, task.grid, k), proof_grid(task.grid, k)) for k in range(4))
-            # Proof the assembled mosaics, not each tile: the transform is per-pixel, so one pass
-            # per frame is identical and far cheaper than one per patch.
-            if task.icc_input_path or task.icc_output_path:
-                mosaics = tuple(
-                    self._soft_proof(m, task.config, task.color_space, task.icc_input_path, task.icc_output_path, task.monitor_icc_bytes)
-                    for m in mosaics
-                )
+            # Unproofed, like every other rendered buffer: the overlay proofs the mosaic
+            # through the same display LUT the canvas uses, so the two cannot disagree.
             self.strip_finished.emit(mosaics, content_rect)
 
         except Exception as e:
@@ -397,6 +343,7 @@ class ThumbnailWorker(QObject):
                 store,
                 color_space=task.color_space,
                 monitor_icc_bytes=task.monitor_icc_bytes,
+                proof=task.proof,
             )
             if thumb:
                 self.rendered_finished.emit({task.file_hash: thumb})

--- a/negpy/desktop/workers/render.py
+++ b/negpy/desktop/workers/render.py
@@ -15,6 +15,7 @@ from negpy.features.process.sensor import apply_sensor_correction, effective_sen
 from negpy.features.rgbscan.models import is_rgb_triplet
 from negpy.features.geometry.processor import GeometryProcessor
 from negpy.infrastructure.display.color_spaces import WORKING_COLOR_SPACE
+from negpy.infrastructure.display.icc_lut import apply_lut_f32
 from negpy.infrastructure.gpu.resources import GPUTexture
 from negpy.kernel.system.config import APP_CONFIG, DEFAULT_WORKSPACE_CONFIG
 from negpy.kernel.system.logging import get_logger
@@ -262,7 +263,19 @@ class RenderWorker(QObject):
         monitor_icc_bytes: Optional[bytes],
     ) -> np.ndarray:
         """Bake source→output→monitor into the buffer; the display transform is then a
-        no-op (see AppController.display_transform_params)."""
+        no-op (see AppController.display_transform_params).
+
+        The proof rides a cached 3D LUT — rebuilding the littleCMS transform per frame
+        cost ~56ms of every preview. The LUT is built from the same transform, so a
+        fallback to the per-pixel path only happens if the build itself failed.
+        """
+        lut = self._processor.soft_proof_lut(color_space, icc_input_path, icc_output_path, monitor_icc_bytes)
+        if lut is not None and result.dtype == np.float32 and result.ndim == 3 and result.shape[2] >= 3:
+            # A GPU readback carries an alpha lane; apply_lut_f32 wants contiguous RGB.
+            # The canvas dropped that lane itself before, so this moves a copy rather
+            # than adding one.
+            return apply_lut_f32(np.ascontiguousarray(result[:, :, :3]), lut)
+
         pil_proof = self._processor.soft_proof_preview(
             self._processor.buffer_to_pil(result, config),
             color_space,

--- a/negpy/desktop/workers/render.py
+++ b/negpy/desktop/workers/render.py
@@ -45,8 +45,8 @@ class RenderTask:
     # These pixels are the before/after baseline, not the edit. Echoed in metrics so
     # the BEFORE badge tracks what is painted, not the pending toggle.
     compare: bool = False
-    # A frame produced while a gesture is live. Echoed in metrics so the UI thread can
-    # skip everything that only has to be right once the gesture settles.
+    # Produced while a gesture is live. Echoed in metrics so the UI thread can skip
+    # what only has to be right once the gesture settles.
     interactive: bool = False
 
 
@@ -220,16 +220,12 @@ class RenderWorker(QObject):
             if task.readback_metrics and "histogram_raw" not in metrics and isinstance(result, np.ndarray):
                 metrics["histogram_raw"] = output_histogram(result)
 
-            # The soft proof is not baked here: it rides the display LUT
-            # (AppController.display_transform_params), so a GPU texture reaches the
-            # canvas shader without a readback and every consumer of this buffer sees
-            # the same unproofed print.
+            # The soft proof is not baked in: it rides the display LUT, so a GPU
+            # texture reaches the canvas shader without a readback.
 
-            # Host pixels for the filmstrip thumbnail. This is the only thread that can
-            # take them safely — the engine recycles its stage textures on the next
-            # frame. Settle frames only, and never from an HQ render: that copy is
-            # ~976MB and ~700ms of device time to produce a 256px thumbnail that a
-            # preview-sized render already produced identically.
+            # Host pixels for the filmstrip thumbnail, taken here because the engine
+            # recycles its stage textures on the next frame. Settle frames only, and
+            # never from an HQ render — a preview-sized one yields the same thumbnail.
             wants_thumb = task.readback_metrics and task.preview_size <= APP_CONFIG.preview_render_size
             if wants_thumb and isinstance(result, GPUTexture):
                 metrics["thumbnail_source"] = np.ascontiguousarray(result.readback()[:, :, :3])
@@ -288,8 +284,8 @@ class RenderWorker(QObject):
             # One mosaic per quarter-turn while the tiles are still in hand: a rotated ladder needs
             # a different slice of each render. Peak memory is unchanged, the tiles dominate.
             mosaics = tuple(strip_mosaic(rotate_grid(tiles, task.grid, k), proof_grid(task.grid, k)) for k in range(4))
-            # Unproofed, like every other rendered buffer: the overlay proofs the mosaic
-            # through the same display LUT the canvas uses, so the two cannot disagree.
+            # Unproofed like every other rendered buffer; the overlay proofs the mosaic
+            # through the same display LUT the canvas uses.
             self.strip_finished.emit(mosaics, content_rect)
 
         except Exception as e:

--- a/negpy/desktop/workers/render.py
+++ b/negpy/desktop/workers/render.py
@@ -48,6 +48,8 @@ class RenderTask:
     # Produced while a gesture is live. Echoed in metrics so the UI thread can skip
     # what only has to be right once the gesture settles.
     interactive: bool = False
+    # Only the controller knows whether the filmstrip is already current for this config.
+    wants_thumbnail: bool = False
 
 
 @dataclass(frozen=True)
@@ -223,12 +225,12 @@ class RenderWorker(QObject):
             # The soft proof is not baked in: it rides the display LUT, so a GPU
             # texture reaches the canvas shader without a readback.
 
-            # Host pixels for the filmstrip thumbnail, taken here because the engine
-            # recycles its stage textures on the next frame. Settle frames only, and
-            # never from an HQ render — a preview-sized one yields the same thumbnail.
-            wants_thumb = task.readback_metrics and task.preview_size <= APP_CONFIG.preview_render_size
-            if wants_thumb and isinstance(result, GPUTexture):
-                metrics["thumbnail_source"] = np.ascontiguousarray(result.readback()[:, :, :3])
+            # Taken here because the engine recycles its stage textures next frame.
+            # Always assigned: the controller merges metrics into a running dict, so a
+            # stale entry would be filed under this asset's key.
+            metrics["thumbnail_source"] = (
+                np.ascontiguousarray(result.readback()[:, :, :3]) if task.wants_thumbnail and isinstance(result, GPUTexture) else None
+            )
 
             # Ensure ground truth is stored in metrics for view consumption
             metrics["base_positive"] = result

--- a/negpy/infrastructure/display/color_mgmt.py
+++ b/negpy/infrastructure/display/color_mgmt.py
@@ -62,10 +62,9 @@ def get_display_lut(
     """3D LUT converting the assumed source space (`WORKING_COLOR_SPACE`) to the
     display profile.
 
-    ``proof`` is ``(input_icc_path, output_icc_path)`` when the preview soft-proofs.
-    The LUT then carries source→output-proof→display in one hop, so the canvas
-    shader, the CPU overlay and the filmstrip thumbnail all apply the identical
-    transform to the same buffer — they must, or one frame shows two colours.
+    ``proof`` is ``(input_icc_path, output_icc_path)`` when the preview soft-proofs;
+    the LUT then carries source→output-proof→display in one hop. Every consumer of a
+    rendered buffer must take the same LUT, or one frame shows two colours.
 
     ``working_color_space`` is the profile the camera-native pipeline numbers are
     *assumed* to be in (see `color_spaces.WORKING_COLOR_SPACE`), not a real working
@@ -76,8 +75,8 @@ def get_display_lut(
     profile). Used by both the CPU (`ImageConverter.to_qimage`) and GPU display paths.
     """
     if proof is not None:
-        # Deferred: image_processor owns the proof's branch selection (print profile
-        # vs export space vs GRAY) and pulls this module in itself.
+        # Deferred: image_processor owns the proof's branch selection and imports this
+        # module itself.
         from negpy.services.rendering.image_processor import ImageProcessor
 
         return ImageProcessor.soft_proof_lut(working_color_space, proof[0], proof[1], dst_bytes)

--- a/negpy/infrastructure/display/color_mgmt.py
+++ b/negpy/infrastructure/display/color_mgmt.py
@@ -1,7 +1,7 @@
 import io
 import os
 from functools import lru_cache
-from typing import Any, Optional
+from typing import Any, Optional, Tuple
 
 import numpy as np
 from PIL import Image, ImageCms
@@ -54,9 +54,18 @@ def profile_description(data: Optional[bytes]) -> str:
 
 
 @lru_cache(maxsize=16)
-def get_display_lut(working_color_space: str, dst_bytes: Optional[bytes] = None) -> Optional[np.ndarray]:
+def get_display_lut(
+    working_color_space: str,
+    dst_bytes: Optional[bytes] = None,
+    proof: Optional[Tuple[Optional[str], Optional[str]]] = None,
+) -> Optional[np.ndarray]:
     """3D LUT converting the assumed source space (`WORKING_COLOR_SPACE`) to the
     display profile.
+
+    ``proof`` is ``(input_icc_path, output_icc_path)`` when the preview soft-proofs.
+    The LUT then carries source→output-proof→display in one hop, so the canvas
+    shader, the CPU overlay and the filmstrip thumbnail all apply the identical
+    transform to the same buffer — they must, or one frame shows two colours.
 
     ``working_color_space`` is the profile the camera-native pipeline numbers are
     *assumed* to be in (see `color_spaces.WORKING_COLOR_SPACE`), not a real working
@@ -66,6 +75,12 @@ def get_display_lut(working_color_space: str, dst_bytes: Optional[bytes] = None)
     the display is sRGB), so callers can skip it. Cached per (source, display
     profile). Used by both the CPU (`ImageConverter.to_qimage`) and GPU display paths.
     """
+    if proof is not None:
+        # Deferred: image_processor owns the proof's branch selection (print profile
+        # vs export space vs GRAY) and pulls this module in itself.
+        from negpy.services.rendering.image_processor import ImageProcessor
+
+        return ImageProcessor.soft_proof_lut(working_color_space, proof[0], proof[1], dst_bytes)
     if working_color_space == ColorSpace.SRGB.value and dst_bytes is None:
         return None
     try:
@@ -84,7 +99,12 @@ def get_display_lut(working_color_space: str, dst_bytes: Optional[bytes] = None)
         return None
 
 
-def apply_display_transform(buffer: np.ndarray, working_color_space: str, dst_bytes: Optional[bytes] = None) -> np.ndarray:
+def apply_display_transform(
+    buffer: np.ndarray,
+    working_color_space: str,
+    dst_bytes: Optional[bytes] = None,
+    proof: Optional[Tuple[Optional[str], Optional[str]]] = None,
+) -> np.ndarray:
     """Convert a float32 RGB buffer from the working space to the display profile.
 
     No-op for non-RGB buffers (greyscale display stays neutral) or when the
@@ -94,7 +114,7 @@ def apply_display_transform(buffer: np.ndarray, working_color_space: str, dst_by
     """
     if buffer.dtype != np.float32 or buffer.ndim != 3 or buffer.shape[2] != 3:
         return buffer
-    lut = get_display_lut(working_color_space, dst_bytes)
+    lut = get_display_lut(working_color_space, dst_bytes, proof)
     if lut is None:
         return buffer
     from negpy.infrastructure.display.icc_lut import apply_lut_f32

--- a/negpy/services/assets/thumbnails.py
+++ b/negpy/services/assets/thumbnails.py
@@ -196,17 +196,17 @@ def get_rendered_thumbnail(
     asset_store: Any = None,
     color_space: str = WORKING_COLOR_SPACE,
     monitor_icc_bytes: Optional[bytes] = None,
+    proof: Optional[tuple] = None,
 ) -> Optional[Image.Image]:
     """
     Creates a thumbnail from a rendered float32 buffer, applying the same display
     transform the canvas applied to that buffer (mirrors ImageConverter.to_qimage).
 
-    ``color_space``/``monitor_icc_bytes`` must come from
-    ``AppController.display_transform_params`` — they encode whether the buffer is
-    still in the working space or has already been baked into display space by a
-    soft proof. Assuming working space unconditionally re-applies the working->sRGB
-    conversion to an already-converted buffer, which clips channels and leaves the
-    filmstrip visibly more saturated than the canvas.
+    ``color_space``/``monitor_icc_bytes``/``proof`` must come from
+    ``AppController.display_transform_params``. Rendered buffers are always in the
+    working space — a soft proof is folded into the display LUT, not baked into the
+    buffer — so dropping ``proof`` here leaves the filmstrip unproofed while the
+    canvas is proofed, and the two visibly disagree.
     """
     try:
         from negpy.infrastructure.display.color_mgmt import apply_display_transform
@@ -216,7 +216,7 @@ def get_rendered_thumbnail(
         if isinstance(buffer, np.ndarray) and buffer.ndim == 3 and buffer.shape[2] == 4:
             buffer = buffer[:, :, :3]
         if isinstance(buffer, np.ndarray) and buffer.dtype == np.float32:
-            buffer = apply_display_transform(buffer, color_space, monitor_icc_bytes)
+            buffer = apply_display_transform(buffer, color_space, monitor_icc_bytes, proof)
         u8_arr = float_to_uint8(buffer)
         img = Image.fromarray(u8_arr)
 

--- a/negpy/services/assets/thumbnails.py
+++ b/negpy/services/assets/thumbnails.py
@@ -204,9 +204,8 @@ def get_rendered_thumbnail(
 
     ``color_space``/``monitor_icc_bytes``/``proof`` must come from
     ``AppController.display_transform_params``. Rendered buffers are always in the
-    working space — a soft proof is folded into the display LUT, not baked into the
-    buffer — so dropping ``proof`` here leaves the filmstrip unproofed while the
-    canvas is proofed, and the two visibly disagree.
+    working space: a soft proof rides the display LUT rather than the buffer, so
+    dropping ``proof`` here leaves the filmstrip unproofed beside a proofed canvas.
     """
     try:
         from negpy.infrastructure.display.color_mgmt import apply_display_transform

--- a/negpy/services/rendering/gpu_engine.py
+++ b/negpy/services/rendering/gpu_engine.py
@@ -1094,6 +1094,15 @@ class GPUEngine:
             "neutral_axis_refs": neutral_axis_refs,
         }
 
+        if not tiling_mode and not readback_metrics:
+            # Back-pressure. The caller treats the returned texture as a finished frame,
+            # but submit() only queues the work — an HQ frame is ~2.6ms to submit and
+            # ~359ms to actually run. Without this wait the render queue's "one in
+            # flight" coalescing is defeated: a drag submits frames far faster than the
+            # GPU retires them, and the canvas's own present then blocks behind the
+            # backlog, which reads as a frozen slider. The readback below already waits.
+            device.queue.on_submitted_work_done_sync()
+
         if not tiling_mode and readback_metrics:
             raw_metrics = self._readback_metrics()
             metrics["histogram_raw"] = raw_metrics[:_METRICS_HIST_WORDS].reshape((4, HISTOGRAM_BINS))

--- a/negpy/services/rendering/gpu_engine.py
+++ b/negpy/services/rendering/gpu_engine.py
@@ -252,8 +252,8 @@ class GPUEngine:
         self._last_settings: Optional[WorkspaceConfig] = None
         self._last_targets_rev: int = -1
         self._last_scale_factor: float = 1.0
-        # Layout/paper dims key off render_size_ref, which no config field carries —
-        # without this a size-only change could resume past the layout pass.
+        # No config field carries render_size_ref, so a size-only change would
+        # otherwise resume past the layout pass.
         self._last_render_size_ref: Optional[float] = None
         self._retouch_num_regions = 0
         # Region build+upload cache — retouch re-dispatches on every exposure
@@ -335,7 +335,7 @@ class GPUEngine:
     def _cached_autocrop_roi(
         self, img: np.ndarray, settings: WorkspaceConfig, h_rot: int, w_rot: int, source_hash: Optional[str]
     ) -> Tuple[int, int, int, int]:
-        """Autocrop detection is a ~100ms CPU scan and no creative slider moves it.
+        """Autocrop detection is a CPU scan that no creative slider moves.
 
         Uncached without a source hash (export/tiled paths): the key could not tell
         two different buffers apart.
@@ -784,8 +784,8 @@ class GPUEngine:
                 h_rot,
             )
             if settings.local.masks:
-                # Any exposure slider re-enters this stage, but the map only moves with
-                # the masks, the geometry and the grade — rasterise + upload on those.
+                # This stage re-runs for any exposure change, but the map only moves
+                # with the masks, the geometry and the grade.
                 tiled_maps = local_maps is not None
                 ev_key = (
                     settings.local,
@@ -877,9 +877,8 @@ class GPUEngine:
         else:
             prev_tex = tex_expo
 
-        # With no regions the retouch shader is an identity copy, but its per-thread
-        # MVC arrays (array<..., 64> x5) spill to scratch and cost ~18ms at preview
-        # size whichever branch the pixel takes — so pass the buffer through instead.
+        # With no regions the shader is an identity copy, but its per-thread MVC arrays
+        # spill to scratch whichever branch a pixel takes, so pass the buffer through.
         if self._retouch_num_regions > 0:
             tex_ret = self._get_intermediate_texture(
                 w_rot,
@@ -2043,9 +2042,8 @@ class GPUEngine:
         self._bind_group_cache.clear()
         self._bind_layout_cache.clear()
         self._uv_grid_cache = None
-        # The stage textures the incremental render would resume onto are gone, so the
-        # next frame must re-upload and re-run from stage 0. Likewise the local_ev
-        # texture the dodge/burn key tracks.
+        # The stage textures a resume would paint onto are gone (local_ev included),
+        # so the next frame must re-upload and start from stage 0.
         self._current_source_hash = None
         self._last_settings = None
         self._local_ev_key = None

--- a/negpy/services/rendering/gpu_engine.py
+++ b/negpy/services/rendering/gpu_engine.py
@@ -252,6 +252,9 @@ class GPUEngine:
         self._last_settings: Optional[WorkspaceConfig] = None
         self._last_targets_rev: int = -1
         self._last_scale_factor: float = 1.0
+        # Layout/paper dims key off render_size_ref, which no config field carries —
+        # without this a size-only change could resume past the layout pass.
+        self._last_render_size_ref: Optional[float] = None
         self._retouch_num_regions = 0
         # Region build+upload cache — retouch re-dispatches on every exposure
         # frame, and rebuilds aren't free at hundreds of synthesized regions.
@@ -271,8 +274,12 @@ class GPUEngine:
 
         # (key, grid) — pure function of geometry, reused across settled frames
         self._uv_grid_cache: Optional[Tuple[Tuple, np.ndarray]] = None
+        # (key, roi) — autocrop detection, likewise geometry-only
+        self._autocrop_cache: Optional[Tuple[Tuple, Tuple[int, int, int, int]]] = None
+        # Identity of the dodge/burn EV map currently sitting in the local_ev texture.
+        self._local_ev_key: Optional[Tuple] = None
 
-    def _detect_invalidated_stage(self, settings: WorkspaceConfig, scale_factor: float) -> int:
+    def _detect_invalidated_stage(self, settings: WorkspaceConfig, scale_factor: float, render_size_ref: Optional[float] = None) -> int:
         """
         Determines the earliest pipeline stage that needs re-running.
         Returns stage index (5 unused — dodge/burn lives in the exposure pass):
@@ -288,6 +295,7 @@ class GPUEngine:
         if (
             self._last_settings is None
             or self._last_scale_factor != scale_factor
+            or self._last_render_size_ref != render_size_ref
             or self._last_settings.process.process_mode != settings.process.process_mode
         ):
             return 0
@@ -323,6 +331,36 @@ class GPUEngine:
             return 8
 
         return 9  # Nothing changed
+
+    def _cached_autocrop_roi(
+        self, img: np.ndarray, settings: WorkspaceConfig, h_rot: int, w_rot: int, source_hash: Optional[str]
+    ) -> Tuple[int, int, int, int]:
+        """Autocrop detection is a ~100ms CPU scan and no creative slider moves it.
+
+        Uncached without a source hash (export/tiled paths): the key could not tell
+        two different buffers apart.
+        """
+        if source_hash is None:
+            return _detect_autocrop_roi(img, settings, h_rot, w_rot)
+        g = settings.geometry
+        key = (
+            source_hash,
+            g.rotation,
+            g.flip_horizontal,
+            g.flip_vertical,
+            g.fine_rotation,
+            g.autocrop_offset,
+            g.autocrop_ratio,
+            g.autocrop_mode,
+            g.autocrop_rebate_trim,
+            h_rot,
+            w_rot,
+        )
+        if self._autocrop_cache is not None and self._autocrop_cache[0] == key:
+            return self._autocrop_cache[1]
+        roi = _detect_autocrop_roi(img, settings, h_rot, w_rot)
+        self._autocrop_cache = (key, roi)
+        return roi
 
     def _get_intermediate_texture(self, w: int, h: int, usage: int, label: str) -> GPUTexture:
         """Retrieves or creates a texture from the pool.
@@ -467,7 +505,7 @@ class GPUEngine:
         elif tiling_mode:
             start_stage = 0
         else:
-            start_stage = self._detect_invalidated_stage(settings, scale_factor)
+            start_stage = self._detect_invalidated_stage(settings, scale_factor, render_size_ref)
 
         # ROI calculation
         if tiling_mode and full_dims:
@@ -494,7 +532,7 @@ class GPUEngine:
                     scale_factor=scale_factor,
                 )
             elif settings.geometry.auto_crop_enabled:
-                roi = _detect_autocrop_roi(img, settings, h_rot, w_rot)
+                roi = self._cached_autocrop_roi(img, settings, h_rot, w_rot, analysis_source_hash)
             elif settings.geometry.autocrop_offset > 0:
                 margin = settings.geometry.autocrop_offset * scale_factor
                 roi = apply_margin_to_roi((0, h_rot, 0, w_rot), h_rot, w_rot, margin)
@@ -689,12 +727,6 @@ class GPUEngine:
             wgpu.TextureUsage.STORAGE_BINDING | wgpu.TextureUsage.TEXTURE_BINDING,
             "clahe",
         )
-        tex_ret = self._get_intermediate_texture(
-            w_rot,
-            h_rot,
-            wgpu.TextureUsage.STORAGE_BINDING | wgpu.TextureUsage.TEXTURE_BINDING,
-            "ret",
-        )
         tex_lab = self._get_intermediate_texture(
             w_rot,
             h_rot,
@@ -752,31 +784,49 @@ class GPUEngine:
                 h_rot,
             )
             if settings.local.masks:
-                if local_maps is None:
-                    local_maps = compute_local_maps(
-                        settings.local,
-                        h_rot,
-                        w_rot,
-                        orig_shape,
-                        rotation=settings.geometry.rotation,
-                        fine_rotation=settings.geometry.fine_rotation,
-                        flip_horizontal=settings.geometry.flip_horizontal,
-                        flip_vertical=settings.geometry.flip_vertical,
-                        distortion_k1=k1_eff,
-                    )
-                from negpy.features.exposure.logic import local_grade_factor_map
-
-                # r = dodge/burn EV, g = local grade slope factor, b unused. One
-                # texture, so the local-grade map costs no bind slot.
-                tex_local_ev.upload(
-                    np.dstack(
-                        [
-                            local_maps[:, :, 0],
-                            local_grade_factor_map(local_maps[:, :, 1], settings.exposure.grade),
-                            np.zeros_like(local_maps[:, :, 0]),
-                        ]
-                    )
+                # Any exposure slider re-enters this stage, but the map only moves with
+                # the masks, the geometry and the grade — rasterise + upload on those.
+                tiled_maps = local_maps is not None
+                ev_key = (
+                    settings.local,
+                    settings.geometry.rotation,
+                    settings.geometry.fine_rotation,
+                    settings.geometry.flip_horizontal,
+                    settings.geometry.flip_vertical,
+                    k1_eff,
+                    settings.exposure.grade,
+                    orig_shape,
+                    w_rot,
+                    h_rot,
                 )
+                if tiled_maps or self._local_ev_key != ev_key:
+                    if local_maps is None:
+                        local_maps = compute_local_maps(
+                            settings.local,
+                            h_rot,
+                            w_rot,
+                            orig_shape,
+                            rotation=settings.geometry.rotation,
+                            fine_rotation=settings.geometry.fine_rotation,
+                            flip_horizontal=settings.geometry.flip_horizontal,
+                            flip_vertical=settings.geometry.flip_vertical,
+                            distortion_k1=k1_eff,
+                        )
+                    from negpy.features.exposure.logic import local_grade_factor_map
+
+                    # r = dodge/burn EV, g = local grade slope factor, b unused. One
+                    # texture, so the local-grade map costs no bind slot.
+                    tex_local_ev.upload(
+                        np.dstack(
+                            [
+                                local_maps[:, :, 0],
+                                local_grade_factor_map(local_maps[:, :, 1], settings.exposure.grade),
+                                np.zeros_like(local_maps[:, :, 0]),
+                            ]
+                        )
+                    )
+                    # A tiled export passes a per-tile slice — not reusable next frame.
+                    self._local_ev_key = None if tiled_maps else ev_key
             self._dispatch_pass(
                 enc,
                 "exposure",
@@ -827,20 +877,33 @@ class GPUEngine:
         else:
             prev_tex = tex_expo
 
-        if start_stage <= 3:
-            self._dispatch_pass(
-                enc,
-                "retouch",
-                [
-                    (0, prev_tex.view),
-                    (1, tex_ret.view),
-                    (2, self._get_uniform_binding("retouch_u")),
-                    (3, self._buffers["retouch_s"]),
-                    (4, self._buffers["retouch_p"]),
-                ],
+        # With no regions the retouch shader is an identity copy, but its per-thread
+        # MVC arrays (array<..., 64> x5) spill to scratch and cost ~18ms at preview
+        # size whichever branch the pixel takes — so pass the buffer through instead.
+        if self._retouch_num_regions > 0:
+            tex_ret = self._get_intermediate_texture(
                 w_rot,
                 h_rot,
+                wgpu.TextureUsage.STORAGE_BINDING | wgpu.TextureUsage.TEXTURE_BINDING,
+                "ret",
             )
+            if start_stage <= 3:
+                self._dispatch_pass(
+                    enc,
+                    "retouch",
+                    [
+                        (0, prev_tex.view),
+                        (1, tex_ret.view),
+                        (2, self._get_uniform_binding("retouch_u")),
+                        (3, self._buffers["retouch_s"]),
+                        (4, self._buffers["retouch_p"]),
+                    ],
+                    w_rot,
+                    h_rot,
+                )
+            tex_healed = tex_ret
+        else:
+            tex_healed = prev_tex
 
         if start_stage <= 4:
             # Sharpen state (USM blur, or RL deconvolution) feeds the lab pass; a
@@ -852,7 +915,7 @@ class GPUEngine:
                 # div_v, blur_h, mult_v). Final estimate lands back in rl_a.
                 tex_rl_a = self._get_intermediate_texture(w_rot, h_rot, usage, "rl_a")
                 tex_rl_b = self._get_intermediate_texture(w_rot, h_rot, usage, "rl_b")
-                self._dispatch_pass(enc, "rl_init", [(0, tex_ret.view), (1, tex_rl_a.view)], w_rot, h_rot)
+                self._dispatch_pass(enc, "rl_init", [(0, tex_healed.view), (1, tex_rl_a.view)], w_rot, h_rot)
                 sk = self._buffers["sharpen_k"]
                 for _ in range(rl_iterations(settings.lab.sharpen_radius)):
                     self._dispatch_pass(enc, "rl_blur_h", [(0, tex_rl_a.view), (1, tex_rl_b.view), (2, lab_u), (3, sk)], w_rot, h_rot)
@@ -867,7 +930,7 @@ class GPUEngine:
                     enc,
                     "lab_sharpen_h",
                     [
-                        (0, tex_ret.view),
+                        (0, tex_healed.view),
                         (1, tex_sharpen_h.view),
                         (2, lab_u),
                         (3, self._buffers["sharpen_k"]),
@@ -893,7 +956,7 @@ class GPUEngine:
                 enc,
                 "lab",
                 [
-                    (0, tex_ret.view),
+                    (0, tex_healed.view),
                     (1, tex_lab.view),
                     (2, lab_u),
                     (3, tex_sharpen_v.view),
@@ -1068,6 +1131,7 @@ class GPUEngine:
         self._last_settings = settings
         self._last_targets_rev = exposure_models.TARGETS_REVISION
         self._last_scale_factor = scale_factor
+        self._last_render_size_ref = render_size_ref
         return tex_final, metrics
 
     def _upload_unified_uniforms(
@@ -1979,6 +2043,12 @@ class GPUEngine:
         self._bind_group_cache.clear()
         self._bind_layout_cache.clear()
         self._uv_grid_cache = None
+        # The stage textures the incremental render would resume onto are gone, so the
+        # next frame must re-upload and re-run from stage 0. Likewise the local_ev
+        # texture the dodge/burn key tracks.
+        self._current_source_hash = None
+        self._last_settings = None
+        self._local_ev_key = None
         if collect:
             gc.collect()
         logger.info("GPUEngine: VRAM resources released")

--- a/negpy/services/rendering/gpu_engine.py
+++ b/negpy/services/rendering/gpu_engine.py
@@ -1094,15 +1094,6 @@ class GPUEngine:
             "neutral_axis_refs": neutral_axis_refs,
         }
 
-        if not tiling_mode and not readback_metrics:
-            # Back-pressure. The caller treats the returned texture as a finished frame,
-            # but submit() only queues the work — an HQ frame is ~2.6ms to submit and
-            # ~359ms to actually run. Without this wait the render queue's "one in
-            # flight" coalescing is defeated: a drag submits frames far faster than the
-            # GPU retires them, and the canvas's own present then blocks behind the
-            # backlog, which reads as a frozen slider. The readback below already waits.
-            device.queue.on_submitted_work_done_sync()
-
         if not tiling_mode and readback_metrics:
             raw_metrics = self._readback_metrics()
             metrics["histogram_raw"] = raw_metrics[:_METRICS_HIST_WORDS].reshape((4, HISTOGRAM_BINS))

--- a/negpy/services/rendering/image_processor.py
+++ b/negpy/services/rendering/image_processor.py
@@ -64,10 +64,8 @@ from negpy.services.export.print import PrintService
 from negpy.infrastructure.display.color_spaces import ColorSpaceRegistry, WORKING_COLOR_SPACE
 from negpy.infrastructure.display.icc_lut import apply_icc_u16_rgb
 
-# Preview soft-proof LUT grid. Larger than the 33³ display LUT because the proof can
-# clip at the output gamut boundary, and trilinear interpolation across that kink is
-# where the error lives: 65³ halves the worst-case error of the 8-bit PIL round-trip
-# it replaces. Cached per profile combination, so the build cost is paid once.
+# Preview soft-proof LUT grid. Finer than the display LUT because the proof clips at
+# the output gamut boundary, and interpolating across that kink is where the error is.
 PROOF_LUT_SIZE = 65
 
 logger = get_logger(__name__)
@@ -143,8 +141,8 @@ class ImageProcessor:
         self._source_cache_key: Optional[tuple] = None
         self._source_cache_value: Optional[Tuple[np.ndarray, Optional[np.ndarray], str]] = None
 
-        # Flat-field + sensor-unmix corrected source. Both are full-buffer numpy passes
-        # that no creative slider moves, so a drag reuses the corrected buffer.
+        # Flat-field + sensor-unmix corrected source: full-buffer passes that no
+        # creative slider moves.
         self._precorrect_key: Optional[tuple] = None
         self._precorrect_value: Optional[np.ndarray] = None
 
@@ -376,8 +374,8 @@ class ImageProcessor:
         # into source_hash invalidates the engine cache when it changes. Stitch buffers
         # arrive per-part flat-fielded (both decode paths) — correcting the composite
         # canvas as one frame would stretch the gain map across the seam.
-        # Shape is in the key because HQ preview re-decodes the same file at full
-        # resolution under an unchanged source_hash.
+        # Shape is in the key: HQ re-decodes the same file larger under an unchanged
+        # source_hash.
         precorrect_key = (
             source_hash,
             img.shape,
@@ -399,8 +397,7 @@ class ImageProcessor:
             # crosstalk that was never captured.
             if not skip_flatfield and not is_rgb_triplet(settings.rgbscan) and not stitch_has_triplets(settings.stitch):
                 img = apply_sensor_correction(img, effective_sensor_matrix(settings.process))
-            # Both corrections no-op'd — caching would only pin a second reference to a
-            # buffer the preview cache already holds.
+            # Both no-op'd: caching would pin a second reference to the same buffer.
             if img is not source:
                 self._precorrect_key = precorrect_key
                 self._precorrect_value = img
@@ -1295,10 +1292,8 @@ class ImageProcessor:
         """``soft_proof_preview`` baked into an (N,N,N,3) LUT, for the preview only.
 
         Built by pushing the identity grid through ``soft_proof_preview`` itself, so
-        the print-profile / export-space / GRAY branches cannot drift from the real
-        transform. The preview proof previously rebuilt its littleCMS transform per
-        frame (~56ms); this is cached and applies in ~3ms. Export keeps the exact
-        per-pixel transform.
+        the print-profile / export-space / GRAY branches cannot drift from it. Export
+        keeps the exact per-pixel transform.
         """
         try:
             axis = np.linspace(0, 255, size).round().astype(np.uint8)

--- a/negpy/services/rendering/image_processor.py
+++ b/negpy/services/rendering/image_processor.py
@@ -6,6 +6,7 @@ import tifffile
 import imagecodecs
 import numpy as np
 from dataclasses import replace as dc_replace
+from functools import lru_cache
 from PIL import Image, ImageCms
 from typing import Callable, Tuple, Optional, Any, Dict, List
 from negpy.kernel.system.logging import get_logger
@@ -62,6 +63,12 @@ from negpy.infrastructure.loaders.helpers import NonStandardFileWrapper, get_bes
 from negpy.services.export.print import PrintService
 from negpy.infrastructure.display.color_spaces import ColorSpaceRegistry, WORKING_COLOR_SPACE
 from negpy.infrastructure.display.icc_lut import apply_icc_u16_rgb
+
+# Preview soft-proof LUT grid. Larger than the 33³ display LUT because the proof can
+# clip at the output gamut boundary, and trilinear interpolation across that kink is
+# where the error lives: 65³ halves the worst-case error of the 8-bit PIL round-trip
+# it replaces. Cached per profile combination, so the build cost is paid once.
+PROOF_LUT_SIZE = 65
 
 logger = get_logger(__name__)
 
@@ -135,6 +142,11 @@ class ImageProcessor:
         # One entry only (full-res buffers are large); treated read-only downstream.
         self._source_cache_key: Optional[tuple] = None
         self._source_cache_value: Optional[Tuple[np.ndarray, Optional[np.ndarray], str]] = None
+
+        # Flat-field + sensor-unmix corrected source. Both are full-buffer numpy passes
+        # that no creative slider moves, so a drag reuses the corrected buffer.
+        self._precorrect_key: Optional[tuple] = None
+        self._precorrect_value: Optional[np.ndarray] = None
 
         # Source-space dust detection cache. Geometry deliberately excluded from
         # the key (strokes are source-normalized); resolution excluded so an
@@ -364,14 +376,34 @@ class ImageProcessor:
         # into source_hash invalidates the engine cache when it changes. Stitch buffers
         # arrive per-part flat-fielded (both decode paths) — correcting the composite
         # canvas as one frame would stretch the gain map across the seam.
-        if not skip_flatfield and not settings.stitch.stitch_enabled:
-            img = apply_flatfield(img, settings.flatfield)
-        # Sensor unmix is a source pre-correction like flat-field. skip_flatfield buffers
-        # come from _load_source_f32, which already applied it; triplet composites take
-        # each channel from its own single-band exposure, so unmixing them would inject
-        # crosstalk that was never captured.
-        if not skip_flatfield and not is_rgb_triplet(settings.rgbscan) and not stitch_has_triplets(settings.stitch):
-            img = apply_sensor_correction(img, effective_sensor_matrix(settings.process))
+        # Shape is in the key because HQ preview re-decodes the same file at full
+        # resolution under an unchanged source_hash.
+        precorrect_key = (
+            source_hash,
+            img.shape,
+            skip_flatfield,
+            flatfield_token(settings.flatfield),
+            sensor_token(settings.process),
+            rgbscan_token(settings.rgbscan),
+            stitch_token(settings.stitch),
+        )
+        if self._precorrect_key == precorrect_key and self._precorrect_value is not None:
+            img = self._precorrect_value
+        else:
+            source = img
+            if not skip_flatfield and not settings.stitch.stitch_enabled:
+                img = apply_flatfield(img, settings.flatfield)
+            # Sensor unmix is a source pre-correction like flat-field. skip_flatfield buffers
+            # come from _load_source_f32, which already applied it; triplet composites take
+            # each channel from its own single-band exposure, so unmixing them would inject
+            # crosstalk that was never captured.
+            if not skip_flatfield and not is_rgb_triplet(settings.rgbscan) and not stitch_has_triplets(settings.stitch):
+                img = apply_sensor_correction(img, effective_sensor_matrix(settings.process))
+            # Both corrections no-op'd — caching would only pin a second reference to a
+            # buffer the preview cache already holds.
+            if img is not source:
+                self._precorrect_key = precorrect_key
+                self._precorrect_value = img
         h_orig, w_cols = img.shape[:2]
         # Fold the buffer resolution into source_hash: toggling HQ re-decodes the same
         # file at full resolution with unchanged settings, so without this the engine
@@ -441,6 +473,7 @@ class ImageProcessor:
                     scale_factor=scale_factor,
                     render_size_ref=render_size_ref,
                     readback_metrics=readback_metrics,
+                    source_hash=source_hash,
                     analysis_source_hash=source_hash,
                 )
                 context.metrics.update(gpu_metrics)
@@ -891,6 +924,8 @@ class ImageProcessor:
             # cache only pins ~300MB (24MP) across the next frame's decode.
             self._source_cache_key = None
             self._source_cache_value = None
+            self._precorrect_key = None
+            self._precorrect_value = None
 
             # A Print/Target-px export setting sizes the paper from print_size x DPI,
             # which would re-inflate the tile to full print resolution right after the
@@ -1162,8 +1197,8 @@ class ImageProcessor:
             logger.error(f"CMS transformation failed: {e}")
             return pil_img, None
 
+    @staticmethod
     def soft_proof_preview(
-        self,
         pil_img: Image.Image,
         working_color_space: str,
         input_icc_path: Optional[str],
@@ -1186,15 +1221,15 @@ class ImageProcessor:
             # littleCMS needs RGB against the RGB working/output profiles.
             if pil_img.mode != "RGB":
                 pil_img = pil_img.convert("RGB")
-            p_src = self._resolve_src_profile(working_color_space, input_icc_path)
+            p_src = ImageProcessor._resolve_src_profile(working_color_space, input_icc_path)
             # Custom output profile, or the working space when only an input is set.
-            p_dst = self._resolve_dst_profile(working_color_space, output_icc_path)
+            p_dst = ImageProcessor._resolve_dst_profile(working_color_space, output_icc_path)
             if p_dst is None:
                 return pil_img
             # Display the proof lands on: the monitor profile when detected, else sRGB.
             p_display = open_profile_from_bytes(monitor_icc_bytes) if monitor_icc_bytes else ImageCms.createProfile("sRGB")
 
-            if self._is_print_profile(p_dst):
+            if ImageProcessor._is_print_profile(p_dst):
                 # Paper/printer profile: simulate the print on screen (paper white + ink)
                 # via a proof transform — relative-colorimetric source→paper, then
                 # absolute-colorimetric paper→display so the paper white/Dmax show.
@@ -1248,6 +1283,40 @@ class ImageProcessor:
             logger.error(f"Soft-proof preview failed: {e}")
             return pil_img
 
+    @staticmethod
+    @lru_cache(maxsize=8)
+    def soft_proof_lut(
+        working_color_space: str,
+        input_icc_path: Optional[str],
+        output_icc_path: Optional[str],
+        monitor_icc_bytes: Optional[bytes] = None,
+        size: int = PROOF_LUT_SIZE,
+    ) -> Optional[np.ndarray]:
+        """``soft_proof_preview`` baked into an (N,N,N,3) LUT, for the preview only.
+
+        Built by pushing the identity grid through ``soft_proof_preview`` itself, so
+        the print-profile / export-space / GRAY branches cannot drift from the real
+        transform. The preview proof previously rebuilt its littleCMS transform per
+        frame (~56ms); this is cached and applies in ~3ms. Export keeps the exact
+        per-pixel transform.
+        """
+        try:
+            axis = np.linspace(0, 255, size).round().astype(np.uint8)
+            r, g, b = np.meshgrid(axis, axis, axis, indexing="ij")
+            grid = np.ascontiguousarray(np.stack((r, g, b), axis=-1)).reshape(size, size * size, 3)
+            proofed = ImageProcessor.soft_proof_preview(
+                Image.fromarray(grid, mode="RGB"),
+                working_color_space,
+                input_icc_path,
+                output_icc_path,
+                monitor_icc_bytes,
+            )
+            lut = np.asarray(proofed, dtype=np.float32).reshape(size, size, size, 3) / 255.0
+            return np.ascontiguousarray(lut)
+        except Exception as e:
+            logger.warning("Soft-proof LUT build failed, falling back to the per-pixel transform", exc_info=e)
+            return None
+
     def _save_to_pil_buffer(
         self,
         pil_img: Image.Image,
@@ -1273,6 +1342,8 @@ class ImageProcessor:
         if release_source_cache:
             self._source_cache_key = None
             self._source_cache_value = None
+            self._precorrect_key = None
+            self._precorrect_value = None
         if self.engine_gpu:
             self.engine_gpu.cleanup(collect=collect)
 

--- a/tests/metrics/test_render_frame.py
+++ b/tests/metrics/test_render_frame.py
@@ -1,11 +1,9 @@
 """
 Wall-clock metrics for a preview *render frame* (synthetic buffers, real GPU).
 
-`test_preview_load` covers decode. Nothing measured a frame until now, which is how
-`source_hash` sat unwired through roughly eight perf passes: the machinery to resume
-from the first dirty stage existed, was maintained, and had never once executed.
+`test_preview_load` covers decode; this covers the render itself.
 
-A frame's cost is render-thread wall time **plus the GPU time it still owes** —
+A frame is timed as render-thread wall time **plus the GPU time it still owes**:
 `submit()` only queues work, so timing the call alone lets a change that defers work
 look like a speed-up.
 
@@ -116,9 +114,9 @@ def test_settle_frame(rig) -> None:
 def test_stage_skipping_is_actually_engaged(rig) -> None:
     """The guard the wall-clock budgets cannot give.
 
-    A regression that silently stopped passing ``source_hash`` would still land well
-    inside the budgets at this resolution — it did for eight perf passes — so assert
-    the resume itself: a toning-only change must not re-run the geometry stage.
+    A render that stopped resuming would still land inside the budgets at this
+    resolution, so assert the resume itself: a toning-only change must not re-run
+    the geometry stage.
     """
     proc, img, _ = rig
     engine = proc.engine_gpu

--- a/tests/metrics/test_render_frame.py
+++ b/tests/metrics/test_render_frame.py
@@ -1,0 +1,142 @@
+"""
+Wall-clock metrics for a preview *render frame* (synthetic buffers, real GPU).
+
+`test_preview_load` covers decode. Nothing measured a frame until now, which is how
+`source_hash` sat unwired through roughly eight perf passes: the machinery to resume
+from the first dirty stage existed, was maintained, and had never once executed.
+
+A frame's cost is render-thread wall time **plus the GPU time it still owes** —
+`submit()` only queues work, so timing the call alone lets a change that defers work
+look like a speed-up.
+
+Recorded under ``render.frame.*``; the regression check in ``test_preview_load``
+compares every metric in the session snapshot against ``NEGPY_METRICS_BASELINE``.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import time
+
+import numpy as np
+import pytest
+
+from negpy.domain.models import WorkspaceConfig
+from negpy.infrastructure.gpu.device import GPUDevice
+
+from . import recorder
+
+pytestmark = [pytest.mark.slow, pytest.mark.metrics]
+
+# Big enough that per-frame cost dominates fixed overhead, small enough to stay quick.
+_W, _H = 1600, 1066
+_FRAMES = 8
+
+
+def _gpu_available() -> bool:
+    return GPUDevice.get().is_available
+
+
+@pytest.fixture(scope="module")
+def rig():
+    if not _gpu_available():
+        pytest.skip("GPU not available")
+    import wgpu
+
+    from negpy.services.rendering.image_processor import ImageProcessor
+
+    rng = np.random.default_rng(0)
+    img = rng.random((_H, _W, 3), dtype=np.float32) * 0.5 + 0.2
+    proc = ImageProcessor()
+    engine = proc.engine_gpu
+    device = engine.gpu.device
+    sync = device.create_buffer(size=256, usage=wgpu.BufferUsage.COPY_DST | wgpu.BufferUsage.MAP_READ)
+
+    def drain() -> float:
+        """Seconds the GPU still owed when the render call returned."""
+        enc = device.create_command_encoder()
+        enc.copy_buffer_to_buffer(engine._buffers["metrics"].buffer, 0, sync, 0, 256)
+        device.queue.submit([enc.finish()])
+        t0 = time.perf_counter()
+        sync.map_sync(wgpu.MapMode.READ)
+        sync.unmap()
+        return time.perf_counter() - t0
+
+    try:
+        yield proc, img, drain
+    finally:
+        proc.destroy_all()
+
+
+def _frame_seconds(rig, mutate, *, settle: bool) -> float:
+    """Median wall time of one frame, GPU included."""
+    proc, img, drain = rig
+    base = WorkspaceConfig()
+
+    def render(i):
+        cfg = mutate(base, i)
+        t0 = time.perf_counter()
+        proc.run_pipeline(img, cfg, "metrics-frame", render_size_ref=float(_W), prefer_gpu=True, readback_metrics=settle)
+        cpu = time.perf_counter() - t0
+        return cpu + drain()
+
+    render(0)  # warm the shaders, the analysis cache and the source upload
+    return float(np.median([render(i) for i in range(1, _FRAMES + 1)]))
+
+
+def _density(base, i):
+    return dataclasses.replace(base, exposure=dataclasses.replace(base.exposure, density=0.005 * (i + 1)))
+
+
+def _sepia(base, i):
+    return dataclasses.replace(base, toning=dataclasses.replace(base.toning, sepia_strength=0.02 * (i + 1)))
+
+
+def test_drag_frame(rig) -> None:
+    """An exposure slider step: resumes from the exposure stage, no metrics readback."""
+    elapsed = _frame_seconds(rig, _density, settle=False)
+    recorder.record("render.frame.drag_s", elapsed)
+    assert elapsed < 0.5, f"a {_W}px drag frame took {elapsed * 1000:.0f}ms"
+
+
+def test_late_stage_drag_frame(rig) -> None:
+    """A toning step resumes far later in the chain, so it must not cost more."""
+    elapsed = _frame_seconds(rig, _sepia, settle=False)
+    recorder.record("render.frame.drag_late_stage_s", elapsed)
+    assert elapsed < 0.5, f"a toning-only frame took {elapsed * 1000:.0f}ms"
+
+
+def test_settle_frame(rig) -> None:
+    """Release: the same render plus the metrics/histogram readback."""
+    elapsed = _frame_seconds(rig, _density, settle=True)
+    recorder.record("render.frame.settle_s", elapsed)
+    assert elapsed < 1.0, f"a settle frame took {elapsed * 1000:.0f}ms"
+
+
+def test_stage_skipping_is_actually_engaged(rig) -> None:
+    """The guard the wall-clock budgets cannot give.
+
+    A regression that silently stopped passing ``source_hash`` would still land well
+    inside the budgets at this resolution — it did for eight perf passes — so assert
+    the resume itself: a toning-only change must not re-run the geometry stage.
+    """
+    proc, img, _ = rig
+    engine = proc.engine_gpu
+    base = WorkspaceConfig()
+    proc.run_pipeline(img, base, "skip-probe", render_size_ref=float(_W), prefer_gpu=True, readback_metrics=False)
+
+    dispatched: list[str] = []
+    real = engine._dispatch_pass
+
+    def spy(enc, name, bindings, w, h):
+        dispatched.append(name)
+        return real(enc, name, bindings, w, h)
+
+    engine._dispatch_pass = spy
+    try:
+        proc.run_pipeline(img, _sepia(base, 1), "skip-probe", render_size_ref=float(_W), prefer_gpu=True, readback_metrics=False)
+    finally:
+        engine._dispatch_pass = real
+
+    assert "toning" in dispatched, "the changed stage must run"
+    assert "geometry" not in dispatched, f"stage skipping is not engaged — geometry re-ran for a toning change: {dispatched}"

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -327,7 +327,7 @@ class TestAppController(unittest.TestCase):
         self.controller.state.config = cfg
         self.controller._on_render_finished(None, {})
         self.assertEqual(self.controller._update_thumbnail_from_state.call_count, 1)
-        self.controller._update_thumbnail_from_state.assert_called_with(force_readback=True, persist=False)
+        self.controller._update_thumbnail_from_state.assert_called_with(persist=False)
 
         # Same config object -> no redundant refresh.
         self.controller._on_render_finished(None, {})

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1859,31 +1859,59 @@ class TestDisplayTransformParams(unittest.TestCase):
         del self.controller
         gc.collect()
 
-    def test_proof_active_yields_a_no_op_transform(self):
-        self.controller.proof_active = lambda: True
-        cs, monitor = self.controller.display_transform_params()
-        # sRGB source + no monitor profile is the documented identity case in
-        # get_display_lut, i.e. the already-baked buffer is passed through untouched.
-        self.assertEqual(cs, ColorSpace.SRGB.value)
-        self.assertIsNone(monitor)
+    def test_proof_active_still_reports_the_working_space(self):
+        """The proof is not baked into the buffer — it rides the display LUT.
 
-    def test_proof_inactive_converts_from_the_working_space(self):
-        self.controller.proof_active = lambda: False
-        cs, monitor = self.controller.display_transform_params()
+        Reporting sRGB here (as the baked-buffer era did) would skip the
+        working→display conversion the render still needs.
+        """
+        self.controller.state.soft_proof_enabled = True
+        cs, monitor, proof = self.controller.display_transform_params()
         self.assertEqual(cs, self.controller.state.workspace_color_space)
         self.assertEqual(monitor, b"fake-monitor-profile")
+        self.assertIsNotNone(proof)
+
+    def test_proof_inactive_converts_from_the_working_space(self):
+        self.controller.proof_profiles = lambda: None
+        cs, monitor, proof = self.controller.display_transform_params()
+        self.assertEqual(cs, self.controller.state.workspace_color_space)
+        self.assertEqual(monitor, b"fake-monitor-profile")
+        self.assertIsNone(proof)
 
     def test_splash_buffer_is_treated_as_srgb(self):
-        self.controller.proof_active = lambda: False
-        cs, monitor = self.controller.display_transform_params(splash=True)
+        self.controller.proof_profiles = lambda: None
+        cs, monitor, proof = self.controller.display_transform_params(splash=True)
         self.assertEqual(cs, ColorSpace.SRGB.value)
         self.assertEqual(monitor, b"fake-monitor-profile")
+        self.assertIsNone(proof)
+
+    def test_proof_profiles_follows_the_soft_proof_toggle(self):
+        self.controller.state.soft_proof_enabled = False
+        self.controller.state.config = replace(
+            self.controller.state.config,
+            process=replace(self.controller.state.config.process, narrowband_scan=False),
+        )
+        self.assertIsNone(self.controller.proof_profiles())
+        self.controller.state.soft_proof_enabled = True
+        self.assertIsNotNone(self.controller.proof_profiles())
+
+    def test_narrowband_supplies_an_input_profile_with_the_toggle_off(self):
+        """Narrowband Scan proofs through its own input profile regardless."""
+        self.controller.state.soft_proof_enabled = False
+        self.controller.state.config = replace(
+            self.controller.state.config,
+            process=replace(self.controller.state.config.process, narrowband_scan=True),
+        )
+        proof = self.controller.proof_profiles()
+        self.assertIsNotNone(proof)
+        self.assertTrue(proof[0], "narrowband must supply the input profile")
+        self.assertIsNone(proof[1], "the output profile stays gated on the toggle")
 
     def test_thumbnail_task_carries_the_same_params_as_the_canvas(self):
         """The actual regression: the thumbnail used to hardcode the working space."""
         import numpy as np
 
-        self.controller.proof_active = lambda: True
+        self.controller.state.soft_proof_enabled = True
         state = self.controller.state
         state.uploaded_files = [{"name": "frame.cr2", "path": "/tmp/frame.cr2", "hash": "hash-1"}]
         state.selected_file_idx = 0
@@ -1903,8 +1931,13 @@ class TestDisplayTransformParams(unittest.TestCase):
 
         self.assertEqual(len(emitted), 1)
         task = emitted[0]
-        self.assertEqual((task.color_space, task.monitor_icc_bytes), self.controller.display_transform_params())
-        self.assertNotEqual(task.color_space, state.workspace_color_space)
+        self.assertEqual(
+            (task.color_space, task.monitor_icc_bytes, task.proof),
+            self.controller.display_transform_params(),
+        )
+        # The proof must reach the filmstrip too, or it shows an unproofed frame
+        # next to a proofed canvas.
+        self.assertIsNotNone(task.proof)
 
 
 class TestCompareFlatPeekInteraction(unittest.TestCase):

--- a/tests/test_gpu_stage_skip.py
+++ b/tests/test_gpu_stage_skip.py
@@ -1,0 +1,400 @@
+"""Incremental GPU rendering: stage skipping, the retouch bypass and the autocrop cache.
+
+``process_to_texture`` resumes from the first dirty stage when it is given a
+``source_hash``. That path had never run in production (the caller passed only
+``analysis_source_hash``), so these tests pin its two contracts: an incremental
+render is bit-identical to a full one, and the caches it relies on hit and miss
+in the right places.
+"""
+
+import unittest
+from dataclasses import replace
+
+import numpy as np
+
+from negpy.domain.models import WorkspaceConfig
+from negpy.features.process.models import ProcessMode
+from negpy.infrastructure.gpu.device import GPUDevice
+
+
+def _gpu_available() -> bool:
+    return GPUDevice.get().is_available
+
+
+def _sub(cfg: WorkspaceConfig, name: str, **kw) -> WorkspaceConfig:
+    return replace(cfg, **{name: replace(getattr(cfg, name), **kw)})
+
+
+@unittest.skipUnless(_gpu_available(), "GPU not available")
+class TestStageSkipParity(unittest.TestCase):
+    """Every stage boundary: resuming must equal re-running the whole chain."""
+
+    @classmethod
+    def setUpClass(cls):
+        from negpy.services.rendering.gpu_engine import GPUEngine
+
+        cls.GPUEngine = GPUEngine
+        rng = np.random.default_rng(0)
+        cls.img = rng.random((384, 512, 3), dtype=np.float32) * 0.6 + 0.05
+
+    def setUp(self):
+        self.inc = self.GPUEngine()
+        self.ref = self.GPUEngine()
+        self.addCleanup(self.inc.destroy_all)
+        self.addCleanup(self.ref.destroy_all)
+
+    def _assert_same(self, label, cfg, *, source_hash="frame", size=1600.0, scale=1.0):
+        inc_tex, _ = self.inc.process_to_texture(
+            self.img,
+            cfg,
+            scale_factor=scale,
+            render_size_ref=size,
+            readback_metrics=True,
+            source_hash=source_hash,
+            analysis_source_hash=source_hash,
+        )
+        incremental = inc_tex.readback().copy()
+        # source_hash=None is the full-rebuild path: upload + start_stage 0.
+        ref_tex, _ = self.ref.process_to_texture(
+            self.img,
+            cfg,
+            scale_factor=scale,
+            render_size_ref=size,
+            readback_metrics=True,
+            source_hash=None,
+            analysis_source_hash=source_hash,
+        )
+        full = ref_tex.readback().copy()
+        self.assertEqual(incremental.shape, full.shape, f"{label}: shape drift")
+        self.assertTrue(np.array_equal(incremental, full), f"{label}: incremental render differs from a full one")
+
+    def test_every_stage_boundary_is_bit_identical(self):
+        base = WorkspaceConfig()
+        lit = _sub(base, "exposure", density=0.35)
+        for label, cfg in (
+            ("baseline", base),
+            ("exposure.density", lit),
+            ("exposure.grade", _sub(lit, "exposure", grade=3.0)),
+            ("process.luma_range_clip", _sub(lit, "process", luma_range_clip=0.4)),
+            ("lab.clahe on", _sub(lit, "lab", clahe_strength=0.5)),
+            ("lab.clahe off", lit),
+            ("lab.sharpen", _sub(lit, "lab", sharpen=0.8)),
+            ("lab.saturation", _sub(lit, "lab", saturation=1.4)),
+            ("retouch spot added", _sub(lit, "retouch", manual_dust_spots=[(0.5, 0.5, 100.0)])),
+            ("retouch cleared", _sub(lit, "retouch", manual_dust_spots=[])),
+            ("toning.sepia", _sub(lit, "toning", sepia_strength=0.4)),
+            ("finish.border", _sub(lit, "finish", border_size=4.0)),
+            ("geometry.rotation", _sub(lit, "geometry", rotation=1)),
+            ("geometry.rotation back", lit),
+            ("geometry.flip_horizontal", _sub(lit, "geometry", flip_horizontal=True)),
+            ("geometry.autocrop_offset", _sub(lit, "geometry", autocrop_offset=6.0)),
+            ("process_mode BW", _sub(lit, "process", process_mode=ProcessMode.BW)),
+            ("process_mode C41", _sub(lit, "process", process_mode=ProcessMode.C41)),
+            ("back to baseline", base),
+        ):
+            with self.subTest(change=label):
+                self._assert_same(label, cfg)
+
+    def test_render_size_and_scale_changes_rebuild(self):
+        """Neither is carried by a config field, so both must force a full re-run."""
+        cfg = _sub(WorkspaceConfig(), "exposure", density=0.35)
+        self._assert_same("warm-up", cfg)
+        self._assert_same("smaller print", cfg, size=900.0)
+        self._assert_same("back to full print", cfg, size=1600.0)
+        self._assert_same("scale 2.0", cfg, scale=2.0)
+        self._assert_same("scale 1.0", cfg, scale=1.0)
+
+    def test_cleanup_forces_a_full_rebuild(self):
+        """cleanup() destroys the stage textures a resume would paint onto."""
+        cfg = _sub(WorkspaceConfig(), "exposure", density=0.35)
+        self._assert_same("warm-up", cfg)
+        self.inc.cleanup(collect=False)
+        self.assertIsNone(self.inc._current_source_hash)
+        self.assertIsNone(self.inc._last_settings)
+        self._assert_same("after cleanup", cfg)
+
+    def test_export_render_does_not_poison_the_next_preview(self):
+        """process() shares the engine and passes no source_hash."""
+        cfg = _sub(WorkspaceConfig(), "exposure", density=0.35)
+        self._assert_same("warm-up", cfg)
+        self.inc.process(self.img, _sub(cfg, "exposure", density=0.9), scale_factor=1.0, readback_metrics=False)
+        self._assert_same("preview after export", cfg)
+
+
+@unittest.skipUnless(_gpu_available(), "GPU not available")
+class TestRetouchBypass(unittest.TestCase):
+    """With no heal regions the retouch shader is an identity copy, so it is skipped."""
+
+    @classmethod
+    def setUpClass(cls):
+        from negpy.services.rendering.gpu_engine import GPUEngine
+
+        cls.GPUEngine = GPUEngine
+        rng = np.random.default_rng(1)
+        img = rng.random((256, 320, 3), dtype=np.float32) * 0.1 + 0.4
+        # The heal is gated on pixels brighter than the membrane prediction, so a
+        # flat field would clone but change nothing — plant a speck to heal.
+        img[122:135, 154:167] = 0.02
+        cls.img = img
+
+    def setUp(self):
+        self.eng = self.GPUEngine()
+        self.addCleanup(self.eng.destroy_all)
+
+    def _render(self, cfg):
+        tex, _ = self.eng.process_to_texture(
+            self.img, cfg, scale_factor=1.0, readback_metrics=False, source_hash="frame", analysis_source_hash="frame"
+        )
+        return tex.readback().copy()
+
+    def test_no_regions_skips_the_dispatch(self):
+        cfg = WorkspaceConfig()
+        self._render(cfg)
+        self.assertEqual(self.eng._retouch_num_regions, 0)
+        # Skipped means the pass never allocated its output texture.
+        self.assertFalse(any(key[3] == "ret" for key in self.eng._tex_cache))
+
+    def test_heal_region_still_runs_and_changes_pixels(self):
+        cfg = WorkspaceConfig()
+        clean = self._render(cfg)
+        # Spots are (x, y) normalized to the frame plus a size in tenths of a pixel.
+        healed = self._render(_sub(cfg, "retouch", manual_dust_spots=[(0.5, 0.5, 100.0)]))
+        self.assertEqual(self.eng._retouch_num_regions, 1)
+        self.assertTrue(any(key[3] == "ret" for key in self.eng._tex_cache))
+        self.assertFalse(np.array_equal(clean, healed), "a heal region must alter the render")
+
+
+@unittest.skipUnless(_gpu_available(), "GPU not available")
+class TestAutocropCache(unittest.TestCase):
+    """Autocrop detection is a CPU scan no creative slider moves."""
+
+    @classmethod
+    def setUpClass(cls):
+        from negpy.services.rendering.gpu_engine import GPUEngine
+
+        cls.GPUEngine = GPUEngine
+        rng = np.random.default_rng(2)
+        img = rng.random((256, 320, 3), dtype=np.float32) * 0.2 + 0.05
+        img[40:210, 50:270] += 0.5  # a frame inside a rebate, so autocrop has something to find
+        cls.img = img
+
+    def setUp(self):
+        self.eng = self.GPUEngine()
+        self.addCleanup(self.eng.destroy_all)
+        self.cfg = _sub(WorkspaceConfig(), "geometry", auto_crop_enabled=True)
+
+    def _render(self, cfg, source_hash="frame"):
+        self.eng.process_to_texture(
+            self.img, cfg, scale_factor=1.0, readback_metrics=False, source_hash=source_hash, analysis_source_hash=source_hash
+        )
+
+    def _count_detections(self, fn):
+        import negpy.services.rendering.gpu_engine as ge
+
+        calls = {"n": 0}
+        real = ge._detect_autocrop_roi
+
+        def spy(*a, **k):
+            calls["n"] += 1
+            return real(*a, **k)
+
+        ge._detect_autocrop_roi = spy
+        try:
+            fn()
+        finally:
+            ge._detect_autocrop_roi = real
+        return calls["n"]
+
+    def test_creative_drag_detects_once(self):
+        def drag():
+            for d in (0.1, 0.2, 0.3, 0.4):
+                self._render(_sub(self.cfg, "exposure", density=d))
+
+        self.assertEqual(self._count_detections(drag), 1)
+
+    def test_geometry_change_redetects(self):
+        def move_geometry():
+            self._render(self.cfg)
+            self._render(_sub(self.cfg, "geometry", auto_crop_enabled=True, autocrop_offset=3.0))
+
+        self.assertEqual(self._count_detections(move_geometry), 2)
+
+    def test_new_source_redetects(self):
+        def switch_source():
+            self._render(self.cfg, source_hash="a")
+            self._render(self.cfg, source_hash="b")
+
+        self.assertEqual(self._count_detections(switch_source), 2)
+
+    def test_uncached_without_a_source_hash(self):
+        """The export/tiled paths pass none — the key could not tell two buffers apart."""
+
+        def no_hash():
+            for _ in range(3):
+                self.eng.process_to_texture(self.img, self.cfg, scale_factor=1.0, readback_metrics=False)
+
+        self.assertEqual(self._count_detections(no_hash), 3)
+
+
+@unittest.skipUnless(_gpu_available(), "GPU not available")
+class TestLocalMapCache(unittest.TestCase):
+    """The dodge/burn EV map is rasterised on the CPU and uploaded whole."""
+
+    @classmethod
+    def setUpClass(cls):
+        from negpy.features.local.models import LocalMask, MaskShape
+        from negpy.services.rendering.gpu_engine import GPUEngine
+
+        cls.GPUEngine = GPUEngine
+        rng = np.random.default_rng(3)
+        cls.img = rng.random((256, 320, 3), dtype=np.float32) * 0.5 + 0.2
+        cls.mask = LocalMask(
+            vertices=((0.3, 0.3), (0.7, 0.3), (0.7, 0.7), (0.3, 0.7)),
+            stops=0.8,
+            grade=1.0,
+            shape=MaskShape.POLYGON,
+        )
+
+    def setUp(self):
+        self.eng = self.GPUEngine()
+        self.addCleanup(self.eng.destroy_all)
+        base = WorkspaceConfig()
+        self.cfg = replace(base, local=replace(base.local, masks=(self.mask,)))
+
+    def _render(self, cfg):
+        self.eng.process_to_texture(
+            self.img, cfg, scale_factor=1.0, readback_metrics=False, source_hash="frame", analysis_source_hash="frame"
+        )
+
+    def _count_rasterisations(self, fn):
+        import negpy.services.rendering.gpu_engine as ge
+
+        calls = {"n": 0}
+        real = ge.compute_local_maps
+
+        def spy(*a, **k):
+            calls["n"] += 1
+            return real(*a, **k)
+
+        ge.compute_local_maps = spy
+        try:
+            fn()
+        finally:
+            ge.compute_local_maps = real
+        return calls["n"]
+
+    def test_creative_drag_rasterises_once(self):
+        def drag():
+            for d in (0.1, 0.2, 0.3, 0.4):
+                self._render(_sub(self.cfg, "exposure", density=d))
+
+        self.assertEqual(self._count_rasterisations(drag), 1)
+
+    def test_grade_change_rebuilds_the_map(self):
+        """The green lane carries a grade-derived slope factor."""
+
+        def move_grade():
+            self._render(self.cfg)
+            self._render(_sub(self.cfg, "exposure", grade=4.0))
+
+        self.assertEqual(self._count_rasterisations(move_grade), 2)
+
+    def test_mask_edit_rebuilds_the_map(self):
+        def move_mask():
+            self._render(self.cfg)
+            edited = replace(self.cfg.local, masks=(replace(self.mask, stops=-0.5),))
+            self._render(replace(self.cfg, local=edited))
+
+        self.assertEqual(self._count_rasterisations(move_mask), 2)
+
+
+@unittest.skipUnless(_gpu_available(), "GPU not available")
+class TestSourcePreCorrectionCache(unittest.TestCase):
+    """Flat-field and sensor unmix are full-buffer passes no creative slider moves."""
+
+    MATRIX = (1.06, -0.04, -0.02, -0.05, 1.08, -0.03, -0.01, -0.04, 1.05)
+
+    @classmethod
+    def setUpClass(cls):
+        from negpy.services.rendering.image_processor import ImageProcessor
+
+        cls.ImageProcessor = ImageProcessor
+        rng = np.random.default_rng(4)
+        cls.img = rng.random((256, 320, 3), dtype=np.float32) * 0.5 + 0.2
+
+    def setUp(self):
+        self.proc = self.ImageProcessor()
+        self.addCleanup(self.proc.destroy_all)
+        # The unmix only applies on a Linear RAW basis (see sensor_unmix_available).
+        self.cfg = _sub(WorkspaceConfig(), "process", sensor_matrix=self.MATRIX, linear_raw=True)
+
+    def _render(self, cfg, img=None):
+        buffer, _ = self.proc.run_pipeline(
+            self.img if img is None else img,
+            cfg,
+            "frame",
+            render_size_ref=1600.0,
+            prefer_gpu=True,
+            readback_metrics=False,
+        )
+        return buffer.readback().copy()
+
+    def _count_corrections(self, fn):
+        import negpy.services.rendering.image_processor as ipm
+
+        calls = {"n": 0}
+        real = ipm.apply_sensor_correction
+
+        def spy(*a, **k):
+            calls["n"] += 1
+            return real(*a, **k)
+
+        ipm.apply_sensor_correction = spy
+        try:
+            fn()
+        finally:
+            ipm.apply_sensor_correction = real
+        return calls["n"]
+
+    def test_cached_render_matches_an_uncached_one(self):
+        from negpy.features.process.sensor import effective_sensor_matrix
+
+        self.assertIsNotNone(effective_sensor_matrix(self.cfg.process), "matrix must be active for this test to mean anything")
+        cached = self._render(_sub(self.cfg, "exposure", density=0.4))
+        fresh = self.ImageProcessor()
+        try:
+            uncached, _ = fresh.run_pipeline(
+                self.img, _sub(self.cfg, "exposure", density=0.4), "frame", render_size_ref=1600.0, prefer_gpu=True, readback_metrics=False
+            )
+            self.assertTrue(np.array_equal(cached, uncached.readback()))
+        finally:
+            fresh.destroy_all()
+
+    def test_creative_drag_corrects_once(self):
+        def drag():
+            for d in (0.1, 0.2, 0.3, 0.4):
+                self._render(_sub(self.cfg, "exposure", density=d))
+
+        self.assertEqual(self._count_corrections(drag), 1)
+
+    def test_matrix_change_recorrects(self):
+        def change():
+            self._render(self.cfg)
+            self._render(_sub(self.cfg, "process", sensor_matrix=(1.1, 0, 0, 0, 1.1, 0, 0, 0, 1.1), linear_raw=True))
+
+        self.assertEqual(self._count_corrections(change), 2)
+
+    def test_resolution_change_recorrects(self):
+        """HQ preview re-decodes the same file larger under an unchanged source hash."""
+        rng = np.random.default_rng(5)
+        big = rng.random((512, 640, 3), dtype=np.float32) * 0.5 + 0.2
+
+        def toggle_hq():
+            self._render(self.cfg)
+            self._render(self.cfg, img=big)
+
+        self.assertEqual(self._count_corrections(toggle_hq), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gpu_stage_skip.py
+++ b/tests/test_gpu_stage_skip.py
@@ -396,54 +396,5 @@ class TestSourcePreCorrectionCache(unittest.TestCase):
         self.assertEqual(self._count_corrections(toggle_hq), 2)
 
 
-@unittest.skipUnless(_gpu_available(), "GPU not available")
-class TestFrameCompletionBackPressure(unittest.TestCase):
-    """A returned texture must be a finished frame, not a queued one.
-
-    ``submit()`` only enqueues work: an HQ frame is ~2.6ms to submit and ~359ms to
-    run. Returning at submit time defeats the render queue's "one in flight"
-    coalescing, so a drag piles frames onto the GPU far faster than it retires them
-    and the canvas's own present blocks behind the backlog — a frozen slider.
-    """
-
-    @classmethod
-    def setUpClass(cls):
-        from negpy.services.rendering.gpu_engine import GPUEngine
-
-        cls.GPUEngine = GPUEngine
-        rng = np.random.default_rng(6)
-        cls.img = rng.random((256, 320, 3), dtype=np.float32) * 0.5 + 0.2
-
-    def setUp(self):
-        self.eng = self.GPUEngine()
-        self.addCleanup(self.eng.destroy_all)
-
-    def _count_waits(self, **kw):
-        self.eng.process_to_texture(self.img, WorkspaceConfig(), scale_factor=1.0, **kw)
-        queue = self.eng.gpu.device.queue
-        calls = {"n": 0}
-        real = queue.on_submitted_work_done_sync
-
-        def spy(*a, **k):
-            calls["n"] += 1
-            return real(*a, **k)
-
-        queue.on_submitted_work_done_sync = spy
-        try:
-            self.eng.process_to_texture(self.img, WorkspaceConfig(), scale_factor=1.0, **kw)
-        finally:
-            queue.on_submitted_work_done_sync = real
-        return calls["n"]
-
-    def test_drag_frame_waits_for_the_gpu(self):
-        waits = self._count_waits(readback_metrics=False, source_hash="f", analysis_source_hash="f")
-        self.assertEqual(waits, 1, "a drag frame must not report done while the GPU is still working")
-
-    def test_settle_frame_relies_on_the_metrics_readback(self):
-        """The readback already blocks on completion — waiting twice is wasted."""
-        waits = self._count_waits(readback_metrics=True, source_hash="f", analysis_source_hash="f")
-        self.assertEqual(waits, 0)
-
-
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_gpu_stage_skip.py
+++ b/tests/test_gpu_stage_skip.py
@@ -396,5 +396,54 @@ class TestSourcePreCorrectionCache(unittest.TestCase):
         self.assertEqual(self._count_corrections(toggle_hq), 2)
 
 
+@unittest.skipUnless(_gpu_available(), "GPU not available")
+class TestFrameCompletionBackPressure(unittest.TestCase):
+    """A returned texture must be a finished frame, not a queued one.
+
+    ``submit()`` only enqueues work: an HQ frame is ~2.6ms to submit and ~359ms to
+    run. Returning at submit time defeats the render queue's "one in flight"
+    coalescing, so a drag piles frames onto the GPU far faster than it retires them
+    and the canvas's own present blocks behind the backlog — a frozen slider.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        from negpy.services.rendering.gpu_engine import GPUEngine
+
+        cls.GPUEngine = GPUEngine
+        rng = np.random.default_rng(6)
+        cls.img = rng.random((256, 320, 3), dtype=np.float32) * 0.5 + 0.2
+
+    def setUp(self):
+        self.eng = self.GPUEngine()
+        self.addCleanup(self.eng.destroy_all)
+
+    def _count_waits(self, **kw):
+        self.eng.process_to_texture(self.img, WorkspaceConfig(), scale_factor=1.0, **kw)
+        queue = self.eng.gpu.device.queue
+        calls = {"n": 0}
+        real = queue.on_submitted_work_done_sync
+
+        def spy(*a, **k):
+            calls["n"] += 1
+            return real(*a, **k)
+
+        queue.on_submitted_work_done_sync = spy
+        try:
+            self.eng.process_to_texture(self.img, WorkspaceConfig(), scale_factor=1.0, **kw)
+        finally:
+            queue.on_submitted_work_done_sync = real
+        return calls["n"]
+
+    def test_drag_frame_waits_for_the_gpu(self):
+        waits = self._count_waits(readback_metrics=False, source_hash="f", analysis_source_hash="f")
+        self.assertEqual(waits, 1, "a drag frame must not report done while the GPU is still working")
+
+    def test_settle_frame_relies_on_the_metrics_readback(self):
+        """The readback already blocks on completion — waiting twice is wasted."""
+        waits = self._count_waits(readback_metrics=True, source_hash="f", analysis_source_hash="f")
+        self.assertEqual(waits, 0)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_interactive_decoupling.py
+++ b/tests/test_interactive_decoupling.py
@@ -1,0 +1,93 @@
+"""While a gesture is live, the UI thread must not handle a full-resolution frame.
+
+Qt runs widget input and painting on one thread, so "decoupled" can only mean that
+nothing expensive runs on that thread while the user is dragging. Interactive frames
+render against a preview-resolution proxy and skip every consumer that only has to be
+right once the gesture settles.
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import numpy as np
+
+from negpy.desktop.controller import _interactive_proxy
+from negpy.kernel.system.config import APP_CONFIG
+
+
+class TestInteractiveProxy(unittest.TestCase):
+    def test_hq_buffer_gets_a_preview_sized_proxy(self):
+        raw = np.zeros((4000, 6000, 3), dtype=np.float32)
+        proxy = _interactive_proxy(raw)
+        self.assertIsNotNone(proxy)
+        self.assertEqual(max(proxy.shape[:2]), APP_CONFIG.preview_render_size)
+        self.assertAlmostEqual(proxy.shape[1] / proxy.shape[0], 6000 / 4000, places=2)
+
+    def test_preview_sized_buffer_needs_no_proxy(self):
+        raw = np.zeros((1066, APP_CONFIG.preview_render_size, 3), dtype=np.float32)
+        self.assertIsNone(_interactive_proxy(raw), "a proxy of the same size would be pure copying")
+
+    def test_non_array_buffers_are_ignored(self):
+        self.assertIsNone(_interactive_proxy(None))
+        self.assertIsNone(_interactive_proxy(object()))
+
+
+class TestSettleOnlyWorkIsSkipped(unittest.TestCase):
+    def test_thumbnail_is_not_refreshed_mid_gesture(self):
+        from negpy.desktop.controller import AppController
+
+        stub = SimpleNamespace(
+            _is_rendering=True,
+            _clear_busy_toast=MagicMock(),
+            _first_render_t0=None,
+            _pending_render_task=None,
+            _thumb_config=object(),
+            _render_memo=MagicMock(),
+            _gpu_fallback_notified=True,
+            state=SimpleNamespace(
+                config=object(),
+                metrics_lock=MagicMock(__enter__=lambda s: None, __exit__=lambda s, *a: None),
+                last_metrics={},
+                current_file_hash="h1",
+            ),
+            image_updated=MagicMock(),
+            _update_thumbnail_from_state=MagicMock(),
+            set_status=MagicMock(),
+            render_requested=MagicMock(),
+        )
+        AppController._on_render_finished(stub, None, {"interactive": True, "source_hash": "h1"})
+        stub._update_thumbnail_from_state.assert_not_called()
+
+        stub._thumb_config = object()
+        AppController._on_render_finished(stub, None, {"interactive": False, "source_hash": "h1"})
+        stub._update_thumbnail_from_state.assert_called_once()
+
+    def test_analysis_panel_skips_interactive_frames(self):
+        from negpy.desktop.view.sidebar.right_panel import RightPanel
+
+        panel = MagicMock()
+        panel.controller.session.state.last_metrics = {"interactive": True}
+        RightPanel._update_analysis(panel)
+        panel._update_histograms.assert_not_called()
+
+    def test_bounds_are_not_persisted_mid_gesture(self):
+        from negpy.desktop.controller import AppController
+
+        stub = SimpleNamespace(
+            state=SimpleNamespace(
+                metrics_lock=MagicMock(__enter__=lambda s: None, __exit__=lambda s, *a: None),
+                last_metrics={},
+                ir_degenerate=False,
+                current_file_hash="h1",
+                config=MagicMock(),
+            ),
+            metrics_available=MagicMock(),
+            session=MagicMock(),
+        )
+        AppController._on_metrics_updated(stub, {"interactive": True, "log_bounds": object(), "source_hash": "h1"})
+        stub.session.update_config.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_interactive_decoupling.py
+++ b/tests/test_interactive_decoupling.py
@@ -12,7 +12,7 @@ from unittest.mock import MagicMock
 
 import numpy as np
 
-from negpy.desktop.controller import _interactive_proxy
+from negpy.desktop.controller import _interactive_ir_proxy, _interactive_proxy
 from negpy.kernel.system.config import APP_CONFIG
 
 
@@ -31,6 +31,43 @@ class TestInteractiveProxy(unittest.TestCase):
     def test_non_array_buffers_are_ignored(self):
         self.assertIsNone(_interactive_proxy(None))
         self.assertIsNone(_interactive_proxy(object()))
+
+
+class TestIrFollowsTheProxy(unittest.TestCase):
+    """The pipeline reads the IR plane against the image it is handed.
+
+    Proxying one without the other does not raise — it silently applies the wrong
+    dust correction, which is why this is pinned rather than left to a shape check.
+    """
+
+    def setUp(self):
+        rng = np.random.default_rng(0)
+        self.raw = rng.random((2000, 3000, 3), dtype=np.float32).astype(np.float32)
+        self.ir = np.full((2000, 3000), 0.9, dtype=np.float32)
+        self.ir[500:520, 700:720] = 0.2  # a defect: a minimum in transmittance
+
+    def test_ir_proxy_matches_the_image_proxy(self):
+        proxy = _interactive_proxy(self.raw)
+        ir_proxy = _interactive_ir_proxy(self.ir, proxy)
+        self.assertIsNotNone(ir_proxy)
+        self.assertEqual(ir_proxy.shape[:2], proxy.shape[:2])
+
+    def test_defect_minimum_survives_the_downsample(self):
+        """A defect is a minimum; averaging it away would hide dust from the drag preview."""
+        proxy = _interactive_proxy(self.raw)
+        ir_proxy = _interactive_ir_proxy(self.ir, proxy)
+        self.assertLess(ir_proxy.min(), 0.4)
+
+    def test_no_ir_proxy_without_an_image_proxy(self):
+        self.assertIsNone(_interactive_ir_proxy(self.ir, None))
+
+    def test_no_ir_proxy_without_ir(self):
+        self.assertIsNone(_interactive_ir_proxy(None, _interactive_proxy(self.raw)))
+
+    def test_already_matching_ir_is_passed_through(self):
+        proxy = _interactive_proxy(self.raw)
+        matched = np.full(proxy.shape[:2], 0.9, dtype=np.float32)
+        self.assertIs(_interactive_ir_proxy(matched, proxy), matched)
 
 
 class TestSettleOnlyWorkIsSkipped(unittest.TestCase):

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -3,38 +3,82 @@ from unittest.mock import patch
 
 import numpy as np
 
-from negpy.desktop.view.main_window import _display_buffer_for_canvas
-
 
 class _FakeGPUTexture:
+    """Counts readbacks, so a test can prove the GPU display path never triggers one."""
+
     def __init__(self, array: np.ndarray):
         self._array = array
+        self.height, self.width = array.shape[:2]
+        self.readbacks = 0
 
     def readback(self) -> np.ndarray:
+        self.readbacks += 1
         return self._array
 
 
-class TestDisplayBufferForCanvas(unittest.TestCase):
-    def test_gpu_readback_drops_alpha_channel(self):
-        rgba = np.zeros((4, 5, 4), dtype=np.float32)
-        rgba[:, :, 0] = 0.25
-        rgba[:, :, 1] = 0.5
-        rgba[:, :, 2] = 0.75
-        rgba[:, :, 3] = 1.0
+def _rgba() -> np.ndarray:
+    rgba = np.zeros((4, 5, 4), dtype=np.float32)
+    rgba[:, :, 0] = 0.25
+    rgba[:, :, 1] = 0.5
+    rgba[:, :, 2] = 0.75
+    rgba[:, :, 3] = 1.0
+    return rgba
 
-        with patch("negpy.desktop.view.main_window.GPUTexture", _FakeGPUTexture):
-            buffer = _display_buffer_for_canvas(_FakeGPUTexture(rgba))
 
-        self.assertIsInstance(buffer, np.ndarray)
+class TestCanvasBufferRouting(unittest.TestCase):
+    """A GPU texture goes to the shader untouched; only the CPU overlay reads it back."""
+
+    def _stub(self, gpu_enabled: bool):
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock
+
+        return SimpleNamespace(
+            state=SimpleNamespace(gpu_enabled=gpu_enabled),
+            gpu_widget=MagicMock(),
+            overlay=MagicMock(),
+            _raise_floating_widgets=MagicMock(),
+            zoom_changed=MagicMock(),
+            zoom_level=1.0,
+            _last_buffer=None,
+        )
+
+    def test_gpu_path_does_not_read_back(self):
+        from negpy.desktop.view.canvas.widget import ImageCanvas
+
+        tex = _FakeGPUTexture(_rgba())
+        stub = self._stub(True)
+        with patch("negpy.desktop.view.canvas.widget.GPUTexture", _FakeGPUTexture):
+            ImageCanvas.update_buffer(stub, tex, "Adobe RGB")
+
+        self.assertEqual(tex.readbacks, 0, "the GPU display path must not copy pixels to the host")
+        stub.gpu_widget.update_texture.assert_called_once_with(tex)
+        self.assertIsNone(stub.overlay.update_buffer.call_args[0][0])
+
+    def test_cpu_path_reads_back_and_drops_alpha(self):
+        from negpy.desktop.view.canvas.widget import ImageCanvas
+
+        tex = _FakeGPUTexture(_rgba())
+        stub = self._stub(False)
+        with patch("negpy.desktop.view.canvas.widget.GPUTexture", _FakeGPUTexture):
+            ImageCanvas.update_buffer(stub, tex, "Adobe RGB")
+
+        self.assertEqual(tex.readbacks, 1)
+        buffer = stub.overlay.update_buffer.call_args[0][0]
         self.assertEqual(buffer.shape, (4, 5, 3))
         np.testing.assert_allclose(buffer[:, :, 0], 0.25)
         np.testing.assert_allclose(buffer[:, :, 1], 0.5)
         np.testing.assert_allclose(buffer[:, :, 2], 0.75)
 
-    def test_non_gpu_buffer_passes_through(self):
-        array = np.zeros((2, 2, 3), dtype=np.float32)
+    def test_ndarray_passes_through_untouched(self):
+        from negpy.desktop.view.canvas.widget import ImageCanvas
 
-        self.assertIs(_display_buffer_for_canvas(array), array)
+        array = np.zeros((2, 2, 3), dtype=np.float32)
+        stub = self._stub(True)
+        with patch("negpy.desktop.view.canvas.widget.GPUTexture", _FakeGPUTexture):
+            ImageCanvas.update_buffer(stub, array, "Adobe RGB")
+
+        self.assertIs(stub.overlay.update_buffer.call_args[0][0], array)
 
 
 class TestDropEvent(unittest.TestCase):

--- a/tests/test_overlay_gpu_instruments.py
+++ b/tests/test_overlay_gpu_instruments.py
@@ -1,0 +1,114 @@
+"""Canvas instruments that measure pixels, on the GPU display path.
+
+The GPU path hands the canvas a texture instead of host pixels, so the zone grid, the
+grain loupe and the notes sheet lost their input. They read the texture back themselves,
+once, and only when one of them is actually on.
+"""
+
+import numpy as np
+from PyQt6.QtCore import QPointF, QRectF
+from PyQt6.QtGui import QPainter, QPixmap
+
+from negpy.desktop.session import AppState
+from negpy.desktop.view.canvas.overlay import CanvasOverlay
+
+W, H = 400, 300
+
+
+class _FakeTexture:
+    def __init__(self, value: float = 0.5):
+        self.width, self.height = W, H
+        self._array = np.full((H, W, 4), value, dtype=np.float32)
+        self.readbacks = 0
+
+    def readback(self):
+        self.readbacks += 1
+        return self._array
+
+
+def _overlay(tex: _FakeTexture) -> CanvasOverlay:
+    overlay = CanvasOverlay(AppState())
+    overlay.update_buffer(None, "Adobe RGB", gpu_size=(W, H), gpu_texture=tex)
+    overlay._view_rect = QRectF(0, 0, W, H)
+    overlay._mouse_pos = QPointF(W / 2, H / 2)
+    return overlay
+
+
+def test_host_pixels_come_off_the_texture_once():
+    tex = _FakeTexture()
+    overlay = _overlay(tex)
+    buf = overlay._host_buffer()
+
+    assert buf is not None and buf.shape == (H, W, 3)
+    assert overlay._host_buffer() is buf
+    assert tex.readbacks == 1
+
+
+def test_a_new_frame_invalidates_the_host_copy():
+    overlay = _overlay(_FakeTexture(0.25))
+    first = overlay._host_buffer()
+    overlay.update_buffer(None, "Adobe RGB", gpu_size=(W, H), gpu_texture=_FakeTexture(0.75))
+
+    assert float(overlay._host_buffer().mean()) != float(first.mean())
+
+
+def test_the_zone_grid_builds_from_the_texture():
+    """Regression: the zone map went blank on the GPU path — _display_buffer was None."""
+    overlay = _overlay(_FakeTexture())
+    overlay.state.zones_overlay = True
+    pixmap = QPixmap(W, H)
+    painter = QPainter(pixmap)
+    overlay._draw_zone_grid(painter)
+    painter.end()
+
+    assert overlay._zone_cells is not None
+
+
+def test_the_loupe_gets_an_image_and_caches_it():
+    overlay = _overlay(_FakeTexture())
+    img = overlay._host_qimage()
+
+    assert img is not None and (img.width(), img.height()) == (W, H)
+    assert overlay._host_qimage() is img
+
+
+def test_the_notes_sheet_has_pixels_to_annotate():
+    overlay = _overlay(_FakeTexture())
+    assert overlay.printing_notes_sheet() is not None
+
+
+def test_nothing_is_read_back_while_no_instrument_asks():
+    """The readback is what the GPU display path exists to avoid."""
+    tex = _FakeTexture()
+    overlay = _overlay(tex)
+    pixmap = QPixmap(W, H)
+    painter = QPainter(pixmap)
+    overlay._draw_ui(painter)
+    painter.end()
+
+    assert tex.readbacks == 0
+
+
+def test_dropping_the_texture_stops_the_instruments():
+    overlay = _overlay(_FakeTexture())
+    overlay.drop_gpu_texture()
+
+    assert overlay._host_buffer() is None
+    assert overlay._host_qimage() is None
+
+
+def test_a_failed_readback_does_not_break_the_paint():
+    tex = _FakeTexture()
+    tex.readback = lambda: (_ for _ in ()).throw(RuntimeError("device lost"))
+    overlay = _overlay(tex)
+
+    assert overlay._host_buffer() is None
+
+
+def test_the_cpu_path_keeps_using_its_own_buffer():
+    overlay = CanvasOverlay(AppState())
+    buf = np.full((H, W, 3), 0.5, dtype=np.float32)
+    overlay.update_buffer(buf, "Adobe RGB")
+
+    assert overlay._host_buffer() is buf
+    assert overlay._host_qimage() is overlay._qimage

--- a/tests/test_render_worker_histogram.py
+++ b/tests/test_render_worker_histogram.py
@@ -1,7 +1,6 @@
-"""CPU renders must publish a float-domain histogram_raw before soft-proof quantization."""
+"""CPU renders must publish a float-domain histogram_raw off the pipeline output."""
 
 import numpy as np
-from PIL import Image
 
 from negpy.desktop.workers.render import RenderTask, RenderWorker
 from negpy.features.exposure.analysis import output_histogram
@@ -14,17 +13,6 @@ class _StubProcessor:
 
     def run_pipeline(self, *args, **kwargs):
         return self._result, {}
-
-    def buffer_to_pil(self, result, config):
-        return Image.fromarray((np.clip(result, 0.0, 1.0) * 255.0).astype(np.uint8))
-
-    def soft_proof_preview(self, pil_img, *args, **kwargs):
-        return pil_img
-
-    def soft_proof_lut(self, *args, **kwargs):
-        # None routes the worker to the per-pixel PIL path, whose 8-bit round-trip is
-        # what makes the "histogram came from the float buffer" assertion meaningful.
-        return None
 
 
 def _make_worker(result: np.ndarray) -> RenderWorker:
@@ -41,7 +29,7 @@ def _run(worker: RenderWorker, task: RenderTask) -> dict:
     return got
 
 
-def test_histogram_raw_binned_from_float_output_before_soft_proof():
+def test_histogram_raw_binned_from_the_float_pipeline_output():
     rng = np.random.default_rng(0)
     float_result = rng.uniform(0.2, 0.8, (32, 32, 3)).astype(np.float32)
     worker = _make_worker(float_result)
@@ -52,12 +40,12 @@ def test_histogram_raw_binned_from_float_output_before_soft_proof():
             config=DEFAULT_WORKSPACE_CONFIG,
             source_hash="h",
             preview_size=32.0,
-            icc_output_path="/fake/display.icc",
         ),
     )
     assert np.array_equal(metrics["histogram_raw"], output_histogram(float_result))
-    # base_positive is the quantized proof buffer; the histogram must not come from it.
-    assert not np.array_equal(metrics["histogram_raw"], output_histogram(metrics["base_positive"]))
+    # The worker hands the render on untouched — no proof is baked into it, so the
+    # histogram and the published buffer describe the same pixels.
+    assert metrics["base_positive"] is float_result
 
 
 def test_histogram_raw_not_recomputed_when_pipeline_provides_it():

--- a/tests/test_render_worker_histogram.py
+++ b/tests/test_render_worker_histogram.py
@@ -21,6 +21,11 @@ class _StubProcessor:
     def soft_proof_preview(self, pil_img, *args, **kwargs):
         return pil_img
 
+    def soft_proof_lut(self, *args, **kwargs):
+        # None routes the worker to the per-pixel PIL path, whose 8-bit round-trip is
+        # what makes the "histogram came from the float buffer" assertion meaningful.
+        return None
+
 
 def _make_worker(result: np.ndarray) -> RenderWorker:
     worker = RenderWorker.__new__(RenderWorker)

--- a/tests/test_sensor_calibration.py
+++ b/tests/test_sensor_calibration.py
@@ -145,6 +145,8 @@ def test_run_pipeline_gates_triplets(monkeypatch):
     ip.engine_gpu = None
     ip.engine_cpu = __import__("unittest.mock", fromlist=["MagicMock"]).MagicMock()
     ip.engine_cpu.process.return_value = np.zeros((8, 8, 3), dtype=np.float32)
+    ip._precorrect_key = None
+    ip._precorrect_value = None
     ip._augment_retouch = lambda settings, img, key: (settings, None, [])
     ip._ir_bake = lambda img, ir, settings, key: (img, None, None, None)
     ip._is_flat = lambda settings: False

--- a/tests/test_slider_widgets.py
+++ b/tests/test_slider_widgets.py
@@ -1,4 +1,3 @@
-import time
 from unittest.mock import MagicMock
 
 from PyQt6.QtCore import QEvent, QPointF, Qt
@@ -37,11 +36,12 @@ def test_adjust_by_clamps_to_range(qapp):
     assert slider.value() == 0.0
 
 
-def test_label_scrub_emits_leading_then_coalesces(qapp):
-    """Leading edge so the preview moves with the gesture, then throttled.
+def test_label_scrub_debounces_value_changes(qapp):
+    """The handle must never wait on a render.
 
-    A pure trailing debounce emitted nothing until the drag paused, which read as a
-    frozen preview; a per-move emit renders faster than the pipeline can keep up.
+    A leading-edge emit was tried and reverted: dispatching mid-drag drags the whole
+    per-render UI fan-out along with the handle, which at HQ preview makes it visibly
+    lag the mouse. Moves are coalesced until the gesture pauses.
     """
     slider = CompactSlider("Density", 0.0, 2.0, 1.0)
     changed = MagicMock()
@@ -56,15 +56,11 @@ def test_label_scrub_emits_leading_then_coalesces(qapp):
 
     assert slider.eventFilter(slider.label, press)
     assert slider.eventFilter(slider.label, move)
-
-    changed.assert_called_once_with(1.2)  # dx=40 * span/400 sensitivity
-    assert not slider.timer.isActive()
-
-    # A second move inside the throttle window is coalesced into one trailing frame.
     assert slider.eventFilter(slider.label, move_again)
-    changed.assert_called_once_with(1.2)
+
+    changed.assert_not_called()
     assert slider.timer.isActive()
-    assert slider.value() == 1.3
+    assert slider.value() == 1.3  # dx=60 * span/400 sensitivity
 
     assert slider.eventFilter(slider.label, release)
     committed.assert_called_once_with(1.3)
@@ -81,7 +77,6 @@ def test_commit_flushes_a_pending_frame_when_the_value_returned(qapp):
     slider.valueChanged.connect(changed)
     slider.valueCommitted.connect(committed)
 
-    slider._last_emit_ms = time.monotonic() * 1000.0  # inside the throttle window
     slider.slider.setValue(slider._to_int(1.5))
     assert slider.timer.isActive()
     changed.assert_not_called()

--- a/tests/test_slider_widgets.py
+++ b/tests/test_slider_widgets.py
@@ -39,9 +39,8 @@ def test_adjust_by_clamps_to_range(qapp):
 def test_label_scrub_debounces_value_changes(qapp):
     """The handle must never wait on a render.
 
-    A leading-edge emit was tried and reverted: dispatching mid-drag drags the whole
-    per-render UI fan-out along with the handle, which at HQ preview makes it visibly
-    lag the mouse. Moves are coalesced until the gesture pauses.
+    Emitting mid-drag pulls the whole per-render UI fan-out onto the handle's own
+    thread, so moves are coalesced until the gesture pauses.
     """
     slider = CompactSlider("Density", 0.0, 2.0, 1.0)
     changed = MagicMock()

--- a/tests/test_slider_widgets.py
+++ b/tests/test_slider_widgets.py
@@ -1,3 +1,4 @@
+import time
 from unittest.mock import MagicMock
 
 from PyQt6.QtCore import QEvent, QPointF, Qt
@@ -36,7 +37,12 @@ def test_adjust_by_clamps_to_range(qapp):
     assert slider.value() == 0.0
 
 
-def test_label_scrub_debounces_value_changes(qapp):
+def test_label_scrub_emits_leading_then_coalesces(qapp):
+    """Leading edge so the preview moves with the gesture, then throttled.
+
+    A pure trailing debounce emitted nothing until the drag paused, which read as a
+    frozen preview; a per-move emit renders faster than the pipeline can keep up.
+    """
     slider = CompactSlider("Density", 0.0, 2.0, 1.0)
     changed = MagicMock()
     committed = MagicMock()
@@ -45,19 +51,47 @@ def test_label_scrub_debounces_value_changes(qapp):
 
     press = _label_event(QEvent.Type.MouseButtonPress, 0.0)
     move = _label_event(QEvent.Type.MouseMove, 40.0, button=Qt.MouseButton.NoButton)
-    release = _label_event(QEvent.Type.MouseButtonRelease, 40.0, buttons=Qt.MouseButton.NoButton)
+    move_again = _label_event(QEvent.Type.MouseMove, 60.0, button=Qt.MouseButton.NoButton)
+    release = _label_event(QEvent.Type.MouseButtonRelease, 60.0, buttons=Qt.MouseButton.NoButton)
 
     assert slider.eventFilter(slider.label, press)
     assert slider.eventFilter(slider.label, move)
 
-    # Scrub moves are coalesced through the debounce timer, not emitted per move.
-    changed.assert_not_called()
+    changed.assert_called_once_with(1.2)  # dx=40 * span/400 sensitivity
+    assert not slider.timer.isActive()
+
+    # A second move inside the throttle window is coalesced into one trailing frame.
+    assert slider.eventFilter(slider.label, move_again)
+    changed.assert_called_once_with(1.2)
     assert slider.timer.isActive()
-    assert slider.value() == 1.2  # dx=40 * span/400 sensitivity
+    assert slider.value() == 1.3
 
     assert slider.eventFilter(slider.label, release)
-    committed.assert_called_once_with(1.2)
-    slider.timer.stop()
+    committed.assert_called_once_with(1.3)
+    # The commit renders that value, so the pending frame must not fire again.
+    assert not slider.timer.isActive()
+
+
+def test_commit_flushes_a_pending_frame_when_the_value_returned(qapp):
+    """Dragging away and back emits no commit, so the trailing frame is the only
+    thing that would restore the preview."""
+    slider = CompactSlider("Density", 0.0, 2.0, 1.0)
+    changed = MagicMock()
+    committed = MagicMock()
+    slider.valueChanged.connect(changed)
+    slider.valueCommitted.connect(committed)
+
+    slider._last_emit_ms = time.monotonic() * 1000.0  # inside the throttle window
+    slider.slider.setValue(slider._to_int(1.5))
+    assert slider.timer.isActive()
+    changed.assert_not_called()
+
+    slider.slider.setValue(slider._to_int(1.0))  # back to the committed value
+    slider._on_committed()
+
+    committed.assert_not_called()
+    changed.assert_called_once_with(1.0)
+    assert not slider.timer.isActive()
 
 
 def test_setvalue_rebases_commit_baseline_across_reuse(qapp):

--- a/tests/test_soft_proof_lut.py
+++ b/tests/test_soft_proof_lut.py
@@ -1,9 +1,8 @@
 """The preview soft proof rides a cached 3D LUT instead of a per-frame littleCMS transform.
 
-Rebuilding the transform on every frame cost ~56ms of every preview render. The LUT is
-built by pushing the identity grid through ``soft_proof_preview`` itself, so it cannot
-drift from the branch (print profile / export space / GRAY) it is standing in for.
-Export is unaffected — it keeps the exact per-pixel transform.
+The LUT is built by pushing the identity grid through ``soft_proof_preview`` itself,
+so it cannot drift from the branch (print profile / export space / GRAY) it stands in
+for. Export is unaffected — it keeps the exact per-pixel transform.
 """
 
 import unittest

--- a/tests/test_soft_proof_lut.py
+++ b/tests/test_soft_proof_lut.py
@@ -97,40 +97,42 @@ class TestSoftProofLut(unittest.TestCase):
         self.assertFalse(np.array_equal(plain, on_p3), "the proof must land on the monitor profile")
 
 
-class TestWorkerUsesTheLut(unittest.TestCase):
-    """The worker applies the LUT and falls back when it cannot be built."""
+class TestDisplayTransformCarriesTheProof(unittest.TestCase):
+    """The proof reaches pixels through the display transform, not the render worker."""
 
     def setUp(self):
-        from negpy.desktop.workers.render import RenderWorker
+        from negpy.infrastructure.display.color_mgmt import get_display_lut
 
-        self.worker = RenderWorker.__new__(RenderWorker)
+        get_display_lut.cache_clear()
+        ImageProcessor.soft_proof_lut.cache_clear()
         rng = np.random.default_rng(1)
         self.img = np.ascontiguousarray(rng.random((32, 48, 3), dtype=np.float32))
 
-    def test_lut_path_matches_the_pil_path(self):
-        from negpy.kernel.system.config import DEFAULT_WORKSPACE_CONFIG
+    def test_get_display_lut_returns_the_proof_lut(self):
+        from negpy.infrastructure.display.color_mgmt import get_display_lut
 
-        class _Proc:
-            soft_proof_lut = staticmethod(ImageProcessor.soft_proof_lut)
-            soft_proof_preview = staticmethod(ImageProcessor.soft_proof_preview)
-            buffer_to_pil = ImageProcessor.buffer_to_pil
-
-        self.worker._processor = _Proc()
         out_path = _srgb_path()
-        via_lut = self.worker._soft_proof(self.img, DEFAULT_WORKSPACE_CONFIG, WORKING_COLOR_SPACE, None, out_path, None)
+        proofed = get_display_lut(WORKING_COLOR_SPACE, None, (None, out_path))
+        plain = get_display_lut(WORKING_COLOR_SPACE, None, None)
+        self.assertIsNotNone(proofed)
+        self.assertEqual(proofed.shape, (PROOF_LUT_SIZE, PROOF_LUT_SIZE, PROOF_LUT_SIZE, 3))
+        self.assertFalse(plain is not None and plain.shape == proofed.shape and np.array_equal(plain, proofed))
 
-        class _NoLut(_Proc):
-            @staticmethod
-            def soft_proof_lut(*a, **k):
-                return None
+    def test_apply_display_transform_proofs(self):
+        from negpy.infrastructure.display.color_mgmt import apply_display_transform
 
-        self.worker._processor = _NoLut()
-        via_pil = self.worker._soft_proof(self.img, DEFAULT_WORKSPACE_CONFIG, WORKING_COLOR_SPACE, None, out_path, None)
-        # Both stand in for the same transform; the gap is the 8-bit round-trip the
-        # fallback still does, so it is bounded rather than zero.
-        self.assertLess(np.abs(via_lut - via_pil).mean() * 255.0, 1.0)
-        self.assertEqual(via_lut.shape, via_pil.shape)
-        self.assertEqual(via_lut.dtype, np.float32)
+        out_path = _srgb_path()
+        proofed = apply_display_transform(self.img, WORKING_COLOR_SPACE, None, (None, out_path))
+        plain = apply_display_transform(self.img, WORKING_COLOR_SPACE, None, None)
+        self.assertFalse(np.array_equal(proofed, plain), "the proof must change the displayed pixels")
+        expected = apply_lut_f32(self.img, ImageProcessor.soft_proof_lut(WORKING_COLOR_SPACE, None, out_path, None))
+        self.assertTrue(np.array_equal(proofed, expected))
+
+    def test_the_render_worker_no_longer_bakes_a_proof(self):
+        """Baking would strand the buffer on the host and break the zero-copy path."""
+        from negpy.desktop.workers.render import RenderWorker
+
+        self.assertFalse(hasattr(RenderWorker, "_soft_proof"))
 
 
 if __name__ == "__main__":

--- a/tests/test_soft_proof_lut.py
+++ b/tests/test_soft_proof_lut.py
@@ -1,0 +1,137 @@
+"""The preview soft proof rides a cached 3D LUT instead of a per-frame littleCMS transform.
+
+Rebuilding the transform on every frame cost ~56ms of every preview render. The LUT is
+built by pushing the identity grid through ``soft_proof_preview`` itself, so it cannot
+drift from the branch (print profile / export space / GRAY) it is standing in for.
+Export is unaffected — it keeps the exact per-pixel transform.
+"""
+
+import unittest
+
+import numpy as np
+
+from negpy.infrastructure.display.color_spaces import ColorSpaceRegistry, WORKING_COLOR_SPACE
+from negpy.infrastructure.display.icc_lut import apply_lut_f32
+from negpy.services.rendering.image_processor import PROOF_LUT_SIZE, ImageProcessor
+
+# Fine enough to stand in for the continuous transform when scoring the shipped grid.
+_TRUTH_LUT_SIZE = 129
+
+
+def _srgb_path() -> str:
+    return ColorSpaceRegistry.get_icc_path("sRGB")
+
+
+def _proof_lut(out_path, size, monitor=None):
+    ImageProcessor.soft_proof_lut.cache_clear()
+    return ImageProcessor.soft_proof_lut(WORKING_COLOR_SPACE, None, out_path, monitor, size)
+
+
+class TestSoftProofLut(unittest.TestCase):
+    def setUp(self):
+        ImageProcessor.soft_proof_lut.cache_clear()
+        rng = np.random.default_rng(0)
+        self.img = rng.random((48, 64, 3), dtype=np.float32)
+
+    def _per_pixel(self, img, out_path, monitor=None):
+        from PIL import Image
+
+        u8 = np.clip(img, 0.0, 1.0)
+        pil = Image.fromarray((u8 * 255.0 + 0.5).astype(np.uint8), mode="RGB")
+        proofed = ImageProcessor.soft_proof_preview(pil, WORKING_COLOR_SPACE, None, out_path, monitor)
+        return np.asarray(proofed, dtype=np.float32) / 255.0
+
+    def test_shape_and_range(self):
+        lut = ImageProcessor.soft_proof_lut(WORKING_COLOR_SPACE, None, _srgb_path())
+        self.assertIsNotNone(lut)
+        n = PROOF_LUT_SIZE
+        self.assertEqual(lut.shape, (n, n, n, 3))
+        self.assertEqual(lut.dtype, np.float32)
+        self.assertGreaterEqual(lut.min(), 0.0)
+        self.assertLessEqual(lut.max(), 1.0)
+
+    def test_more_accurate_than_the_path_it_replaces(self):
+        """The old path quantized the float buffer to 8 bits before transforming.
+
+        Scored against a 129³ stand-in for the continuous transform, the shipped grid
+        must beat that round-trip on every bundled output space — otherwise this is a
+        fidelity regression, not a speed-up. An absolute bound would be arbitrary:
+        wide-gamut destinations clip harder at the boundary, and both paths err more
+        there.
+        """
+        for space in ("sRGB", "Adobe RGB", "ProPhoto RGB", "P3 D65", "Rec 2020", "Greyscale"):
+            path = ColorSpaceRegistry.get_icc_path(space)
+            self.assertIsNotNone(path, f"{space} should be a bundled export profile")
+            with self.subTest(space=space):
+                truth = apply_lut_f32(self.img, _proof_lut(path, _TRUTH_LUT_SIZE))
+                lut_err = np.abs(apply_lut_f32(self.img, _proof_lut(path, PROOF_LUT_SIZE)) - truth)
+                old_err = np.abs(self._per_pixel(self.img, path) - truth)
+                self.assertLess(
+                    lut_err.max(),
+                    old_err.max(),
+                    f"{space}: worst-case {lut_err.max() * 255:.2f}/255 vs the old path's {old_err.max() * 255:.2f}/255",
+                )
+                self.assertLess(lut_err.mean(), old_err.mean(), f"{space}: mean error regressed")
+
+    def test_different_output_spaces_give_different_luts(self):
+        srgb = ImageProcessor.soft_proof_lut(WORKING_COLOR_SPACE, None, ColorSpaceRegistry.get_icc_path("sRGB"))
+        prophoto = ImageProcessor.soft_proof_lut(WORKING_COLOR_SPACE, None, ColorSpaceRegistry.get_icc_path("ProPhoto RGB"))
+        self.assertFalse(np.array_equal(srgb, prophoto), "the proof must depend on the output space")
+
+    def test_built_once_per_profile_combination(self):
+        out_path = _srgb_path()
+        ImageProcessor.soft_proof_lut.cache_clear()
+        for _ in range(5):
+            ImageProcessor.soft_proof_lut(WORKING_COLOR_SPACE, None, out_path)
+        self.assertEqual(ImageProcessor.soft_proof_lut.cache_info().misses, 1)
+        self.assertEqual(ImageProcessor.soft_proof_lut.cache_info().hits, 4)
+
+    def test_monitor_profile_is_part_of_the_key(self):
+        out_path = _srgb_path()
+        from negpy.infrastructure.display.color_mgmt import icc_bytes_for_space
+
+        monitor = icc_bytes_for_space("P3 D65")
+        self.assertIsNotNone(monitor, "P3 D65 should be a bundled profile")
+        plain = ImageProcessor.soft_proof_lut(WORKING_COLOR_SPACE, None, out_path)
+        on_p3 = ImageProcessor.soft_proof_lut(WORKING_COLOR_SPACE, None, out_path, monitor)
+        self.assertFalse(np.array_equal(plain, on_p3), "the proof must land on the monitor profile")
+
+
+class TestWorkerUsesTheLut(unittest.TestCase):
+    """The worker applies the LUT and falls back when it cannot be built."""
+
+    def setUp(self):
+        from negpy.desktop.workers.render import RenderWorker
+
+        self.worker = RenderWorker.__new__(RenderWorker)
+        rng = np.random.default_rng(1)
+        self.img = np.ascontiguousarray(rng.random((32, 48, 3), dtype=np.float32))
+
+    def test_lut_path_matches_the_pil_path(self):
+        from negpy.kernel.system.config import DEFAULT_WORKSPACE_CONFIG
+
+        class _Proc:
+            soft_proof_lut = staticmethod(ImageProcessor.soft_proof_lut)
+            soft_proof_preview = staticmethod(ImageProcessor.soft_proof_preview)
+            buffer_to_pil = ImageProcessor.buffer_to_pil
+
+        self.worker._processor = _Proc()
+        out_path = _srgb_path()
+        via_lut = self.worker._soft_proof(self.img, DEFAULT_WORKSPACE_CONFIG, WORKING_COLOR_SPACE, None, out_path, None)
+
+        class _NoLut(_Proc):
+            @staticmethod
+            def soft_proof_lut(*a, **k):
+                return None
+
+        self.worker._processor = _NoLut()
+        via_pil = self.worker._soft_proof(self.img, DEFAULT_WORKSPACE_CONFIG, WORKING_COLOR_SPACE, None, out_path, None)
+        # Both stand in for the same transform; the gap is the 8-bit round-trip the
+        # fallback still does, so it is bounded rather than zero.
+        self.assertLess(np.abs(via_lut - via_pil).mean() * 255.0, 1.0)
+        self.assertEqual(via_lut.shape, via_pil.shape)
+        self.assertEqual(via_lut.dtype, np.float32)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_step_wedge_widget.py
+++ b/tests/test_step_wedge_widget.py
@@ -47,16 +47,18 @@ def test_patch_bounds_tile_a_width_that_does_not_divide_evenly() -> None:
 
 
 def test_the_patches_use_the_canvas_display_transform() -> None:
-    """Guards the double-proof trap: under a soft proof the render worker already baked the
-    proof into the buffer, so the wedge must reuse the canvas's transform, not apply a second."""
+    """The wedge must reuse the canvas's whole transform, proof included — otherwise
+    it describes a different print from the frame beside it."""
     widget = StepWedgeWidget()
+    proof = (None, "/icc/sRGB-v4.icc")
     with patch("negpy.desktop.converters.ImageConverter.to_qimage") as to_qimage:
         to_qimage.return_value = QPixmap(WEDGE_STEPS, 1).toImage()
-        widget.update_data(np.linspace(0.0, 1.0, WEDGE_STEPS), 0.15, "Display P3", b"fake-icc")
+        widget.update_data(np.linspace(0.0, 1.0, WEDGE_STEPS), 0.15, "Display P3", b"fake-icc", proof)
 
-    _buf, cs, icc = to_qimage.call_args[0]
+    _buf, cs, icc, got_proof = to_qimage.call_args[0]
     assert cs == "Display P3"
     assert icc == b"fake-icc"
+    assert got_proof == proof
 
 
 def test_no_data_paints_an_empty_strip_rather_than_raising() -> None:
@@ -117,7 +119,7 @@ def _panel_stub(flat_peek: bool) -> MagicMock:
     panel.controller.state.flat_peek = flat_peek
     panel.controller.session.state.config = WorkspaceConfig()
     panel.controller.session.state.last_metrics = {}
-    panel.controller.display_transform_params.return_value = ("sRGB", None)
+    panel.controller.display_transform_params.return_value = ("sRGB", None, None)
     panel.step_wedge = StepWedgeWidget()
     return panel
 

--- a/tests/test_thumbnail_readback_thread.py
+++ b/tests/test_thumbnail_readback_thread.py
@@ -6,7 +6,6 @@ from its pool on the next frame.
 """
 
 import unittest
-from dataclasses import replace
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -82,42 +81,54 @@ class TestWorkerAttachesTheHostCopy(unittest.TestCase):
             worker.process(task)
         return got
 
-    def _task(self, buffer, readback_metrics):
+    def _task(self, buffer, wants_thumbnail, preview_size=8.0):
         return RenderTask(
             buffer=np.zeros((8, 8, 3), dtype=np.float32),
             config=DEFAULT_WORKSPACE_CONFIG,
             source_hash="h",
-            preview_size=8.0,
-            readback_metrics=readback_metrics,
+            preview_size=preview_size,
+            readback_metrics=True,
+            wants_thumbnail=wants_thumbnail,
         )
 
-    def test_settle_frame_attaches_a_host_copy(self):
+    def test_attaches_a_host_copy_when_asked(self):
         tex = _FakeTexture(np.full((8, 8, 4), 0.5, dtype=np.float32))
-        metrics = self._run(self._worker(tex), self._task(tex, readback_metrics=True))
+        metrics = self._run(self._worker(tex), self._task(tex, wants_thumbnail=True))
         self.assertEqual(tex.readbacks, 1)
         self.assertIsInstance(metrics.get("thumbnail_source"), np.ndarray)
         self.assertEqual(metrics["thumbnail_source"].shape[2], 3, "alpha lane dropped for the thumbnail")
 
-    def test_drag_frame_does_not_read_back(self):
+    def test_no_copy_when_not_asked(self):
         tex = _FakeTexture(np.full((8, 8, 4), 0.5, dtype=np.float32))
-        metrics = self._run(self._worker(tex), self._task(tex, readback_metrics=False))
-        self.assertEqual(tex.readbacks, 0, "a drag frame must never pay the readback")
+        metrics = self._run(self._worker(tex), self._task(tex, wants_thumbnail=False))
+        self.assertEqual(tex.readbacks, 0)
         self.assertIsNone(metrics.get("thumbnail_source"))
 
-    def test_cpu_render_needs_no_copy(self):
-        arr = np.full((8, 8, 3), 0.5, dtype=np.float32)
-        metrics = self._run(self._worker(arr), self._task(arr, readback_metrics=True))
-        self.assertIsNone(metrics.get("thumbnail_source"), "a host render is already its own thumbnail source")
-
-    def test_hq_render_is_not_copied(self):
-        """A preview-sized render yields the same thumbnail for a fraction of the copy."""
+    def test_hq_render_still_produces_a_thumbnail(self):
+        """Switching images with HQ on never renders that image at preview size."""
         from negpy.kernel.system.config import APP_CONFIG
 
         tex = _FakeTexture(np.full((8, 8, 4), 0.5, dtype=np.float32))
-        task = replace(self._task(tex, readback_metrics=True), preview_size=float(APP_CONFIG.preview_render_size * 4))
+        task = self._task(tex, wants_thumbnail=True, preview_size=float(APP_CONFIG.preview_render_size * 4))
         metrics = self._run(self._worker(tex), task)
-        self.assertEqual(tex.readbacks, 0)
-        self.assertIsNone(metrics.get("thumbnail_source"))
+        self.assertEqual(tex.readbacks, 1)
+        self.assertIsInstance(metrics.get("thumbnail_source"), np.ndarray)
+
+    def test_key_is_always_assigned_so_a_stale_copy_cannot_survive(self):
+        """The controller merges metrics into a running dict, so a render that produced
+        no copy must clear the previous image's."""
+        tex = _FakeTexture(np.full((8, 8, 4), 0.5, dtype=np.float32))
+        metrics = self._run(self._worker(tex), self._task(tex, wants_thumbnail=False))
+        self.assertIn("thumbnail_source", metrics)
+
+        running = {"thumbnail_source": np.full((4, 4, 3), 0.9, dtype=np.float32)}  # previous image
+        running.update(metrics)
+        self.assertIsNone(running["thumbnail_source"])
+
+    def test_cpu_render_needs_no_copy(self):
+        arr = np.full((8, 8, 3), 0.5, dtype=np.float32)
+        metrics = self._run(self._worker(arr), self._task(arr, wants_thumbnail=True))
+        self.assertIsNone(metrics.get("thumbnail_source"), "a host render is already its own thumbnail source")
 
 
 if __name__ == "__main__":

--- a/tests/test_thumbnail_readback_thread.py
+++ b/tests/test_thumbnail_readback_thread.py
@@ -7,6 +7,7 @@ recycles stage textures from its pool on the next frame.
 """
 
 import unittest
+from dataclasses import replace
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -108,6 +109,16 @@ class TestWorkerAttachesTheHostCopy(unittest.TestCase):
         arr = np.full((8, 8, 3), 0.5, dtype=np.float32)
         metrics = self._run(self._worker(arr), self._task(arr, readback_metrics=True))
         self.assertIsNone(metrics.get("thumbnail_source"), "a host render is already its own thumbnail source")
+
+    def test_hq_render_is_not_copied(self):
+        """~976MB of device time for a 256px thumbnail a preview render already made."""
+        from negpy.kernel.system.config import APP_CONFIG
+
+        tex = _FakeTexture(np.full((8, 8, 4), 0.5, dtype=np.float32))
+        task = replace(self._task(tex, readback_metrics=True), preview_size=float(APP_CONFIG.preview_render_size * 4))
+        metrics = self._run(self._worker(tex), task)
+        self.assertEqual(tex.readbacks, 0)
+        self.assertIsNone(metrics.get("thumbnail_source"))
 
 
 if __name__ == "__main__":

--- a/tests/test_thumbnail_readback_thread.py
+++ b/tests/test_thumbnail_readback_thread.py
@@ -1,9 +1,8 @@
 """The filmstrip thumbnail must never read a GPU texture back on the Qt main thread.
 
-At HQ preview the render texture is ~976MB; reading it back costs ~695ms, and doing
-that on the UI thread freezes the slider mid-drag. The render worker owns the
-readback — it is the only thread that can do it safely anyway, since the engine
-recycles stage textures from its pool on the next frame.
+A full-frame copy there stalls the UI mid-drag. The render worker owns the readback,
+and is the only thread that can take it safely: the engine recycles stage textures
+from its pool on the next frame.
 """
 
 import unittest
@@ -111,7 +110,7 @@ class TestWorkerAttachesTheHostCopy(unittest.TestCase):
         self.assertIsNone(metrics.get("thumbnail_source"), "a host render is already its own thumbnail source")
 
     def test_hq_render_is_not_copied(self):
-        """~976MB of device time for a 256px thumbnail a preview render already made."""
+        """A preview-sized render yields the same thumbnail for a fraction of the copy."""
         from negpy.kernel.system.config import APP_CONFIG
 
         tex = _FakeTexture(np.full((8, 8, 4), 0.5, dtype=np.float32))

--- a/tests/test_thumbnail_readback_thread.py
+++ b/tests/test_thumbnail_readback_thread.py
@@ -1,0 +1,114 @@
+"""The filmstrip thumbnail must never read a GPU texture back on the Qt main thread.
+
+At HQ preview the render texture is ~976MB; reading it back costs ~695ms, and doing
+that on the UI thread freezes the slider mid-drag. The render worker owns the
+readback — it is the only thread that can do it safely anyway, since the engine
+recycles stage textures from its pool on the next frame.
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+
+from negpy.desktop.workers.render import RenderTask, RenderWorker
+from negpy.kernel.system.config import DEFAULT_WORKSPACE_CONFIG
+
+
+class _FakeTexture:
+    """Stands in for GPUTexture; counts full readbacks."""
+
+    def __init__(self, array):
+        self._array = array
+        self.height, self.width = array.shape[:2]
+        self.readbacks = 0
+
+    def readback(self):
+        self.readbacks += 1
+        return self._array
+
+
+class TestControllerDoesNotReadBack(unittest.TestCase):
+    def _controller_stub(self, metrics):
+        from negpy.desktop.controller import AppController
+
+        stub = SimpleNamespace(
+            state=SimpleNamespace(
+                current_file_path="/tmp/a.arw",
+                current_file_hash="h1",
+                selected_file_idx=0,
+                uploaded_files=[{"name": "a.arw", "path": "/tmp/a.arw", "hash": "h1"}],
+                last_metrics=metrics,
+                metrics_lock=MagicMock(__enter__=lambda s: None, __exit__=lambda s, *a: None),
+            ),
+            display_transform_params=lambda splash=False: ("Adobe RGB", None, None),
+            thumbnail_update_requested=MagicMock(),
+        )
+        return AppController._update_thumbnail_from_state, stub
+
+    def test_gpu_texture_is_not_read_back_on_the_ui_thread(self):
+        tex = _FakeTexture(np.zeros((8, 8, 4), dtype=np.float32))
+        fn, stub = self._controller_stub({"base_positive": tex})
+        with patch("negpy.desktop.controller.GPUTexture", _FakeTexture):
+            fn(stub)
+        self.assertEqual(tex.readbacks, 0, "the UI thread must not read back the render texture")
+        stub.thumbnail_update_requested.emit.assert_not_called()
+
+    def test_uses_the_host_copy_the_worker_attached(self):
+        tex = _FakeTexture(np.zeros((8, 8, 4), dtype=np.float32))
+        host = np.full((8, 8, 3), 0.25, dtype=np.float32)
+        fn, stub = self._controller_stub({"base_positive": tex, "thumbnail_source": host})
+        with patch("negpy.desktop.controller.GPUTexture", _FakeTexture):
+            fn(stub)
+        self.assertEqual(tex.readbacks, 0)
+        stub.thumbnail_update_requested.emit.assert_called_once()
+        self.assertIs(stub.thumbnail_update_requested.emit.call_args[0][0].buffer, host)
+
+
+class TestWorkerAttachesTheHostCopy(unittest.TestCase):
+    """Only settle frames pay for it — a drag frame must stay readback-free."""
+
+    def _worker(self, result):
+        worker = RenderWorker.__new__(RenderWorker)
+        super(RenderWorker, worker).__init__()
+        worker._processor = SimpleNamespace(run_pipeline=lambda *a, **k: (result, {}))
+        return worker
+
+    def _run(self, worker, task):
+        got = {}
+        worker.finished.connect(lambda _r, m: got.update(m))
+        with patch("negpy.desktop.workers.render.GPUTexture", _FakeTexture):
+            worker.process(task)
+        return got
+
+    def _task(self, buffer, readback_metrics):
+        return RenderTask(
+            buffer=np.zeros((8, 8, 3), dtype=np.float32),
+            config=DEFAULT_WORKSPACE_CONFIG,
+            source_hash="h",
+            preview_size=8.0,
+            readback_metrics=readback_metrics,
+        )
+
+    def test_settle_frame_attaches_a_host_copy(self):
+        tex = _FakeTexture(np.full((8, 8, 4), 0.5, dtype=np.float32))
+        metrics = self._run(self._worker(tex), self._task(tex, readback_metrics=True))
+        self.assertEqual(tex.readbacks, 1)
+        self.assertIsInstance(metrics.get("thumbnail_source"), np.ndarray)
+        self.assertEqual(metrics["thumbnail_source"].shape[2], 3, "alpha lane dropped for the thumbnail")
+
+    def test_drag_frame_does_not_read_back(self):
+        tex = _FakeTexture(np.full((8, 8, 4), 0.5, dtype=np.float32))
+        metrics = self._run(self._worker(tex), self._task(tex, readback_metrics=False))
+        self.assertEqual(tex.readbacks, 0, "a drag frame must never pay the readback")
+        self.assertIsNone(metrics.get("thumbnail_source"))
+
+    def test_cpu_render_needs_no_copy(self):
+        arr = np.full((8, 8, 3), 0.5, dtype=np.float32)
+        metrics = self._run(self._worker(arr), self._task(arr, readback_metrics=True))
+        self.assertIsNone(metrics.get("thumbnail_source"), "a host render is already its own thumbnail source")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Draft — performance pass over the preview render path. GPU is the primary route; the CPU engine is only the fallback, so everything targets the GPU/host path.

Measured on an AMD Radeon 890M iGPU (RADV/Vulkan), `samples/DSC00448.ARW`, preview 1600px / HQ 9564x6376 (61 Mpx). Both branches measured with the same harness: render-thread wall time **plus the GPU time that frame still owes**, so a branch that returns early at submit cannot look faster than it is.

| Frame | main | this branch |
|---|---|---|
| preview drag | 135.3 ms | **12.0 ms** |
| preview settle | 128.2 ms | **37.7 ms** |
| **HQ drag** | **5580 ms** | **11.3 ms** |
| HQ settle | 4670 ms | **412.5 ms** |

Soft proofing is on out of the box (`soft_proof_enabled=True`, `export_color_space="sRGB"` resolves to a bundled profile), so the main column is the default experience, not a corner case.

## The defects

**1. `source_hash` was never passed to `process_to_texture`.** The only production caller passed `analysis_source_hash=` and nothing else, so the parameter was `None` every frame: the full ~27 MB source texture was re-uploaded *and* `start_stage` was pinned to 0. `_detect_invalidated_stage` had never executed in production — the resume-from-first-dirty-stage machinery was dead code, through roughly eight prior perf passes.

`cleanup()` now also resets `_current_source_hash` / `_last_settings` / `_local_ev_key`, because it destroys the very stage textures a resume would paint onto.

**2. The `retouch` pass cost 18.5 ms of a 26 ms GPU frame with zero heal regions.** Not the region loop — that never executes. It is ~1.8 KB of dynamically-indexed private arrays forcing a scratch spill that destroys occupancy whichever branch a pixel takes. An in-shader early `return` (18.6 ms) and dropping four of the five arrays (19.2 ms) were both built and measured, and neither helped. Skipping the dispatch does; the shader is a bit-identical copy at zero regions.

**3. `_detect_autocrop_roi` ran every frame — 100 ms** with auto-crop on, standard for film scans. The CPU engine already cached it; only the GPU path recomputed it. Flat-field, sensor unmix and the dodge/burn map get the same treatment.

**4. The soft proof rebuilt its littleCMS transform every frame** (~56 ms). It now rides a cached 65³ LUT built by pushing the identity grid through `soft_proof_preview` itself, so the print / export-space / GRAY branches cannot drift from it.

**This is strictly more accurate than the path it replaces**, which quantized to 8 bits first. Against a 129³ reference: sRGB 13.2 → **6.4**/255 worst case, Adobe RGB 13.2 → **6.4**, ProPhoto 18.1 → **10.3**, P3 14.5 → **6.5**, Rec2020 15.7 → **9.7**, Greyscale 1.33 → **0.67**. 33³ would not have been enough. **Export is untouched.**

**5. The proof was baked into the buffer, stranding every frame on the host.** It now rides the display LUT: `display_transform_params` reports the profile pair, `get_display_lut` folds it in, and canvas shader / CPU overlay / thumbnail / step wedge / test strip all take that one LUT. The LUT texture became `rgba16float` — re-quantizing a 65³ proof LUT to `rgba8unorm` would have given back exactly what item 4 bought (f16 costs 0.06/255, rgba8unorm 11.1/255).

**6. Interactive frames rendered at full HQ resolution.** Qt runs widget input and painting on one thread, so a drag put a 61 Mpx frame on it. Interactive frames now render against a preview-resolution proxy built once per load (18 ms); release re-renders the full frame. Per drag frame at HQ: GPU 381.5 → **7.6 ms**, canvas present 6.4–52 → **0.4 ms**. The same flag skips the analysis panel, the thumbnail refresh and bounds persistence — all UI-thread work that only has to be right once a gesture settles.

## Regressions found during review, and fixed here

Reviewer testing caught three things the tests did not. All are fixed, with regression tests:

- **A 695 ms readback on the Qt main thread.** Once the proof stopped baking, `_update_thumbnail_from_state` had no host array and read the texture back itself — ~976 MB at HQ. Moved to the render worker, and skipped entirely for HQ renders: 976 MB of device time to produce a 256 px thumbnail that the preview-sized render already produced identically.
- **A live GPU validation error.** The canvas samples a pooled texture directly and nothing told it to let go before the engine freed the pool on a file switch or HQ toggle — `Texture has been destroyed`. Added `gpu_textures_released`.
- **The slider throttle coupled the handle to rendering.** A leading edge with a max-wait was tried and reverted; emitting mid-drag drags the whole per-render UI fan-out along with the handle. Trailing debounce, now 33 ms since drag frames are proxied.

Also: the Analysis histogram silently blanked on drag frames (`np.asarray` on a GPU texture yields a 0-d object array).

## Measured and rejected

| Idea | Measurement |
|---|---|
| `rgba16float` intermediates | Passes are ALU-bound, not bandwidth-bound: 0.87 ms vs 0.32 ms for a pure copy. ~0.3 ms/pass at best. |
| Merge compute passes / 16×16 workgroups | Dispatch overhead is 0.28 ms/frame; 16×16 measured *slower*. |
| GPU completion back-pressure in the engine | Targeted a pileup the trailing debounce cannot create, and parked the render thread in a device poll while the canvas wanted to present. |
| Async metrics readback | ~8 ms once the fixes above land. |
| Config hashing / `_render_memo_key` | 0.083 ms total. |

## Behaviour changes worth reviewing

- **Dragging at HQ shows the preview-resolution render**, sharpening on release. Deliberate; what you inspect at HQ is unchanged.
- **The densitometer and analysis panel read the unproofed print**, not a monitor simulation whose numbers shifted with the export profile. `normalized_log` was never proofed, so the two now agree.
- **The navigate-back render memo only stores host arrays**, so on the GPU path it no longer stores — already true whenever proofing was off, and a re-render is now ~12 ms against the ~135 ms the memo was built to avoid.
- `RenderTask` / `TestStripTask` lose the four ICC fields that only fed the bake.

## Testing

`make all` green: ruff, ty, **3587 passed**, 2 skipped.

New: `tests/test_gpu_stage_skip.py` (incremental render bit-identical to a full one across every stage boundary, plus scale / render_size / cleanup / interleaved-export, and the retouch bypass + cache hit-miss counts), `tests/test_soft_proof_lut.py` (LUT beats the 8-bit path on every bundled output space against a 129³ reference), `tests/test_thumbnail_readback_thread.py`, `tests/test_interactive_decoupling.py`.

Driven end-to-end against the real desktop app: stage 1/4/6 resumes produce correctly changed pixels, re-rendering an identical config is deterministic, and with soft proof on the canvas receives a `GPUTexture` with zero readbacks.

## Known limits

- **Zoomed in at HQ, each repaint still bicubically samples the 61 Mpx texture** (~52 ms worst case). Drags are proxied so this only bites once settled and zoomed past 1:1. Proper fix is mipmaps, which needs a filterable format and a generate pass.
- **Frames with heal regions still pay the 18.5 ms retouch cost** — auto dust detection synthesizes them. The fix (a `copy_texture_to_texture` plus a bbox-limited dispatch) needs its own correctness argument.
- No `PIPELINE.md` / `USER_GUIDE.md` change: no stage order, math, mirrored constant, default or control changed. The `verify` skill referenced a helper this PR removes; fixed here.
