### PR TITLE
fix(test): read source files as UTF-8 and split paths portably

### DIFF
--- a/tests/test_hdr.py
+++ b/tests/test_hdr.py
@@ -172,7 +172,7 @@ class TestReferenceChoice(unittest.TestCase):
         for path in root.rglob("*.py"):
             if path.parts[-2:] == ("hdr", "logic.py"):
                 continue  # the definitions themselves
-            for node in ast.walk(ast.parse(path.read_text())):
+            for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"))):
                 if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Name):
                     continue
                 if node.func.id not in callers:

--- a/tests/test_ir_sidecar_discovery.py
+++ b/tests/test_ir_sidecar_discovery.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os.path
+
 import pytest
 
 from negpy.infrastructure.filesystem.watcher import FolderWatchService
@@ -38,4 +40,4 @@ def test_watcher_skips_ir_sidecars(tmp_path) -> None:
 
     found = FolderWatchService.scan_for_new_files(str(tmp_path), set())
 
-    assert sorted(p.rsplit("/", 1)[-1] for p in found) == ["frame1.tif", "orphan_IR.tif"]
+    assert sorted(os.path.basename(p) for p in found) == ["frame1.tif", "orphan_IR.tif"]

--- a/tests/test_parallel_gate.py
+++ b/tests/test_parallel_gate.py
@@ -27,7 +27,7 @@ class TestNothingBypassesTheGate:
         """`@njit(parallel=True)` outside parallel_njit is the bypass."""
         offenders = []
         for path in _python_files():
-            tree = ast.parse(path.read_text(), filename=str(path))
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
             for node in ast.walk(tree):
                 if not isinstance(node, ast.Call):
                     continue
@@ -40,12 +40,14 @@ class TestNothingBypassesTheGate:
         """A file using prange but not parallel_njit is either a bypass or a kernel that
         silently degraded to a serial loop — both worth failing on."""
         offenders = [
-            str(p.relative_to(ROOT.parent)) for p in _python_files() if "prange" in (src := p.read_text()) and "parallel_njit" not in src
+            str(p.relative_to(ROOT.parent))
+            for p in _python_files()
+            if "prange" in (src := p.read_text(encoding="utf-8")) and "parallel_njit" not in src
         ]
         assert not offenders, "prange outside a parallel_njit kernel: " + ", ".join(offenders)
 
     def test_the_parallel_variant_is_never_called_directly(self):
-        offenders = [str(p.relative_to(ROOT.parent)) for p in _python_files() if ".parallel(" in p.read_text()]
+        offenders = [str(p.relative_to(ROOT.parent)) for p in _python_files() if ".parallel(" in p.read_text(encoding="utf-8")]
         assert not offenders, "call the dispatcher, not the parallel variant: " + ", ".join(offenders)
 
 

--- a/tests/test_text_plurals.py
+++ b/tests/test_text_plurals.py
@@ -59,7 +59,7 @@ def test_no_user_facing_string_still_says_s_in_brackets():
     for path in root.rglob("*.py"):
         if path.name == "text.py":
             continue  # the helper's own docstring quotes the pattern it replaces
-        tree = ast.parse(path.read_text())
+        tree = ast.parse(path.read_text(encoding="utf-8"))
         docstrings = set()
         for node in ast.walk(tree):
             if isinstance(node, (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):


### PR DESCRIPTION
Related: #835 (fixes categories A and B; C and D stay open there)

## Summary

Six of the twelve Windows failures in #835 are test-side portability gaps with two causes: five source-scanning tests decode the tree with the locale codepage, and one test splits watcher paths on a hardcoded `/`. This fixes both in the tests' own idiom, and touches nothing else.

## Changes

- `tests/test_parallel_gate.py:30,43,48`, `tests/test_hdr.py:175`, `tests/test_text_plurals.py:62` — `read_text()` → `read_text(encoding="utf-8")`. On Windows the bare call decodes as cp1252 and dies on 13 product files (`'charmap' codec can't decode byte 0x9d`, first hit in `negpy/desktop/controller.py`) before any assertion runs. The explicit encoding is already the codebase's pattern (`tests/metrics/test_preview_load.py:88`, `negpy/desktop/view/widgets/section_help_dialog.py:32`).
- `tests/test_ir_sidecar_discovery.py:41` — `p.rsplit("/", 1)[-1]` → `os.path.basename(p)`, which handles both separators.

## Testing

Windows 11, Python 3.13, `uv sync --all-groups`.

Before (clean `eaa1948`):

```
tests/test_parallel_gate.py tests/test_hdr.py tests/test_text_plurals.py tests/test_ir_sidecar_discovery.py
  6 failed, 61 passed
full suite: 12 failed, 3985 passed, 10 skipped, 11 deselected
```

After:

```
same four files: 67 passed
full suite: 6 failed, 3991 passed, 10 skipped, 11 deselected  (9m20s)
```

The remaining six are #835's categories C and D (POSIX-literal expectations and the mixed-separator resource path) — deliberately not touched here, since C is arguably fine as-is and D changes product code.

`ruff check` and `ruff format` pass on the four files. On Linux this is behaviour-neutral: UTF-8 is the default locale encoding there, and `os.path.basename` splits `/` identically.

No failing test is possible for this change on Linux CI by construction — the defect only manifests under a cp1252 locale. The before/after runs above are the discriminating evidence.
