### PR TITLE
fix(test): make the separator-spill overflow-bar test environment-stable

### DIFF
--- a/tests/test_overflow_bar.py
+++ b/tests/test_overflow_bar.py
@@ -133,13 +133,21 @@ def test_menu_mirrors_toggle_state(qapp, toolbar):
 
 
 def test_overflow_button_stays_hidden_when_only_a_separator_would_spill(qapp):
+    """A separator's own footprint must never spuriously force the overflow reservation once
+    real content already fits — separators are decorative and, per the trailing-drop rule
+    (test_a_trailing_separator_is_dropped_rather_than_left_dangling), never count as spilled
+    content. _visible_items/_relayout measure widgets by sizeHint(), not setFixedWidth() (which
+    only clamps min/max), so avail must be derived from the real sizeHints; the separator needs
+    a real frame shape too — a bare QFrame's sizeHint is invalid (-1, -1) — matching the VLine
+    frames the app actually uses (files.py:_create_separator)."""
     bar = OverflowBar(height=28, spacing=0)
     btn = QToolButton()
-    btn.setFixedWidth(24)
     bar.add_button(btn, "Only")
     sep = QFrame()
+    sep.setFrameShape(QFrame.Shape.VLine)
+    sep.setFrameShadow(QFrame.Shadow.Plain)
     sep.setFixedWidth(1)
     bar.add_separator(sep)
     bar.show()
-    _resize(qapp, bar, 24)
+    _resize(qapp, bar, btn.sizeHint().width() + sep.sizeHint().width())
     assert not bar.overflow_btn.isVisible()


### PR DESCRIPTION
## Summary

- `test_overflow_button_stays_hidden_when_only_a_separator_would_spill`
  assumed `setFixedWidth()` on a `QToolButton` changes `sizeHint()` — it
  doesn't, only min/max size — and used a bare `QFrame` separator whose
  `sizeHint()` is invalid (`-1, -1`) without a frame shape set. Both made
  the pass/fail outcome depend on incidental style/Qt-version pixel values
  instead of the behaviour under test, so it flakes under styles where the
  hardcoded resize width doesn't match the real layout (e.g. macOS's native
  Aqua `QToolButton` chrome; CI runs Ubuntu-only, so this never surfaces
  there).
- Derive the resize width from the widgets' real `sizeHint()`s and give the
  separator a `VLine` shape, matching the separators the app actually
  builds (`files.py:_create_separator`).

## Test plan

- [x] `uv run pytest tests/test_overflow_bar.py -v` — all 14 pass
- [x] `uv run ruff check tests/test_overflow_bar.py` — clean