### PR TITLE
feat(update): install a new release from inside the app

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ It is built with **Python**, running natively on Linux, macOS, and Windows.
 ### Download
 Grab the latest release for your OS from the **[Releases Page](https://github.com/marcinz606/NegPy/releases)**.
 
+After that NegPy keeps itself current: when a new release is out, the left panel shows an **⬇ Update Available** link that downloads and installs it for you, then reopens on the new version. No manual download, uninstall or reinstall.
+
 #### Linux
 I provide an `.AppImage`. Make it executable using `chmod +x` and It should just work.
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -41,7 +41,7 @@ Both side panels can be narrowed to give the canvas more room. As the controls p
 
 ## 2. Film strip (left panel)
 
-The header shows the NegPy logo and version (and an update link when a new release is out); the chevron at its top-right folds the branding away to give the frames more room, and NegPy remembers that too. Below it: the toolbar, the search box, and then two collapsible sections — **Library** (the folders your scans live in) and **Film Strip** (the frames you have open). Click either heading to fold it away; the one still open takes the whole panel, and a folded one keeps just its heading. NegPy remembers which were open.
+The header shows the NegPy logo and version. When a newer release is out, a green **⬇ Update Available** line appears under it — click it to read what changed and let NegPy install it ([§15](#15-updating-negpy)). The chevron at the header's top-right folds the branding away to give the frames more room, and NegPy remembers that too. Below it: the toolbar, the search box, and then two collapsible sections — **Library** (the folders your scans live in) and **Film Strip** (the frames you have open). Click either heading to fold it away; the one still open takes the whole panel, and a folded one keeps just its heading. NegPy remembers which were open.
 
 ### Your library
 
@@ -663,6 +663,28 @@ If NegPy crashes on launch or has rendering glitches, you can force backend sett
 *   **Black/blank preview on Windows** → `backend = "dx12"` or `qt_rhi_backend = "software"`.
 *   **Wayland rendering issues** → `qt_platform = "xcb"` to force X11.
 *   **GPU out-of-memory during export** → `max_texture_size = 4096`.
+
+---
+
+## 15. Updating NegPy
+
+NegPy asks GitHub for the newest release once at startup. If there is one, a green **⬇ Update Available: vX.Y.Z** line appears under the logo in the left panel. Click it to open the update window: the release notes, the download size, and one button.
+
+**Install Update** downloads the build that matches how *this* copy was installed, then closes NegPy, installs it over the old version, and reopens on the new one. You do not download, uninstall or reinstall anything by hand. Nothing is replaced until NegPy has exited, so a failed download or a refused permission prompt leaves your working install exactly as it was.
+
+What happens per platform:
+
+| Install | What NegPy fetches | How it installs |
+|---------|--------------------|-----------------|
+| **Windows** | the `-Setup.exe` installer | Runs it silently over your existing install — Windows asks for administrator approval first, because the app lives in Program Files. Approve it *before* NegPy closes. |
+| **macOS** | the `.dmg` for your chip (Apple silicon or Intel) | Mounts the image and replaces the `NegPy.app` bundle where it currently sits, then reopens it. |
+| **Linux** | the `.AppImage` | Replaces the AppImage file you launched, keeps it executable, and relaunches it. |
+
+Your edits, presets, settings and library are untouched: they live in `Documents/NegPy` and the local database, not in the installation folder.
+
+**When the button says "Open Releases Page" instead**, NegPy cannot swap itself and sends you to GitHub. That is the case when you run from a source checkout, when the release has no build for your platform, or when the app was moved somewhere it no longer matches its installer's layout. The same happens if the folder holding the app is not writable by you (an AppImage in a system directory, or an app bundle in a `/Applications` you do not own) — NegPy says so rather than failing halfway.
+
+You can ask for the check again at any time with the **Check for updates** action (unbound by default — give it a key in the shortcut editor).
 
 ---
 

--- a/installer.nsi
+++ b/installer.nsi
@@ -18,6 +18,8 @@
 Name "${APPNAME}"
 OutFile "dist\${OUTFILE}"
 InstallDir "$PROGRAMFILES64\${APPNAME}"
+# An upgrade must land on top of the existing install, wherever the user put it.
+InstallDirRegKey HKLM "Software\${APPNAME}" "InstallDir"
 RequestExecutionLevel admin
 
 !insertmacro MUI_PAGE_WELCOME
@@ -38,6 +40,8 @@ Section "Install"
 
     WriteUninstaller "$INSTDIR\uninstall.exe"
 
+    WriteRegStr HKLM "Software\${APPNAME}" "InstallDir" "$INSTDIR"
+
     # Registry info for Add/Remove Programs
     WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}" "DisplayName" "${APPNAME}"
     WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}" "UninstallString" "$\"$INSTDIR\uninstall.exe$\""
@@ -54,5 +58,6 @@ Section "Uninstall"
     Delete "$SMPROGRAMS\${APPNAME}.lnk"
     Delete "$DESKTOP\${APPNAME}.lnk"
     DeleteRegKey HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}"
+    DeleteRegKey HKLM "Software\${APPNAME}"
     RMDir /r "$INSTDIR"
 SectionEnd

--- a/negpy/desktop/view/keyboard_shortcuts.py
+++ b/negpy/desktop/view/keyboard_shortcuts.py
@@ -149,6 +149,7 @@ class ShortcutManager:
             "redo": controller.session.redo,
             "show_shortcuts": lambda: _show_shortcuts(self.window),
             "show_analysis_help": self.window.right_panel.show_analysis_help,
+            "check_for_updates": lambda: self.window.session_panel.check_for_updates(),
         }
 
         widgets = slider_widget_map(controls)

--- a/negpy/desktop/view/shortcut_registry.py
+++ b/negpy/desktop/view/shortcut_registry.py
@@ -166,6 +166,7 @@ REGISTRY: dict[str, ShortcutEntry] = {
     "redo": ShortcutEntry("Ctrl+Y", "Redo", "Actions"),
     "show_shortcuts": ShortcutEntry("?", "Show shortcuts", "Help"),
     "show_analysis_help": ShortcutEntry("", "Analysis panel guide", "Help"),
+    "check_for_updates": ShortcutEntry("", "Check for updates", "Help"),
 }
 
 _CURRENT_BINDINGS: dict[str, str] = {}

--- a/negpy/desktop/view/sidebar/session_panel.py
+++ b/negpy/desktop/view/sidebar/session_panel.py
@@ -1,24 +1,19 @@
+from typing import Optional
+
 from PyQt6.QtWidgets import (
     QWidget,
     QVBoxLayout,
     QLabel,
+    QMessageBox,
 )
-from PyQt6.QtCore import pyqtSignal, Qt, QThread
+from PyQt6.QtCore import Qt
 from negpy.desktop.controller import AppController
 from negpy.desktop.view.sidebar.header import SidebarHeader
 from negpy.desktop.view.sidebar.files import FileBrowser
-from negpy.kernel.system.version import check_for_updates
-
-
-class UpdateCheckWorker(QThread):
-    """Background worker to check for new releases."""
-
-    finished = pyqtSignal(str)
-
-    def run(self):
-        new_ver = check_for_updates()
-        if new_ver:
-            self.finished.emit(new_ver)
+from negpy.desktop.view.styles.theme import THEME
+from negpy.desktop.view.widgets.update_dialog import UpdateDialog, start_update_check
+from negpy.kernel.system.updater import UpdateInfo
+from negpy.kernel.system.version import get_app_version
 
 
 class SessionPanel(QWidget):
@@ -30,6 +25,7 @@ class SessionPanel(QWidget):
     def __init__(self, controller: AppController):
         super().__init__()
         self.controller = controller
+        self.update_info: Optional[UpdateInfo] = None
 
         self._init_ui()
         self._connect_signals()
@@ -48,15 +44,14 @@ class SessionPanel(QWidget):
         self.update_label = QLabel("")
         self.update_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.update_label.setObjectName("update_label")
-        self.update_label.setOpenExternalLinks(True)
+        self.update_label.setOpenExternalLinks(False)
         self.update_label.setTextInteractionFlags(Qt.TextInteractionFlag.TextBrowserInteraction)
         self.update_label.setCursor(Qt.CursorShape.PointingHandCursor)
         self.update_label.setVisible(False)
+        self.update_label.linkActivated.connect(lambda _href: self.show_update_dialog())
         layout.addWidget(self.update_label)
 
-        self.update_worker = UpdateCheckWorker()
-        self.update_worker.finished.connect(self._on_update_found)
-        self.update_worker.start()
+        start_update_check(self._on_update_checked)
 
         self.file_browser = FileBrowser(self.controller)
         self.library_tree = self.file_browser.library_tree
@@ -112,10 +107,36 @@ class SessionPanel(QWidget):
         section = self.file_browser.library_section
         section.toggle_button.setChecked(not section.toggle_button.isChecked())
 
-    def _on_update_found(self, version: str) -> None:
+    def _on_update_checked(self, info: Optional[UpdateInfo]) -> None:
+        if info is None:
+            return
+        self.update_info = info
         self.update_label.setText(
-            '<a href="https://github.com/marcinz606/NegPy/releases" '
-            'style="color:#558B2F; text-decoration:none;">'
-            f"⬇ Update Available: v{version}</a>"
+            f'<a href="#update" style="color:{THEME.status_success}; text-decoration:none;">⬇ Update Available: v{info.version}</a>'
+        )
+        self.update_label.setToolTip(
+            "Install this update — NegPy downloads it, closes, and reopens on the new version"
+            if info.can_self_install
+            else "See what is new and where to download it"
         )
         self.update_label.setVisible(True)
+
+    def show_update_dialog(self) -> None:
+        """Open the update window. Silent while the startup check has found nothing."""
+        if self.update_info is None:
+            return
+        UpdateDialog(self.update_info, self).exec()
+
+    def check_for_updates(self) -> None:
+        """Re-run the release check on demand and report either way."""
+        if self.update_info is not None:
+            self.show_update_dialog()
+            return
+        start_update_check(self._on_manual_check)
+
+    def _on_manual_check(self, info: Optional[UpdateInfo]) -> None:
+        if info is None:
+            QMessageBox.information(self, "NegPy", f"NegPy {get_app_version()} is up to date.")
+            return
+        self._on_update_checked(info)
+        self.show_update_dialog()

--- a/negpy/desktop/view/widgets/update_dialog.py
+++ b/negpy/desktop/view/widgets/update_dialog.py
@@ -1,0 +1,272 @@
+"""The update window behind the sidebar's "Update Available" notice.
+
+Shows the release notes, downloads the asset that matches this install, and hands
+it to `updater.apply_update`. NegPy then closes: the swap only happens once this
+process is gone.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable, Optional
+
+from PyQt6.QtCore import Qt, QThread, QUrl, pyqtSignal
+from PyQt6.QtGui import QDesktopServices
+from PyQt6.QtWidgets import (
+    QApplication,
+    QDialog,
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QProgressBar,
+    QPushButton,
+    QTextBrowser,
+    QVBoxLayout,
+    QWidget,
+)
+
+from negpy.desktop.view.styles.theme import THEME
+from negpy.kernel.system.logging import get_logger
+from negpy.kernel.system.updater import (
+    UpdateError,
+    UpdateInfo,
+    apply_update,
+    download_asset,
+    find_update,
+    staging_dir,
+)
+from negpy.kernel.system.version import get_app_version
+
+logger = get_logger(__name__)
+
+
+class UpdateCheckWorker(QThread):
+    """Background release check. `checked` always fires — with None when the running
+    version is current or the check could not reach GitHub."""
+
+    checked = pyqtSignal(object)
+
+    def run(self) -> None:
+        try:
+            info = find_update()
+        except Exception:
+            logger.exception("Update check failed")
+            info = None
+        self.checked.emit(info)
+
+
+# Every network thread this module starts, kept here for its whole life. A QThread
+# destroyed while it still runs takes the process down with it, and a stalled socket
+# outlives the panel or dialog that asked for it — so neither owns one.
+_RUNNING: list[QThread] = []
+_QUIT_HOOKED = False
+
+
+def _wait_for_checks() -> None:
+    for worker in _RUNNING:
+        worker.wait(6000)
+
+
+def _own(worker: QThread) -> None:
+    """Take ownership of `worker` and make sure the app waits for it on the way out."""
+    global _QUIT_HOOKED
+
+    _RUNNING.append(worker)
+    app = QApplication.instance()
+    if app is not None and not _QUIT_HOOKED:
+        _QUIT_HOOKED = True
+        app.aboutToQuit.connect(_wait_for_checks)
+
+
+def start_update_check(on_checked: Callable[[Optional[UpdateInfo]], None]) -> None:
+    """Run the release check off the UI thread, then hand `on_checked` the result.
+
+    Qt drops the connection by itself once the receiver is gone, so a check that
+    outlives the panel that started it simply reports to nobody.
+    """
+    worker = UpdateCheckWorker()
+    worker.checked.connect(on_checked)
+    _own(worker)
+    worker.start()
+
+
+class DownloadWorker(QThread):
+    """Streams the release asset, reporting bytes as they land."""
+
+    progress = pyqtSignal(int, int)
+    ready = pyqtSignal(object)
+    failed = pyqtSignal(str)
+
+    def __init__(self, info: UpdateInfo) -> None:
+        super().__init__()
+        self._info = info
+        self._cancelled = False
+
+    def cancel(self) -> None:
+        self._cancelled = True
+
+    def run(self) -> None:
+        try:
+            path = download_asset(
+                self._info,
+                staging_dir(),
+                on_progress=lambda done, total: self.progress.emit(done, total),
+                is_cancelled=lambda: self._cancelled,
+            )
+        except UpdateError as exc:
+            self.failed.emit(str(exc))
+        except Exception as exc:
+            logger.exception("Update download failed")
+            self.failed.emit(f"Download failed: {exc}")
+        else:
+            self.ready.emit(path)
+
+
+def _mb(value: int) -> str:
+    return f"{value / 1_048_576:.0f} MB"
+
+
+class UpdateDialog(QDialog):
+    """Release notes, one button, and a progress bar for the swap."""
+
+    def __init__(self, info: UpdateInfo, parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent)
+        self.info = info
+        self._worker: Optional[DownloadWorker] = None
+
+        self.setWindowTitle(f"NegPy {info.version} is available")
+        self.setWindowFlags(Qt.WindowType.Dialog | Qt.WindowType.WindowCloseButtonHint)
+        self.setModal(True)
+        self.resize(640, 560)
+
+        root = QVBoxLayout(self)
+        root.setContentsMargins(18, 18, 18, 18)
+        root.setSpacing(THEME.space_xl)
+
+        heading = QLabel(f"NegPy {info.version}")
+        heading.setStyleSheet(f"color: {THEME.text_primary}; font-size: {THEME.font_size_title}px; font-weight: bold;")
+        root.addWidget(heading)
+
+        subtitle = f"You are on {get_app_version()}."
+        if info.can_self_install:
+            subtitle += f" NegPy can install this for you ({_mb(info.size)} download)."
+        else:
+            subtitle += " Download it from the releases page to update."
+        self.subtitle = QLabel(subtitle)
+        self.subtitle.setWordWrap(True)
+        self.subtitle.setStyleSheet(f"color: {THEME.text_secondary}; font-size: {THEME.font_size_base}px;")
+        root.addWidget(self.subtitle)
+
+        divider = QFrame()
+        divider.setFrameShape(QFrame.Shape.HLine)
+        divider.setStyleSheet(f"color: {THEME.border_color};")
+        root.addWidget(divider)
+
+        self.notes = QTextBrowser()
+        self.notes.setReadOnly(True)
+        self.notes.setOpenLinks(False)
+        self.notes.setFrameShape(QFrame.Shape.NoFrame)
+        self.notes.setStyleSheet(
+            f"QTextBrowser {{ background: transparent; border: none; color: {THEME.text_secondary}; font-size: {THEME.font_size_base}px; }}"
+        )
+        self.notes.setMarkdown(info.notes or "_No release notes._")
+        root.addWidget(self.notes, stretch=1)
+
+        self.status = QLabel("")
+        self.status.setWordWrap(True)
+        self.status.setStyleSheet(f"color: {THEME.text_secondary}; font-size: {THEME.font_size_xs}px;")
+        self.status.setVisible(False)
+        root.addWidget(self.status)
+
+        self.bar = QProgressBar()
+        self.bar.setFixedHeight(6)
+        self.bar.setTextVisible(False)
+        self.bar.setRange(0, 0)
+        self.bar.setVisible(False)
+        self.bar.setStyleSheet(f"""
+            QProgressBar {{ background-color: {THEME.border_primary}; border: none; border-radius: {THEME.radius_sm}px; }}
+            QProgressBar::chunk {{ background-color: {THEME.status_success}; border-radius: {THEME.radius_sm}px; }}
+        """)
+        root.addWidget(self.bar)
+
+        actions = QHBoxLayout()
+        self.page_button = QPushButton("Release Notes on GitHub")
+        self.page_button.clicked.connect(lambda: QDesktopServices.openUrl(QUrl(self.info.page_url)))
+        actions.addWidget(self.page_button)
+        actions.addStretch()
+
+        self.later_button = QPushButton("Later")
+        self.later_button.clicked.connect(self.reject)
+        actions.addWidget(self.later_button)
+
+        self.install_button = QPushButton("Install Update" if info.can_self_install else "Open Releases Page")
+        self.install_button.setProperty("primary", True)
+        self.install_button.setDefault(True)
+        self.install_button.clicked.connect(self._on_install)
+        actions.addWidget(self.install_button)
+        root.addLayout(actions)
+
+    def _on_install(self) -> None:
+        if not self.info.can_self_install:
+            QDesktopServices.openUrl(QUrl(self.info.page_url))
+            self.accept()
+            return
+
+        self.install_button.setEnabled(False)
+        self.later_button.setText("Cancel")
+        self.bar.setVisible(True)
+        self._set_status(f"Downloading {self.info.asset_name}…")
+
+        self._worker = DownloadWorker(self.info)
+        self._worker.progress.connect(self._on_progress)
+        self._worker.ready.connect(self._on_ready)
+        self._worker.failed.connect(self._on_failed)
+        _own(self._worker)
+        self._worker.start()
+
+    def _set_status(self, text: str) -> None:
+        self.status.setText(text)
+        self.status.setVisible(True)
+
+    def _on_progress(self, done: int, total: int) -> None:
+        if total > 0:
+            if self.bar.maximum() != total:
+                self.bar.setRange(0, total)
+            self.bar.setValue(done)
+            self._set_status(f"Downloading {self.info.asset_name} — {_mb(done)} of {_mb(total)}")
+
+    def _on_ready(self, path: Path) -> None:
+        self.later_button.setEnabled(False)
+        self.bar.setRange(0, 1)
+        self.bar.setValue(1)
+        self._set_status("Installing — NegPy will close and reopen on the new version.")
+
+        try:
+            apply_update(path, self.info)
+        except UpdateError as exc:
+            self._on_failed(str(exc))
+            return
+        except Exception as exc:
+            logger.exception("Failed to start the installer")
+            self._on_failed(f"Could not start the installer: {exc}")
+            return
+
+        self.accept()
+        app = QApplication.instance()
+        if app is not None:
+            app.closeAllWindows()
+            app.quit()
+
+    def _on_failed(self, message: str) -> None:
+        self.bar.setVisible(False)
+        self._set_status(f"{message}\nYou can still download it from the releases page.")
+        self.install_button.setEnabled(True)
+        self.later_button.setEnabled(True)
+        self.later_button.setText("Close")
+
+    def reject(self) -> None:
+        # The worker outlives this window (see `_own`), so closing need not block on
+        # a socket read: it stops at the next chunk and drops the part file.
+        if self._worker is not None and self._worker.isRunning():
+            self._worker.cancel()
+        super().reject()

--- a/negpy/kernel/system/updater.py
+++ b/negpy/kernel/system/updater.py
@@ -1,0 +1,334 @@
+"""In-place self update.
+
+The app finds the release asset that matches how *this* copy was installed,
+downloads it, then hands a small detached script the job of swapping the
+installation while NegPy is closed — a running program cannot overwrite itself.
+The script waits for our PID to disappear, installs, and starts the new build.
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+import shlex
+import stat
+import subprocess
+import sys
+import tempfile
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+from negpy.kernel.system.logging import get_logger
+from negpy.kernel.system.version import (
+    RELEASES_PAGE,
+    USER_AGENT,
+    fetch_latest_release,
+    get_app_version,
+    is_newer,
+)
+
+logger = get_logger(__name__)
+
+_CHUNK = 256 * 1024
+
+# How the running copy was installed. "" means it cannot replace itself: a source
+# checkout, or a bundle moved out of the layout its installer produced.
+APPIMAGE = "appimage"
+NSIS = "nsis"
+APP_BUNDLE = "app_bundle"
+
+
+class UpdateError(Exception):
+    """A self update that cannot proceed, with a message fit for the user."""
+
+
+@dataclass(frozen=True)
+class UpdateInfo:
+    """A newer release, and the asset that suits this install (if there is one)."""
+
+    version: str
+    notes: str
+    page_url: str
+    asset_name: str = ""
+    download_url: str = ""
+    size: int = 0
+
+    @property
+    def can_self_install(self) -> bool:
+        return bool(self.download_url) and bool(install_kind())
+
+
+def install_kind() -> str:
+    """Which installer produced the running copy, or "" when it cannot self update."""
+    if not getattr(sys, "frozen", False):
+        return ""
+    if sys.platform == "win32":
+        return NSIS
+    if sys.platform == "darwin":
+        return APP_BUNDLE if app_bundle_path() is not None else ""
+    if sys.platform.startswith("linux"):
+        return APPIMAGE if os.environ.get("APPIMAGE") else ""
+    return ""
+
+
+def app_bundle_path() -> Optional[Path]:
+    """The `.app` the running executable lives in, or None outside a bundle."""
+    exe = Path(sys.executable).resolve()
+    for parent in exe.parents:
+        if parent.suffix == ".app":
+            return parent
+    return None
+
+
+def _macos_arch() -> str:
+    machine = platform.machine()
+    return "arm64" if machine in ("arm64", "aarch64") else "x86_64"
+
+
+def select_asset(assets: list[dict[str, Any]], kind: str) -> Optional[dict[str, Any]]:
+    """The release asset matching `kind`, or None when the release has no such build.
+
+    macOS ships one DMG per architecture, so the arch suffix decides; a release with
+    a single DMG is taken as-is, which keeps a one-arch release usable.
+    """
+    named = [a for a in assets if isinstance(a, dict) and a.get("name") and a.get("browser_download_url")]
+
+    if kind == APPIMAGE:
+        return next((a for a in named if a["name"].endswith(".AppImage")), None)
+    if kind == NSIS:
+        return next((a for a in named if a["name"].endswith("-Setup.exe")), None)
+    if kind == APP_BUNDLE:
+        dmgs = [a for a in named if a["name"].endswith(".dmg")]
+        exact = [a for a in dmgs if a["name"].endswith(f"-{_macos_arch()}.dmg")]
+        if exact:
+            return exact[0]
+        return dmgs[0] if len(dmgs) == 1 else None
+    return None
+
+
+def find_update(timeout: float = 5.0) -> Optional[UpdateInfo]:
+    """The newest release when it is later than the running one, else None.
+
+    An UpdateInfo without a `download_url` still gets reported: the release page is
+    always an answer, even when nothing here can be installed automatically.
+    """
+    current = get_app_version()
+    if current == "unknown":
+        return None
+
+    payload = fetch_latest_release(timeout)
+    if not payload:
+        return None
+
+    latest = str(payload.get("tag_name") or "").lstrip("v")
+    if not is_newer(latest, current):
+        return None
+
+    assets = payload.get("assets") or []
+    asset = select_asset(assets if isinstance(assets, list) else [], install_kind())
+
+    return UpdateInfo(
+        version=latest,
+        notes=str(payload.get("body") or ""),
+        page_url=str(payload.get("html_url") or RELEASES_PAGE),
+        asset_name=str(asset["name"]) if asset else "",
+        download_url=str(asset["browser_download_url"]) if asset else "",
+        size=int(asset.get("size") or 0) if asset else 0,
+    )
+
+
+def staging_dir() -> Path:
+    """Where the downloaded asset lands.
+
+    An AppImage is replaced by a rename, so it is staged beside the target to keep
+    that rename on one filesystem; everything else goes to the temp directory.
+    """
+    running = os.environ.get("APPIMAGE")
+    if install_kind() == APPIMAGE and running:
+        target = Path(running).resolve().parent
+        if os.access(target, os.W_OK):
+            return target
+    return Path(tempfile.mkdtemp(prefix="negpy-update-"))
+
+
+def download_asset(
+    info: UpdateInfo,
+    dest_dir: Path,
+    on_progress: Optional[Callable[[int, int], None]] = None,
+    is_cancelled: Optional[Callable[[], bool]] = None,
+) -> Path:
+    """Stream the asset into `dest_dir` and return the file. Raises UpdateError."""
+    if not info.download_url:
+        raise UpdateError("This release has no download for your platform.")
+
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    target = dest_dir / f"{info.asset_name}.part"
+    request = urllib.request.Request(info.download_url, headers={"User-Agent": USER_AGENT})
+
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            total = int(response.headers.get("Content-Length") or info.size or 0)
+            done = 0
+            with open(target, "wb") as out:
+                while True:
+                    if is_cancelled is not None and is_cancelled():
+                        raise UpdateError("Download cancelled.")
+                    chunk = response.read(_CHUNK)
+                    if not chunk:
+                        break
+                    out.write(chunk)
+                    done += len(chunk)
+                    if on_progress is not None:
+                        on_progress(done, total)
+    except UpdateError:
+        target.unlink(missing_ok=True)
+        raise
+    except Exception as exc:
+        target.unlink(missing_ok=True)
+        raise UpdateError(f"Download failed: {exc}") from exc
+
+    final = dest_dir / info.asset_name
+    target.replace(final)
+    return final
+
+
+def _wait_and_run_sh(pid: int, body: str) -> str:
+    """A script that starts once NegPy is gone.
+
+    The read on stdin is the death signal: it returns EOF when our end of the pipe
+    closes, which happens when the process dies however it dies. Polling the PID
+    alone cannot do this — an exited-but-unreaped process is a zombie, and a zombie
+    still answers `kill -0`. The poll that follows is only a short grace period,
+    bounded because POSIX lets an open file be replaced under a running process.
+    """
+    return (
+        "#!/bin/sh\n"
+        "cat >/dev/null 2>&1\n"
+        "waited=0\n"
+        f"while kill -0 {pid} 2>/dev/null && [ $waited -lt 20 ]; do\n"
+        "    sleep 0.5\n"
+        "    waited=$((waited + 1))\n"
+        "done\n"
+        f"{body}"
+    )
+
+
+def appimage_script(downloaded: Path, target: Path, pid: int) -> str:
+    """Replace the running AppImage with the downloaded one and start it."""
+    new, old = shlex.quote(str(downloaded)), shlex.quote(str(target))
+    return _wait_and_run_sh(
+        pid,
+        f'set -e\nchmod +x {new}\nmv -f {new} {old}\nrm -f "$0"\nexec {old}\n',
+    )
+
+
+def macos_script(dmg: Path, bundle: Path, pid: int, mountpoint: Path, stage: Path) -> str:
+    """Mount the DMG, swap the bundle for the one inside it, and reopen the app.
+
+    The new bundle is staged whole before the old one goes: a copy that dies
+    half way must not take the installed app with it.
+    """
+    q = shlex.quote
+    return _wait_and_run_sh(
+        pid,
+        f"""set -e
+mkdir -p {q(str(mountpoint))}
+hdiutil attach {q(str(dmg))} -nobrowse -readonly -mountpoint {q(str(mountpoint))}
+rm -rf {q(str(stage))}
+ditto {q(str(mountpoint / bundle.name))} {q(str(stage))}
+hdiutil detach {q(str(mountpoint))} -quiet || true
+rm -rf {q(str(bundle))}
+mv {q(str(stage))} {q(str(bundle))}
+xattr -dr com.apple.quarantine {q(str(bundle))} 2>/dev/null || true
+rm -f {q(str(dmg))} "$0"
+open {q(str(bundle))}
+""",
+    )
+
+
+def nsis_script(setup: Path, install_dir: Path, exe: Path, pid: int) -> str:
+    """Run the installer silently over the current install, then restart NegPy.
+
+    NSIS wants `/D` last and unquoted even when the path has spaces, which is why
+    this is a batch file rather than an argument list. NegPy is restarted through
+    Explorer: this script runs elevated, and a child of it would inherit the admin
+    token that the app itself must not have.
+    """
+    return (
+        "@echo off\r\n"
+        f'powershell -NoProfile -Command "try {{ Wait-Process -Id {pid} -Timeout 240 }} catch {{ }}"\r\n'
+        f'start "" /wait "{setup}" /S /D={install_dir}\r\n'
+        f'del /q "{setup}"\r\n'
+        f'explorer.exe "{exe}"\r\n'
+        'del "%~f0"\r\n'
+    )
+
+
+# Holds each swap script's Popen — and with it the write end of the pipe the script
+# waits on — open for the rest of this process's life. Dropping it would close the
+# pipe early and start the swap under the running app.
+_SPAWNED: list[subprocess.Popen] = []
+
+
+def _spawn_posix(script: str, workdir: Path) -> None:
+    path = workdir / "negpy-update.sh"
+    path.write_text(script, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+    _SPAWNED.append(
+        subprocess.Popen(
+            ["/bin/sh", str(path)],
+            start_new_session=True,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    )
+
+
+def _spawn_elevated_bat(script: str, workdir: Path) -> None:
+    """Launch the batch file through UAC — Program Files needs an admin token."""
+    import ctypes
+
+    path = workdir / "negpy-update.bat"
+    path.write_text(script, encoding="utf-8")
+
+    # SW_HIDE: the console window is noise, the installer runs silently anyway.
+    result = ctypes.windll.shell32.ShellExecuteW(None, "runas", str(path), None, str(workdir), 0)
+    if int(result) <= 32:
+        raise UpdateError("Windows refused to start the installer (administrator approval is required).")
+
+
+def apply_update(downloaded: Path, info: UpdateInfo) -> None:
+    """Start the swap and return; the caller must then quit so it can finish.
+
+    Nothing is replaced until this process exits, so a failure here leaves the
+    current install untouched.
+    """
+    kind = install_kind()
+    pid = os.getpid()
+
+    if kind == APPIMAGE:
+        target = Path(os.environ["APPIMAGE"]).resolve()
+        if not os.access(target.parent, os.W_OK):
+            raise UpdateError(f"{target.parent} is not writable — move NegPy somewhere you own, or install the new AppImage yourself.")
+        _spawn_posix(appimage_script(downloaded, target, pid), downloaded.parent)
+
+    elif kind == APP_BUNDLE:
+        bundle = app_bundle_path()
+        if bundle is None:
+            raise UpdateError("NegPy is not running from an application bundle.")
+        if not os.access(bundle.parent, os.W_OK):
+            raise UpdateError(f"{bundle.parent} is not writable — install the update from the disk image yourself.")
+        work = downloaded.parent
+        _spawn_posix(macos_script(downloaded, bundle, pid, work / "mnt", work / bundle.name), work)
+
+    elif kind == NSIS:
+        exe = Path(sys.executable).resolve()
+        _spawn_elevated_bat(nsis_script(downloaded, exe.parent, exe, pid), downloaded.parent)
+
+    else:
+        raise UpdateError("This copy of NegPy cannot update itself.")
+
+    logger.info("Update to %s staged from %s", info.version, downloaded)

--- a/negpy/kernel/system/version.py
+++ b/negpy/kernel/system/version.py
@@ -2,7 +2,12 @@ import os
 import sys
 import json
 import urllib.request
-from typing import Optional
+from typing import Any, Optional
+
+GITHUB_REPO = "marcinz606/NegPy"
+LATEST_RELEASE_API = f"https://api.github.com/repos/{GITHUB_REPO}/releases/latest"
+RELEASES_PAGE = f"https://github.com/{GITHUB_REPO}/releases"
+USER_AGENT = "NegPy-Updater"
 
 
 def get_app_version() -> str:
@@ -32,42 +37,31 @@ def get_app_version() -> str:
         return "unknown"
 
 
-def check_for_updates() -> Optional[str]:
-    """
-    Checks if there is new version available in github and if it is return it's version, else return none.
-    """
-    current_version = get_app_version()
-    if current_version == "unknown":
+def parse_version(v_str: str) -> list[int]:
+    """The numeric parts of a version string, for ordered comparison."""
+    try:
+        return [int(x) for x in v_str.split(".") if x.isdigit()]
+    except Exception:
+        return []
+
+
+def fetch_latest_release(timeout: float = 5.0) -> Optional[dict[str, Any]]:
+    """The GitHub payload for the newest release, or None if it cannot be read."""
+    try:
+        req = urllib.request.Request(LATEST_RELEASE_API, headers={"User-Agent": USER_AGENT})
+        with urllib.request.urlopen(req, timeout=timeout) as response:
+            if response.status != 200:
+                return None
+            payload = json.loads(response.read().decode())
+    except Exception:
         return None
 
-    url = "https://api.github.com/repos/marcinz606/NegPy/releases/latest"
+    return payload if isinstance(payload, dict) else None
 
-    try:
-        req = urllib.request.Request(
-            url,
-            headers={"User-Agent": "NegPy-Updater"},
-        )
-        with urllib.request.urlopen(req, timeout=3) as response:
-            if response.status == 200:
-                data = json.loads(response.read().decode())
-                latest_tag = data.get("tag_name", "").lstrip("v")
 
-                if not latest_tag:
-                    return None
-
-                def parse_version(v_str: str) -> list[int]:
-                    try:
-                        return [int(x) for x in v_str.split(".") if x.isdigit()]
-                    except Exception:
-                        return []
-
-                current_parts = parse_version(current_version)
-                latest_parts = parse_version(latest_tag)
-
-                if latest_parts > current_parts:
-                    return str(latest_tag)
-
-    except Exception:
-        pass
-
-    return None
+def is_newer(candidate: str, current: str) -> bool:
+    """True when `candidate` names a release later than `current`."""
+    candidate_parts = parse_version(candidate)
+    if not candidate_parts or current == "unknown":
+        return False
+    return candidate_parts > parse_version(current)

--- a/tests/test_empty_state_and_header.py
+++ b/tests/test_empty_state_and_header.py
@@ -88,7 +88,7 @@ def test_overlay_stays_centred_on_its_parent(overlay, host):
 
 @pytest.fixture
 def controller(tmp_path, monkeypatch):
-    monkeypatch.setattr("negpy.desktop.view.sidebar.session_panel.check_for_updates", lambda: None)
+    monkeypatch.setattr("negpy.desktop.view.widgets.update_dialog.find_update", lambda *a, **k: None)
     repo = StorageRepository(str(tmp_path / "edits.db"), str(tmp_path / "settings.db"))
     repo.initialize()
     ctrl = MagicMock()

--- a/tests/test_session_panel.py
+++ b/tests/test_session_panel.py
@@ -5,6 +5,7 @@ import pytest
 from negpy.desktop.session import DesktopSessionManager
 from negpy.desktop.view.sidebar.session_panel import SessionPanel
 from negpy.infrastructure.storage.repository import StorageRepository
+from negpy.kernel.system.updater import UpdateInfo
 
 
 def _controller(tmp_path, roots: list[str]) -> MagicMock:
@@ -22,7 +23,7 @@ def _controller(tmp_path, roots: list[str]) -> MagicMock:
 @pytest.fixture
 def panel(qapp, tmp_path, monkeypatch):
     # The update check would hit the network on construction.
-    monkeypatch.setattr("negpy.desktop.view.sidebar.session_panel.check_for_updates", lambda: None)
+    monkeypatch.setattr("negpy.desktop.view.widgets.update_dialog.find_update", lambda *a, **k: None)
     root = tmp_path / "library"
     root.mkdir()
     return SessionPanel(_controller(tmp_path, [str(root)]))
@@ -52,7 +53,7 @@ def test_tree_is_shown_when_the_library_has_roots(panel):
 
 
 def test_tree_hidden_when_no_roots(qapp, tmp_path, monkeypatch):
-    monkeypatch.setattr("negpy.desktop.view.sidebar.session_panel.check_for_updates", lambda: None)
+    monkeypatch.setattr("negpy.desktop.view.widgets.update_dialog.find_update", lambda *a, **k: None)
 
     panel = SessionPanel(_controller(tmp_path, []))
 
@@ -166,3 +167,56 @@ def test_section_states_are_remembered(panel):
     repo = panel.controller.session.repo
     assert repo.get_global_setting("library_section_expanded") is False
     assert repo.get_global_setting("frames_section_expanded") is False
+
+
+# --- the update notice ----------------------------------------------------
+
+
+def _update(**overrides) -> UpdateInfo:
+    fields = dict(
+        version="9.9.9",
+        notes="## What's new",
+        page_url="https://example.test/release",
+        asset_name="NegPy-9.9.9-x86_64.AppImage",
+        download_url="https://example.test/asset",
+        size=1,
+    )
+    return UpdateInfo(**{**fields, **overrides})
+
+
+def test_no_notice_until_a_newer_release_turns_up(panel):
+    panel._on_update_checked(None)
+
+    assert not panel.update_label.isVisibleTo(panel)
+    assert panel.update_info is None
+
+
+def test_the_notice_names_the_new_version(panel, monkeypatch):
+    monkeypatch.setattr("negpy.kernel.system.updater.install_kind", lambda: "appimage")
+
+    panel._on_update_checked(_update())
+
+    assert panel.update_label.isVisibleTo(panel)
+    assert "9.9.9" in panel.update_label.text()
+    assert "#update" in panel.update_label.text()  # the click stays in the app
+
+
+def test_clicking_the_notice_opens_the_update_window(panel, monkeypatch):
+    opened = []
+    monkeypatch.setattr(
+        "negpy.desktop.view.sidebar.session_panel.UpdateDialog", lambda info, parent: MagicMock(exec=lambda: opened.append(info))
+    )
+    panel._on_update_checked(_update())
+
+    panel.update_label.linkActivated.emit("#update")
+
+    assert opened and opened[0].version == "9.9.9"
+
+
+def test_the_window_stays_shut_while_the_running_version_is_current(panel, monkeypatch):
+    monkeypatch.setattr(
+        "negpy.desktop.view.sidebar.session_panel.UpdateDialog",
+        lambda info, parent: pytest.fail("no update to show"),
+    )
+
+    panel.show_update_dialog()

--- a/tests/test_update_dialog.py
+++ b/tests/test_update_dialog.py
@@ -1,0 +1,145 @@
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from negpy.desktop.view.widgets import update_dialog as dialog_module
+from negpy.desktop.view.widgets.update_dialog import UpdateDialog
+from negpy.kernel.system.updater import UpdateError, UpdateInfo
+
+
+def _info(**overrides) -> UpdateInfo:
+    fields = dict(
+        version="9.9.9",
+        notes="## What's new\n\n- A thing",
+        page_url="https://example.test/release",
+        asset_name="NegPy-9.9.9-x86_64.AppImage",
+        download_url="https://example.test/asset",
+        size=2 * 1_048_576,
+    )
+    return UpdateInfo(**{**fields, **overrides})
+
+
+@pytest.fixture
+def installable(monkeypatch):
+    monkeypatch.setattr("negpy.kernel.system.updater.install_kind", lambda: "appimage")
+
+
+def test_the_notes_and_the_size_are_shown(qapp, installable):
+    dlg = UpdateDialog(_info())
+
+    assert "What's new" in dlg.notes.toMarkdown()
+    assert "2 MB" in dlg.subtitle.text()
+    assert dlg.install_button.text() == "Install Update"
+
+
+def test_a_release_without_a_build_for_this_install_only_offers_the_page(qapp, monkeypatch):
+    monkeypatch.setattr("negpy.kernel.system.updater.install_kind", lambda: "")
+    opened = []
+    monkeypatch.setattr(dialog_module.QDesktopServices, "openUrl", lambda url: opened.append(url.toString()))
+
+    dlg = UpdateDialog(_info(download_url="", asset_name=""))
+    assert dlg.install_button.text() == "Open Releases Page"
+
+    dlg.install_button.click()
+
+    assert opened == ["https://example.test/release"]
+
+
+def test_the_download_progress_reads_in_megabytes(qapp, installable):
+    dlg = UpdateDialog(_info())
+
+    dlg._on_progress(1_048_576, 4 * 1_048_576)
+
+    assert dlg.bar.maximum() == 4 * 1_048_576
+    assert "1 MB of 4 MB" in dlg.status.text()
+
+
+def test_a_downloaded_asset_is_handed_to_the_installer_and_the_app_closes(qapp, installable, monkeypatch, tmp_path):
+    applied = []
+    quit_calls = []
+    monkeypatch.setattr(dialog_module, "apply_update", lambda path, info: applied.append((path, info.version)))
+    monkeypatch.setattr(dialog_module.QApplication, "closeAllWindows", lambda *a: quit_calls.append("close"))
+    monkeypatch.setattr(dialog_module.QApplication, "quit", lambda *a: quit_calls.append("quit"))
+    dlg = UpdateDialog(_info())
+
+    dlg._on_ready(tmp_path / "NegPy-9.9.9-x86_64.AppImage")
+
+    assert applied == [(tmp_path / "NegPy-9.9.9-x86_64.AppImage", "9.9.9")]
+    assert quit_calls == ["close", "quit"]
+
+
+def test_a_refused_installer_leaves_the_app_running(qapp, installable, monkeypatch):
+    quit_calls = []
+
+    def refuse(path, info):
+        raise UpdateError("Windows refused to start the installer")
+
+    monkeypatch.setattr(dialog_module, "apply_update", refuse)
+    monkeypatch.setattr(dialog_module.QApplication, "quit", lambda *a: quit_calls.append("quit"))
+    dlg = UpdateDialog(_info())
+
+    dlg._on_ready(Path("/tmp/NegPy.AppImage"))
+
+    assert not quit_calls
+    assert "refused" in dlg.status.text()
+    assert dlg.install_button.isEnabled()  # the user can try again
+
+
+def test_the_module_owns_the_check_thread_not_the_caller(qapp, monkeypatch):
+    """A QThread destroyed while it still runs aborts the process, and a stalled
+    network call outlives the panel that asked for it."""
+    started, release = threading.Event(), threading.Event()
+
+    def slow(*_args, **_kwargs):
+        started.set()
+        release.wait(5)
+        return None
+
+    monkeypatch.setattr(dialog_module, "find_update", slow)
+    before = len(dialog_module._RUNNING)
+    try:
+        dialog_module.start_update_check(lambda info: None)
+
+        assert started.wait(2)
+        assert len(dialog_module._RUNNING) == before + 1
+    finally:
+        release.set()
+        dialog_module._wait_for_checks()
+        dialog_module._RUNNING.clear()
+
+
+def test_closing_the_window_stops_the_download_without_waiting_on_it(qapp, installable, monkeypatch):
+    running, cancelled = threading.Event(), threading.Event()
+
+    def blocking_download(info, dest_dir, on_progress=None, is_cancelled=None):
+        running.set()
+        while not is_cancelled():
+            time.sleep(0.01)
+        cancelled.set()
+        raise UpdateError("Download cancelled.")
+
+    monkeypatch.setattr(dialog_module, "download_asset", blocking_download)
+    before = len(dialog_module._RUNNING)
+    dlg = UpdateDialog(_info())
+    try:
+        dlg.install_button.click()
+        assert running.wait(2)
+        assert len(dialog_module._RUNNING) == before + 1  # not the dialog's to destroy
+
+        dlg.reject()
+
+        assert cancelled.wait(2)
+    finally:
+        dialog_module._wait_for_checks()
+        dialog_module._RUNNING.clear()
+
+
+def test_a_failed_download_points_back_at_the_releases_page(qapp, installable):
+    dlg = UpdateDialog(_info())
+
+    dlg._on_failed("Download failed: connection reset")
+
+    assert not dlg.bar.isVisibleTo(dlg)
+    assert "releases page" in dlg.status.text()

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -1,0 +1,268 @@
+import io
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from negpy.kernel.system import updater
+from negpy.kernel.system.updater import (
+    APP_BUNDLE,
+    APPIMAGE,
+    NSIS,
+    UpdateError,
+    UpdateInfo,
+    appimage_script,
+    apply_update,
+    download_asset,
+    find_update,
+    macos_script,
+    nsis_script,
+    select_asset,
+)
+
+
+def _asset(name: str, size: int = 10) -> dict:
+    return {"name": name, "browser_download_url": f"https://example.test/{name}", "size": size}
+
+
+ASSETS = [
+    _asset("NegPy-0.9.5-x86_64.AppImage"),
+    _asset("NegPy-0.9.5-Win64-Setup.exe"),
+    _asset("NegPy-0.9.5-macOS-arm64.dmg"),
+    _asset("NegPy-0.9.5-macOS-x86_64.dmg"),
+]
+
+
+# --- asset selection ------------------------------------------------------
+
+
+def test_each_install_kind_picks_its_own_asset():
+    assert select_asset(ASSETS, APPIMAGE)["name"].endswith(".AppImage")
+    assert select_asset(ASSETS, NSIS)["name"].endswith("-Setup.exe")
+
+
+@pytest.mark.parametrize("machine, expected", [("arm64", "arm64"), ("aarch64", "arm64"), ("x86_64", "x86_64")])
+def test_the_mac_build_follows_the_machine_architecture(monkeypatch, machine, expected):
+    monkeypatch.setattr("platform.machine", lambda: machine)
+
+    assert select_asset(ASSETS, APP_BUNDLE)["name"] == f"NegPy-0.9.5-macOS-{expected}.dmg"
+
+
+def test_a_single_dmg_release_serves_any_mac(monkeypatch):
+    monkeypatch.setattr("platform.machine", lambda: "arm64")
+    only = [_asset("NegPy-0.9.5-macOS-x86_64.dmg")]
+
+    assert select_asset(only, APP_BUNDLE) is only[0]
+
+
+def test_no_asset_for_an_install_kind_that_cannot_update_itself():
+    assert select_asset(ASSETS, "") is None
+    assert select_asset([_asset("source.zip")], APPIMAGE) is None
+
+
+# --- finding the update ---------------------------------------------------
+
+
+def _release(tag: str = "v0.9.5", assets: list | None = None) -> dict:
+    return {
+        "tag_name": tag,
+        "body": "## Notes",
+        "html_url": "https://example.test/release",
+        "assets": ASSETS if assets is None else assets,
+    }
+
+
+@pytest.fixture
+def frozen_appimage(monkeypatch, tmp_path):
+    """A running copy that looks like an installed AppImage."""
+    target = tmp_path / "NegPy.AppImage"
+    target.write_bytes(b"old")
+    monkeypatch.setattr(updater.sys, "frozen", True, raising=False)
+    monkeypatch.setattr(updater.sys, "platform", "linux")
+    monkeypatch.setenv("APPIMAGE", str(target))
+    return target
+
+
+def test_a_newer_release_reports_the_matching_asset(monkeypatch, frozen_appimage):
+    monkeypatch.setattr(updater, "get_app_version", lambda: "0.9.0")
+    monkeypatch.setattr(updater, "fetch_latest_release", lambda timeout=5.0: _release())
+
+    info = find_update()
+
+    assert info.version == "0.9.5"
+    assert info.asset_name == "NegPy-0.9.5-x86_64.AppImage"
+    assert info.can_self_install
+
+
+def test_the_current_release_is_no_update(monkeypatch, frozen_appimage):
+    monkeypatch.setattr(updater, "get_app_version", lambda: "0.9.5")
+    monkeypatch.setattr(updater, "fetch_latest_release", lambda timeout=5.0: _release())
+
+    assert find_update() is None
+
+
+def test_an_unknown_version_never_offers_an_update(monkeypatch):
+    monkeypatch.setattr(updater, "get_app_version", lambda: "unknown")
+
+    assert find_update() is None
+
+
+def test_an_unreachable_github_is_no_update(monkeypatch):
+    monkeypatch.setattr(updater, "get_app_version", lambda: "0.9.0")
+    monkeypatch.setattr(updater, "fetch_latest_release", lambda timeout=5.0: None)
+
+    assert find_update() is None
+
+
+def test_a_release_without_a_build_for_this_install_still_points_at_the_page(monkeypatch, frozen_appimage):
+    monkeypatch.setattr(updater, "get_app_version", lambda: "0.9.0")
+    monkeypatch.setattr(updater, "fetch_latest_release", lambda timeout=5.0: _release(assets=[_asset("source.zip")]))
+
+    info = find_update()
+
+    assert info.version == "0.9.5"
+    assert not info.can_self_install
+    assert info.page_url == "https://example.test/release"
+
+
+# --- downloading ----------------------------------------------------------
+
+
+def _urlopen_serving(payload: bytes) -> MagicMock:
+    response = MagicMock()
+    response.headers = {"Content-Length": str(len(payload))}
+    stream = io.BytesIO(payload)
+    response.read.side_effect = lambda n: stream.read(n)
+    response.__enter__.return_value = response
+    return MagicMock(return_value=response)
+
+
+def _info(size: int = 6) -> UpdateInfo:
+    return UpdateInfo(
+        version="0.9.5",
+        notes="",
+        page_url="https://example.test/release",
+        asset_name="NegPy-0.9.5-x86_64.AppImage",
+        download_url="https://example.test/asset",
+        size=size,
+    )
+
+
+def test_the_asset_lands_whole_and_progress_is_reported(tmp_path):
+    seen: list[tuple[int, int]] = []
+
+    with patch("urllib.request.urlopen", _urlopen_serving(b"payload")):
+        path = download_asset(_info(7), tmp_path, on_progress=lambda d, t: seen.append((d, t)))
+
+    assert path == tmp_path / "NegPy-0.9.5-x86_64.AppImage"
+    assert path.read_bytes() == b"payload"
+    assert seen[-1] == (7, 7)
+
+
+def test_a_cancelled_download_leaves_nothing_behind(tmp_path):
+    with patch("urllib.request.urlopen", _urlopen_serving(b"payload")):
+        with pytest.raises(UpdateError):
+            download_asset(_info(), tmp_path, is_cancelled=lambda: True)
+
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_a_failed_download_leaves_nothing_behind(tmp_path):
+    with patch("urllib.request.urlopen", side_effect=OSError("connection reset")):
+        with pytest.raises(UpdateError):
+            download_asset(_info(), tmp_path)
+
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_a_release_with_no_asset_cannot_be_downloaded(tmp_path):
+    info = UpdateInfo(version="0.9.5", notes="", page_url="https://example.test/release")
+
+    with pytest.raises(UpdateError):
+        download_asset(info, tmp_path)
+
+
+# --- the swap scripts -----------------------------------------------------
+
+
+def test_the_appimage_script_waits_then_replaces_and_relaunches():
+    script = appimage_script(Path("/tmp/new.AppImage"), Path("/home/u/NegPy.AppImage"), 4242)
+
+    assert "kill -0 4242" in script
+    assert "mv -f /tmp/new.AppImage /home/u/NegPy.AppImage" in script
+    assert script.rstrip().endswith("exec /home/u/NegPy.AppImage")
+
+
+def test_the_posix_scripts_wait_on_the_pipe_not_only_the_pid():
+    """A zombie still answers `kill -0`, so the pipe's EOF is what starts the swap."""
+    script = appimage_script(Path("/tmp/new"), Path("/tmp/old"), 1)
+
+    assert script.index("cat >/dev/null") < script.index("kill -0 1")
+    assert "waited -lt 20" in script  # the PID poll is only a grace period
+
+
+def test_the_windows_script_does_not_wait_on_a_stuck_pid_forever():
+    assert "Wait-Process -Id 1 -Timeout 240" in nsis_script(Path("s.exe"), Path("d"), Path("e.exe"), 1)
+
+
+def test_the_macos_script_mounts_swaps_the_bundle_and_reopens():
+    script = macos_script(Path("/tmp/n.dmg"), Path("/Applications/NegPy.app"), 7, Path("/tmp/mnt"), Path("/tmp/NegPy.app"))
+
+    assert "kill -0 7" in script
+    assert "hdiutil attach /tmp/n.dmg" in script
+    assert "ditto /tmp/mnt/NegPy.app /tmp/NegPy.app" in script
+    assert "rm -rf /Applications/NegPy.app" in script
+    assert "open /Applications/NegPy.app" in script
+
+
+def test_the_windows_script_installs_silently_over_the_current_install():
+    script = nsis_script(Path(r"C:\Temp\Setup.exe"), Path(r"C:\Program Files\NegPy"), Path(r"C:\Program Files\NegPy\NegPy.exe"), 9)
+
+    assert "Wait-Process -Id 9" in script
+    # NSIS wants /D last and unquoted, spaces and all.
+    assert r'start "" /wait "C:\Temp\Setup.exe" /S /D=C:\Program Files\NegPy' in script
+    # Through Explorer: the script is elevated, the app it restarts must not be.
+    assert r'explorer.exe "C:\Program Files\NegPy\NegPy.exe"' in script
+
+
+# --- applying -------------------------------------------------------------
+
+
+def test_a_source_checkout_refuses_to_swap_itself(monkeypatch, tmp_path):
+    monkeypatch.setattr(updater.sys, "frozen", False, raising=False)
+
+    with pytest.raises(UpdateError):
+        apply_update(tmp_path / "new.AppImage", _info())
+
+
+def test_an_appimage_in_a_read_only_folder_says_so(monkeypatch, frozen_appimage, tmp_path):
+    monkeypatch.setattr(updater.os, "access", lambda path, mode: False)
+
+    with pytest.raises(UpdateError, match="not writable"):
+        apply_update(tmp_path / "new.AppImage", _info())
+
+
+def test_applying_spawns_the_script_detached_and_touches_nothing_yet(monkeypatch, frozen_appimage, tmp_path):
+    spawned = {}
+    monkeypatch.setattr(updater.subprocess, "Popen", lambda cmd, **kw: spawned.update(cmd=cmd, kw=kw))
+    downloaded = tmp_path / "new.AppImage"
+    downloaded.write_bytes(b"new")
+
+    apply_update(downloaded, _info())
+
+    assert spawned["kw"]["start_new_session"] is True
+    assert Path(spawned["cmd"][1]).read_text().count(str(frozen_appimage)) >= 1
+    assert frozen_appimage.read_bytes() == b"old"  # the running copy survives until it exits
+
+
+def test_the_appimage_stages_next_to_the_target(frozen_appimage):
+    assert updater.staging_dir() == frozen_appimage.parent
+
+
+def test_the_release_payload_shape_matches_what_github_sends():
+    """Guards the field names find_update() reads out of the API response."""
+    sample = json.loads(json.dumps(_release()))
+
+    assert {"tag_name", "body", "html_url", "assets"} <= sample.keys()
+    assert {"name", "browser_download_url", "size"} <= sample["assets"][0].keys()

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,47 +1,54 @@
-import unittest
-from unittest.mock import patch, MagicMock
-from negpy.kernel.system.version import check_for_updates
 import json
+import unittest
+from unittest.mock import MagicMock, patch
+
+from negpy.kernel.system.version import fetch_latest_release, is_newer, parse_version
 
 
-class TestVersionCheck(unittest.TestCase):
-    @patch("negpy.kernel.system.version.get_app_version")
+def _response(payload: dict, status: int = 200) -> MagicMock:
+    response = MagicMock()
+    response.status = status
+    response.read.return_value = json.dumps(payload).encode()
+    response.__enter__.return_value = response
+    return response
+
+
+class TestVersionParsing(unittest.TestCase):
+    def test_parse_version_keeps_numeric_parts(self):
+        self.assertEqual(parse_version("0.9.5"), [0, 9, 5])
+        self.assertEqual(parse_version("v0.9.5"), [9, 5])  # the caller strips the "v"
+
+    def test_a_later_release_is_newer(self):
+        self.assertTrue(is_newer("0.9.5", "0.9.0"))
+        self.assertTrue(is_newer("0.10.0", "0.9.9"))
+
+    def test_the_same_or_older_release_is_not_newer(self):
+        self.assertFalse(is_newer("0.9.5", "0.9.5"))
+        self.assertFalse(is_newer("0.9.0", "0.9.5"))
+
+    def test_an_unusable_version_is_never_newer(self):
+        self.assertFalse(is_newer("", "0.9.0"))
+        self.assertFalse(is_newer("0.9.5", "unknown"))
+
+
+class TestFetchLatestRelease(unittest.TestCase):
     @patch("urllib.request.urlopen")
-    def test_check_for_updates_available(self, mock_urlopen, mock_get_version):
-        mock_get_version.return_value = "0.9.0"
+    def test_returns_the_payload(self, mock_urlopen):
+        mock_urlopen.return_value = _response({"tag_name": "v0.9.5"})
 
-        # Mock GitHub response
-        mock_response = MagicMock()
-        mock_response.status = 200
-        mock_response.read.return_value = json.dumps({"tag_name": "v0.9.5"}).encode()
-        mock_response.__enter__.return_value = mock_response
-        mock_urlopen.return_value = mock_response
+        self.assertEqual(fetch_latest_release(), {"tag_name": "v0.9.5"})
 
-        new_ver = check_for_updates()
-        self.assertEqual(new_ver, "0.9.5")
-
-    @patch("negpy.kernel.system.version.get_app_version")
     @patch("urllib.request.urlopen")
-    def test_check_for_updates_latest(self, mock_urlopen, mock_get_version):
-        mock_get_version.return_value = "0.9.5"
+    def test_a_non_200_reads_as_no_release(self, mock_urlopen):
+        mock_urlopen.return_value = _response({"tag_name": "v0.9.5"}, status=404)
 
-        mock_response = MagicMock()
-        mock_response.status = 200
-        mock_response.read.return_value = json.dumps({"tag_name": "v0.9.5"}).encode()
-        mock_response.__enter__.return_value = mock_response
-        mock_urlopen.return_value = mock_response
+        self.assertIsNone(fetch_latest_release())
 
-        new_ver = check_for_updates()
-        self.assertIsNone(new_ver)
-
-    @patch("negpy.kernel.system.version.get_app_version")
     @patch("urllib.request.urlopen")
-    def test_check_for_updates_error(self, mock_urlopen, mock_get_version):
-        mock_get_version.return_value = "0.9.0"
+    def test_a_network_error_reads_as_no_release(self, mock_urlopen):
         mock_urlopen.side_effect = Exception("Network error")
 
-        new_ver = check_for_updates()
-        self.assertIsNone(new_ver)
+        self.assertIsNone(fetch_latest_release())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The "Update Available" notice sent you to the releases page to download, uninstall and reinstall by hand. It now opens an update window — release notes, download size, one button — that fetches the build matching how this copy was installed, closes NegPy, installs over the old version and reopens on the new one.

Per platform: the NSIS installer runs silently over the current install (elevated, since it lives in Program Files, and restarted through Explorer so the app itself does not inherit the admin token); the macOS DMG is mounted and its bundle swapped in where the running one sits; the Linux AppImage file is replaced and relaunched.

A running program cannot overwrite itself, so the swap is a detached script that starts only once this process is gone. It waits on the pipe NegPy holds rather than polling the PID — an exited-but-unreaped process is a zombie, and a zombie still answers `kill -0`. Nothing is replaced before then, so a failed download or a refused UAC prompt leaves the install as it was, and a directory the user cannot write is reported instead of half-applied.

Where NegPy cannot swap itself — a source checkout, a release with no build for the platform — the notice still appears and the button opens the releases page.

Also:
- installer.nsi records its install directory, so a silent upgrade lands on top of an existing install wherever the user put it.
- The check thread belongs to the module, not to the panel that starts it: a QThread destroyed while a stalled socket read is in flight aborts the process.
- New unbound "Check for updates" action in the shortcut registry.