### PR TITLE
Read a hash suffix for what it is, and let a batch export finish

### DIFF
--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -66,7 +66,7 @@ from negpy.domain.models import (
     preset_from_export_config,
     resolve_preset_export,
 )
-from negpy.services.assets.half_frame import half_hash
+from negpy.services.assets.half_frame import base_hash, half_hash, half_of
 from negpy.services.assets.sidecar import load_or_promote, write_sidecar
 from negpy.features.exposure.analysis import (
     RING_GRID,
@@ -3729,9 +3729,9 @@ class AppController(QObject):
         # if one half was calibrated and the other wasn't (still at default), both need
         # the same correction during export.
         base = f.get("hash", "")
-        if "#" in base:
-            half_val = int(base.split("#")[-1])
-            sibling_hash = half_hash(base.rsplit("#", 1)[0], 3 - half_val)
+        half_val = half_of(base)
+        if half_val is not None:
+            sibling_hash = half_hash(base_hash(base) or base, 3 - half_val)
             sibling_params = self.session.repo.load_file_settings(sibling_hash)
             session_ct = self.state.config.process.crosstalk_strength
             params_ct = params.process.crosstalk_strength

--- a/negpy/services/assets/half_frame.py
+++ b/negpy/services/assets/half_frame.py
@@ -22,6 +22,16 @@ def half_hash(file_hash: str, half: int) -> str:
     return f"{file_hash}{_SEP}{half}"
 
 
+def half_of(file_hash: Optional[str]) -> Optional[int]:
+    """The half index of a ``#``-suffixed hash, or None when it is not a half.
+
+    Composite hashes (``#stitch``, ``#hdr``) share the separator by design, so the
+    suffix — not its presence — decides.
+    """
+    _, sep, suffix = (file_hash or "").rpartition(_SEP)
+    return int(suffix) if sep and suffix.isdigit() else None
+
+
 def base_hash(file_hash: Optional[str]) -> Optional[str]:
     """The unsuffixed file hash — the decode-cache identity shared by both halves."""
     return file_hash.split(_SEP, 1)[0] if file_hash else file_hash

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1109,6 +1109,23 @@ class TestBatchExportFiltering(unittest.TestCase):
             # export_path is validated by _ensure_valid_export_path (mocked to /tmp/out)
             self.assertEqual(t.params.export.export_path, "/tmp/out")
 
+    def test_composite_frames_export_beside_a_half_frame(self):
+        """An HDR or stitched composite hash ends in "#hdr"/"#stitch". The sibling
+        lookup read that suffix as a half index, and int("hdr") stopped the batch
+        before any frame was written."""
+        from negpy.features.hdr.models import hdr_hash
+        from negpy.features.stitch.models import stitch_hash
+
+        self.mock_session_manager.state.uploaded_files = [
+            {"name": "bracket", "path": "/tmp/_DSC1722.NEF", "hash": hdr_hash(["h1", "h2"])},
+            {"name": "panorama", "path": "/tmp/_DSC1730.NEF", "hash": stitch_hash(["h3", "h4"])},
+            {"name": "left half", "path": "/tmp/scan.tif", "hash": "h5#1"},
+        ]
+        self.visible_indices = [0, 1, 2]
+        self.controller.request_batch_export()
+        tasks = self._captured_tasks()
+        self.assertEqual([t.file_info["name"] for t in tasks], ["bracket", "panorama", "left half"])
+
 
 class TestLinearOutputExportCurrentFile(unittest.TestCase):
     """Regression: exporting Linear Output for the *current* file (files=None) must

--- a/tests/test_half_frame.py
+++ b/tests/test_half_frame.py
@@ -94,6 +94,19 @@ class TestIdentities:
         assert base_hash("abc") == "abc"
         assert base_hash(None) is None
 
+    def test_half_of_reads_only_a_numeric_suffix(self):
+        from negpy.features.hdr.models import hdr_hash
+        from negpy.features.stitch.models import stitch_hash
+        from negpy.services.assets.half_frame import half_of
+
+        assert half_of("abc#1") == 1
+        assert half_of("abc#2") == 2
+        assert half_of("abc") is None
+        assert half_of(None) is None
+        # A composite shares the separator by design, so only the suffix can decide.
+        assert half_of(hdr_hash(["a", "b"])) is None
+        assert half_of(stitch_hash(["a", "b"])) is None
+
     def test_half_name(self):
         assert half_name("IMG420.tif", 2) == "IMG420.tif [2]"
 


### PR DESCRIPTION
Batch export stopped on any composite frame. The half-frame sibling lookup in _batch_params_for read every "#" suffix as a half index, but a stitched or merged composite carries "#stitch" / "#hdr" — deliberately, so base_hash strips it — and int("hdr") raised. The loop builds every ExportTask before it dispatches any, so one composite in the visible set stopped the whole run, and the ordinary frames beside it were not written either.

half_of() returns the index only when the suffix is a number. It lives in half_frame.py, the module that owns the "#" convention, so a later suffix cannot reopen this.