### PR TITLE
Camera scanning: parse shutter labels that carry their unit (fixes #768)

### DIFF
--- a/negpy/desktop/view/sidebar/scanlight.py
+++ b/negpy/desktop/view/sidebar/scanlight.py
@@ -780,7 +780,13 @@ class ScanlightSidebar(QWidget):
         and meters noise instead of light."""
         data = self._settings_json()
         floor, ceiling = shutter_seconds(SHUTTER_CANDIDATES[0]), shutter_seconds(SHUTTER_CANDIDATES[-1])
-        labels = tuple(str(o.get("label", "")).strip() for o in (data.get("shutter") or {}).get("options", []))
+        info = data.get("shutter") or {}
+        if not info.get("writable", True):  # absent = unknown, so only an explicit read-only blocks
+            # A body that reports the shutter read-only will silently ignore every write, and the
+            # only symptom is a read-back that never settles (issue #768). Publishing no ladder is
+            # what makes the caller refuse instead of solving against speeds it cannot set.
+            return ()
+        labels = tuple(str(o.get("label", "")).strip() for o in info.get("options", []))
         # usable_ladder drops the unparseables (bulb-like "1/0", "Bulb", "") and returns ascending =
         # fastest-first; the range clamp on top is this UI's own policy, not the solver's.
         return tuple(label for label in usable_ladder(labels) if floor <= shutter_seconds(label) <= ceiling)
@@ -797,6 +803,17 @@ class ScanlightSidebar(QWidget):
         if roi is None:
             self.calib_window.set_status("Click the clear film base (crosshair) first.")
             return
+        candidates = self._available_shutters()
+        if not candidates:
+            # Without the body's own ladder the only speeds we could name are the built-in ones,
+            # and those are spelled in one vendor's vocabulary — writing them onto another body
+            # is ignored rather than refused, which reads as "camera rejected it or it did not
+            # settle" (issue #768, a Nikon D600 handed "0.4"). Say what is actually wrong.
+            self.calib_window.set_status(
+                "This camera is not reporting settable shutter speeds. Set it to Manual (M), "
+                "make sure live view is running, then try again."
+            )
+            return
         # Live view stays up — calibration captures within it (no ~4 s reconnect), like a scan.
         # It's torn down when calibration finishes/fails (_stop_calibration_live_view).
         self._calibrating_preset = name
@@ -810,7 +827,6 @@ class ScanlightSidebar(QWidget):
         # Phase 1: scale the fixed reference start point to the body's live ISO/aperture so the probe
         # begins near target (fewer captures). Levels stay fixed; only the shutter is corrected. On a
         # manual lens the aperture reads blank → ISO-only correction, and the probe absorbs the rest.
-        candidates = self._available_shutters()
         start_levels, start_shutter = normalize_start_point(
             self._current_setting_label("iso"),
             self._current_setting_label("aperture", require_writable=True),

--- a/negpy/infrastructure/capture/gphoto.py
+++ b/negpy/infrastructure/capture/gphoto.py
@@ -425,6 +425,21 @@ class GphotoCamera:
                 return True  # already there — skip the round trip (a scan re-sends the shutter)
 
             widget = camera.get_single_config(name)
+            offered = _choices(self._gp, widget)
+            if offered and value not in offered:
+                # Writing a label the body never published is how a Sony-flavoured fallback
+                # ladder reached a Nikon: libgphoto2 takes the string, the camera ignores it,
+                # and the only symptom is a read-back that never settles (issue #768). Name
+                # what it does offer — that is the answer to "why", and it costs one log line.
+                logger.warning(
+                    "gphoto2: %s does not offer %r; this body publishes %d values (%s%s)",
+                    name,
+                    value,
+                    len(offered),
+                    ", ".join(offered[:8]),
+                    ", …" if len(offered) > 8 else "",
+                )
+                return False
             widget.set_value(value)
             camera.set_single_config(name, widget)
         except self._gp.GPhoto2Error as exc:

--- a/negpy/services/capture/calibration.py
+++ b/negpy/services/capture/calibration.py
@@ -145,7 +145,10 @@ def shutter_seconds(label: str) -> float:
     number is multiplied into the physics (k, the level solve, shutter_at_least's ≥-comparison)
     must use `true_seconds` instead.
     """
-    label = label.strip()
+    # Nikon publishes decimal seconds with the unit attached ("0.4000s", "0.0666s"); a D600's
+    # whole ladder parsed as junk, left the body with no usable speeds, and the fallback then
+    # wrote a Sony-spelled "0.4" the camera silently ignored (issue #768).
+    label = re.sub(r"(?i)\s*(?:sec(?:onds?)?|s)$", "", label.strip()).strip()
     if "/" in label:
         num, den = label.split("/", 1)
         denominator = float(den)

--- a/tests/test_capture_calibration.py
+++ b/tests/test_capture_calibration.py
@@ -425,3 +425,62 @@ def test_clip_fraction_counts_saturated_pixels():
     plane = np.zeros((100, 100))
     plane.reshape(-1)[:100] = 65500.0  # 1 % at/above saturation
     assert clip_fraction(plane, Roi(0, 0, 1, 1)) == pytest.approx(0.01, abs=1e-4)
+
+
+# Real ladder as published by a Nikon D600 (issue #768): decimal seconds with the unit attached.
+_D600 = tuple(
+    f"{v}s"
+    for v in (
+        "0.0040",
+        "0.0050",
+        "0.0062",
+        "0.0080",
+        "0.0100",
+        "0.0125",
+        "0.0166",
+        "0.0200",
+        "0.0250",
+        "0.0333",
+        "0.0400",
+        "0.0500",
+        "0.0666",
+        "0.0769",
+        "0.1000",
+        "0.1250",
+        "0.1666",
+        "0.2000",
+        "0.2500",
+        "0.3333",
+        "0.4000",
+        "0.5000",
+        "0.6250",
+        "0.7692",
+        "1.0000",
+        "1.3000",
+        "1.6000",
+        "2.0000",
+    )
+) + ("Bulb",)
+
+
+def test_shutter_labels_may_carry_their_unit():
+    """Nikon spells its ladder '0.4000s'. Every label failing to parse emptied the body's ladder,
+    the fallback then wrote a Sony-spelled '0.4', and the D600 silently ignored it (issue #768)."""
+    assert shutter_seconds("0.4000s") == pytest.approx(0.4)
+    assert shutter_seconds("0.0666s") == pytest.approx(0.0666)
+    assert shutter_seconds("2 sec") == pytest.approx(2.0)
+    assert shutter_seconds("0.4") == pytest.approx(0.4)  # unchanged for bodies that omit it
+    with pytest.raises(ValueError):
+        shutter_seconds("Bulb")  # still dropped, not silently parsed
+
+
+def test_a_nikon_ladder_survives_and_keeps_its_own_labels():
+    ladder = usable_ladder(_D600)
+    assert len(ladder) == len(_D600) - 1  # only "Bulb" is dropped
+    assert _ladder_stops(ladder) == pytest.approx(1 / 3)  # third-stops, read off the body
+    assert true_seconds("0.3333s", ladder) == pytest.approx(2 ** (-5 / 3), rel=0.01)
+
+    # The start point must come from the body's own vocabulary — writing "0.4" onto a D600 is
+    # exactly the bug: accepted by libgphoto2, ignored by the camera, "did not settle".
+    _, shutter = normalize_start_point("100", "f/8", candidates=_D600)
+    assert shutter in ladder and shutter.endswith("s")

--- a/tests/test_capture_gphoto.py
+++ b/tests/test_capture_gphoto.py
@@ -862,10 +862,10 @@ def test_capture_target_left_alone_when_the_body_offers_no_memory_option(caplog)
 
 
 def test_setting_a_value_the_body_rejects_warns_instead_of_raising(cam, fake, caplog):
-    """A shutter label from the built-in fallback ladder may not exist on this body. The
+    """A value the body offers but refuses at write time (mode-locked dial, busy body). The
     scan should degrade to the current exposure, not die."""
     fake.reject_writes = True
-    assert cam._set_verified("iso", "999") is False
+    assert cam._set_verified("iso", "200") is False  # "200" IS on this body's list
     assert "could not set iso" in caplog.text
 
 
@@ -876,3 +876,15 @@ def test_pin_locale_overrides_a_preset_language(monkeypatch):
     monkeypatch.setenv("LANGUAGE", "de_DE:de")
     _pin_locale()
     assert os.environ["LANGUAGE"] == "C"
+
+
+def test_a_value_the_body_never_published_is_refused_not_written(cam, fake, caplog):
+    """Issue #768: a Nikon D600 was handed '0.4' from the built-in (Sony-spelled) ladder.
+    libgphoto2 takes the string, the camera ignores it, and the only symptom is a read-back that
+    never settles. Refuse up front and name what the body does offer."""
+    with caplog.at_level(logging.WARNING):
+        assert cam._set_verified("shutterspeed", "0.4") is False
+
+    assert fake.writes == []  # nothing was sent to the body
+    message = caplog.text
+    assert "does not offer" in message and "1/5" in message  # the body's real choices are named

--- a/tests/test_scanlight_sidebar.py
+++ b/tests/test_scanlight_sidebar.py
@@ -1334,3 +1334,39 @@ def test_legacy_white_process_mode_names_still_load():
     assert ScanlightSettings(white_process_mode="E-6").white_process_mode is WhiteCaptureMode.E6
     assert ScanlightSettings(white_process_mode="B&W").white_process_mode is WhiteCaptureMode.BW
     assert ScanlightSettings(white_process_mode="nonsense").white_process_mode is WhiteCaptureMode.AUTO
+
+def _settings_json(tmp_path, monkeypatch, *, writable=True, options=("1/60", "1/30", "1/8")):
+    import json
+
+    from negpy.desktop.view.sidebar import scanlight as mod
+
+    path = tmp_path / "lv.json"
+    payload = {"shutter": {"cur": 0, "writable": writable, "options": [{"label": lbl, "raw": i} for i, lbl in enumerate(options)]}}
+    path.write_text(json.dumps(payload))
+    monkeypatch.setattr(mod, "default_settings_path", lambda: str(path))
+    return path
+
+
+def test_shutter_ladder_ignores_a_body_that_reports_it_read_only(tmp_path, monkeypatch):
+    """Issue #768: a body that reports the shutter read-only swallows every write silently, and
+    solving against speeds it cannot set is what produced "camera rejected it or it did not settle"."""
+    w = _sidebar()
+    _settings_json(tmp_path, monkeypatch, writable=True)
+    assert w._available_shutters() == ("1/60", "1/30", "1/8")
+
+    _settings_json(tmp_path, monkeypatch, writable=False)
+    assert w._available_shutters() == ()
+
+
+def test_calibration_refuses_rather_than_writing_a_foreign_shutter_label(tmp_path, monkeypatch):
+    """With no ladder from the body, the only labels available are the built-in ones — spelled in
+    one vendor's vocabulary. Say what is wrong instead of writing them onto someone else's camera."""
+    w = _sidebar()
+    _settings_json(tmp_path, monkeypatch, writable=False)
+    w.calib_window.image._roi = (0.4, 0.4, 0.2, 0.2)
+
+    w._on_calibrate_new_preset("Portra 400")
+
+    assert not w.controller.start_calibration.called
+    assert "settable shutter speeds" in w.calib_window.status.text()
+    assert not w._calibrating_preset  # the run never started

--- a/tests/test_scanlight_sidebar.py
+++ b/tests/test_scanlight_sidebar.py
@@ -1335,6 +1335,7 @@ def test_legacy_white_process_mode_names_still_load():
     assert ScanlightSettings(white_process_mode="B&W").white_process_mode is WhiteCaptureMode.BW
     assert ScanlightSettings(white_process_mode="nonsense").white_process_mode is WhiteCaptureMode.AUTO
 
+
 def _settings_json(tmp_path, monkeypatch, *, writable=True, options=("1/60", "1/30", "1/8")):
     import json
 


### PR DESCRIPTION
Fixes #768.

A Nikon D600 could not calibrate: `could not set shutter to '0.4': camera rejected it or it did not settle`. The camera captured and live-viewed fine, and its log showed the write was never refused, only ignored.

## Cause

The D600 publishes its shutter ladder as decimal seconds **with the unit attached**, straight from `gphoto2 --get-config shutterspeed`:

```
Readonly: 0
Choice: 24 0.0666s
Choice: 32 0.4000s
Choice: 36 1.0000s
```

`shutter_seconds` parsed neither form, so **every** label was dropped as junk, the body's ladder came out empty, and `normalize_start_point` fell back to the built-in one. That ladder is spelled the way a Sony spells it, so the calibration then wrote `"0.4"` onto a camera that has no such value. libgphoto2 accepts the string, the body ignores it, and the read-back never settles.

## Fix

The parser now strips a trailing unit (`0.4000s`, `2 sec`), leaving labels without one untouched and still dropping `Bulb`. With that, the D600's own 52-rung ladder survives: the third-stop spacing is read off it correctly and `true_seconds("0.3333s")` resolves to 2^(-5/3), so the physics is unchanged.

Two guards come with it, because the failure was silent for far too long:

- **A value the body never published is refused before the write**, and the log names what it does offer. Any future body with an unparseable ladder now fails visibly on the first attempt instead of producing "did not settle".
- **The shutter ladder respects the `writable` flag**, as the aperture already did, and calibration says so plainly rather than solving against speeds it cannot set. This one turned out not to be the D600's problem — it reports `Readonly: 0` — but the gap was real.

## Verification

New tests cover the unit-carrying labels, the real D600 ladder (spacing, `true_seconds`, and that the start point comes from the body's own vocabulary rather than ours), the refused-write path, and the read-only ladder. All of them fail without the change. `make all` is green with and without the optional camera group.

I do not have a D600, so confirmation from @sir-oscar-isaac-newton would be welcome.