### PR TITLE
fix(preview): give the navigate-back memo its pixels back

### DIFF
--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -276,7 +276,7 @@ class AppController(QObject):
     flat_peek_changed = pyqtSignal(bool)
     zoom_requested = pyqtSignal(float)
     zoom_changed = pyqtSignal(float)
-    _render_cleanup_requested = pyqtSignal()
+    _render_cleanup_requested = pyqtSignal(object)  # texture to spare, or None
     status_message_requested = pyqtSignal(str, int)
     status_progress_requested = pyqtSignal(int, int)
     batch_started = pyqtSignal(str, bool)  # title, abortable
@@ -429,6 +429,9 @@ class AppController(QObject):
         # Last displayed render per frame — navigate-back paints it instantly
         # while the authoritative render refreshes underneath.
         self._render_memo = RenderMemo()
+        # (source_hash, memo_key, content_rect) of the settle render whose GPU texture
+        # is on screen; load_file files it under this identity on the way out.
+        self._last_render_identity: Optional[tuple] = None
         # Test strips, keyed density/grade-blind (see _strip_memo_key).
         self._strip_memo = RenderMemo()
 
@@ -1254,6 +1257,24 @@ class AppController(QObject):
             exposure = replace(exposure, density=1.0, grade=115.0)
         return f"{kind}:{self._render_memo_key(replace(self.state.config, exposure=exposure))}"
 
+    def _retain_displayed_texture(self) -> Optional[GPUTexture]:
+        """File the on-screen GPU render in the memo and return it, so the engine
+        cleanup that follows spares it instead of destroying it.
+
+        Refused while a render is in flight or queued: it paints into that same pooled
+        texture, and the pixels would stop matching the key they are filed under.
+        """
+        identity = self._last_render_identity
+        self._last_render_identity = None
+        texture = self.state.last_metrics.get("base_positive")
+        if identity is None or not isinstance(texture, GPUTexture):
+            return None
+        if self._is_rendering or self._pending_render_task is not None:
+            return None
+        source_hash, memo_key, content_rect = identity
+        self._render_memo.store(source_hash, memo_key, {"base_positive": texture, "content_rect": content_rect})
+        return texture
+
     def _on_file_selected_load(self, file_path: str) -> None:
         """``session.file_selected`` handler: navigation honors the sticky-zoom preference."""
         self.load_file(file_path, preserve_zoom=self.state.sticky_zoom)
@@ -1284,8 +1305,13 @@ class AppController(QObject):
             self.loading_started.emit()
         self._thumb_config = None
 
-        self.gpu_textures_released.emit()
-        self._render_cleanup_requested.emit()
+        retained = self._retain_displayed_texture()
+        # The canvas samples the retained texture directly and it now outlives the pool,
+        # so the previous frame stays up under the dimmed spinner. Without one, the
+        # canvas must let go before the engine frees what it is sampling.
+        if retained is None:
+            self.gpu_textures_released.emit()
+        self._render_cleanup_requested.emit(retained)
         # The cleanup destroys the GPU textures last_metrics still points at; drop the
         # densitometer's probe sources so hover readouts go quiet until the next render.
         self.state.last_metrics.pop("normalized_log", None)
@@ -1478,6 +1504,9 @@ class AppController(QObject):
             self.load_file(self.state.current_file_path, preserve_zoom=True, force_detect=True)
 
     def toggle_hq_preview(self) -> None:
+        # Resolution is part of the memo key, so every entry is now a permanent miss
+        # holding a full-size texture. Free them rather than wait for the LRU.
+        self._render_memo.clear()
         self.session.set_hq_preview(not self.state.hq_preview)
         if self.state.current_file_path:
             self.load_file(self.state.current_file_path, preserve_zoom=True)
@@ -4100,23 +4129,32 @@ class AppController(QObject):
             self.state.last_metrics.update(metrics)
             self.state.last_metrics["splash"] = False
 
-        # Memoize the displayed pixels for instant navigate-back. ndarray only:
-        # GPU textures are destroyed on navigation (in the default soft-proof
-        # path the displayed buffer is already a CPU array). Stored by reference
-        # — display buffers are read-only downstream.
         result = metrics.get("base_positive")
-        if metrics.get("memo_key") and isinstance(result, np.ndarray) and metrics.get("source_hash") == self.state.current_file_hash:
-            self._render_memo.store(
-                metrics["source_hash"],
-                metrics["memo_key"],
-                {"base_positive": result, "content_rect": metrics.get("content_rect")},
-            )
+        memoizable = bool(metrics.get("memo_key")) and metrics.get("source_hash") == self.state.current_file_hash
+        # A GPU texture belongs to the engine's pool until the file switch frees it, so
+        # only its identity is kept here; load_file files the texture itself on the way
+        # out, retaining it from that teardown.
+        self._last_render_identity = (
+            (metrics["source_hash"], metrics["memo_key"], metrics.get("content_rect"))
+            if memoizable and isinstance(result, GPUTexture)
+            else None
+        )
 
         if metrics.get("gpu_fallback") and not self._gpu_fallback_notified:
             self._gpu_fallback_notified = True
             self.set_status("GPU acceleration failed — using CPU", 5000)
 
         self.image_updated.emit()
+
+        # Memoize the displayed pixels for instant navigate-back, by reference — display
+        # buffers are read-only downstream. After the repaint: overwriting this frame's
+        # entry frees the texture it owned, which the canvas has just stopped sampling.
+        if memoizable and isinstance(result, np.ndarray):
+            self._render_memo.store(
+                metrics["source_hash"],
+                metrics["memo_key"],
+                {"base_positive": result, "content_rect": metrics.get("content_rect")},
+            )
 
         if should_update_thumb:
             self._thumb_config = self.state.config
@@ -4168,8 +4206,16 @@ class AppController(QObject):
                 )
                 # render=False: the displayed pixels already reflect these measured
                 # bounds — move the frame's memo entry to the updated config's key
-                # so the first navigate-back after an initial render still hits.
+                # so the first navigate-back after an initial render still hits. A GPU
+                # render is not filed until navigate-away, so its pending identity has
+                # to follow the same way.
                 self._render_memo.rekey(src or self.state.current_file_hash or "", self._render_memo_key())
+                if self._last_render_identity is not None:
+                    self._last_render_identity = (
+                        self._last_render_identity[0],
+                        self._render_memo_key(),
+                        self._last_render_identity[2],
+                    )
 
     def _on_render_error(self, message: str) -> None:
         self.state.is_processing = self._is_rendering = False
@@ -4267,6 +4313,8 @@ class AppController(QObject):
         if self.capture_thread.isRunning():
             self.capture_thread.quit()
             self.capture_thread.wait()
+        # Memo-owned textures outlive the pool, so they must die before the device.
+        self._render_memo.clear()
         self.render_worker.destroy_all()
 
         # All GPU-touching threads are now joined; release the wgpu device.

--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -429,11 +429,14 @@ class AppController(QObject):
         # Last displayed render per frame — navigate-back paints it instantly
         # while the authoritative render refreshes underneath.
         self._render_memo = RenderMemo()
-        # (source_hash, memo_key, content_rect) of the settle render whose GPU texture
-        # is on screen; load_file files it under this identity on the way out.
+        # (source_hash, memo_key, content_rect) of the on-screen GPU render; load_file
+        # files its texture under this on the way out.
         self._last_render_identity: Optional[tuple] = None
-        # Test strips, keyed density/grade-blind (see _strip_memo_key).
+        self._render_memo.large_entries = self.state.hq_preview
+        # Test strips, keyed density/grade-blind (see _strip_memo_key). Four mosaics an
+        # entry, so the conservative budget.
         self._strip_memo = RenderMemo()
+        self._strip_memo.large_entries = True
 
         self._render_debounce = QTimer()
         self._render_debounce.setSingleShot(True)
@@ -1258,11 +1261,10 @@ class AppController(QObject):
         return f"{kind}:{self._render_memo_key(replace(self.state.config, exposure=exposure))}"
 
     def _retain_displayed_texture(self) -> Optional[GPUTexture]:
-        """File the on-screen GPU render in the memo and return it, so the engine
-        cleanup that follows spares it instead of destroying it.
+        """File the on-screen GPU render in the memo and return it for the cleanup to spare.
 
-        Refused while a render is in flight or queued: it paints into that same pooled
-        texture, and the pixels would stop matching the key they are filed under.
+        Refused mid-render: that render paints into the same pooled texture, so the pixels
+        would stop matching the key they are filed under.
         """
         identity = self._last_render_identity
         self._last_render_identity = None
@@ -1306,9 +1308,8 @@ class AppController(QObject):
         self._thumb_config = None
 
         retained = self._retain_displayed_texture()
-        # The canvas samples the retained texture directly and it now outlives the pool,
-        # so the previous frame stays up under the dimmed spinner. Without one, the
-        # canvas must let go before the engine frees what it is sampling.
+        # A retained texture outlives the pool, so the canvas keeps sampling it; without
+        # one it must let go before the engine frees what it is showing.
         if retained is None:
             self.gpu_textures_released.emit()
         self._render_cleanup_requested.emit(retained)
@@ -1504,10 +1505,11 @@ class AppController(QObject):
             self.load_file(self.state.current_file_path, preserve_zoom=True, force_detect=True)
 
     def toggle_hq_preview(self) -> None:
-        # Resolution is part of the memo key, so every entry is now a permanent miss
-        # holding a full-size texture. Free them rather than wait for the LRU.
+        # Resolution is in the memo key: every entry is now a permanent miss holding a
+        # full-size texture.
         self._render_memo.clear()
         self.session.set_hq_preview(not self.state.hq_preview)
+        self._render_memo.large_entries = self.state.hq_preview
         if self.state.current_file_path:
             self.load_file(self.state.current_file_path, preserve_zoom=True)
 
@@ -4131,9 +4133,8 @@ class AppController(QObject):
 
         result = metrics.get("base_positive")
         memoizable = bool(metrics.get("memo_key")) and metrics.get("source_hash") == self.state.current_file_hash
-        # A GPU texture belongs to the engine's pool until the file switch frees it, so
-        # only its identity is kept here; load_file files the texture itself on the way
-        # out, retaining it from that teardown.
+        # The pool overwrites a GPU texture on the next frame, so only its identity is
+        # kept here; load_file files the texture itself on the way out.
         self._last_render_identity = (
             (metrics["source_hash"], metrics["memo_key"], metrics.get("content_rect"))
             if memoizable and isinstance(result, GPUTexture)
@@ -4146,9 +4147,8 @@ class AppController(QObject):
 
         self.image_updated.emit()
 
-        # Memoize the displayed pixels for instant navigate-back, by reference — display
-        # buffers are read-only downstream. After the repaint: overwriting this frame's
-        # entry frees the texture it owned, which the canvas has just stopped sampling.
+        # By reference — display buffers are read-only downstream. After the repaint:
+        # overwriting an entry frees the texture the canvas has just stopped sampling.
         if memoizable and isinstance(result, np.ndarray):
             self._render_memo.store(
                 metrics["source_hash"],
@@ -4207,8 +4207,7 @@ class AppController(QObject):
                 # render=False: the displayed pixels already reflect these measured
                 # bounds — move the frame's memo entry to the updated config's key
                 # so the first navigate-back after an initial render still hits. A GPU
-                # render is not filed until navigate-away, so its pending identity has
-                # to follow the same way.
+                # render is not filed until navigate-away, so its identity follows too.
                 self._render_memo.rekey(src or self.state.current_file_hash or "", self._render_memo_key())
                 if self._last_render_identity is not None:
                     self._last_render_identity = (

--- a/negpy/desktop/render_memo.py
+++ b/negpy/desktop/render_memo.py
@@ -9,9 +9,9 @@ the authoritative render refreshes metrics quietly in the background (so a
 stale memo can only ever flash briefly, never persist).
 
 Buffers are stored by reference under the same read-only contract as the
-preview cache. GPU-texture results are never memoized (textures are destroyed
-on navigation); in the default soft-proof path the displayed buffer is a CPU
-array, which is what lands here.
+preview cache. A GPU render lands here as the texture itself, retained out of
+the engine's pool on the file switch that would otherwise destroy it — so the
+memo *owns* those textures and frees them when an entry leaves.
 """
 
 from __future__ import annotations
@@ -34,13 +34,26 @@ class RenderMemo:
         # one navigated from (see preview_cache_max_full_res_entries).
         return max(2, int(getattr(self._app, "preview_cache_max_full_res_entries", 2)))
 
+    def _dispose(self, entry: "Optional[tuple[str, dict]]", keep: "Optional[dict]" = None) -> None:
+        """Free the GPU textures an entry owns. Duck-typed: strip mosaics are plain
+        arrays and must pass through untouched. ``keep`` spares anything the
+        replacing payload also holds — re-storing a frame served *from* the memo
+        hands back the very texture that entry owns."""
+        if entry is None:
+            return
+        spared = [] if keep is None else list(keep.values())
+        for value in entry[1].values():
+            destroy = getattr(value, "destroy", None)
+            if callable(destroy) and not any(value is s for s in spared):
+                destroy()
+
     def store(self, file_hash: str, memo_key: str, payload: dict) -> None:
         if not file_hash or not memo_key:
             return
-        self._entries.pop(file_hash, None)
+        self._dispose(self._entries.pop(file_hash, None), keep=payload)
         self._entries[file_hash] = (memo_key, payload)
         while len(self._entries) > self._budget():
-            self._entries.popitem(last=False)
+            self._dispose(self._entries.popitem(last=False)[1], keep=payload)
 
     def get(self, file_hash: str, memo_key: str) -> Optional[dict]:
         entry = self._entries.get(file_hash)
@@ -58,7 +71,9 @@ class RenderMemo:
             self._entries[file_hash] = (new_key, entry[1])
 
     def invalidate(self, file_hash: str) -> None:
-        self._entries.pop(file_hash, None)
+        self._dispose(self._entries.pop(file_hash, None))
 
     def clear(self) -> None:
+        for entry in self._entries.values():
+            self._dispose(entry)
         self._entries.clear()

--- a/negpy/desktop/render_memo.py
+++ b/negpy/desktop/render_memo.py
@@ -9,9 +9,8 @@ the authoritative render refreshes metrics quietly in the background (so a
 stale memo can only ever flash briefly, never persist).
 
 Buffers are stored by reference under the same read-only contract as the
-preview cache. A GPU render lands here as the texture itself, retained out of
-the engine's pool on the file switch that would otherwise destroy it — so the
-memo *owns* those textures and frees them when an entry leaves.
+preview cache. A GPU render lands here as the texture itself, retained out of the
+engine's pool on the file switch — so the memo owns those textures and frees them.
 """
 
 from __future__ import annotations
@@ -28,17 +27,18 @@ class RenderMemo:
     def __init__(self, app_config: Any = None) -> None:
         self._app = app_config or APP_CONFIG
         self._entries: "OrderedDict[str, tuple[str, dict]]" = OrderedDict()
+        # Hundreds of MB an entry (HQ renders, strip mosaics): use the full-res knob.
+        self.large_entries = False
 
     def _budget(self) -> int:
-        # One knob governs both HQ retention caches: the active frame plus the
-        # one navigated from (see preview_cache_max_full_res_entries).
-        return max(2, int(getattr(self._app, "preview_cache_max_full_res_entries", 2)))
+        if self.large_entries:
+            return max(2, int(getattr(self._app, "preview_cache_max_full_res_entries", 2)))
+        return max(2, int(getattr(self._app, "render_memo_max_entries", 8)))
 
     def _dispose(self, entry: "Optional[tuple[str, dict]]", keep: "Optional[dict]" = None) -> None:
-        """Free the GPU textures an entry owns. Duck-typed: strip mosaics are plain
-        arrays and must pass through untouched. ``keep`` spares anything the
-        replacing payload also holds — re-storing a frame served *from* the memo
-        hands back the very texture that entry owns."""
+        """Free the GPU textures an entry owns; strip mosaics are arrays and pass
+        through. ``keep`` spares what the replacing payload also holds — re-storing a
+        frame served *from* the memo hands back that entry's own texture."""
         if entry is None:
             return
         spared = [] if keep is None else list(keep.values())

--- a/negpy/desktop/workers/render.py
+++ b/negpy/desktop/workers/render.py
@@ -191,10 +191,10 @@ class RenderWorker(QObject):
     def processor(self) -> ImageProcessor:
         return self._processor
 
-    @pyqtSlot()
-    def cleanup(self) -> None:
-        """Evacuates transient GPU resources."""
-        self._processor.cleanup()
+    @pyqtSlot(object)
+    def cleanup(self, retain: object = None) -> None:
+        """Evacuates transient GPU resources; ``retain`` is handed to its new owner."""
+        self._processor.cleanup(retain=retain)
 
     def destroy_all(self) -> None:
         """Full teardown of processing resources."""

--- a/negpy/domain/types.py
+++ b/negpy/domain/types.py
@@ -55,6 +55,9 @@ class AppConfig:
     # slot budget inside the LRU: enough to make navigating back to the previous
     # frame instant, without letting HQ buffers push every small preview out.
     preview_cache_max_full_res_entries: int = 2
+    # Rendered frames kept for instant navigate-back. ~27 MB of VRAM each at
+    # preview_render_size=1600; HQ frames stay on the full-res budget above.
+    render_memo_max_entries: int = 8
     # Canvas zoom (1.0 = 100%)
     canvas_zoom_min: float = 0.25
     canvas_zoom_max: float = 8.0

--- a/negpy/kernel/system/override.py
+++ b/negpy/kernel/system/override.py
@@ -49,6 +49,10 @@ max_texture_size = "auto"
 # instant. Raise on high-RAM machines together with preview_cache_max_bytes.
 # preview_cache_max_full_res_entries = 2
 
+# How many rendered frames to keep for instant navigate-back (no spinner, no re-render).
+# A preview-size frame is ~27 MB of VRAM; HQ frames follow the full-res budget above.
+# render_memo_max_entries = 8
+
 [logging]
 # Verbosity: "debug", "info", "warning", "error"
 level = "info"
@@ -72,6 +76,7 @@ class OverrideConfig:
     preview_cache_max_bytes: int | None = None
     preview_cache_max_entries: int | None = None
     preview_cache_max_full_res_entries: int | None = None
+    render_memo_max_entries: int | None = None
     log_level: str = "info"
 
     @property
@@ -145,6 +150,9 @@ def _parse(data: dict) -> OverrideConfig:
     raw_cache_fr = performance.get("preview_cache_max_full_res_entries")
     cache_fr: int | None = int(raw_cache_fr) if isinstance(raw_cache_fr, int) and raw_cache_fr > 0 else None
 
+    raw_memo_n = performance.get("render_memo_max_entries")
+    memo_n: int | None = int(raw_memo_n) if isinstance(raw_memo_n, int) and raw_memo_n > 0 else None
+
     log_level = str(logging_section.get("level", "info")).lower()
     if log_level not in ("debug", "info", "warning", "error"):
         log_level = "info"
@@ -159,6 +167,7 @@ def _parse(data: dict) -> OverrideConfig:
         preview_cache_max_bytes=cache_b,
         preview_cache_max_entries=cache_n,
         preview_cache_max_full_res_entries=cache_fr,
+        render_memo_max_entries=memo_n,
         log_level=log_level,
     )
 
@@ -227,3 +236,6 @@ def apply(cfg: OverrideConfig, app_config: AppConfig) -> None:
 
     if cfg.preview_cache_max_full_res_entries is not None:
         app_config.preview_cache_max_full_res_entries = cfg.preview_cache_max_full_res_entries
+
+    if cfg.render_memo_max_entries is not None:
+        app_config.render_memo_max_entries = cfg.render_memo_max_entries

--- a/negpy/services/rendering/gpu_engine.py
+++ b/negpy/services/rendering/gpu_engine.py
@@ -2042,10 +2042,8 @@ class GPUEngine:
     def cleanup(self, collect: bool = True, retain: Optional[GPUTexture] = None) -> None:
         """Evacuates the texture pool; optionally forces garbage collection.
 
-        ``retain`` hands one texture to the caller instead of destroying it (the
-        navigate-back memo keeps the displayed frame alive across a file switch).
-        Its pool key goes with it, so the next render allocates a fresh one rather
-        than painting over pixels somebody else now owns.
+        ``retain`` is handed to the caller instead: its pool key goes with it, so the
+        next render allocates a fresh one rather than painting over borrowed pixels.
         """
         for tex in self._tex_cache.values():
             if tex is not retain:

--- a/negpy/services/rendering/gpu_engine.py
+++ b/negpy/services/rendering/gpu_engine.py
@@ -2039,10 +2039,17 @@ class GPUEngine:
         result[off_y : off_y + content_h, off_x : off_x + content_w] = scaled_content
         return result, metrics_ref
 
-    def cleanup(self, collect: bool = True) -> None:
-        """Evacuates the texture pool; optionally forces garbage collection."""
+    def cleanup(self, collect: bool = True, retain: Optional[GPUTexture] = None) -> None:
+        """Evacuates the texture pool; optionally forces garbage collection.
+
+        ``retain`` hands one texture to the caller instead of destroying it (the
+        navigate-back memo keeps the displayed frame alive across a file switch).
+        Its pool key goes with it, so the next render allocates a fresh one rather
+        than painting over pixels somebody else now owns.
+        """
         for tex in self._tex_cache.values():
-            tex.destroy()
+            if tex is not retain:
+                tex.destroy()
         self._tex_cache.clear()
         # Bind groups reference the destroyed views — drop them.
         self._bind_group_cache.clear()

--- a/negpy/services/rendering/image_processor.py
+++ b/negpy/services/rendering/image_processor.py
@@ -1332,15 +1332,15 @@ class ImageProcessor:
             compression="tiff_lzw" if fmt == "TIFF" else None,
         )
 
-    def cleanup(self, release_source_cache: bool = True, collect: bool = True) -> None:
-        """Evacuates transient GPU resources."""
+    def cleanup(self, release_source_cache: bool = True, collect: bool = True, retain: Any = None) -> None:
+        """Evacuates transient GPU resources; ``retain`` survives the teardown."""
         if release_source_cache:
             self._source_cache_key = None
             self._source_cache_value = None
             self._precorrect_key = None
             self._precorrect_value = None
         if self.engine_gpu:
-            self.engine_gpu.cleanup(collect=collect)
+            self.engine_gpu.cleanup(collect=collect, retain=retain)
 
     def destroy_all(self) -> None:
         """Teardown GPU engine."""

--- a/tests/test_gpu_engine.py
+++ b/tests/test_gpu_engine.py
@@ -67,6 +67,20 @@ class TestGPUEngine(unittest.TestCase):
         self.assertEqual(len(self.engine._tex_cache), 0)
         self.assertIsNone(self.engine._uv_grid_cache)
 
+    def test_cleanup_spares_the_retained_texture(self):
+        """The navigate-back memo keeps the displayed frame across a file switch."""
+        img = np.random.rand(64, 64, 3).astype(np.float32)
+        tex, _ = self.engine.process_to_texture(img, WorkspaceConfig())
+
+        self.engine.cleanup(retain=tex)
+        self.assertIsNotNone(tex.texture, "the memo owns it now")
+        self.assertEqual(len(self.engine._tex_cache), 0, "its pool key goes with it")
+
+        # The next render must not paint over pixels the memo owns.
+        again, _ = self.engine.process_to_texture(img, WorkspaceConfig())
+        self.assertIsNot(again, tex)
+        tex.destroy()
+
     def test_uv_grid_cached_across_frames(self):
         """Same geometry -> reused grid object; geometry change -> rebuilt."""
         from dataclasses import replace

--- a/tests/test_navigate_back_memo.py
+++ b/tests/test_navigate_back_memo.py
@@ -1,0 +1,136 @@
+"""Navigating back to a frame must paint its last render, with no spinner.
+
+The memo used to hold host arrays, which the soft-proof bake produced as a side
+effect. Once the proof moved to the display LUT a render publishes a GPU texture,
+the store site's ndarray guard stopped matching and the memo went permanently
+empty — a spinner on every switch. The texture is now retained out of the engine's
+pool on the way out, so these pin the identity bookkeeping that makes that safe.
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+
+from negpy.desktop.controller import AppController
+from negpy.desktop.render_memo import RenderMemo
+
+
+class _FakeTexture:
+    """Stands in for a GPUTexture; the engine pool owns it until a switch."""
+
+    def __init__(self) -> None:
+        self.destroyed = 0
+
+    def destroy(self) -> None:
+        self.destroyed += 1
+
+
+def _stub(memo, **overrides):
+    stub = SimpleNamespace(
+        _is_rendering=False,
+        _clear_busy_toast=MagicMock(),
+        _first_render_t0=None,
+        _pending_render_task=None,
+        _thumb_config=object(),
+        _render_memo=memo,
+        _last_render_identity=None,
+        _gpu_fallback_notified=True,
+        state=SimpleNamespace(
+            config=object(),
+            metrics_lock=MagicMock(__enter__=lambda s: None, __exit__=lambda s, *a: None),
+            last_metrics={},
+            current_file_hash="h1",
+        ),
+        image_updated=MagicMock(),
+        _update_thumbnail_from_state=MagicMock(),
+        set_status=MagicMock(),
+        render_requested=MagicMock(),
+    )
+    for key, value in overrides.items():
+        setattr(stub, key, value)
+    return stub
+
+
+def _finish(stub, result, **metrics):
+    with patch("negpy.desktop.controller.GPUTexture", _FakeTexture):
+        AppController._on_render_finished(stub, result, {"base_positive": result, "source_hash": "h1", **metrics})
+
+
+def _retain(stub):
+    with patch("negpy.desktop.controller.GPUTexture", _FakeTexture):
+        return AppController._retain_displayed_texture(stub)
+
+
+class TestGpuRenderIsMemoized(unittest.TestCase):
+    def test_a_settle_render_is_filed_on_the_way_out(self):
+        memo = RenderMemo(SimpleNamespace(preview_cache_max_full_res_entries=2))
+        tex = _FakeTexture()
+        stub = _stub(memo)
+
+        _finish(stub, tex, memo_key="k")
+        self.assertEqual(stub._last_render_identity, ("h1", "k", None))
+        self.assertIsNone(memo.get("h1", "k"), "the pool still owns it mid-session")
+
+        self.assertIs(_retain(stub), tex, "the engine cleanup must be told to spare it")
+        payload = memo.get("h1", "k")
+        self.assertIsNotNone(payload)
+        self.assertIs(payload["base_positive"], tex)
+
+    def test_a_frame_the_memo_cannot_reproduce_is_not_filed(self):
+        # Compare peek, splash, tool preview and drag frames all clear the memo key.
+        memo = RenderMemo(SimpleNamespace(preview_cache_max_full_res_entries=2))
+        stub = _stub(memo)
+        _finish(stub, _FakeTexture(), memo_key="")
+        self.assertIsNone(stub._last_render_identity)
+        self.assertIsNone(_retain(stub))
+
+    def test_a_late_render_of_the_outgoing_file_is_not_filed(self):
+        memo = RenderMemo(SimpleNamespace(preview_cache_max_full_res_entries=2))
+        stub = _stub(memo)
+        _finish(stub, _FakeTexture(), memo_key="k", source_hash="other")
+        self.assertIsNone(stub._last_render_identity)
+
+    def test_the_cpu_path_still_files_its_array_directly(self):
+        memo = RenderMemo(SimpleNamespace(preview_cache_max_full_res_entries=2))
+        stub = _stub(memo)
+        buf = np.zeros((4, 4, 3), dtype=np.float32)
+        _finish(stub, buf, memo_key="k")
+        self.assertIsNone(stub._last_render_identity, "nothing to retain from the pool")
+        self.assertIs(memo.get("h1", "k")["base_positive"], buf)
+
+
+class TestRetentionRefusesUnsafeTextures(unittest.TestCase):
+    """A render in flight paints into the same pooled texture, so its pixels would
+    stop matching the key they are filed under."""
+
+    def test_refused_while_a_render_is_in_flight(self):
+        memo = RenderMemo(SimpleNamespace(preview_cache_max_full_res_entries=2))
+        tex = _FakeTexture()
+        stub = _stub(memo)
+        _finish(stub, tex, memo_key="k")
+        stub._is_rendering = True
+        self.assertIsNone(_retain(stub))
+        self.assertIsNone(memo.get("h1", "k"))
+
+    def test_refused_while_a_render_is_queued(self):
+        memo = RenderMemo(SimpleNamespace(preview_cache_max_full_res_entries=2))
+        tex = _FakeTexture()
+        stub = _stub(memo)
+        _finish(stub, tex, memo_key="k")
+        stub._pending_render_task = object()
+        self.assertIsNone(_retain(stub))
+
+    def test_the_identity_is_spent_once(self):
+        # Two switches with no render between them: the second must not re-file the
+        # first frame's identity over whatever is on screen now.
+        memo = RenderMemo(SimpleNamespace(preview_cache_max_full_res_entries=2))
+        stub = _stub(memo)
+        _finish(stub, _FakeTexture(), memo_key="k")
+        self.assertIsNotNone(_retain(stub))
+        self.assertIsNone(_retain(stub))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_navigate_back_memo.py
+++ b/tests/test_navigate_back_memo.py
@@ -1,10 +1,9 @@
 """Navigating back to a frame must paint its last render, with no spinner.
 
-The memo used to hold host arrays, which the soft-proof bake produced as a side
-effect. Once the proof moved to the display LUT a render publishes a GPU texture,
-the store site's ndarray guard stopped matching and the memo went permanently
-empty — a spinner on every switch. The texture is now retained out of the engine's
-pool on the way out, so these pin the identity bookkeeping that makes that safe.
+The memo used to hold host arrays, produced as a side effect of the soft-proof bake.
+Once the proof moved to the display LUT the store site's ndarray guard stopped
+matching and the memo went permanently empty. These pin the identity bookkeeping
+that lets a GPU texture be retained out of the engine's pool instead.
 """
 
 import unittest

--- a/tests/test_override_config.py
+++ b/tests/test_override_config.py
@@ -81,6 +81,17 @@ class TestOverrideConfigParsing(unittest.TestCase):
         self.assertEqual(cfg.max_texture_size, 4096)
         self.assertEqual(cfg.log_level, "debug")
 
+    def test_parse_render_memo_max_entries(self):
+        cfg = _parse({"performance": {"render_memo_max_entries": 16}})
+        self.assertEqual(cfg.render_memo_max_entries, 16)
+        app = _make_app_config()
+        apply(cfg, app)
+        self.assertEqual(app.render_memo_max_entries, 16)
+
+    def test_parse_render_memo_max_entries_rejects_nonsense(self):
+        for value in (0, -1, "eight", None):
+            self.assertIsNone(_parse({"performance": {"render_memo_max_entries": value}}).render_memo_max_entries)
+
     def test_parse_invalid_backend_falls_back_to_auto(self):
         cfg = _parse({"rendering": {"backend": "directx9"}})
         self.assertEqual(cfg.backend, "auto")

--- a/tests/test_render_memo.py
+++ b/tests/test_render_memo.py
@@ -5,8 +5,11 @@ import numpy as np
 from negpy.desktop.render_memo import RenderMemo
 
 
-def _cfg(slots: int = 2) -> SimpleNamespace:
-    return SimpleNamespace(preview_cache_max_full_res_entries=slots)
+def _cfg(slots: int = 2, memo_slots: int | None = None) -> SimpleNamespace:
+    return SimpleNamespace(
+        preview_cache_max_full_res_entries=slots,
+        render_memo_max_entries=slots if memo_slots is None else memo_slots,
+    )
 
 
 def _payload() -> dict:
@@ -54,6 +57,18 @@ def test_budget_evicts_least_recent_file() -> None:
     assert m.get("B", "k") is None
     assert m.get("A", "k") is not None
     assert m.get("C", "k") is not None
+
+
+def test_preview_frames_get_the_bigger_budget() -> None:
+    # Several frames along a roll stay instant; HQ falls back to the full-res budget.
+    m = RenderMemo(_cfg(slots=2, memo_slots=5))
+    for i in range(5):
+        m.store(f"f{i}", "k", _payload())
+    assert m.get("f0", "k") is not None
+
+    m.large_entries = True
+    m.store("f5", "k", _payload())
+    assert len([h for h in ("f0", "f1", "f2", "f3", "f4", "f5") if m.get(h, "k") is not None]) == 2
 
 
 def test_budget_floor_is_two() -> None:
@@ -117,8 +132,7 @@ def test_owned_textures_are_destroyed_when_the_entry_leaves() -> None:
 
 
 def test_restoring_a_frame_from_the_memo_does_not_free_its_own_texture() -> None:
-    # Navigate away, back (served from the memo), away again: the same texture is
-    # re-filed under the entry that owns it.
+    # Away, back (served from the memo), away again: the same texture is re-filed.
     m = RenderMemo(_cfg())
     tex = _FakeTexture()
     m.store("A", "k", _gpu_payload(tex))

--- a/tests/test_render_memo.py
+++ b/tests/test_render_memo.py
@@ -13,6 +13,20 @@ def _payload() -> dict:
     return {"base_positive": np.zeros((2, 2, 3), dtype=np.float32), "content_rect": None}
 
 
+class _FakeTexture:
+    """Stands in for a GPUTexture: the memo frees by duck-typed destroy()."""
+
+    def __init__(self) -> None:
+        self.destroyed = 0
+
+    def destroy(self) -> None:
+        self.destroyed += 1
+
+
+def _gpu_payload(tex: _FakeTexture) -> dict:
+    return {"base_positive": tex, "content_rect": None}
+
+
 def test_hit_requires_matching_key() -> None:
     m = RenderMemo(_cfg())
     p = _payload()
@@ -81,3 +95,52 @@ def test_clear_and_invalidate() -> None:
     assert m.get("B", "k") is not None
     m.clear()
     assert m.get("B", "k") is None
+
+
+def test_owned_textures_are_destroyed_when_the_entry_leaves() -> None:
+    # A GPU render is retained out of the engine's pool, so the memo owns it.
+    m = RenderMemo(_cfg(slots=2))
+    evicted, overwritten, invalidated, cleared = (_FakeTexture() for _ in range(4))
+
+    m.store("A", "k", _gpu_payload(evicted))
+    m.store("B", "k", _gpu_payload(overwritten))
+    m.store("B", "k2", _gpu_payload(invalidated))  # same frame, new edit
+    assert overwritten.destroyed == 1
+
+    m.store("C", "k", _gpu_payload(cleared))  # evicts A, the least recent
+    assert evicted.destroyed == 1
+
+    m.invalidate("B")
+    assert invalidated.destroyed == 1
+    m.clear()
+    assert cleared.destroyed == 1
+
+
+def test_restoring_a_frame_from_the_memo_does_not_free_its_own_texture() -> None:
+    # Navigate away, back (served from the memo), away again: the same texture is
+    # re-filed under the entry that owns it.
+    m = RenderMemo(_cfg())
+    tex = _FakeTexture()
+    m.store("A", "k", _gpu_payload(tex))
+    payload = m.get("A", "k")
+    assert payload is not None
+    m.store("A", "k", payload)
+    assert tex.destroyed == 0
+    assert m.get("A", "k") is payload
+
+
+def test_rekey_keeps_the_texture_alive() -> None:
+    m = RenderMemo(_cfg())
+    tex = _FakeTexture()
+    m.store("A", "pre-bounds", _gpu_payload(tex))
+    m.rekey("A", "post-bounds")
+    assert tex.destroyed == 0
+    assert m.get("A", "post-bounds") is not None
+
+
+def test_array_payloads_are_left_alone() -> None:
+    # The test-strip memo shares this class and stores plain mosaics.
+    m = RenderMemo(_cfg())
+    m.store("A", "k", _payload())
+    m.store("A", "k2", _payload())
+    m.clear()  # must not raise: ndarray has no destroy()


### PR DESCRIPTION
Switching to a frame viewed a moment ago blanked the canvas and ran the "Processing" spinner, where it used to repaint instantly. Regression from #777.

## Cause

#777 moved the soft proof into the display LUT, so a render publishes a `GPUTexture` instead of a host array on the GPU path — the primary one. Two consumers depended on it being an array:

- The memo's only store site (`controller.py`) is guarded by `isinstance(result, np.ndarray)`, so it stopped storing entirely and every navigate-back missed → spinner on every switch. It still worked with the GPU disabled.
- `load_file` emits `gpu_textures_released` so the canvas stops sampling a pooled texture the engine is about to free. With a host array the previous frame used to stay up dimmed under the spinner — which is what `main_window._on_loading_started` still claims to do. With a texture there was nothing to fall back on, so the canvas went black.

Neither the memo's own code nor its store site changed in #777; the premise under them did.

## Fix

The memo now holds the texture itself. A file switch destroys the whole pool anyway, so the displayed texture is handed over instead of destroyed: `GPUEngine.cleanup(retain=tex)` skips it and drops its pool key, and the next render allocates a fresh one. No readback (~10 ms preview / ~695 ms HQ), no copy. `RenderMemo` frees what it owns on eviction, overwrite, `invalidate` and `clear`.

A GPU result cannot be filed at render time — the pool overwrites that texture on the next frame, and `select_file` has already hydrated the *incoming* file's config by the time `load_file` runs, so the outgoing memo key is unrecoverable there. Only the identity is kept; `load_file` files the texture under it on the way out.

Retention is refused while a render is in flight or queued: it paints into that same pooled texture, so the pixels would stop matching the key they are filed under. Falling back there costs today's spinner, not correctness.

With the texture retained the canvas keeps sampling it, so the previous frame stays up under the dimmed spinner while a genuinely new frame loads.

## Notes

- Memo VRAM is capped by `preview_cache_max_full_res_entries` (default 2 = current + previous), the same knob as the preview cache. The pre-#777 memo held two host arrays of the same size.
- The HQ toggle now clears the memo: resolution is part of the key, so every entry would be a permanent miss holding a full-size texture.
- Memo-owned textures are freed before the device is destroyed at shutdown.

## Tests

- `tests/test_navigate_back_memo.py` (new) — a settle GPU render is filed on the way out; compare/splash/tool/drag frames are not; a late render of the outgoing file is not; the CPU path still files its array directly; retention refused mid-render and while queued; the identity is spent once.
- `tests/test_render_memo.py` — owned textures freed on evict/overwrite/invalidate/clear; re-storing a frame served *from* the memo does not free its own texture; `rekey` keeps it alive; array payloads untouched (the test-strip memo shares the class).
- `tests/test_gpu_engine.py` — `cleanup(retain=tex)` leaves it alive, drops its pool key, and the next render gets a different texture.

`make all` green (3627 passed, 4 skipped).