### PR TITLE
test: pass RgbScanConfig to load_linear_preview_rgb

### DIFF
--- a/tests/test_rgbscan.py
+++ b/tests/test_rgbscan.py
@@ -173,7 +173,7 @@ def test_preview_merge_pulls_green_blue_from_their_files():
 
     pm = PreviewManager()
     r, g, b = (os.path.join("samples", f) for f in _SAMPLES)
-    merged, _, _ = pm.load_linear_preview_rgb(r, g, b, "Adobe RGB", use_camera_wb=True)
+    merged, _, _ = pm.load_linear_preview_rgb(r, RgbScanConfig(enabled=True, green_path=g, blue_path=b), "Adobe RGB", use_camera_wb=True)
     red_only, _, _ = pm.load_linear_preview(r, "Adobe RGB", use_camera_wb=True)
     # Red-only has near-zero G/B (narrowband); the merge fills them from the other shots.
     assert merged[..., 1].mean() > red_only[..., 1].mean() * 3

--- a/tests/test_stitch.py
+++ b/tests/test_stitch.py
@@ -3,6 +3,7 @@ import pytest
 
 import cv2
 
+from negpy.features.rgbscan.models import RgbScanConfig
 from negpy.features.stitch.logic import (
     StitchError,
     build_proxy,
@@ -749,7 +750,11 @@ def test_stitch_real_rgb_triplet_samples():
 
     pm = PreviewManager()
     merged = [
-        np.asarray(pm.load_linear_preview_rgb(r, g, b, "Adobe RGB", use_camera_wb=False)[0], dtype=np.float32) for r, g, b in (part0, part1)
+        np.asarray(
+            pm.load_linear_preview_rgb(r, RgbScanConfig(enabled=True, green_path=g, blue_path=b), "Adobe RGB", use_camera_wb=False)[0],
+            dtype=np.float32,
+        )
+        for r, g, b in (part0, part1)
     ]
     transforms, (cw, ch) = register_parts(merged)
     h, w = merged[0].shape[:2]


### PR DESCRIPTION
## Summary

`make test` failed on `tests/test_stitch.py::test_stitch_real_rgb_triplet_samples`:

```
TypeError: PreviewManager.load_linear_preview_rgb() got multiple values for argument 'use_camera_wb'
```

The HDR merge change (#804) replaced the `green_path` / `blue_path` / `align` parameters of `PreviewManager.load_linear_preview_rgb()` with a single `RgbScanConfig`. Two tests still used the old positional call. Both are sample-gated, so they skip on CI and the stale calls went unnoticed:

- `tests/test_stitch.py::test_stitch_real_rgb_triplet_samples` (samples present locally — the failure)
- `tests/test_rgbscan.py::test_preview_merge_pulls_green_blue_from_their_files` (same bug, still skipping)

Test-only change; no production code touched.

## Test plan

- `make test` — 3999 collected, no failures (was 1 failed before)
- `make lint` / `make type` — clean