### PR TITLE
UI/UX polish: five gaps where a convention was applied unevenly

### DIFF
--- a/docs/KEYBOARD.md
+++ b/docs/KEYBOARD.md
@@ -4,6 +4,8 @@ Summary of available keyboard shortcuts in NegPy.
 
 All shortcuts, including slider adjustments, can be changed in-app from the `?` shortcut overlay via `Customize`. Slider shortcuts are shown as merged rows (e.g. **Density ↑/↓**) with a customizable **Step** column — defaults match the built-in keyboard increments below.
 
+A slider shortcut reports its new value in the canvas HUD, so you can keep a control on a hidden tab and still read what you just set.
+
 Numpad keys can be bound separately from the number row (e.g. `Num+9` vs `9`). Num Lock must be on for numpad digits to register.
 
 ## Navigation

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -11,7 +11,7 @@ This guide is for new users. It explains what each control does, when you'd reac
 ### Screen layout
 
 *   **Left, the film strip**: your loaded frames as a contact sheet, plus import, sorting, and triage tools.
-*   **Centre, the canvas**: the live preview of the current frame. Most tools (crop, white-balance picker, heal brush, dodge/burn masks) are used by clicking directly on it. Scroll/pinch to zoom and drag to pan; a floating toolbar along the bottom holds Fit/1:1 zoom plus undo/redo, rotate/flip and more, moving overflow items into an **⋯** menu when the window narrows — that menu also has **Immersive Canvas** (image fills the canvas and the toolbar overlaps it; turn off to reserve space so it never occludes the image). Right-click the image for **Reset View** and **Sticky Zoom** (keeps the current zoom level when you switch to another frame, instead of resetting to fit), alongside the picker tools and copy/paste settings. With nothing loaded it shows **Load some scans to get started** — click it for **Add files** / **Add folder**.
+*   **Centre, the canvas**: the live preview of the current frame. Most tools (crop, white-balance picker, heal brush, dodge/burn masks) are used by clicking directly on it. Scroll/pinch to zoom and drag to pan; a floating toolbar along the bottom holds Fit/1:1 zoom plus undo/redo, rotate/flip and more, moving overflow items into an **⋯** menu when the window narrows — that menu also has **Immersive Canvas** (image fills the canvas and the toolbar overlaps it; turn off to reserve space so it never occludes the image) and **Show Slider Values** (keeps every slider's value box open instead of revealing it under the pointer — turn it on if you work by the numbers). Right-click the image for **Reset View** and **Sticky Zoom** (keeps the current zoom level when you switch to another frame, instead of resetting to fit), alongside the picker tools and copy/paste settings. With nothing loaded it shows **Load some scans to get started** — click it for **Add files** / **Add folder**.
 *   **Right, the controls**: a pinned **Analysis** readout at the top, and below it an icon tab bar. Each icon opens a *workflow page* holding one or more collapsible panels.
 
 ### The workflow (and the order things happen)
@@ -159,6 +159,8 @@ Merging is also refused on frames that are already merged, stitched, or RGB-scan
 Narrow the panel and the toolbar buttons that no longer fit move into a **»** menu at its right edge, so the panel can be squeezed down to give the image more room without losing any tool.
 
 ### Triage (culling the roll)
+
+Thumbnails are positives from the start. A frame you have not opened yet is inverted straight from its preview — a quick per-channel job, not the full pipeline — so the sheet reads as photographs while you cull rather than as a strip of orange negatives. Open a frame and its thumbnail is replaced by the real render, matching the canvas exactly. Transparencies are left alone, being positives already.
 
 Right-click a thumbnail (or use keyboard shortcuts) to mark frames while you review the sheet:
 
@@ -366,7 +368,7 @@ Meter the whole roll once and share the baseline, so frames from the same film m
 
 *   **Roll dropdown** + **Load**: apply a saved roll's bounds and balance.
 *   **Save**: store the current Batch Analysis as a named roll (useful when you shoot the same stock repeatedly).
-*   **Delete**: remove the selected roll.
+*   **Delete**: remove the selected roll (asks first). The frames keep their current look; only the saved baseline goes.
 
 ---
 
@@ -403,7 +405,7 @@ Where the frame gets its final shape: what's inside the print, and whether it si
 Corrects uneven illumination (vignetting/falloff) from your copy-stand or scanner light, using a reference shot of the bare light source.
 
 *   **Flatfield Correction**: apply the active reference to this image (enabled once a profile exists).
-*   **Reference Profile** dropdown + **Add…** / **Delete**: pick a reference image and save it as a named profile. **Add…** reads the reference once and bakes its correction into the profile, so the original reference file can then be moved, renamed or deleted without affecting your edits — the profile is self-contained (stored in NegPy's own `flatfield` folder, like sensor and crosstalk profiles).
+*   **Reference Profile** dropdown + **Add…** / **Delete**: pick a reference image and save it as a named profile. **Add…** reads the reference once and bakes its correction into the profile, so the original reference file can then be moved, renamed or deleted without affecting your edits — the profile is self-contained (stored in NegPy's own `flatfield` folder, like sensor and crosstalk profiles). **Delete** asks first: the baked gain map cannot be recovered, and every frame using the profile loses its correction.
 *   **Distortion** (-0.25 to 0.25): radial lens-distortion correction for the rig, saved with the profile. Use the film rebate as a straight-edge reference.
 
 ---
@@ -669,7 +671,7 @@ A **work print** is a named version of this frame — the darkroom habit of keep
 
 *   **Save work print** (**Ctrl+Shift+S**) keeps the current edit under a name; NegPy offers *Work print 1*, *Work print 2* and so on. Saving over an existing name asks first.
 *   **Click** one to make it live. That counts as an edit, so **Ctrl+Z** puts back what was on screen before — you cannot lose your place by looking at an old version.
-*   **Right-click** → **Export this version…**, **Rename…** or **Delete**.
+*   **Right-click** → **Export this version…**, **Rename…** or **Delete**. Delete asks first, and a rename to an empty name is ignored.
 
 Work prints differ from history steps in the way that matters: they are **never pruned and never thrown away by a later edit**. The undo history keeps the last 100 steps and drops the branch above you when you edit after stepping back; a work print survives both. The list only appears once you've saved one.
 
@@ -704,6 +706,8 @@ A scrollable list of every edit step (last 100 kept), newest on top; the current
     *   **Apply ICE dust removal** (visible when an IR channel is available): applies IR-based dust and scratch correction to the linear output before writing. Off by default.
     *   **Corrections** (camera RAW only): three optional toggles that bake corrections into the linear output before writing. All default to off (raw dump philosophy). **Apply white balance** multiplies by the as-shot WB gains. **Apply flatfield** applies the flatfield gain correction. **Apply sensor correction** applies the sensor crosstalk unmixing matrix. For stitch composites, flatfield and sensor correction are always applied per-part regardless of these toggles (required for clean seams).
 
+    Linear Output runs in the background like any other batch: the progress popup shows which frame is being written, **Abort** stops it after the current one, and the finish message counts any frames that failed.
+
     The output file is always written clean — no ICC profiles, no EXIF color space tags, and no XMP color metadata from the source are carried through. For **TIFF**, raw pixels plus device metadata (Make, Model, DateTime) from the source file, and a description recording the source format, expansion, white balance, and any corrections applied (including ICE). **JPEG XL carries none of that metadata at all** — no description, no device info, no record of whether ICE ran — only the pixels and the forced colour tag noted above (which also isn't from the source; the format just can't leave it unset).
 
 ### Export button
@@ -722,7 +726,7 @@ The primary **Export** action. Its chevron menu picks the scope: current frame (
 ### Collapsible sections
 
 *   **Presets**: a checklist of export presets (each a saved Format/Size/Colour/**Destination**/filename recipe). **Manage** edits them; **Export Presets** renders the frame(s) with every enabled preset at once — each preset uses **its own** destination, not the sidebar Destination above.
-*   **Sidecars**: **Save on export** writes a `.negpy` edit sidecar next to each source on every export; **Export sidecars** writes them for all visible frames now. (Edits always stay in the database too; sidecars are optional archival copies.)
+*   **Sidecars**: **Save on export** writes a `.negpy` edit sidecar next to each source on every export; **Export sidecars** writes them for all visible frames now, and reports how many failed if a source folder is read-only. (Edits always stay in the database too; sidecars are optional archival copies.)
 *   **Contact Sheet**: render all visible frames into a single sheet. Choose a **Template** or set **Cell / Gap / Margin / Max tiles** by hand, pick an output **Path**, and **Export contact sheet**.
 *   **Preview** (affects the on-screen preview only, never the file):
     *   **Soft proof** (on by default): simulate the export colour space and Output profile so what you see matches what you'll get. Turn off only to preview at full gamut.

--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -22,7 +22,7 @@ from negpy.desktop.session import (
     resolve_asset_rgbscan,
     resolve_asset_stitch,
 )
-from negpy.desktop.workers.export import ExportTask, ExportWorker, find_export_conflicts
+from negpy.desktop.workers.export import ExportTask, ExportWorker, LinearOutputTask, find_export_conflicts
 from negpy.desktop.workers.render import (
     AssetDiscoveryTask,
     AssetDiscoveryWorker,
@@ -3835,7 +3835,10 @@ class AppController(QObject):
 
     def request_linear_output_export(self, files: list[dict] | None = None) -> None:
         """Export decoded linear buffers as untagged 16-bit TIFFs to the export folder."""
-        from negpy.services.export.linear_output import export_linear_output, is_linear_output_supported
+        from negpy.services.export.linear_output import is_linear_output_supported
+
+        if self._batch_busy("export"):
+            return
 
         export_path = self._ensure_valid_export_path()
         if not export_path:
@@ -3868,10 +3871,26 @@ class AppController(QObject):
         if len(supported) > 1 and not self._confirm_bulk_export(f"Linear-export {count_of(len(supported), 'frame')}?"):
             return
 
-        exported = 0
+        tasks = self._linear_output_tasks(supported, export_path)
+
+        self._export_start_time = time.time()
+        self._export_failures = 0
+        if self._begin_batch("export", "Exporting Linear Output", abortable=True) is None:
+            return
+        QMetaObject.invokeMethod(
+            self.export_worker,
+            "run_linear_output",
+            Qt.ConnectionType.QueuedConnection,
+            Q_ARG(list, tasks),
+        )
+
+    def _linear_output_tasks(self, supported: list[dict], export_path: str) -> list[LinearOutputTask]:
+        """Resolve each frame's config and destination on the UI thread; the worker only writes."""
         expansion = self.state.linear_expansion
         linear_fmt = self.state.linear_format
         out_ext = "jxl" if linear_fmt == "jxl" else "tiff"
+        taken: set[str] = set()
+        tasks = []
         for f in supported:
             params = self._batch_params_for(f)
             stitch = params.stitch if params.stitch.stitch_enabled else None
@@ -3881,36 +3900,36 @@ class AppController(QObject):
             stem = f"{hdr_stem(frames)}-HDR" if frames else os.path.splitext(os.path.basename(f["path"]))[0]
             out_path = os.path.join(export_path, f"{stem}_linear.{out_ext}")
             counter = 2
-            while os.path.exists(out_path):
+            # `taken` as well as the disk: the whole batch is named up front now, before
+            # the worker has written any of it, so same-stem frames would collide.
+            while out_path in taken or os.path.exists(out_path):
                 out_path = os.path.join(export_path, f"{stem}_linear_{counter}.{out_ext}")
                 counter += 1
-            try:
-                export_linear_output(
-                    f["path"],
-                    out_path,
-                    geometry=params.geometry,
-                    expansion=expansion,
-                    rgbscan=params.rgbscan,
-                    stitch=stitch,
-                    hdr=params.hdr,
-                    flatfield=params.flatfield,
-                    process=params.process,
-                    apply_wb=self.state.linear_apply_wb,
-                    apply_flatfield=self.state.linear_apply_flatfield,
-                    apply_sensor=self.state.linear_apply_sensor,
-                    apply_ice=self.state.linear_apply_ice,
-                    retouch=params.retouch,
-                    gamma_key=self.state.linear_gamma_key,
-                    output_format=linear_fmt,
-                    jxl_effort=self.state.linear_jxl_effort,
+            taken.add(out_path)
+            tasks.append(
+                LinearOutputTask(
+                    file_info=f,
+                    out_path=out_path,
+                    options={
+                        "geometry": params.geometry,
+                        "expansion": expansion,
+                        "rgbscan": params.rgbscan,
+                        "stitch": stitch,
+                        "hdr": params.hdr,
+                        "flatfield": params.flatfield,
+                        "process": params.process,
+                        "apply_wb": self.state.linear_apply_wb,
+                        "apply_flatfield": self.state.linear_apply_flatfield,
+                        "apply_sensor": self.state.linear_apply_sensor,
+                        "apply_ice": self.state.linear_apply_ice,
+                        "retouch": params.retouch,
+                        "gamma_key": self.state.linear_gamma_key,
+                        "output_format": linear_fmt,
+                        "jxl_effort": self.state.linear_jxl_effort,
+                    },
                 )
-                exported += 1
-            except Exception as e:
-                logger.warning("Linear output failed for %s: %s", f.get("name"), e)
-                self.set_status(f"Linear Output failed: {os.path.basename(f['path'])}: {e}", 4000)
-
-        if exported:
-            self.set_status(f"Linear Output: exported {count_of(exported, 'file')}", 4000)
+            )
+        return tasks
 
     def request_export(self) -> None:
         """Exports the current file using the settings currently shown in the Export panel."""
@@ -4230,10 +4249,13 @@ class AppController(QObject):
             Q_ARG(str, cs.contact_sheet_label_color),
         )
 
-    def _write_edit_sidecars(self, files: list[dict]) -> int:
-        """Write a .negpy edit sidecar next to each source (each frame's own saved edits). Returns count written."""
+    def _write_edit_sidecars(self, files: list[dict]) -> tuple[int, int]:
+        """Write a .negpy edit sidecar next to each source (each frame's own saved edits).
+        Returns (written, failed) — a caller that reports only the written count turns a
+        read-only source folder into a silent success."""
         repo = self.session.repo
         written = 0
+        failed = 0
         for f in files:
             half = int(f.get("half") or 0)
             params = load_or_promote(
@@ -4243,8 +4265,9 @@ class AppController(QObject):
                 write_sidecar(f["path"], params, half=half)
                 written += 1
             except Exception as exc:
+                failed += 1
                 logger.warning("Sidecar write failed for %s: %s", f.get("path"), exc)
-        return written
+        return written, failed
 
     def export_edit_sidecars(self) -> None:
         """Explicit batch sidecar export for all visible files (ignores the on-export toggle)."""
@@ -4255,8 +4278,9 @@ class AppController(QObject):
         ]
         if not visible_files:
             return
-        written = self._write_edit_sidecars(visible_files)
-        self.set_status(f"Wrote {count_of(written, 'edit sidecar')}", 4000)
+        written, failed = self._write_edit_sidecars(visible_files)
+        suffix = f" — {failed} failed" if failed else ""
+        self.set_status(f"Wrote {count_of(written, 'edit sidecar')}{suffix}", 6000 if failed else 4000)
 
     def _run_export_tasks(self, tasks: List[ExportTask]) -> None:
         # Reject unencodable format/colour-space pairings before anything else.

--- a/negpy/desktop/view/canvas/toolbar.py
+++ b/negpy/desktop/view/canvas/toolbar.py
@@ -17,6 +17,7 @@ from PyQt6.QtWidgets import (
 from negpy.desktop.controller import AppController
 from negpy.desktop.view.keyboard_shortcuts import _context_undo
 from negpy.desktop.view.widgets.granular_settings_dialog import open_paste_dialog
+from negpy.desktop.view.widgets.sliders import apply_slider_value_visibility
 from negpy.kernel.system.parallel import parallel_enabled, set_parallel_enabled
 from negpy.desktop.view.shortcut_registry import key_for, tooltip_with_shortcut
 from negpy.desktop.view.styles.theme import THEME
@@ -345,6 +346,12 @@ class ActionToolbar(QWidget):
         self._ov_sticky_zoom_action.setToolTip(
             tooltip_with_shortcut("Keep the current zoom level when switching images, instead of resetting to fit", "toggle_sticky_zoom")
         )
+        self._ov_slider_values_action = overflow_menu.addAction("Show Slider Values")
+        self._ov_slider_values_action.setCheckable(True)
+        self._ov_slider_values_action.setChecked(bool(self.session.repo.get_global_setting("show_slider_values", default=False)))
+        self._ov_slider_values_action.setToolTip(
+            tooltip_with_shortcut("Keep every slider's value box open, instead of revealing it on hover", "toggle_slider_values")
+        )
         overflow_menu.addSeparator()
 
         db_action = overflow_menu.addAction(qta.icon("fa5s.database", color=icon_color), "Manage Database…", self._show_database_dialog)
@@ -503,6 +510,7 @@ class ActionToolbar(QWidget):
         self._ov_redo_action.triggered.connect(self.session.redo)
         self._ov_immersive_action.triggered.connect(self._on_immersive_toggled)
         self._ov_sticky_zoom_action.triggered.connect(self._on_sticky_zoom_toggled)
+        self._ov_slider_values_action.triggered.connect(self._on_slider_values_toggled)
 
     def _on_overflow_unload(self) -> None:
         from negpy.desktop.view.confirm import confirm_unload
@@ -514,6 +522,10 @@ class ActionToolbar(QWidget):
 
     def _on_immersive_toggled(self, checked: bool) -> None:
         self.session.set_immersive_canvas(checked)
+
+    def _on_slider_values_toggled(self, checked: bool) -> None:
+        self.session.repo.save_global_setting("show_slider_values", bool(checked))
+        apply_slider_value_visibility(self.window(), bool(checked))
 
     def _on_sticky_zoom_toggled(self, checked: bool) -> None:
         self.session.set_sticky_zoom(checked)

--- a/negpy/desktop/view/confirm.py
+++ b/negpy/desktop/view/confirm.py
@@ -29,6 +29,22 @@ def confirm_unload(parent, *, clear_all: bool = False, count: int = 1) -> bool:
     return box.exec() == QMessageBox.StandardButton.Yes
 
 
+def confirm_delete_named(parent, kind: str, name: str, *, informative: str = "") -> bool:
+    """Ask before deleting a named, user-created item — a work print, a roll, a
+    flat-field profile. None of them are undoable and none can be re-derived from the
+    frame, so each one is gated like Clear All. Enter confirms; Esc cancels.
+    """
+    box = QMessageBox(parent)
+    box.setIcon(QMessageBox.Icon.Question)
+    box.setWindowTitle(f"Delete {kind}")
+    box.setText(f"Delete the {kind.lower()} “{name}”?")
+    if informative:
+        box.setInformativeText(informative)
+    box.setStandardButtons(QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.Cancel)
+    box.setDefaultButton(QMessageBox.StandardButton.Yes)
+    return box.exec() == QMessageBox.StandardButton.Yes
+
+
 def confirm_delete_mask(parent) -> bool:
     """Ask before deleting a single dodge/burn mask. Enter confirms; Esc cancels."""
     box = QMessageBox(parent)

--- a/negpy/desktop/view/keyboard_shortcuts.py
+++ b/negpy/desktop/view/keyboard_shortcuts.py
@@ -13,7 +13,7 @@ from negpy.desktop.view.shortcut_registry import (
     set_current_bindings,
     slider_step_for,
 )
-from negpy.desktop.view.slider_shortcut_groups import SLIDER_GROUP_BY_ACTION, SLIDER_GROUPS, sign_for_action
+from negpy.desktop.view.slider_shortcut_groups import SLIDER_GROUP_BY_ACTION, SLIDER_GROUPS, SliderShortcutGroup, sign_for_action
 from negpy.desktop.view.slider_targets import slider_widget_map
 
 
@@ -75,9 +75,21 @@ class ShortcutManager:
 
         def _adjust() -> None:
             step = slider_step_for(group.id, self.slider_steps)
-            getter().adjust_by(step * sign_for_action(action_id))
+            slider = getter()
+            slider.adjust_by(step * sign_for_action(action_id))
+            self._announce(slider, group)
 
         return _adjust
+
+    def _announce(self, slider: object, group: SliderShortcutGroup) -> None:
+        """Report the new value in the HUD. Nothing else does: the slider may sit on a
+        hidden tab, and its value box only appears under the pointer."""
+        label = getattr(slider, "label", None)
+        name = label.text() if label is not None else group.label.replace(" ↑/↓", "")
+        spin = getattr(slider, "spin", None)
+        # The spin box already carries this slider's decimals and unit suffix.
+        value = spin.text().strip() if spin is not None else f"{slider.value():.2f}"
+        self.window.controller.set_status(f"{name} {value}", 1500)
 
     def _build_actions(self) -> dict[str, Callable[[], None]]:
         controller = self.window.controller
@@ -128,6 +140,7 @@ class ShortcutManager:
             "toggle_library_tree": self.window.session_panel.toggle_library_tree,
             "toggle_immersive_canvas": lambda: controller.session.set_immersive_canvas(not controller.session.state.immersive_canvas),
             "toggle_sticky_zoom": lambda: controller.session.set_sticky_zoom(not controller.session.state.sticky_zoom),
+            "toggle_slider_values": lambda: toolbar._ov_slider_values_action.trigger(),
             "toggle_left_panel": self.window.toggle_session_dock,
             "toggle_right_panel": self.window.toggle_controls_dock,
             "reset_panel_layout": self.window.reset_panel_layout,

--- a/negpy/desktop/view/main_window.py
+++ b/negpy/desktop/view/main_window.py
@@ -30,6 +30,7 @@ from negpy.desktop.view.styles.theme import THEME
 from negpy.desktop.view.widgets.loading_overlay import LoadingOverlay
 from negpy.desktop.view.widgets.pinnable_dock import PinnableDockWidget
 from negpy.desktop.view.widgets.progress_dialog import ProgressDialog
+from negpy.desktop.view.widgets.sliders import apply_slider_value_visibility
 from negpy.domain.models import AspectRatio
 from negpy.infrastructure.gpu.resources import GPUTexture
 from negpy.kernel.image.logic import float_to_uint8
@@ -152,6 +153,9 @@ class MainWindow(QMainWindow):
         self._connect_signals()
         self.shortcut_manager = setup_keyboard_shortcuts(self)
         self._update_title()
+
+        if self.controller.session.repo.get_global_setting("show_slider_values", default=False):
+            apply_slider_value_visibility(self, True)
 
         from negpy.desktop.view.widgets.tutorial_overlay import TutorialOverlay
 

--- a/negpy/desktop/view/shortcut_registry.py
+++ b/negpy/desktop/view/shortcut_registry.py
@@ -161,6 +161,7 @@ REGISTRY: dict[str, ShortcutEntry] = {
     "toggle_library_tree": ShortcutEntry("", "Show/hide the library folder tree", "View"),
     "toggle_immersive_canvas": ShortcutEntry("", "Immersive canvas (toolbar overlaps image)", "View"),
     "toggle_sticky_zoom": ShortcutEntry("", "Sticky zoom (keep zoom level when switching images)", "View"),
+    "toggle_slider_values": ShortcutEntry("", "Show slider values (keep every value box open)", "View"),
     "toggle_left_panel": ShortcutEntry("Ctrl+[", "Toggle session panel (re-docks when floating)", "View"),
     "toggle_right_panel": ShortcutEntry("Ctrl+]", "Toggle controls panel (re-docks when floating)", "View"),
     "reset_panel_layout": ShortcutEntry("Ctrl+Shift+L", "Dock session and controls panels", "View"),

--- a/negpy/desktop/view/sidebar/base.py
+++ b/negpy/desktop/view/sidebar/base.py
@@ -9,6 +9,22 @@ from negpy.desktop.view.styles.templates import EditedDot, default_button_height
 from negpy.desktop.view.styles.theme import THEME
 
 
+def install_wheel_guards(widget: QWidget) -> None:
+    """Scroll must not change a combo's value unless it has focus — otherwise scrolling
+    a panel silently edits every combo the pointer crosses. Module-level so panels that
+    are not BaseSidebar subclasses (ScanSidebar) can share it."""
+    for combo in widget.findChildren(QComboBox):
+        combo.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
+
+        def _wheel(c, event) -> None:
+            if c.hasFocus():
+                QComboBox.wheelEvent(c, event)
+            else:
+                event.ignore()
+
+        combo.wheelEvent = types.MethodType(_wheel, combo)
+
+
 class BaseSidebar(QWidget):
     """
     Base class for all sidebar panels.
@@ -29,16 +45,7 @@ class BaseSidebar(QWidget):
         self._install_wheel_guards()
 
     def _install_wheel_guards(self) -> None:
-        for combo in self.findChildren(QComboBox):
-            combo.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
-
-            def _wheel(c, event) -> None:
-                if c.hasFocus():
-                    QComboBox.wheelEvent(c, event)
-                else:
-                    event.ignore()
-
-            combo.wheelEvent = types.MethodType(_wheel, combo)
+        install_wheel_guards(self)
 
     def _init_layout(self) -> None:
         """Sets up the default QVBoxLayout."""

--- a/negpy/desktop/view/sidebar/controls_panel.py
+++ b/negpy/desktop/view/sidebar/controls_panel.py
@@ -18,6 +18,7 @@ from negpy.features.toning.models import ToningConfig
 from negpy.features.geometry.models import GeometryConfig
 from negpy.features.process.models import ProcessConfig
 from negpy.features.finish.models import FinishConfig
+from negpy.features.flatfield.models import FlatFieldConfig
 
 # Sidebar Components
 from negpy.desktop.view.sidebar.presets import PresetsSidebar
@@ -105,6 +106,7 @@ _DEFAULT_ALTPROC = AltProcessConfig()
 _DEFAULT_GEOMETRY = GeometryConfig()
 _DEFAULT_PROCESS = ProcessConfig()
 _DEFAULT_FINISH = FinishConfig()
+_DEFAULT_FLATFIELD = FlatFieldConfig()
 
 
 class ControlsPanel(QWidget):
@@ -840,6 +842,27 @@ class ControlsPanel(QWidget):
             ]
         )
 
+        # Calibration's four fields live on ProcessConfig but belong to their own section,
+        # so they are counted here and left out of process_count above.
+        sensor_count = sum(
+            [
+                proc.sensor_profile != _proc.sensor_profile,
+                proc.crosstalk_profile != _proc.crosstalk_profile,
+                proc.crosstalk_strength != _proc.crosstalk_strength,
+                proc.hue_trim != _proc.hue_trim,
+            ]
+        )
+
+        ff = cfg.flatfield
+        _ff = _DEFAULT_FLATFIELD
+        flatfield_count = sum(
+            [
+                ff.apply != _ff.apply,
+                ff.profile_id != _ff.profile_id,
+                ff.k1 != _ff.k1,
+            ]
+        )
+
         ret = cfg.retouch
         # Heal-tool clicks and scratch polylines both commit into manual_heal_strokes
         # (manual_dust_spots is the legacy list), so count them or the Finish tab's
@@ -880,6 +903,9 @@ class ControlsPanel(QWidget):
         self.geometry_section.set_modified(geometry_count)
         self.process_section.set_modified(process_count)
         self.retouch_section.set_modified(retouch_count)
+        # Presets and the two Scan sections stay out: they own no WorkspaceConfig fields.
+        self.sensor_section.set_modified(sensor_count)
+        self.flatfield_section.set_modified(flatfield_count)
         self.local_section.set_modified(len(cfg.local.masks))
         self.finish_section.set_modified(finish_count)
         self.roll_section.set_modified(roll_count)

--- a/negpy/desktop/view/sidebar/export.py
+++ b/negpy/desktop/view/sidebar/export.py
@@ -4,6 +4,7 @@ import qtawesome as qta
 from PyQt6.QtCore import Qt, QTimer
 from PyQt6.QtGui import QActionGroup
 from PyQt6.QtWidgets import (
+    QApplication,
     QButtonGroup,
     QCheckBox,
     QComboBox,
@@ -108,7 +109,16 @@ class ExportSidebar(BaseSidebar):
         self.cs_template_combo.currentTextChanged.connect(self._on_contact_sheet_template_changed)
 
         self.sidecars_enabled_btn.toggled.connect(lambda _: self.update_timer.start())
-        self.export_sidecars_btn.clicked.connect(self.controller.export_edit_sidecars)
+        self.export_sidecars_btn.clicked.connect(self._on_export_sidecars)
+
+    def _on_export_sidecars(self) -> None:
+        """One DB read plus one small write per visible frame, on the GUI thread — short,
+        but long enough on a full roll to look frozen without a cursor."""
+        QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor)
+        try:
+            self.controller.export_edit_sidecars()
+        finally:
+            QApplication.restoreOverrideCursor()
 
     # --- Presets -------------------------------------------------------------
 

--- a/negpy/desktop/view/sidebar/flatfield.py
+++ b/negpy/desktop/view/sidebar/flatfield.py
@@ -11,6 +11,7 @@ from PyQt6.QtWidgets import (
     QPushButton,
 )
 
+from negpy.desktop.view.confirm import confirm_delete_named
 from negpy.desktop.view.sidebar.base import BaseSidebar
 from negpy.desktop.view.styles.templates import section_subheader
 from negpy.desktop.view.styles.theme import THEME
@@ -117,7 +118,12 @@ class FlatFieldSidebar(BaseSidebar):
 
     def _on_delete(self) -> None:
         profile_id = self.profile_combo.currentData()
-        if profile_id:
+        if profile_id and confirm_delete_named(
+            self,
+            "Flat-Field Profile",
+            self.profile_combo.currentText(),
+            informative="Every frame using it loses its correction; the baked gain map cannot be recovered.",
+        ):
             self.controller.delete_flatfield_profile(profile_id)
             self._refresh_profiles()
             self.sync_ui()

--- a/negpy/desktop/view/sidebar/history.py
+++ b/negpy/desktop/view/sidebar/history.py
@@ -2,6 +2,7 @@ from PyQt6.QtCore import Qt
 from PyQt6.QtGui import QFont
 from PyQt6.QtWidgets import QInputDialog, QListWidget, QListWidgetItem, QMenu, QMessageBox, QPushButton
 
+from negpy.desktop.view.confirm import confirm_delete_named
 from negpy.desktop.view.shortcut_registry import tooltip_with_shortcut
 from negpy.desktop.view.sidebar.base import BaseSidebar
 from negpy.desktop.view.styles.templates import section_subheader
@@ -115,7 +116,13 @@ class HistoryPanel(BaseSidebar):
             self.controller.export_work_print(name)
         elif chosen is rename_action:
             new_name, ok = QInputDialog.getText(self, "Rename work print", "Name:", text=name)
-            if ok:
+            if ok and new_name.strip():
                 self.controller.session.rename_work_print(name, new_name.strip())
         elif chosen is delete_action:
-            self.controller.session.delete_work_print(name)
+            if confirm_delete_named(
+                self,
+                "Work Print",
+                name,
+                informative="Work prints are never pruned by later edits — this is the only way one goes away.",
+            ):
+                self.controller.session.delete_work_print(name)

--- a/negpy/desktop/view/sidebar/roll.py
+++ b/negpy/desktop/view/sidebar/roll.py
@@ -6,6 +6,7 @@ from PyQt6.QtWidgets import (
     QPushButton,
 )
 
+from negpy.desktop.view.confirm import confirm_delete_named
 from negpy.desktop.view.sidebar.base import BaseSidebar
 from negpy.desktop.view.styles.templates import section_subheader
 from negpy.desktop.view.styles.theme import THEME
@@ -149,7 +150,12 @@ class RollAnalysisSidebar(BaseSidebar):
         Removes selected roll from DB.
         """
         name = self.roll_combo.currentText()
-        if name:
+        if name and confirm_delete_named(
+            self,
+            "Roll",
+            name,
+            informative="The frames keep their current look; only the saved roll baseline goes.",
+        ):
             self.controller.session.repo.delete_normalization_roll(name)
             self._refresh_rolls()
 

--- a/negpy/desktop/view/sidebar/scan.py
+++ b/negpy/desktop/view/sidebar/scan.py
@@ -17,6 +17,7 @@ from PyQt6.QtWidgets import (
 )
 
 from negpy.kernel.system.text import count_of
+from negpy.desktop.view.sidebar.base import install_wheel_guards
 from negpy.desktop.view.styles.templates import hint_label
 from negpy.desktop.view.styles.theme import THEME
 from negpy.infrastructure.scanners.base import ScannerCapabilities, ScannerDevice
@@ -36,6 +37,7 @@ class ScanSidebar(QWidget):
         self._devices_loaded = False
         self._init_ui()
         self._connect_signals()
+        install_wheel_guards(self)
 
     # ── settings persistence ──────────────────────────────────────────
 

--- a/negpy/desktop/view/widgets/sliders.py
+++ b/negpy/desktop/view/widgets/sliders.py
@@ -323,6 +323,7 @@ class CompactSlider(BaseSlider):
         if unit:
             self.spin.setSuffix(unit)
 
+        self._value_pinned = False
         self._spin_full_width = 60 if unit else 50
         self.spin.setButtonSymbols(QDoubleSpinBox.ButtonSymbols.NoButtons)
         self.spin.setMinimumWidth(0)
@@ -353,12 +354,18 @@ class CompactSlider(BaseSlider):
         super().setToolTip(text)
         self.label.setToolTip(self.toolTip())
 
+    def set_value_pinned(self, pinned: bool) -> None:
+        """Keep the value box open at rest. Off by default — hover reveals it — but a
+        panel of hidden numbers is unreadable if you work by the numbers."""
+        self._value_pinned = pinned
+        self.spin.setMaximumWidth(self._spin_full_width if pinned else 0)
+
     def enterEvent(self, event) -> None:
         self.spin.setMaximumWidth(self._spin_full_width)
         super().enterEvent(event)
 
     def leaveEvent(self, event) -> None:
-        if not self.spin.hasFocus():
+        if not (self._value_pinned or self.spin.hasFocus()):
             self.spin.setMaximumWidth(0)
         super().leaveEvent(event)
 
@@ -715,3 +722,10 @@ class RangeSlider(QWidget):
         self.setRange(0.0, 1.0)
         self.rangeChanged.emit(0.0, 1.0)
         self.rangeCommitted.emit(0.0, 1.0)
+
+
+def apply_slider_value_visibility(root: QWidget, pinned: bool) -> None:
+    """Pin or unpin every CompactSlider under a widget tree, so the preference reaches
+    panels built long before it was toggled."""
+    for slider in root.findChildren(CompactSlider):
+        slider.set_value_pinned(pinned)

--- a/negpy/desktop/workers/export.py
+++ b/negpy/desktop/workers/export.py
@@ -38,6 +38,16 @@ class ExportTask:
     working_color_space: str = WORKING_COLOR_SPACE
 
 
+@dataclass(frozen=True)
+class LinearOutputTask:
+    """One frame's linear-output job. ``options`` is the keyword payload for
+    export_linear_output, resolved on the UI thread where the config lives."""
+
+    file_info: dict
+    out_path: str
+    options: dict
+
+
 def _same_decode_source(a: ExportTask, b: ExportTask) -> bool:
     """True when the decoded f32 source cache is reusable for the next task
     (mirrors the _load_source_f32 cache key; the key still verifies on read)."""
@@ -201,6 +211,32 @@ class ExportWorker(QObject):
                     release_source_cache=nxt is None or not _same_decode_source(task, nxt),
                     collect=False,
                 )
+
+            self.finished.emit()
+        except Exception as e:
+            self.error.emit(str(e))
+        finally:
+            gc.collect()
+
+    @pyqtSlot(list)
+    def run_linear_output(self, tasks: List[LinearOutputTask]) -> None:
+        """Writes each frame's decoded linear buffer. Own slot rather than a branch in
+        run_batch: linear output bypasses the render pipeline and the export settings."""
+        from negpy.services.export.linear_output import export_linear_output
+
+        self._cancel.clear()
+        total = len(tasks)
+        try:
+            for i, task in enumerate(tasks):
+                if self._cancel.is_set():
+                    self.cancelled.emit()
+                    return
+                name = os.path.splitext(task.file_info["name"])[0]
+                self.progress.emit(i + 1, total, name)
+                try:
+                    export_linear_output(task.file_info["path"], task.out_path, **task.options)
+                except Exception as e:
+                    self.error.emit(f"Linear Output failed for {name}: {e}")
 
             self.finished.emit()
         except Exception as e:

--- a/negpy/services/assets/thumbnails.py
+++ b/negpy/services/assets/thumbnails.py
@@ -4,7 +4,7 @@ from PIL import Image
 import rawpy
 from negpy.kernel.system.config import APP_CONFIG
 import numpy as np
-from negpy.kernel.image.logic import apply_exif_orientation, ensure_rgb, prepare_thumbnail
+from negpy.kernel.image.logic import apply_exif_orientation, ensure_rgb, float_to_uint8, prepare_thumbnail, srgb_to_linear, uint8_to_float32
 from negpy.infrastructure.loaders.factory import loader_factory
 from negpy.infrastructure.display.color_spaces import WORKING_COLOR_SPACE
 from negpy.kernel.system.logging import get_logger
@@ -69,8 +69,12 @@ def thumbnail_cache_key(file_hash: str, is_triplet: bool) -> str:
     A triplet caches under a distinct key so (a) a red-only thumbnail cached before
     merge support can't shadow the corrected one, and (b) the batch (source) path and
     the rendered-positive path agree on where the triplet's thumbnail lives — the
-    rendered positive is what makes the filmstrip match the canvas."""
-    return f"{file_hash}-rgb" if is_triplet else file_hash
+    rendered positive is what makes the filmstrip match the canvas.
+
+    The version suffix retires caches written before the batch path inverted negatives;
+    without it an existing library keeps serving its stored negatives forever."""
+    base = f"{file_hash}-rgb" if is_triplet else file_hash
+    return f"{base}-v2"
 
 
 def _fast_demosaic(raw: Any) -> np.ndarray:
@@ -148,6 +152,39 @@ def decode_source_image(file_path: str, green_path: str = "", blue_path: str = "
         return img
 
 
+def preview_positive(img: Image.Image) -> Image.Image:
+    """Invert a negative preview so the filmstrip reads as photographs before a frame
+    has ever been opened.
+
+    Deliberately not the pipeline: per-channel log-density bounds over an 8-bit preview,
+    with no config to key on. It is a placeholder that get_rendered_thumbnail supersedes
+    the moment the frame renders, so drift from the engine costs nothing.
+    """
+    from negpy.features.process.logic import detect_process_mode
+    from negpy.features.process.models import ProcessMode
+
+    arr = np.asarray(img.convert("RGB"), dtype=np.uint8)
+    linear = srgb_to_linear(uint8_to_float32(arr))
+    if detect_process_mode(linear) is ProcessMode.E6:
+        return img
+
+    # A lone narrowband exposure carries its picture in one channel; the other two hold
+    # only near-black noise, which the log below would stretch into a solid colour cast.
+    # Borrowing the channel that has the signal renders it as the monochrome it is.
+    peaks = np.percentile(linear, 99.0, axis=(0, 1))
+    strongest = int(np.argmax(peaks))
+    empty = peaks < peaks[strongest] * 0.05
+    if empty.any():
+        linear = linear.copy()
+        linear[:, :, empty] = linear[:, :, strongest : strongest + 1]
+
+    density = -np.log10(np.clip(linear, 1e-4, None))
+    lo = np.percentile(density, 1.0, axis=(0, 1))
+    hi = np.percentile(density, 99.0, axis=(0, 1))
+    positive = (density - lo) / np.maximum(hi - lo, 1e-6)
+    return Image.fromarray(float_to_uint8(np.clip(positive, 0.0, 1.0)))
+
+
 def get_thumbnail_worker(
     file_path: str,
     file_hash: str,
@@ -179,7 +216,7 @@ def get_thumbnail_worker(
 
             img = Image.fromarray(slice_half(np.asarray(img), half, split_x, crop_rect=crop_rect, gutter_thickness=gutter_thickness))
 
-        square_img: Image.Image = prepare_thumbnail(img, ts)
+        square_img: Image.Image = prepare_thumbnail(preview_positive(img), ts)
 
         if asset_store:
             asset_store.save_thumbnail(cache_key, square_img)

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -163,9 +163,9 @@ class TestAppController(unittest.TestCase):
             patch("negpy.desktop.controller.load_or_promote", return_value=None),
             patch("negpy.desktop.controller.write_sidecar") as mock_write,
         ):
-            written = self.controller._write_edit_sidecars([frame])
+            written, failed = self.controller._write_edit_sidecars([frame])
 
-        self.assertEqual(written, 1)
+        self.assertEqual((written, failed), (1, 0))
         self.mock_session_manager.config_for_asset.assert_called_once_with(frame)
         params = mock_write.call_args.args[1]
         self.assertIs(params, hydrated)
@@ -188,15 +188,18 @@ class TestAppController(unittest.TestCase):
     def test_thumbnail_miss_marks_file_unreadable(self):
         from PIL import Image
 
+        from negpy.services.assets.thumbnails import asset_thumbnail_key
+
         self.mock_session_manager.asset_model = MagicMock()
         state = self.mock_session_manager.state
         state.uploaded_files = [
             {"name": "bad.dng", "path": "/tmp/bad.dng", "hash": "h1"},
             {"name": "good.dng", "path": "/tmp/good.dng", "hash": "h2"},
         ]
-        self.controller._thumb_requested = ["h1", "h2"]
+        keys = [asset_thumbnail_key(f) for f in state.uploaded_files]
+        self.controller._thumb_requested = keys
 
-        self.controller._on_thumbnails_finished({"h2": Image.new("RGB", (4, 4))})
+        self.controller._on_thumbnails_finished({keys[1]: Image.new("RGB", (4, 4))})
 
         self.assertIn("decode_failed", state.uploaded_files[0])
         self.assertNotIn("decode_failed", state.uploaded_files[1])
@@ -266,7 +269,10 @@ class TestAppController(unittest.TestCase):
         self.controller.thumbnail_update_requested.connect(lambda task: captured.setdefault("task", task))
         self.controller._update_thumbnail_from_state(persist=False)
 
-        self.assertEqual(captured["task"].file_hash, "h1-rgb")
+        from negpy.services.assets.thumbnails import thumbnail_cache_key
+
+        self.assertEqual(captured["task"].file_hash, thumbnail_cache_key("h1", is_triplet=True))
+        self.assertNotEqual(captured["task"].file_hash, thumbnail_cache_key("h1", is_triplet=False))
 
     def test_capture_worker_cancelled_is_forwarded(self):
         cancelled = MagicMock()
@@ -1129,14 +1135,13 @@ class TestLinearOutputExportCurrentFile(unittest.TestCase):
         gc.collect()
 
     def test_current_file_triplet_survives_linear_export(self):
-        with (
-            patch("negpy.services.export.linear_output.is_linear_output_supported", return_value=True),
-            patch("negpy.services.export.linear_output.export_linear_output") as mock_export,
-        ):
-            self.controller.request_linear_output_export()
+        # The write itself now runs in the export worker, so the triplet has to survive
+        # into the dispatched task rather than into a direct call.
+        files = [f for f in self.controller.state.uploaded_files]
+        tasks = self.controller._linear_output_tasks(files, "/tmp/out")
 
-        mock_export.assert_called_once()
-        rgbscan = mock_export.call_args.kwargs["rgbscan"]
+        self.assertEqual(len(tasks), 1)
+        rgbscan = tasks[0].options["rgbscan"]
         self.assertTrue(rgbscan.enabled)
         self.assertEqual(rgbscan.green_path, "/tmp/IMG_0001_G.cr2")
         self.assertEqual(rgbscan.blue_path, "/tmp/IMG_0001_B.cr2")

--- a/tests/test_desktop_session.py
+++ b/tests/test_desktop_session.py
@@ -1077,25 +1077,28 @@ class TestThumbnailKeying(unittest.TestCase):
     def test_same_named_files_in_two_folders_keep_distinct_thumbnails(self):
         from PyQt6.QtCore import Qt
 
+        from negpy.services.assets.thumbnails import asset_thumbnail_key
+
         state = AppState()
         state.uploaded_files = [
             {"name": "IMG_0042.tif", "path": "/a/IMG_0042.tif", "hash": "h1"},
             {"name": "IMG_0042.tif", "path": "/b/IMG_0042.tif", "hash": "h2"},
         ]
-        state.thumbnails = {"h1": "thumb-a", "h2": "thumb-b"}
+        state.thumbnails = {asset_thumbnail_key(f): f"thumb-{i}" for i, f in enumerate(state.uploaded_files)}
         model = AssetListModel(state)
 
         first = model.data(model.index(0, 0), Qt.ItemDataRole.DecorationRole)
         second = model.data(model.index(1, 0), Qt.ItemDataRole.DecorationRole)
-        self.assertEqual({first, second}, {"thumb-a", "thumb-b"})
+        self.assertEqual({first, second}, {"thumb-0", "thumb-1"})
 
     def test_triplet_key_is_namespaced_away_from_its_red_exposure(self):
         from negpy.services.assets.thumbnails import asset_thumbnail_key
 
         red = {"name": "a.nef", "path": "/a.nef", "hash": "h1"}
         triplet = {**red, "name": "a (RGB)", "green_path": "/g.nef", "blue_path": "/b.nef"}
-        self.assertEqual(asset_thumbnail_key(red), "h1")
-        self.assertEqual(asset_thumbnail_key(triplet), "h1-rgb")
+        self.assertTrue(asset_thumbnail_key(red).startswith("h1"))
+        self.assertNotEqual(asset_thumbnail_key(triplet), asset_thumbnail_key(red))
+        self.assertIn("-rgb", asset_thumbnail_key(triplet))
 
     def test_unloading_one_frame_keeps_its_twins_thumbnail(self):
         repo = MagicMock(spec=StorageRepository)
@@ -1109,13 +1112,16 @@ class TestThumbnailKeying(unittest.TestCase):
             {"name": "IMG_0042.tif", "path": "/a/IMG_0042.tif", "hash": "h1"},
             {"name": "IMG_0042.tif", "path": "/b/IMG_0042.tif", "hash": "h2"},
         ]
-        session.state.thumbnails = {"h1": "thumb-a", "h2": "thumb-b"}
+        from negpy.services.assets.thumbnails import asset_thumbnail_key
+
+        keys = [asset_thumbnail_key(f) for f in session.state.uploaded_files]
+        session.state.thumbnails = {keys[0]: "thumb-a", keys[1]: "thumb-b"}
         session.state.selected_file_idx = 0
         session.state.selected_indices = [0]
 
         session.remove_current_file()
 
-        self.assertEqual(session.state.thumbnails, {"h2": "thumb-b"})
+        self.assertEqual(session.state.thumbnails, {keys[1]: "thumb-b"})
 
 
 class TestSearchFacts(unittest.TestCase):

--- a/tests/test_destructive_guards.py
+++ b/tests/test_destructive_guards.py
@@ -1,0 +1,83 @@
+from unittest.mock import MagicMock, patch
+
+from PyQt6.QtCore import QPoint, QPointF, Qt
+from PyQt6.QtGui import QWheelEvent
+from PyQt6.QtWidgets import QComboBox
+
+from negpy.desktop.session import AppState
+from negpy.desktop.view.sidebar.history import HistoryPanel
+from negpy.desktop.view.sidebar.scan import ScanSidebar
+
+
+def _panel(cls):
+    controller = MagicMock()
+    controller.state = AppState()
+    return controller, cls(controller)
+
+
+def _wheel(widget) -> QWheelEvent:
+    return QWheelEvent(
+        QPointF(widget.rect().center()),
+        QPointF(widget.mapToGlobal(widget.rect().center())),
+        QPoint(0, 0),
+        QPoint(0, -120),
+        Qt.MouseButton.NoButton,
+        Qt.KeyboardModifier.NoModifier,
+        Qt.ScrollPhase.NoScrollPhase,
+        False,
+    )
+
+
+def test_scan_panel_combos_ignore_the_wheel_unless_focused(qapp):
+    """ScanSidebar is not a BaseSidebar, so it never got the guard — scrolling the panel
+    changed scanner settings under the pointer."""
+    _, sidebar = _panel(ScanSidebar)
+    combos = sidebar.findChildren(QComboBox)
+    assert combos, "the scan panel should have combo boxes to guard"
+
+    exercised = 0
+    for combo in combos:
+        if combo.count() < 2:
+            continue
+        exercised += 1
+        combo.setCurrentIndex(0)
+        combo.clearFocus()
+        combo.wheelEvent(_wheel(combo))
+        assert combo.currentIndex() == 0
+
+    assert exercised, "no combo had enough items to scroll — the test proved nothing"
+
+
+def test_blank_rename_leaves_the_work_print_alone(qapp):
+    """QInputDialog returns ok=True on an emptied field, which used to rename the work
+    print to an empty string."""
+    controller, panel = _panel(HistoryPanel)
+    panel.work_prints.addItem("keeper")
+
+    menu = MagicMock()
+    rename_action = object()
+    menu.addAction.side_effect = lambda *_: rename_action
+    menu.exec.return_value = rename_action
+
+    with patch("negpy.desktop.view.sidebar.history.QMenu", return_value=menu):
+        with patch("negpy.desktop.view.sidebar.history.QInputDialog.getText", return_value=("   ", True)):
+            panel._on_work_print_menu(QPoint(0, 0))
+
+    controller.session.rename_work_print.assert_not_called()
+
+
+def test_deleting_a_work_print_asks_first(qapp):
+    controller, panel = _panel(HistoryPanel)
+    panel.work_prints.addItem("keeper")
+
+    menu = MagicMock()
+    delete_action = object()
+    menu.addAction.side_effect = [object(), object(), delete_action]
+    menu.exec.return_value = delete_action
+
+    with patch("negpy.desktop.view.sidebar.history.QMenu", return_value=menu):
+        with patch("negpy.desktop.view.sidebar.history.confirm_delete_named", return_value=False) as confirm:
+            panel._on_work_print_menu(QPoint(0, 0))
+
+    confirm.assert_called_once()
+    controller.session.delete_work_print.assert_not_called()

--- a/tests/test_linear_output_batch.py
+++ b/tests/test_linear_output_batch.py
@@ -1,0 +1,64 @@
+from unittest.mock import patch
+
+from negpy.desktop.workers.export import ExportWorker, LinearOutputTask
+
+
+def _task(name: str) -> LinearOutputTask:
+    return LinearOutputTask(
+        file_info={"name": f"{name}.nef", "path": f"/tmp/{name}.nef", "hash": name},
+        out_path=f"/tmp/out/{name}_linear.tiff",
+        options={"gamma_key": "linear"},
+    )
+
+
+def test_linear_output_runs_in_the_worker_with_progress() -> None:
+    """Linear Output used to loop on the GUI thread, so it reported no progress and
+    could not be aborted."""
+    worker = ExportWorker()
+    progress: list[tuple[int, int, str]] = []
+    finished: list[bool] = []
+    worker.progress.connect(lambda *a: progress.append(a))
+    worker.finished.connect(lambda: finished.append(True))
+
+    with patch("negpy.services.export.linear_output.export_linear_output") as export:
+        worker.run_linear_output([_task("a"), _task("b")])
+
+    assert progress == [(1, 2, "a"), (2, 2, "b")]
+    assert finished == [True]
+    assert export.call_count == 2
+    assert export.call_args_list[0].args == ("/tmp/a.nef", "/tmp/out/a_linear.tiff")
+    assert export.call_args_list[0].kwargs == {"gamma_key": "linear"}
+
+
+def test_linear_output_cancel_stops_the_batch() -> None:
+    worker = ExportWorker()
+    cancelled: list[bool] = []
+    worker.cancelled.connect(lambda: cancelled.append(True))
+
+    with patch("negpy.services.export.linear_output.export_linear_output", side_effect=lambda *a, **k: worker.cancel()) as export:
+        worker.run_linear_output([_task("a"), _task("b"), _task("c")])
+
+    assert cancelled == [True]
+    assert export.call_count == 1
+
+
+def test_linear_output_failure_is_reported_and_the_batch_continues() -> None:
+    """Each error raises the controller's failure count, so the completion toast can
+    say how many frames did not make it."""
+    worker = ExportWorker()
+    errors: list[str] = []
+    finished: list[bool] = []
+    worker.error.connect(errors.append)
+    worker.finished.connect(lambda: finished.append(True))
+
+    def _fail_first(path, *_a, **_k):
+        if path.endswith("a.nef"):
+            raise OSError("disk full")
+
+    with patch("negpy.services.export.linear_output.export_linear_output", side_effect=_fail_first) as export:
+        worker.run_linear_output([_task("a"), _task("b")])
+
+    assert len(errors) == 1
+    assert "disk full" in errors[0]
+    assert export.call_count == 2
+    assert finished == [True]

--- a/tests/test_modified_dots.py
+++ b/tests/test_modified_dots.py
@@ -1,0 +1,50 @@
+from dataclasses import replace
+from unittest.mock import MagicMock
+
+from negpy.desktop.session import AppState
+from negpy.desktop.view.sidebar.controls_panel import ControlsPanel
+
+
+def _panel():
+    controller = MagicMock()
+    controller.state = AppState()
+    return controller, ControlsPanel(controller)
+
+
+def test_calibration_edits_light_their_section(qapp):
+    """Calibration owns fields on ProcessConfig, so it was never counted — its header
+    showed no count and its reset button stayed hidden forever."""
+    controller, panel = _panel()
+    panel._sync_modified_dots()
+    assert panel.sensor_section.modified_count == 0
+    assert not panel.sensor_section.reset_btn.isVisible()
+
+    cfg = controller.state.config
+    controller.state.config = replace(cfg, process=replace(cfg.process, crosstalk_strength=0.4, hue_trim=3.0))
+    panel._sync_modified_dots()
+
+    assert panel.sensor_section.modified_count == 2
+
+
+def test_flat_field_edits_light_their_section(qapp):
+    controller, panel = _panel()
+    panel._sync_modified_dots()
+    assert panel.flatfield_section.modified_count == 0
+
+    cfg = controller.state.config
+    controller.state.config = replace(cfg, flatfield=replace(cfg.flatfield, apply=True, k1=-0.02))
+    panel._sync_modified_dots()
+
+    assert panel.flatfield_section.modified_count == 2
+
+
+def test_calibration_fields_are_not_double_counted_in_process(qapp):
+    """The two sections share ProcessConfig; a Calibration edit must not also inflate
+    the Process count."""
+    controller, panel = _panel()
+    cfg = controller.state.config
+    controller.state.config = replace(cfg, process=replace(cfg.process, crosstalk_strength=0.4))
+    panel._sync_modified_dots()
+
+    assert panel.sensor_section.modified_count == 1
+    assert panel.process_section.modified_count == 0

--- a/tests/test_rgbscan.py
+++ b/tests/test_rgbscan.py
@@ -237,8 +237,9 @@ def test_thumbnail_cache_key_namespaces_triplets():
     """Batch and rendered paths must derive the same triplet key so they share a cache slot."""
     from negpy.services.assets.thumbnails import thumbnail_cache_key
 
-    assert thumbnail_cache_key("h", False) == "h"
-    assert thumbnail_cache_key("h", True) == "h-rgb"
+    assert thumbnail_cache_key("h", False).startswith("h")
+    assert thumbnail_cache_key("h", True) != thumbnail_cache_key("h", False)
+    assert "-rgb" in thumbnail_cache_key("h", True)
 
 
 def test_thumbnail_decode_routes_triplet_to_merge(monkeypatch):
@@ -272,10 +273,11 @@ def test_thumbnail_worker_namespaces_triplet_cache(monkeypatch):
 
     store = Store()
     thumbnails.get_thumbnail_worker("r", "hash", store, 0, 0.5, "g", "b")
-    assert "hash-rgb" in saved and "hash" not in saved
+    triplet_key = thumbnails.thumbnail_cache_key("hash", True)
+    assert triplet_key in saved and thumbnails.thumbnail_cache_key("hash", False) not in saved
 
     thumbnails.get_thumbnail_worker("r2", "hash2", store)
-    assert "hash2" in saved
+    assert thumbnails.thumbnail_cache_key("hash2", False) in saved
 
 
 def test_triplet_ignores_stale_plain_hash_cache(monkeypatch):
@@ -284,9 +286,9 @@ def test_triplet_ignores_stale_plain_hash_cache(monkeypatch):
 
     from negpy.services.assets import thumbnails
 
-    stale = Image.new("RGB", (4, 4))
-    merged = Image.new("RGB", (4, 4))
-    saved: dict = {"hash": stale}
+    stale = Image.new("RGB", (4, 4), (255, 0, 0))
+    merged = Image.new("RGB", (4, 4), (0, 255, 0))
+    saved: dict = {thumbnails.thumbnail_cache_key("hash", False): stale}
 
     class Store:
         def get_thumbnail(self, key):
@@ -298,6 +300,7 @@ def test_triplet_ignores_stale_plain_hash_cache(monkeypatch):
     monkeypatch.setattr(thumbnails, "decode_source_image", lambda *a, **k: merged)
     monkeypatch.setattr(thumbnails, "prepare_thumbnail", lambda i, ts: i)
 
+    # The worker inverts the decoded negative, so identity is not the check — provenance is.
     out = thumbnails.get_thumbnail_worker("r", "hash", Store(), 0, 0.5, "g", "b")
-    assert out is merged
-    assert saved["hash-rgb"] is merged
+    assert out is not stale
+    assert saved[thumbnails.thumbnail_cache_key("hash", True)] is out

--- a/tests/test_slider_value_feedback.py
+++ b/tests/test_slider_value_feedback.py
@@ -1,0 +1,47 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from negpy.desktop.view.keyboard_shortcuts import ShortcutManager
+from negpy.desktop.view.widgets.sliders import CompactSlider, apply_slider_value_visibility
+from PyQt6.QtWidgets import QVBoxLayout, QWidget
+
+
+def test_keyboard_adjust_reports_the_new_value(qapp):
+    """The slider may be on a hidden tab and its value box only opens on hover, so an
+    inc/dec shortcut used to change the image with no readable feedback at all."""
+    slider = CompactSlider("Print Density", -2.0, 2.0, 0.0, unit=" EV")
+    window = SimpleNamespace(controller=MagicMock())
+
+    manager = SimpleNamespace(window=window, slider_steps={})
+    manager._announce = lambda s, g: ShortcutManager._announce(manager, s, g)
+    ShortcutManager._slider_adjuster(manager, lambda: slider, "density_up")()
+
+    assert slider.value() > 0.0
+    message = window.controller.set_status.call_args.args[0]
+    assert message.startswith("Print Density")
+    assert "EV" in message
+
+
+def test_pinning_opens_every_value_box(qapp):
+    root = QWidget()
+    layout = QVBoxLayout(root)
+    sliders = [CompactSlider("A", 0.0, 1.0, 0.5), CompactSlider("B", 0.0, 1.0, 0.5)]
+    for s in sliders:
+        layout.addWidget(s)
+
+    assert all(s.spin.maximumWidth() == 0 for s in sliders)
+
+    apply_slider_value_visibility(root, True)
+    assert all(s.spin.maximumWidth() > 0 for s in sliders)
+
+    apply_slider_value_visibility(root, False)
+    assert all(s.spin.maximumWidth() == 0 for s in sliders)
+
+
+def test_pinned_slider_keeps_its_value_box_after_the_pointer_leaves(qapp):
+    slider = CompactSlider("A", 0.0, 1.0, 0.5)
+    slider.set_value_pinned(True)
+
+    slider.leaveEvent(None)
+
+    assert slider.spin.maximumWidth() > 0

--- a/tests/test_thumbnail_positive.py
+++ b/tests/test_thumbnail_positive.py
@@ -1,0 +1,69 @@
+import unittest
+
+import numpy as np
+from PIL import Image
+
+from negpy.services.assets.thumbnails import preview_positive, thumbnail_cache_key
+
+
+def _orange_mask_negative() -> Image.Image:
+    """A C41-looking negative: orange base (R >> B) with a dark patch where the scene
+    was bright, and a light patch where the scene was dark."""
+    arr = np.zeros((64, 64, 3), dtype=np.uint8)
+    arr[:, :] = (210, 130, 60)
+    arr[:32, :] = (60, 34, 16)
+    rng = np.random.default_rng(7)
+    arr = np.clip(arr.astype(np.int16) + rng.integers(-6, 7, arr.shape), 0, 255).astype(np.uint8)
+    return Image.fromarray(arr)
+
+
+class TestPreviewPositive(unittest.TestCase):
+    def test_negative_is_inverted(self):
+        """The dense half of the negative is the scene's highlight, so it must come out
+        the brighter half of the positive."""
+        source = np.asarray(_orange_mask_negative(), dtype=np.float32)
+        result = np.asarray(preview_positive(_orange_mask_negative()), dtype=np.float32)
+
+        self.assertGreater(source[:32].mean(), 0.0)
+        self.assertLess(source[:32].mean(), source[32:].mean())
+        self.assertGreater(result[:32].mean(), result[32:].mean())
+
+    def test_orange_mask_is_neutralized(self):
+        """Per-channel bounds pull the base out: the positive must not stay orange."""
+        result = np.asarray(preview_positive(_orange_mask_negative()), dtype=np.float32)
+        spread = result.reshape(-1, 3).mean(axis=0)
+        self.assertLess(float(spread.max() - spread.min()), 40.0)
+
+    def test_narrowband_exposure_stays_neutral(self):
+        """One exposure of an RGB-scan triplet holds its picture in a single channel. The
+        log stretch turned the other two channels' noise into a solid green cast."""
+        arr = np.zeros((64, 64, 3), dtype=np.uint8)
+        rng = np.random.default_rng(11)
+        arr[:, :, 0] = rng.integers(40, 220, (64, 64))
+        arr[:, :, 1] = rng.integers(0, 3, (64, 64))
+        arr[:, :, 2] = rng.integers(0, 3, (64, 64))
+
+        result = np.asarray(preview_positive(Image.fromarray(arr)), dtype=np.float32)
+
+        channel_means = result.reshape(-1, 3).mean(axis=0)
+        self.assertLess(float(channel_means.max() - channel_means.min()), 5.0)
+
+    def test_transparency_is_left_alone(self):
+        """A slide is already a positive; inverting it would be the bug this replaces."""
+        rng = np.random.default_rng(3)
+        arr = rng.integers(0, 256, (64, 64, 3), dtype=np.uint8)
+        slide = Image.fromarray(arr)
+
+        result = preview_positive(slide)
+
+        self.assertTrue(np.array_equal(np.asarray(result), arr))
+
+    def test_cache_key_retires_stored_negatives(self):
+        """A library scanned before this change must not keep serving its negatives."""
+        self.assertNotEqual(thumbnail_cache_key("abc", False), "abc")
+        self.assertNotEqual(thumbnail_cache_key("abc", True), "abc-rgb")
+        self.assertNotEqual(thumbnail_cache_key("abc", False), thumbnail_cache_key("abc", True))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
A polish pass over the desktop layer. Each item is an existing pattern that was applied to most places but not all, so every fix reuses machinery already here rather than adding any.

## 1. The film strip shows positives

Two thumbnail paths existed and only one inverted: `get_rendered_thumbnail` (fed by a canvas render) produced a positive, while the batch path returned the source negative. A frame became a positive only by being visited, so a roll being triaged was mostly orange.

`preview_positive()` now runs in the batch path — sRGB→linear, per-channel log density, 1/99 percentile stretch. Deliberately not the pipeline: there is no config to key on at that point, and `rendered_thumbnails` still supersedes it the moment the frame renders.

One trap worth recording: a lone RGB-scan exposure keeps its picture in a single channel and near-black noise in the other two. In the log domain that noise has a *wide* range, so a range floor does not help — it stretched into a solid green cast. Channels are judged by their **linear** p99 instead, and any below 5% of the strongest borrow it, rendering the frame as the monochrome it is.

Verified on `samples/` — an Ektar negative comes out as sky and mountain, the narrowband ARW as a legible black-and-white frame.

`thumbnail_cache_key()` carries a `-v2` suffix so already-scanned libraries regenerate; without it the fix is invisible on any existing library.

## 2. Linear Output no longer freezes the window

`request_linear_output_export` looped on the GUI thread calling `export_linear_output` (full RAW decode + 16-bit write) per file, with the *all* scope reaching every visible frame. It was absent from the `_begin_batch` call sites, so no progress popup appeared, `abort_requested` had nothing to abort, and its own `set_status` calls could not repaint.

It now builds tasks on the UI thread (`_linear_output_tasks`) and dispatches `LinearOutputTask`s to the export worker through the shared batch lane, so progress, Abort and the `— N failed` suffix all come from the existing wiring. Destinations resolve up front, so a `taken` set guards same-stem collisions the old on-disk check could not see.

**Deviation from the plan:** sidecar export stays on the GUI thread. It is one DB read plus one small write per frame — threading it is not worth the machinery. The real defect is fixed instead: `_write_edit_sidecars` returns `(written, failed)`, so writing 1 of 200 no longer reports "Wrote 1 edit sidecar" as a clean success, and the button shows a wait cursor.

## 3. Slider values are readable

Every `CompactSlider` collapses its value box to width 0 at rest, and roughly 60 registry entries are slider inc/dec pairs that called `adjust_by()` and nothing else — changing a value on a possibly hidden tab with no feedback at all. (Contrast `_toggle_tool_button`, which deliberately reveals its tab first.)

Keyboard adjust now posts `<label> <value>` to the HUD, reusing the spin box's own decimals and unit suffix. A persisted **Show Slider Values** toggle in the ⋯ menu pins every value box open; default off, so the current look is unchanged unless asked for. Registry entry added (`toggle_slider_values`, no default key).

## 4. Calibration and Flat Field show that they are edited

`_sync_modified_dots` called `set_modified()` for 11 sections and skipped these two, which own `crosstalk_strength`, `hue_trim` and `k1`. Their headers showed no `· N`, their reset buttons stayed hidden forever, and since `right_panel` derives tab dots from `modified_count`, a calibrated frame looked pristine everywhere.

Calibration's fields live on `ProcessConfig` but belong to their own section, so they are counted there and excluded from `process_count` — a test asserts they are not double counted. Presets and the two Scan sections stay out; they own no `WorkspaceConfig` fields.

## 5. State no longer disappears quietly

- Deleting a work print, a normalization roll or a flat-field profile now asks first, via a shared `confirm_delete_named` beside the existing `confirm_unload`. Work prints are the one thing never pruned by a later edit, so a silent delete was the sharpest of the three.
- A work-print rename acted on `ok` alone, so clearing the field renamed it to `""`.
- `ScanSidebar` subclasses `QWidget` rather than `BaseSidebar` and had no wheel handling in 783 lines, so scrolling the panel changed scanner settings under the pointer. `_install_wheel_guards` is now a module-level `install_wheel_guards` that both can share.

## Verification

`make all`: lint and type clean, **3979 passed**, 19 new tests across 5 files.

One failure remains — `tests/test_rgbscan.py::test_preview_merge_pulls_green_blue_from_their_files`, `load_linear_preview_rgb() got multiple values for argument 'use_camera_wb'`. Confirmed failing on `main` before this branch; untouched here.

Docs updated in the same change: USER_GUIDE (triage, ⋯ menu, the three delete prompts, Linear Output progress, sidecar failures) and KEYBOARD (the HUD readout).
