### PR TITLE
fix: make script generation and resource paths platform-independent

### DIFF
--- a/negpy/kernel/system/paths.py
+++ b/negpy/kernel/system/paths.py
@@ -18,7 +18,9 @@ def get_resource_path(relative_path: str) -> str:
         # Root is 3 levels up
         base_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
 
-    return os.path.join(base_path, relative_path)
+    # Callers pass forward-slash relatives ("icc/RGBScan.icc"); normpath keeps
+    # the result in the platform's own separators instead of a mixed form.
+    return os.path.normpath(os.path.join(base_path, relative_path))
 
 
 def _usable_user_dir(base: Path) -> Optional[str]:

--- a/negpy/kernel/system/updater.py
+++ b/negpy/kernel/system/updater.py
@@ -217,7 +217,7 @@ def _wait_and_run_sh(pid: int, body: str) -> str:
 
 def appimage_script(downloaded: Path, target: Path, pid: int) -> str:
     """Replace the running AppImage with the downloaded one and start it."""
-    new, old = shlex.quote(str(downloaded)), shlex.quote(str(target))
+    new, old = shlex.quote(downloaded.as_posix()), shlex.quote(target.as_posix())
     return _wait_and_run_sh(
         pid,
         f'set -e\nchmod +x {new}\nmv -f {new} {old}\nrm -f "$0"\nexec {old}\n',
@@ -234,16 +234,16 @@ def macos_script(dmg: Path, bundle: Path, pid: int, mountpoint: Path, stage: Pat
     return _wait_and_run_sh(
         pid,
         f"""set -e
-mkdir -p {q(str(mountpoint))}
-hdiutil attach {q(str(dmg))} -nobrowse -readonly -mountpoint {q(str(mountpoint))}
-rm -rf {q(str(stage))}
-ditto {q(str(mountpoint / bundle.name))} {q(str(stage))}
-hdiutil detach {q(str(mountpoint))} -quiet || true
-rm -rf {q(str(bundle))}
-mv {q(str(stage))} {q(str(bundle))}
-xattr -dr com.apple.quarantine {q(str(bundle))} 2>/dev/null || true
-rm -f {q(str(dmg))} "$0"
-open {q(str(bundle))}
+mkdir -p {q(mountpoint.as_posix())}
+hdiutil attach {q(dmg.as_posix())} -nobrowse -readonly -mountpoint {q(mountpoint.as_posix())}
+rm -rf {q(stage.as_posix())}
+ditto {q((mountpoint / bundle.name).as_posix())} {q(stage.as_posix())}
+hdiutil detach {q(mountpoint.as_posix())} -quiet || true
+rm -rf {q(bundle.as_posix())}
+mv {q(stage.as_posix())} {q(bundle.as_posix())}
+xattr -dr com.apple.quarantine {q(bundle.as_posix())} 2>/dev/null || true
+rm -f {q(dmg.as_posix())} "$0"
+open {q(bundle.as_posix())}
 """,
     )
 

--- a/tests/test_export_presets.py
+++ b/tests/test_export_presets.py
@@ -237,7 +237,7 @@ def test_output_dir_subfolder_of_source():
         output_subfolder="TIFF",
     )
     source = "/photos/roll/IMG_001.RAF"
-    assert _resolve_output_dir(p, source) == "/photos/roll/TIFF"
+    assert _resolve_output_dir(p, source) == os.path.join("/photos/roll", "TIFF")
 
 
 def test_output_dir_subfolder_empty_falls_back_to_source():

--- a/tests/test_half_frame.py
+++ b/tests/test_half_frame.py
@@ -1,5 +1,7 @@
 """Half-frame mode: split detection, slicing, identities, and per-half plumbing."""
 
+import os
+
 import numpy as np
 import pytest
 from unittest.mock import MagicMock
@@ -98,8 +100,8 @@ class TestIdentities:
         assert half_name("IMG420.tif", 2) == "IMG420.tif [2]"
 
     def test_sidecar_path(self):
-        assert sidecar_path_for("/a/roll.tif") == "/a/roll.negpy"
-        assert sidecar_path_for("/a/roll.tif", 1) == "/a/roll.1.negpy"
+        assert sidecar_path_for("/a/roll.tif") == os.path.join("/a", "roll.negpy")
+        assert sidecar_path_for("/a/roll.tif", 1) == os.path.join("/a", "roll.1.negpy")
 
     def test_export_filename_suffix(self):
         plain = render_export_filename("/x/IMG420.tif", ExportConfig())

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -252,7 +252,7 @@ def test_applying_spawns_the_script_detached_and_touches_nothing_yet(monkeypatch
     apply_update(downloaded, _info())
 
     assert spawned["kw"]["start_new_session"] is True
-    assert Path(spawned["cmd"][1]).read_text().count(str(frozen_appimage)) >= 1
+    assert Path(spawned["cmd"][1]).read_text().count(frozen_appimage.as_posix()) >= 1
     assert frozen_appimage.read_bytes() == b"old"  # the running copy survives until it exits
 
 


### PR DESCRIPTION
Closes #835

## Summary

Finishes what #836 started: the six remaining deterministic Windows failures (categories C and D in #835) go to zero. Two are product-side and four are expectation-side, and the split matters, so it's spelled out below.

## Changes

**Product, behaviour-identical on Linux/macOS:**

- `negpy/kernel/system/updater.py` — `appimage_script`/`macos_script` embedded `str(Path)` into the sh they generate, so a script generated on Windows carried `\tmp\new.AppImage`-style paths. These scripts are sh and only ever run on Linux/macOS; `.as_posix()` makes generation produce the same bytes on every platform. On POSIX, `Path.as_posix() == str(Path)`, so shipped behaviour there is unchanged.
- `negpy/kernel/system/paths.py` — `get_resource_path` joined a native base dir with the forward-slash relatives every caller passes (`"icc/RGBScan.icc"` from `controller.py:3425`), leaking `C:\...\resources/icc/RGBScan.icc` mixed forms anywhere a resource path is shown or compared. `os.path.normpath` keeps it in the platform's own separators; for already-native inputs it's a no-op.

**Tests, expectation-side only:**

- `tests/test_export_presets.py`, `tests/test_half_frame.py` — POSIX literals fed through `os.path.join` now assert `os.path.join`-built expectations.
- `tests/test_updater.py` — the spawn test asserted the `str()` form of the AppImage path inside the generated script; it now asserts the `.as_posix()` contract the generator guarantees.

## Testing

Windows 11, Python 3.13, `uv`-synced env (plus `pyopticfilm`, which `--all-groups` can't bring in here because `python-sane` has no Windows build — that's the scanner group, unrelated to this change).

Before (this branch's base, `9c3f449`): the six failures listed in #835 categories C/D.
After:

```
four touched files:  208 passed
full suite:          1 failed, 4042 passed, 10 skipped, 11 deselected  (4m51s)
```

The 1 is `test_hud_toast::test_a_short_message_keeps_its_natural_width` — the order-dependent Qt flake already documented in #835 ("passes in isolation", re-confirmed: `5 passed` alone). Deliberately untouched: it needs diagnosis, not a path fix, and I didn't want to widen this PR with a guess.

`ruff check` and `ruff format --check` pass on all five files.

## Deliberately unchanged

- `nsis_script` still uses native Windows paths — it generates PowerShell for Windows, where those are correct.
- The hud_toast flake, as above.
