### PR TITLE
Discard a thumbnail that cannot be read, instead of stopping the app

### DIFF
--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -3,7 +3,7 @@ import os
 import time
 from collections import Counter
 from dataclasses import dataclass, fields, replace
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple
 
 import cv2
 import numpy as np
@@ -727,27 +727,38 @@ class AppController(QObject):
         self.status_progress_requested.emit(current, total)
         self.batch_progress.emit(current, total, name)
 
-    def _set_thumbnail(self, key: str, pil_img: Any) -> None:
-        u8_arr = np.array(pil_img.convert("RGB"))
+    def _set_thumbnail(self, key: str, pil_img: Any) -> bool:
+        """False when the image will not decode. PIL decodes lazily, so a truncated
+        file raises here — on the UI thread — not in the worker that supplied it."""
+        try:
+            u8_arr = np.array(pil_img.convert("RGB"))
+        except Exception as e:
+            logger.warning(f"Unreadable thumbnail for {key}: {e}")
+            return False
         self.state.thumbnails[key] = QIcon(QPixmap.fromImage(ImageConverter.to_qimage(u8_arr)))
+        return True
 
-    def _apply_thumbnails(self, new_thumbs: Dict[str, Any]) -> None:
-        """Commit a batch (or a chunk of a running one) to the filmstrip."""
+    def _apply_thumbnails(self, new_thumbs: Dict[str, Any]) -> Set[str]:
+        """Commit a batch (or a chunk of a running one) to the filmstrip. Returns the
+        keys whose image would not decode."""
+        broken = set()
         for key, pil_img in new_thumbs.items():
             # A frame that already rendered on the canvas has the correct (inverted)
             # thumbnail; don't let this batch overwrite it with the source-decode placeholder.
             if pil_img and key not in self.state.rendered_thumbnails:
-                self._set_thumbnail(key, pil_img)
+                if not self._set_thumbnail(key, pil_img):
+                    broken.add(key)
         self.session.asset_model.refresh()
+        return broken
 
     def _on_thumbnails_finished(self, new_thumbs: Dict[str, Any]) -> None:
         self.status_progress_requested.emit(0, 0)
         self._end_batch("thumbnails")
-        self._apply_thumbnails(new_thumbs)
+        broken = self._apply_thumbnails(new_thumbs)
 
         requested = getattr(self, "_thumb_requested", [])
         self._thumb_requested = []
-        failed = {k for k in requested if not new_thumbs.get(k)}
+        failed = {k for k in requested if not new_thumbs.get(k)} | broken
         for f in self.state.uploaded_files:
             key = asset_thumbnail_key(f)
             if key in failed:
@@ -759,8 +770,7 @@ class AppController(QObject):
     def _on_rendered_thumbnail(self, new_thumbs: Dict[str, Any]) -> None:
         """A canvas render produced a thumbnail — it supersedes any batch placeholder."""
         for key, pil_img in new_thumbs.items():
-            if pil_img:
-                self._set_thumbnail(key, pil_img)
+            if pil_img and self._set_thumbnail(key, pil_img):
                 self.state.rendered_thumbnails.add(key)
         self.session.asset_model.refresh()
 

--- a/negpy/infrastructure/storage/local_asset_store.py
+++ b/negpy/infrastructure/storage/local_asset_store.py
@@ -74,6 +74,9 @@ class LocalAssetStore(IAssetStore):
                 img = Image.open(thumb_path)
                 if max(img.size) != APP_CONFIG.thumbnail_size:
                     return None
+                # Decode here: Image.open reads the header only, so a truncated entry
+                # would pass as a hit and raise later, on the thread that paints it.
+                img.load()
                 return img
             except Exception:
                 return None

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -44,6 +44,19 @@ class TestThumbnailCacheSize(unittest.TestCase):
     def test_missing_thumbnail_is_a_miss(self):
         self.assertIsNone(self.store.get_thumbnail("h_absent"))
 
+    def test_truncated_thumbnail_is_a_miss(self):
+        """A half-written entry (a kill or a full disk during the write) opens on its
+        header alone. It has to fail here, where the miss regenerates it, and not later
+        on the thread that paints it."""
+        ts = APP_CONFIG.thumbnail_size
+        self.store.save_thumbnail("h_cut", Image.new("RGB", (ts, ts), (10, 20, 30)))
+        path = os.path.join(self.store.thumb_dir, "h_cut.jpg")
+        with open(path, "rb") as f:
+            data = f.read()
+        with open(path, "wb") as f:
+            f.write(data[: len(data) // 2])
+        self.assertIsNone(self.store.get_thumbnail("h_cut"))
+
 
 class TestThumbnailCacheClearing(unittest.TestCase):
     """The Manage Database dialog reports and empties the thumbnail cache."""

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -204,6 +204,26 @@ class TestAppController(unittest.TestCase):
         self.assertIn("decode_failed", state.uploaded_files[0])
         self.assertNotIn("decode_failed", state.uploaded_files[1])
 
+    def test_a_thumbnail_that_cannot_decode_badges_its_frame(self):
+        """A PIL image decodes lazily, so a truncated cache entry raises on the UI
+        thread, inside a Qt slot, where an exception ends the process."""
+        from PIL import Image
+
+        from negpy.services.assets.thumbnails import asset_thumbnail_key
+
+        self.mock_session_manager.asset_model = MagicMock()
+        state = self.mock_session_manager.state
+        state.uploaded_files = [{"name": "cut.dng", "path": "/tmp/cut.dng", "hash": "h1"}]
+        key = asset_thumbnail_key(state.uploaded_files[0])
+        self.controller._thumb_requested = [key]
+
+        broken = MagicMock(spec=Image.Image)
+        broken.convert.side_effect = OSError("broken data stream when reading image file")
+        self.controller._on_thumbnails_finished({key: broken})
+
+        self.assertNotIn(key, state.thumbnails)
+        self.assertIn("decode_failed", state.uploaded_files[0])
+
     def test_render_thumbnail_update_does_not_badge_other_frames(self):
         from PIL import Image
 


### PR DESCRIPTION
A truncated thumbnail in the cache stopped the app on the frame that showed it, and again on each launch after, because the bad entry stayed in the cache. A kill or a full disk during the write is enough to leave one.

get_thumbnail opened the file but read only the header, so a half-written JPEG passed the size check as a hit. PIL decodes lazily, so the break came later, in _set_thumbnail — on the UI thread, inside a Qt slot, where an exception ends the process.

The store now decodes before it returns, which makes a broken entry a miss that regenerates. _set_thumbnail reports the failure instead of raising, and the frame gets the same decode-failed mark as an unreadable source file.