### PR TITLE
Let a crop handle be grabbed wherever its cursor says it can be

### DIFF
--- a/negpy/desktop/view/canvas/overlay.py
+++ b/negpy/desktop/view/canvas/overlay.py
@@ -1952,10 +1952,19 @@ class CanvasOverlay(QWidget):
                 return
 
         coords = self._map_to_image_coords(event.position())
-        if coords:
+        if coords is not None:
             self.clicked.emit(*coords)
-            if self._tool_mode == ToolMode.CROP_MANUAL:
-                self._start_crop_drag(event.position())
+
+        # Not gated on coords: the crop rect lives in view-rect space, so its handles
+        # sit on the frame edge — and outside the content rect entirely once a print
+        # border insets it. _update_crop_hover_cursor hit-tests them by distance and
+        # offers the resize, so a press within the same grab radius has to take it.
+        if self._tool_mode == ToolMode.CROP_MANUAL and self._view_rect.adjusted(
+            -_CROP_HANDLE_PX, -_CROP_HANDLE_PX, _CROP_HANDLE_PX, _CROP_HANDLE_PX
+        ).contains(event.position()):
+            self._start_crop_drag(event.position())
+
+        if coords is not None or self._crop_drag_mode is not None:
             self.update()
 
     def _zone_pin_screen_points(self) -> List[QPointF]:

--- a/tests/test_crop_handle_grab.py
+++ b/tests/test_crop_handle_grab.py
@@ -1,0 +1,106 @@
+"""A crop handle must start a drag wherever its grab radius reaches.
+
+The handles sit on the crop rect, which can lie on — or, with a print border,
+outside — the image content. The hover cursor hit-tests them geometrically, so
+it offers a resize the press then has to honour.
+"""
+
+from PyQt6.QtCore import QEvent, QPointF, QRectF, Qt
+from PyQt6.QtGui import QMouseEvent
+from PyQt6.QtWidgets import QWidget
+
+from negpy.desktop.session import AppState, ToolMode
+from negpy.desktop.view.canvas.overlay import CanvasOverlay
+
+_DISPLAY = (200, 160)
+
+
+def _mouse_event(kind: QEvent.Type, pos: QPointF, buttons=Qt.MouseButton.LeftButton) -> QMouseEvent:
+    return QMouseEvent(kind, pos, Qt.MouseButton.LeftButton, buttons, Qt.KeyboardModifier.NoModifier)
+
+
+def _crop_overlay(content_rect=None) -> CanvasOverlay:
+    parent = QWidget()
+    parent._is_panning = False
+    overlay = CanvasOverlay(AppState(), parent)
+    overlay._test_parent = parent
+    overlay._view_rect = QRectF(0, 0, *_DISPLAY)
+    overlay._current_size = _DISPLAY
+    overlay._content_rect = content_rect
+    overlay.set_tool_mode(ToolMode.CROP_MANUAL)
+    # Full-frame crop: every handle sits on the image boundary.
+    overlay._crop_rect_norm = (0.0, 0.0, 1.0, 1.0)
+    return overlay
+
+
+def test_handle_on_the_frame_edge_starts_a_drag():
+    """The grab radius straddles the boundary, so half of it lands outside the
+    content rect — the press there used to be dropped without a word."""
+    overlay = _crop_overlay()
+
+    # 4 px outside the top-left corner: inside the 10 px grab radius.
+    press = QPointF(-4, -4)
+    overlay._update_crop_hover_cursor(press)
+    offered_resize = overlay.cursor().shape() in (Qt.CursorShape.SizeFDiagCursor, Qt.CursorShape.SizeBDiagCursor)
+
+    overlay.mousePressEvent(_mouse_event(QEvent.Type.MouseButtonPress, press))
+
+    assert offered_resize, "hover did not offer a resize; the premise of this test is gone"
+    assert overlay._crop_drag_mode == "corner"
+    assert overlay._crop_anchor_screen is not None
+
+
+def test_the_drag_then_actually_moves_the_rect():
+    overlay = _crop_overlay()
+    emitted: list = []
+    overlay.crop_rect_changed.connect(lambda *a: emitted.append(a))
+
+    overlay.mousePressEvent(_mouse_event(QEvent.Type.MouseButtonPress, QPointF(-4, -4)))
+    overlay.mouseMoveEvent(_mouse_event(QEvent.Type.MouseMove, QPointF(40, 32)))
+
+    assert emitted, "corner drag emitted no rect change"
+    assert emitted[-1][:4] != (0.0, 0.0, 1.0, 1.0)
+
+
+def test_handle_outside_a_bordered_content_rect_starts_a_drag():
+    """With a print border the content rect is inset, so a full-frame crop's
+    handles sit well outside it — not merely on its edge."""
+    overlay = _crop_overlay(content_rect=(20, 16, 160, 128))
+
+    press = QPointF(0, 0)  # the crop rect's own top-left, 20 px outside the content
+    overlay._update_crop_hover_cursor(press)
+    offered_resize = overlay.cursor().shape() in (Qt.CursorShape.SizeFDiagCursor, Qt.CursorShape.SizeBDiagCursor)
+
+    overlay.mousePressEvent(_mouse_event(QEvent.Type.MouseButtonPress, press))
+
+    assert offered_resize
+    assert overlay._crop_drag_mode == "corner"
+
+
+def test_interior_press_still_moves_the_box():
+    overlay = _crop_overlay()
+
+    overlay.mousePressEvent(_mouse_event(QEvent.Type.MouseButtonPress, QPointF(100, 80)))
+
+    assert overlay._crop_drag_mode == "move"
+
+
+def test_press_outside_the_view_does_not_start_a_crop_drag():
+    """Past the widget entirely — no handle in reach, nothing to start."""
+    overlay = _crop_overlay()
+
+    overlay.mousePressEvent(_mouse_event(QEvent.Type.MouseButtonPress, QPointF(-80, -80)))
+
+    assert overlay._crop_drag_mode is None
+
+
+def test_clicked_still_only_fires_over_the_image():
+    """The picker signal stays gated on real image coords; only the crop drag
+    is allowed to start from outside."""
+    overlay = _crop_overlay(content_rect=(20, 16, 160, 128))
+    clicks: list = []
+    overlay.clicked.connect(lambda x, y: clicks.append((x, y)))
+
+    overlay.mousePressEvent(_mouse_event(QEvent.Type.MouseButtonPress, QPointF(0, 0)))
+
+    assert clicks == []


### PR DESCRIPTION
A press on a corner handle only started a drag when it landed inside the image content rect, but the hover cursor hit-tests the handles by distance alone. So the pointer promised a resize and the press was dropped without a word: the handle looked live and would not move.

The crop rect is mapped through the view rect, and its handles carry a 10 px grab radius, so half that radius hangs off the frame whenever an edge of the rect sits on an edge of the image — which a full-frame crop does on all four. Which side of the boundary a press landed on decided whether it worked, hence the intermittence. A print border makes it worse than a boundary case: the content rect is inset from the view rect, so every handle of a full-frame crop sits outside it and none of them can be grabbed at all.

Start the drag on tool mode and the view rect (grown by the grab radius) instead. The clicked signal stays gated on real image coords — only the crop drag is allowed to begin from outside the content.

Also `if coords:` -> `is not None`: a tuple is always truthy, so it read as a None check that happened to work.

Fixes #831 