### PR TITLE
Batch export follows the export panel, not a stale per-frame block

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -575,7 +575,7 @@ A scrollable list of every edit step (last 100 kept), newest on top; the current
 
 ### Export button
 
-The primary **Export** action. Its chevron menu picks the scope: current frame (Ctrl+E), selected frames, all visible with current settings, or all visible with each frame's saved settings.
+The primary **Export** action. Its chevron menu picks the scope: current frame (Ctrl+E), selected frames, or all visible frames. Every scope uses the settings below — to deliver the same frames in more than one format or size in a single run, use Export Presets.
 
 ### Format / Size / Colour / Destination
 

--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -3704,12 +3704,12 @@ class AppController(QObject):
         )
 
     def request_export_selected(self) -> None:
-        """Batch-exports the currently selected files using each file's own saved settings."""
+        """Batch-exports the currently selected files using the current export settings."""
         selected = [self.state.uploaded_files[i] for i in self.state.selected_indices if 0 <= i < len(self.state.uploaded_files)]
         self.request_batch_export(files=[f for f in selected if not f.get("excluded")])
 
-    def request_batch_export(self, override_settings: bool = False, files: list[dict] | None = None) -> None:
-        """Batch-exports the given files (all visible by default) using current settings, optionally applied to all."""
+    def request_batch_export(self, files: list[dict] | None = None) -> None:
+        """Batch-exports the given files (all visible by default) using the current export settings."""
         self._flush_export_ui()
         if self._batch_busy("export"):
             return
@@ -3738,26 +3738,11 @@ class AppController(QObject):
 
         tasks = []
         for f in files:
-            params = self._batch_params_for(f)
-
-            if override_settings:
-                params = replace(params, export=current_export)
-            else:
-                # Always use current session export path/mode/format even for
-                # per-file exports. Per-file configs from the DB bypass
-                # _apply_sticky_settings and may have stale ABSOLUTE/export_path
-                # or export_fmt values that don't match what the UI shows.
-                params = replace(
-                    params,
-                    export=replace(
-                        params.export,
-                        output_mode=current_export.output_mode,
-                        export_path=current_export.export_path,
-                        output_subfolder=current_export.output_subfolder,
-                        export_fmt=current_export.export_fmt,
-                        export_color_space=current_export.export_color_space,
-                    ),
-                )
+            # Delivery settings are session-level. A per-file config from the DB
+            # bypasses _apply_sticky_settings and carries whatever export block was
+            # current when that frame was last saved, so honouring it exports at a
+            # size/format the panel never shows (#750).
+            params = replace(self._batch_params_for(f), export=current_export)
 
             final_export = replace(
                 params.export,

--- a/negpy/desktop/view/sidebar/export.py
+++ b/negpy/desktop/view/sidebar/export.py
@@ -1033,19 +1033,18 @@ class ExportSidebar(BaseSidebar):
         "selected": (
             "Export selected frames",
             " Export Selected",
-            "Export the selected filmstrip frames, each with its own saved export settings",
+            "Export the selected filmstrip frames using the settings below",
         ),
-        "all_current": (
-            "Export all visible — current settings",
-            " Export All (current settings)",
+        "all": (
+            "Export all visible frames",
+            " Export All",
             "Export every visible frame using the settings below",
         ),
-        "all_saved": (
-            "Export all visible — saved per-frame settings",
-            " Export All (saved settings)",
-            "Export every visible frame using each frame's own saved export settings",
-        ),
     }
+
+    # The two "all visible" scopes (current vs saved per-frame settings) collapsed
+    # into one when per-frame export settings were retired.
+    _RETIRED_EXPORT_SCOPES = {"all_current": "all", "all_saved": "all"}
 
     _PRESET_SCOPES = {
         "current": (
@@ -1090,6 +1089,7 @@ class ExportSidebar(BaseSidebar):
         self.layout.addWidget(container)
 
         saved = self.controller.session.repo.get_global_setting("export_scope", "current")
+        saved = self._RETIRED_EXPORT_SCOPES.get(saved, saved)
         self._set_export_scope(saved if saved in self._EXPORT_SCOPES else "current", persist=False)
 
     def _set_export_scope(self, key: str, persist: bool = True) -> None:
@@ -1110,7 +1110,7 @@ class ExportSidebar(BaseSidebar):
         self._flush_export_settings()
         if self.state.linear_output:
             scope = self._export_scope
-            if scope in ("all_current", "all_saved"):
+            if scope == "all":
                 files = [
                     self.state.uploaded_files[i]
                     for i in self.controller.session.asset_model.visible_actual_indices_ordered()
@@ -1130,10 +1130,8 @@ class ExportSidebar(BaseSidebar):
         scope = self._export_scope
         if scope == "selected":
             self.controller.request_export_selected()
-        elif scope == "all_current":
-            self.controller.request_batch_export(override_settings=True)
-        elif scope == "all_saved":
-            self.controller.request_batch_export(override_settings=False)
+        elif scope == "all":
+            self.controller.request_batch_export()
         else:
             self.controller.request_export()
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -11,7 +11,15 @@ from PyQt6.QtWidgets import QApplication
 from negpy.desktop.controller import AppController
 from negpy.desktop.session import DesktopSessionManager, AppState, ToolMode
 from negpy.desktop.workers.export import ExportTask, resolve_export_target_path
-from negpy.domain.models import ColorSpace, ExportConfig, ExportFormat, ExportPreset, ExportPresetOutputMode, WorkspaceConfig
+from negpy.domain.models import (
+    ColorSpace,
+    ExportConfig,
+    ExportFormat,
+    ExportPreset,
+    ExportPresetOutputMode,
+    ExportResolutionMode,
+    WorkspaceConfig,
+)
 from negpy.infrastructure.scanners.params import ScanParams
 from negpy.services.rendering.preview_manager import PreviewManager
 
@@ -979,25 +987,28 @@ class TestBatchExportFiltering(unittest.TestCase):
         tasks = self._captured_tasks()
         self.assertEqual([t.file_info["name"] for t in tasks], ["scan.tif", "IMG_0001.cr2"])
 
-    def test_export_all_override_settings_applies_current_export_to_all(self):
+    def test_export_all_applies_current_export_to_all(self):
         self.visible_indices = [0, 1]
         self.controller.state.config = replace(
             self.controller.state.config,
             export=replace(self.controller.state.config.export, export_path="/orig"),
         )
-        self.controller.request_batch_export(override_settings=True)
+        self.controller.request_batch_export()
         tasks = self._captured_tasks()
         for t in tasks:
             self.assertEqual(t.params.export.export_path, "/tmp/out")
 
-    def test_export_all_saved_overrides_path_with_session_values(self):
-        """all_saved scope uses session path/mode/format even when per-file configs are stale."""
+    def test_batch_export_ignores_stale_per_file_export_settings(self):
+        """A frame's saved export block never overrides the panel (issue #750: batch
+        exports came out at the stale 2000px target while the panel said Original)."""
         self.visible_indices = [0, 1]
-        session_export = self.controller.state.config.export
-        # Per-file config has stale SAME_AS_SOURCE (differs from session default
-        # ABSOLUTE) + stale PNG + stale AdobeRGB + stale jpeg_quality — delivery
-        # overrides (mode, fmt, color_space) must use session; sizing (quality) is
-        # preserved from per-file.
+        session_export = replace(
+            self.controller.state.config.export,
+            export_resolution_mode=ExportResolutionMode.ORIGINAL.value,
+            jpeg_quality=90,
+        )
+        self.controller.state.config = replace(self.controller.state.config, export=session_export)
+
         stale_export = replace(
             session_export,
             output_mode=ExportPresetOutputMode.SAME_AS_SOURCE,
@@ -1005,32 +1016,37 @@ class TestBatchExportFiltering(unittest.TestCase):
             output_subfolder="old_sub",
             export_fmt=ExportFormat.PNG,
             export_color_space=ColorSpace.ADOBE_RGB.value,
+            export_resolution_mode=ExportResolutionMode.TARGET_PX.value,
+            export_target_long_edge_px=2000,
+            paper_aspect_ratio="1:1",
+            export_print_size=10.0,
+            export_dpi=150,
             jpeg_quality=50,
+            filename_pattern="{{ original_name }}_stale",
         )
         stale_config = replace(self.controller.state.config, export=stale_export)
         self.mock_session_manager.repo.load_file_settings.return_value = stale_config
-        self.controller.request_batch_export(override_settings=False)
+        self.controller.request_batch_export()
         tasks = self._captured_tasks()
         self.assertEqual(len(tasks), 2)
         for t in tasks:
-            # output_mode is overridden from session (ABSOLUTE), NOT stale (SAME_AS_SOURCE)
-            self.assertEqual(t.params.export.output_mode, session_export.output_mode)
-            self.assertNotEqual(t.params.export.output_mode, ExportPresetOutputMode.SAME_AS_SOURCE)
-            self.assertEqual(t.params.export.output_subfolder, session_export.output_subfolder)
+            for field in (
+                "output_mode",
+                "output_subfolder",
+                "export_fmt",
+                "export_color_space",
+                "export_resolution_mode",
+                "export_target_long_edge_px",
+                "paper_aspect_ratio",
+                "export_print_size",
+                "export_dpi",
+                "jpeg_quality",
+                "filename_pattern",
+            ):
+                self.assertEqual(getattr(t.params.export, field), getattr(session_export, field), field)
+                self.assertEqual(getattr(t.export_settings, field), getattr(session_export, field), field)
             # export_path is validated by _ensure_valid_export_path (mocked to /tmp/out)
             self.assertEqual(t.params.export.export_path, "/tmp/out")
-            # Format/color-space from session config overrides per-file values so
-            # the delivery format matches what the UI shows, not a stale per-file setting.
-            # Without the fix, stale_export.export_fmt=PNG would leak into the export.
-            self.assertEqual(t.params.export.export_fmt, session_export.export_fmt)
-            self.assertNotEqual(t.params.export.export_fmt, ExportFormat.PNG)
-            self.assertEqual(t.params.export.export_color_space, session_export.export_color_space)
-            self.assertNotEqual(t.params.export.export_color_space, ColorSpace.ADOBE_RGB.value)
-            # Quality/sizing from per-file config is preserved
-            self.assertEqual(t.params.export.jpeg_quality, stale_export.jpeg_quality)
-            # Verify export_settings (the delivery config the worker actually reads)
-            self.assertEqual(t.export_settings.export_fmt, session_export.export_fmt)
-            self.assertEqual(t.export_settings.export_color_space, session_export.export_color_space)
 
 
 class TestPresetBatchExport(unittest.TestCase):

--- a/tests/test_export_scope.py
+++ b/tests/test_export_scope.py
@@ -1,0 +1,41 @@
+"""The Export split button dispatches each scope to the matching controller call."""
+
+from unittest.mock import MagicMock
+
+from negpy.desktop.view.sidebar.export import ExportSidebar
+
+
+def _sidebar(scope: str) -> MagicMock:
+    sidebar = MagicMock()
+    sidebar._export_scope = scope
+    sidebar.state.linear_output = False
+    sidebar.controller = MagicMock()
+    return sidebar
+
+
+def test_scope_all_exports_every_visible_frame():
+    sidebar = _sidebar("all")
+    ExportSidebar._on_export_clicked(sidebar)
+    sidebar.controller.request_batch_export.assert_called_once_with()
+    sidebar.controller.request_export.assert_not_called()
+
+
+def test_scope_selected_exports_selection():
+    sidebar = _sidebar("selected")
+    ExportSidebar._on_export_clicked(sidebar)
+    sidebar.controller.request_export_selected.assert_called_once_with()
+
+
+def test_scope_current_exports_current_frame():
+    sidebar = _sidebar("current")
+    ExportSidebar._on_export_clicked(sidebar)
+    sidebar.controller.request_export.assert_called_once_with()
+
+
+def test_retired_scope_keys_map_to_a_live_scope():
+    """A persisted "all_current"/"all_saved" must not silently reset to the
+    single-frame scope now that the two collapsed into one."""
+    assert ExportSidebar._RETIRED_EXPORT_SCOPES
+    for legacy, current in ExportSidebar._RETIRED_EXPORT_SCOPES.items():
+        assert legacy not in ExportSidebar._EXPORT_SCOPES
+        assert current in ExportSidebar._EXPORT_SCOPES


### PR DESCRIPTION
Fixes #750.

## The bug

Exporting several frames capped them at 2000 px on the long edge while the panel said *Original*; exporting the same frame alone came out full size.

2000 is not a preview size (`preview_render_size` is 1600) — it is the default of `ExportConfig.export_target_long_edge_px`.

`request_batch_export` took each frame's delivery settings from its **saved DB `WorkspaceConfig`** and copied only five fields from the live session config (`output_mode`, `export_path`, `output_subfolder`, `export_fmt`, `export_color_space`). Everything else — `export_resolution_mode`, `export_target_long_edge_px`, `export_print_size`, `export_dpi`, `paper_aspect_ratio`, the quality settings and `filename_pattern` — came from the stale per-frame block. A frame last persisted while the panel sat on Pixels / 2000 px kept exporting at 2000 px. `request_export` uses the live config, which is why single export was correct.

`request_export_selected` delegated with `override_settings=False`, so "Export selected frames" hit the stale path too — the workflow both reporters used.

## Why the per-frame block goes

It is unreachable by design. The export panel is session-level and `_apply_sticky_settings` overlays the global `last_export_config` onto every config it loads, so a frame's saved export block is an accident of when that frame was last written, never something the user chose or can inspect. Export presets already cover genuinely different delivery settings.

- Batch export always applies the session export settings.
- The "all visible — current settings" / "all visible — saved per-frame settings" scopes collapse into one **Export All**; a persisted `all_current`/`all_saved` maps onto it so existing installs keep their scope.

Quality and filename pattern now follow the panel in batch too — same stale class, same fix.

## Verification

`make all` green (3634 passed).

New regression test `test_batch_export_ignores_stale_per_file_export_settings` fails on `export_resolution_mode` without the controller change.

End-to-end on a real 8780 px scan, with the frame's DB row holding TARGET_PX / 2000 and the panel on Original:

| | exported size |
|---|---|
| before | 1480 x 2000 |
| after | 6499 x 8780 (source resolution) |