### PR TITLE
Test the pieusb backend in CI, and ship it on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,9 @@ jobs:
           sudo apt-get install -y libegl1 libxkbcommon-x11-0 libdbus-1-3 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 x11-utils libgl1
 
       - name: Install Dependencies
-        run: uv sync --group dev
+        # pieusb is pure Python plus a bundled libusb, so it installs without any
+        # system package — without it the pieusb backend tests importorskip away.
+        run: uv sync --group dev --group pieusb
 
       - name: Run Linting (Ruff)
         run: uv run ruff check .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,7 +98,10 @@ jobs:
 
       - name: Install Dependencies (Windows)
         if: matrix.os == 'windows-latest'
-        run: uv sync --no-group scanner
+        # Everything except SANE, which has no Windows build. `--all-groups` rather
+        # than the default groups alone, or the pieusb backend ships uninstalled and
+        # the Scan tab has no working backend at all on Windows.
+        run: uv sync --all-groups --no-group scanner
 
       - name: Set Version
         shell: bash

--- a/build.py
+++ b/build.py
@@ -61,6 +61,14 @@ params = [
     # Camera scanning: see collect_gphoto2_plugins() — the plugin trees need their
     # directory layout preserved, which --collect-all does not do.
     *([] if is_windows else ["--collect-all=gphoto2"]),
+    # pieusb scanner support (all platforms; it is the only backend on Windows).
+    # libusb_package's own PyInstaller hook drops the bundled libusb at the bundle
+    # root, but get_library_path() resolves it with importlib_resources against the
+    # *package* directory — so without this it finds nothing and pyusb falls back to
+    # a system libusb that Windows does not have. --collect-all puts it where the
+    # lookup actually looks.
+    "--hidden-import=pieusb",
+    "--collect-all=libusb_package",
     # Exclude unused modules
     # Metadata
     "--copy-metadata=imageio",


### PR DESCRIPTION
The pieusb backend landed in #747 with tests that never run and a Windows build that never contains it. Three config fixes, no behaviour change.

## CI never ran the pieusb tests

`ci.yml` installed only the `dev` group, so both pieusb test files `importorskip`'d away and the suite reported green while covering none of the backend. pieusb is pure Python plus a bundled libusb — no system package needed.

```
before: 0 passed, 2 skipped
after:  20 passed, 1 skipped
```

`tests/scanners/test_pieusb_autoexposure.py` is the remaining skip and CI cannot fix it: it imports `pieusb.calibration`, which does not exist in `pieusb==0.3.7`, the pinned floor. It also tests only upstream library internals, no NegPy code. Worth deleting separately.

## Windows shipped the Scan tab with no backend

The Windows release step ran `uv sync --no-group scanner`, which was a no-op: there is no `default-groups` setting, so uv installs `dev` alone and `scanner` was never in to begin with. `pieusb` was left out with it. Since #747 removed the `_ScanUnsupportedPlaceholder` gate, Windows shipped a Scan tab where both backend factories raise `ScannerUnavailable`.

Now `uv sync --all-groups --no-group scanner` — everything except SANE, which genuinely has no Windows build.

## PyInstaller missed the libusb pieusb needs

`libusb_package`'s own PyInstaller hook does `collect_dynamic_libs(..., destdir='.')`, putting the bundled library at the bundle root. But `get_library_path()` resolves it with `importlib_resources.files('libusb_package')` — the *package* directory. Verified with two probe builds:

```
without --collect-all:  LIBPATH: None
with    --collect-all:  LIBPATH: .../_internal/libusb_package/libusb-1.0.so
```

The `without` build still got a backend on Linux only because `ctypes.util.find_library` fell through to the host's system libusb. Windows has none, so `get_backend()` would return `None` and no scanner would ever enumerate.

Also confirmed PyInstaller exits 0 on `--collect-all` for an uninstalled package, so a local build without the group degrades exactly like gphoto2 does — no conditional needed.

## Verification

- `ruff check` and `ruff format` clean
- Full suite in the CI-equivalent env: one pre-existing unrelated failure, `test_stitch.py::test_stitch_real_rgb_triplet_samples` (stale `load_linear_preview_rgb` call signature, same on `main`, sample-gated so CI skips it)