### PR TITLE
fix: source-based IR detection, alignment, and progress for two-pass scanners

### DIFF
--- a/negpy/infrastructure/scanners/sane_backend.py
+++ b/negpy/infrastructure/scanners/sane_backend.py
@@ -4,6 +4,7 @@ import sys
 import threading
 from typing import Callable
 
+import cv2
 import numpy as np
 
 from negpy.infrastructure.scanners.base import (
@@ -388,13 +389,30 @@ def _find_coolscan3_ir_option(opt, device_id: str) -> str | None:
     return None
 
 
+def _find_ir_source(opt) -> str | None:
+    """Return an IR-named `source` constraint value, if the device switches to IR
+    via source string (e.g. Plustek, or genesys's "Transparency Adapter Infrared")."""
+    if "source" not in opt:
+        return None
+    constraint = opt["source"].constraint
+    if not isinstance(constraint, (list, tuple)):
+        return None
+    for s in constraint:
+        s_lower = str(s).strip().lower()
+        if "ir" in s_lower or "infrared" in s_lower:
+            return str(s)
+    return None
+
+
 def _detect_ir(opt, device_id: str = "") -> bool:
     if _mode_has_rgbi(opt):
         return True
     if _find_ir_option(opt) is not None:
         return True
     coolscan_ir = _find_coolscan3_ir_option(opt, device_id)
-    return coolscan_ir is not None and _option_is_usable(opt[coolscan_ir])
+    if coolscan_ir is not None and _option_is_usable(opt[coolscan_ir]):
+        return True
+    return _find_ir_source(opt) is not None
 
 
 def _has_usable_option(opt, name: str) -> bool:
@@ -529,6 +547,63 @@ def _caps_from_options(opt, device_id: str = "") -> ScannerCapabilities:
 def _split_rgbi(arr: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
     """Split an RGBI scan `(H, W, 4)` into RGB `(H, W, 3)` and IR `(H, W)`."""
     return arr[:, :, :3], arr[:, :, 3]
+
+
+# Downsample width for the phase-correlation probe: cheap and denoises the FFT peak
+# (mirrors negpy.features.rgbscan.logic._EST_WIDTH's same tradeoff).
+_IR_ALIGN_PROBE_WIDTH = 1024
+# Correlation-failure guard: past this the estimate is noise, not a real carriage offset.
+_IR_ALIGN_MAX_SHIFT_FRAC = 0.02
+
+
+def _align_ir_to_rgb(rgb: np.ndarray, ir: np.ndarray) -> np.ndarray:
+    """Register a separately-scanned IR plane onto the RGB frame by a whole-pixel shift.
+
+    Only the 'source' IR strategy (a second full mechanical pass — e.g. Plustek, or
+    genesys's "Transparency Adapter Infrared") needs this: the carriage re-homes
+    between the two scans and is not perfectly repeatable, so IR can land a few
+    pixels off the visible frame. Inline RGBI/coolscan3 IR shares one photosite
+    read per line with RGB and is always aligned already.
+
+    Whole pixels only, no sub-pixel interpolation: a dust defect is a *minimum* in
+    the IR ratio, and resampling softens that dip — downsample_ir documents the same
+    failure mode for INTER_AREA (a thin hair's dip shallowed 0.22 -> 0.31 and
+    shattered). This runs on raw sensor counts, upstream of every noise-calibrated
+    landmark in ir_ratio_and_gain (_ir_normalize_ratio's per-frame MAD sigma), so
+    blurring it here would bias those measurements on exactly the low-native-sigma
+    hardware (Plustek/SilverFast, σ ~0.005 per #715) this strategy exists for. A
+    carriage-repeatability offset is whole pixels anyway — nothing is lost by not
+    going sub-pixel.
+    """
+    if ir.size == 0 or rgb.shape[:2] != ir.shape[:2]:
+        return ir
+    ref = rgb.astype(np.float32)
+    if ref.ndim == 3:
+        ref = ref.mean(axis=2)
+    mov = ir.astype(np.float32)
+    if mov.ndim == 3:
+        mov = mov[:, :, 0]
+    h, w = ref.shape[:2]
+    scale = max(1.0, w / _IR_ALIGN_PROBE_WIDTH)
+    if scale > 1.0:
+        sz = (_IR_ALIGN_PROBE_WIDTH, max(1, round(h / scale)))
+        r = cv2.resize(ref, sz, interpolation=cv2.INTER_AREA)
+        m = cv2.resize(mov, sz, interpolation=cv2.INTER_AREA)
+    else:
+        r, m = ref, mov
+    win = cv2.createHanningWindow((r.shape[1], r.shape[0]), cv2.CV_32F)
+    (dx, dy), _resp = cv2.phaseCorrelate(np.ascontiguousarray(r), np.ascontiguousarray(m), win)
+    dx, dy = dx * scale, dy * scale
+    if max(abs(dx), abs(dy)) > max(16.0, _IR_ALIGN_MAX_SHIFT_FRAC * w):
+        return ir
+    ix, iy = int(round(dx)), int(round(dy))
+    if ix == 0 and iy == 0:
+        return ir
+    # out(x, y) = ir(x + ix, y + iy), edge-replicated — matches _estimate_shift's
+    # convention (mov ≈ ref shifted by (dx, dy)) with zero interpolation.
+    x_idx = np.clip(np.arange(w) + ix, 0, w - 1)
+    y_idx = np.clip(np.arange(h) + iy, 0, h - 1)
+    return ir[y_idx][:, x_idx]
 
 
 def _validate_inline_rgbi_parameters(
@@ -1053,16 +1128,24 @@ class SaneBackend:
                 dev.cancel()
                 raise RuntimeError("Scan cancelled")
 
-            # Legacy IR: separate scan via an IR source string (Plustek).
+            # Legacy IR: separate scan via an IR source string (Plustek). Its own
+            # full pass, so it reports its own 0->1 — matches the RGB pass above
+            # rather than sharing one bar, and needs no ir_strategy conditionality.
             if ir_strategy == "source":
                 try:
                     old_source = dev.source
                     ir_source = self._get_ir_source(dev)
                     if ir_source:
                         dev.source = ir_source
+                    if progress:
+                        try:
+                            progress(0.0)
+                        except Exception:
+                            pass
                     dev.start()
-                    ir_array = dev.arr_snap()
+                    ir_array = dev.arr_snap(progress=_snap_progress_callback(progress))
                     dev.source = old_source
+                    ir_array = _align_ir_to_rgb(rgb_array, ir_array)
                 except Exception as e:
                     logger.warning(f"IR scan failed, continuing without IR: {e}")
                     ir_array = None
@@ -1192,13 +1275,6 @@ class SaneBackend:
     @staticmethod
     def _get_ir_source(dev) -> str | None:
         """Find an IR-specific source string if available."""
-        if not hasattr(dev, "opt") or "source" not in dev.opt:
+        if not hasattr(dev, "opt"):
             return None
-        constraint = dev.opt["source"].constraint
-        if not isinstance(constraint, (list, tuple)):
-            return None
-        for s in constraint:
-            s_lower = str(s).strip().lower()
-            if "ir" in s_lower:
-                return str(s)
-        return None
+        return _find_ir_source(dev.opt)

--- a/tests/scanners/test_capabilities.py
+++ b/tests/scanners/test_capabilities.py
@@ -242,6 +242,16 @@ class TestCapsFromOptions:
         caps = _caps_from_options(opt, "plustek:libusb:001:008")
         assert caps.ir_channel is True
 
+    def test_ir_from_source_name(self) -> None:
+        # genesys (e.g. Epson flatbeds with a transparency adapter) exposes IR
+        # only as a second `source` value, not a dedicated option or RGBI mode.
+        opt = {
+            "mode": FakeOption(constraint=["Color", "Gray"]),
+            "source": FakeOption(constraint=["Transparency Adapter", "Transparency Adapter Infrared"]),
+        }
+        caps = _caps_from_options(opt, "genesys:libusb:001:003")
+        assert caps.ir_channel is True
+
 
 class TestAutoExposureCapability:
     """Hardware auto-exposure is a presence-only UI gate, mirroring _detect_ir."""

--- a/tests/scanners/test_ir_alignment.py
+++ b/tests/scanners/test_ir_alignment.py
@@ -1,0 +1,82 @@
+"""Regression coverage for the two-pass IR registration fix (genesys 'Transparency
+Adapter Infrared' and Plustek-style separate IR scans land off by a few pixels).
+
+Whole-pixel only: interpolating the IR plane biases the per-frame noise sigma
+that _ir_normalize_ratio (retouch/logic.py, #659/#715) calibrates against."""
+
+import cv2
+import numpy as np
+
+from negpy.infrastructure.scanners.sane_backend import _align_ir_to_rgb
+
+
+def _texture(h=128, w=128, seed=0):
+    rng = np.random.default_rng(seed)
+    base = rng.random((h, w), dtype=np.float32)
+    return cv2.GaussianBlur(base, (0, 0), 1.5)
+
+
+def _shift(img, dx, dy):
+    m = np.array([[1.0, 0.0, dx], [0.0, 1.0, dy]], dtype=np.float32)
+    return cv2.warpAffine(img, m, (img.shape[1], img.shape[0]), flags=cv2.INTER_CUBIC, borderMode=cv2.BORDER_REFLECT)
+
+
+def test_align_ir_to_rgb_recovers_whole_pixel_offset_exactly():
+    # An integer carriage offset (the realistic case) must round-trip bit-exact —
+    # this is the whole point of not interpolating.
+    base = _texture()
+    rgb = np.stack([base, base, base], axis=-1)
+    ir = np.roll(np.roll(base, 2, axis=1), -3, axis=0)  # shifted +2 px right, 3 px up
+
+    aligned = _align_ir_to_rgb(rgb, ir)
+
+    sl = (slice(8, -8), slice(8, -8))
+    np.testing.assert_allclose(aligned[sl], base[sl], atol=1e-6)
+
+
+def test_align_ir_to_rgb_never_interpolates():
+    # Every output pixel must be a value copied verbatim from the input IR plane
+    # (rounded to the nearest whole-pixel shift), never a blend of neighbours.
+    base = _texture()
+    rgb = np.stack([base, base, base], axis=-1)
+    ir = _shift(base, 1.5, -2.0)  # sub-pixel carriage offset
+
+    aligned = _align_ir_to_rgb(rgb, ir)
+
+    assert np.isin(aligned, ir).all()
+
+
+def test_align_ir_to_rgb_corrects_carriage_offset():
+    base = _texture()
+    rgb = np.stack([base, base, base], axis=-1)
+    ir = _shift(base, 1.5, -2.0)  # second-pass carriage landed a bit high and left
+
+    aligned = _align_ir_to_rgb(rgb, ir)
+
+    sl = (slice(8, -8), slice(8, -8))
+    err_aligned = np.abs(aligned[sl] - base[sl]).mean()
+    err_raw = np.abs(ir[sl] - base[sl]).mean()
+    assert err_aligned < err_raw * 0.5
+
+
+def test_align_ir_to_rgb_preserves_dtype_and_shape():
+    base = _texture()
+    rgb = np.stack([base, base, base], axis=-1)
+    ir = (_shift(base, 1.0, 1.0) * 65535).astype(np.uint16)
+
+    aligned = _align_ir_to_rgb((rgb * 65535).astype(np.uint16), ir)
+
+    assert aligned.dtype == ir.dtype
+    assert aligned.shape == ir.shape
+
+
+def test_align_ir_to_rgb_shape_mismatch_is_noop():
+    rgb = np.zeros((10, 10, 3), np.uint16)
+    ir = np.zeros((12, 10), np.uint16)
+    assert _align_ir_to_rgb(rgb, ir) is ir
+
+
+def test_align_ir_to_rgb_zero_shift_is_noop_identity():
+    base = _texture()
+    rgb = np.stack([base, base, base], axis=-1)
+    assert _align_ir_to_rgb(rgb, base) is base

--- a/tests/scanners/test_ir_progress.py
+++ b/tests/scanners/test_ir_progress.py
@@ -1,0 +1,159 @@
+"""Regression coverage for the two-pass IR progress-bar fix: the 'source' IR
+strategy (Plustek/genesys) runs a second, separate arr_snap() for IR. It used to
+report no progress at all, so the bar hit 100% after the RGB pass and sat still.
+Each physical pass now reports its own independent 0->1 (no phase-splitting, no
+conditionality on whether IR was requested)."""
+
+import threading
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+
+from negpy.infrastructure.scanners.params import ScanParams
+from negpy.infrastructure.scanners.sane_backend import SaneBackend
+
+
+@dataclass
+class FakeOption:
+    constraint: Any = None
+    desc: str = ""
+    active: bool = True
+    settable: bool = True
+
+    def is_active(self) -> bool:
+        return self.active
+
+    def is_settable(self) -> bool:
+        return self.settable
+
+
+_SOURCE_OPT = {
+    "source": FakeOption(constraint=["Negative", "Negative (IR)"]),
+    "depth": FakeOption(constraint=[8, 16]),
+    "resolution": FakeOption(constraint=[300, 600, 1200]),
+}
+
+
+class TwoPassFakeSaneDev:
+    """Plustek/genesys-style: switches `source` for a second full arr_snap() pass."""
+
+    _INTERNAL = ("recorded", "true_frame", "closed", "cancelled", "rgb_frame", "ir_frame")
+
+    def __init__(self, rgb_frame: np.ndarray, ir_frame: np.ndarray) -> None:
+        object.__setattr__(self, "recorded", {"source": "Negative"})
+        object.__setattr__(self, "rgb_frame", rgb_frame)
+        object.__setattr__(self, "ir_frame", ir_frame)
+        object.__setattr__(self, "true_frame", rgb_frame)
+        object.__setattr__(self, "closed", False)
+        object.__setattr__(self, "cancelled", False)
+
+    @property
+    def opt(self):
+        return _SOURCE_OPT
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        if name in self._INTERNAL:
+            object.__setattr__(self, name, value)
+            return
+        if name not in _SOURCE_OPT:
+            raise AttributeError(f"No such SANE option: {name}")
+        self.recorded[name] = value
+
+    def __getattr__(self, name: str) -> Any:
+        if name in _SOURCE_OPT:
+            return self.recorded.get(name)
+        raise AttributeError(f"No readable SANE option: {name}")
+
+    def start(self) -> None:
+        pass
+
+    def get_parameters(self):
+        h, w = self.rgb_frame.shape[:2]
+        return ("color", 1, (w, h), 16, w * 3 * 2)
+
+    def arr_snap(self, progress=None) -> np.ndarray:
+        frame = self.ir_frame if self.recorded.get("source") == "Negative (IR)" else self.rgb_frame
+        if progress is not None:
+            h = frame.shape[0]
+            for i in range(1, h + 1):
+                progress(i, h)
+        return frame
+
+    def cancel(self) -> None:
+        object.__setattr__(self, "cancelled", True)
+
+    def close(self) -> None:
+        object.__setattr__(self, "closed", True)
+
+
+@dataclass
+class FakeSaneModule:
+    dev: TwoPassFakeSaneDev
+    opened: list = field(default_factory=list)
+
+    def open(self, device_id: str) -> TwoPassFakeSaneDev:
+        self.opened.append(device_id)
+        return self.dev
+
+
+def _make_backend(dev: TwoPassFakeSaneDev) -> SaneBackend:
+    backend = SaneBackend.__new__(SaneBackend)
+    backend._sane = FakeSaneModule(dev)
+    backend._sane_initialized = True
+    backend._devices_cache = None
+    backend._id_remap = {}
+    backend._active_sessions = {}
+    backend._session_lock = threading.Lock()
+    return backend
+
+
+def test_source_strategy_scan_reports_0_to_1_on_each_pass_independently():
+    h, w = 20, 8
+    rgb = np.zeros((h, w, 3), dtype=np.uint16)
+    ir = np.zeros((h, w), dtype=np.uint16)
+    dev = TwoPassFakeSaneDev(rgb, ir)
+    backend = _make_backend(dev)
+
+    calls: list[float] = []
+    backend.scan(
+        "plustek:libusb:001:008",
+        ScanParams(dpi=300, depth=16, capture_ir=True),
+        calls.append,
+        threading.Event(),
+    )
+
+    # The RGB pass reaches 1.0 on its own...
+    rgb_end = calls.index(1.0)
+    assert rgb_end > 0
+    # ...then the IR pass explicitly resets to 0.0 rather than continuing from
+    # wherever the RGB pass left off (that was the whole point: no shared bar).
+    assert calls[rgb_end + 1] == 0.0
+    # ...and climbs back to 1.0 on its own by the end (a harmless duplicate 1.0
+    # from the scan's own final "done" call may follow — not asserted on here).
+    assert calls[-1] == 1.0
+    assert 1.0 in calls[rgb_end + 1 :]
+    # Each pass individually is monotonically non-decreasing.
+    first_pass, second_pass = calls[: rgb_end + 1], calls[rgb_end + 1 :]
+    assert first_pass == sorted(first_pass)
+    assert second_pass == sorted(second_pass)
+
+
+def test_no_ir_scan_still_reaches_100_percent():
+    h, w = 10, 6
+    rgb = np.zeros((h, w, 3), dtype=np.uint16)
+    dev = TwoPassFakeSaneDev(rgb, rgb)
+    backend = _make_backend(dev)
+
+    calls: list[float] = []
+    backend.scan(
+        "plustek:libusb:001:008",
+        ScanParams(dpi=300, depth=16, capture_ir=False),
+        calls.append,
+        threading.Event(),
+    )
+
+    assert calls[0] == 0.0
+    assert calls[-1] == 1.0
+    assert calls.count(0.0) == 1  # single pass — never resets back to 0 mid-scan
+    assert calls == sorted(calls)


### PR DESCRIPTION
Fixes #214

A device whose only IR mechanism is a `source` string (Plustek, and genesys's
"Transparency Adapter Infrared" on Epson-class flatbeds) could never actually
use it — three separate bugs, all in the same code path.

1. Capability detection never checked `source` at all

_detect_ir() only recognised RGBI mode, a dedicated `ir` option, or coolscan3's
`infrared` boolean — never the source-string mechanism `_ir_strategy()` already
used at scan time. So the "Capture IR" checkbox stayed permanently disabled for
any device relying on it, even though the scan-time code path already worked.

2. The source-name heuristic didn't match "infrared"

Once wired up, the substring check `"ir" in name` doesn't actually match the
word "infrared" — there's no `i` immediately followed by `r` in that word. This
silently broke source-string IR detection for any device spelling it out in
full (genesys's "Transparency Adapter Infrared") rather than using a short "IR"
token. Fixed by also checking for "infrared" explicitly.

3. No registration between the two passes

The 'source' strategy runs two full, independent scans (RGB, then IR after
switching `source`). Unlike inline RGBI/coolscan3 IR — one photosite read,
inherently aligned — a two-pass flatbed's carriage does not re-home with
pixel-perfect repeatability, so the IR plane can land a few pixels off. Added
_align_ir_to_rgb(): phase-correlates the IR plane against RGB and applies the
estimated offset via whole-pixel array indexing only — no sub-pixel warp. A
dust defect is a *minimum* in the IR ratio, and downsample_ir a few functions
away already documents that interpolating this plane softens exactly that
minimum (a thin hair's dip shallowed 0.22 -> 0.31 and shattered under
INTER_AREA). More importantly, _ir_normalize_ratio in retouch/logic.py (#659,
#715) calibrates its clean-film pivot and dip-depth stretch against this
plane's own per-frame MAD sigma — interpolating it here would bias exactly
that measurement, worst on the low-native-sigma hardware (Plustek/SilverFast,
σ ~0.005) this strategy exists for. A carriage-repeatability offset is whole
pixels anyway, so nothing is lost by not going sub-pixel.

Also: the second (IR) arr_snap() had no progress callback wired to it at all,
so the bar hit 100% after the RGB pass and sat still through the whole IR
pass. Both passes now report their own independent 0->1 (explicit reset to
0.0 before the second pass) rather than sharing one range — no conditionality
needed on whether IR was requested.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>