### PR TITLE
chore: rename the scanner dependency group to sane

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,7 @@ jobs:
         # Everything except SANE, which has no Windows build. `--all-groups` rather
         # than the default groups alone, or pieusb / plustek ship uninstalled and
         # the Scan tab has no working backend on Windows.
-        run: uv sync --all-groups --no-group scanner
+        run: uv sync --all-groups --no-group sane
 
       - name: Set Version
         shell: bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ Install [uv](https://docs.astral.sh/uv/getting-started/installation/) if you hav
 
 **Scanner support (optional):**
 
-- **SANE** (Linux/macOS) — Coolscans and other SANE film scanners:
+- **SANE** (Linux/macOS) — Coolscans and other SANE film scanners. Install the system library, then the `sane` group (`uv sync --group sane` or `pip install negpy[sane]`):
   - **Linux** (Debian/Ubuntu):
     ```bash
     sudo pacman -S sane  # arch

--- a/build.py
+++ b/build.py
@@ -56,7 +56,7 @@ params = [
     # Scanner support: bundle the python-sane C extension but NOT libsane.so.1.
     # libsane.so.1 must come from the host so SANE can find its backend plugins
     # in /usr/lib/sane/. See libs_to_remove in package_linux().
-    # Requires: uv sync --group scanner before building on Linux/macOS.
+    # Requires: uv sync --group sane before building on Linux/macOS.
     *([] if is_windows else ["--hidden-import=sane", "--hidden-import=_sane"]),
     # Camera scanning: see collect_gphoto2_plugins() — the plugin trees need their
     # directory layout preserved, which --collect-all does not do.

--- a/negpy/desktop/view/keyboard_shortcuts.py
+++ b/negpy/desktop/view/keyboard_shortcuts.py
@@ -121,9 +121,7 @@ class ShortcutManager:
             "flip_v": lambda: toolbar.flip("vertical"),
             "lock_bounds_toggle": lambda: controls.process_sidebar.lock_bounds_btn.toggle(),
             "scan_setup": lambda: controls.sensor_sidebar.scan_setup_btn.click(),
-            "scan_prescan": (
-                lambda: right.scan_sidebar.prescan_btn.click() if getattr(right, "scan_sidebar", None) is not None else None
-            ),
+            "scan_prescan": (lambda: right.scan_sidebar.prescan_btn.click() if getattr(right, "scan_sidebar", None) is not None else None),
             "mode_color_negative": lambda: controls.process_sidebar.mode_btns[0].click(),
             "mode_bw_negative": lambda: controls.process_sidebar.mode_btns[1].click(),
             "mode_transparency": lambda: controls.process_sidebar.mode_btns[2].click(),

--- a/negpy/infrastructure/scanners/sane_backend.py
+++ b/negpy/infrastructure/scanners/sane_backend.py
@@ -126,9 +126,9 @@ def _infer_film_scanner(opt, device_id: str) -> bool:
 
 def _resolve_install_hint() -> str:
     if sys.platform == "darwin":
-        return "Install: brew install sane-backends && uv sync"
+        return "Install: brew install sane-backends && uv sync --group sane"
     if sys.platform.startswith("linux"):
-        return "Install: sudo apt install libsane-dev && uv sync"
+        return "Install: sudo apt install libsane-dev && uv sync --group sane"
     return "Scanner support is not available on this platform."
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ classifiers = [
 
 [project.optional-dependencies]
 plustek = ["pyopticfilm>=1.0"]
-scanner = ["python-sane>=2.9"]
+sane = ["python-sane>=2.9"]
 camera = ["gphoto2>=2.5 ; sys_platform != 'win32'"]
 
 [dependency-groups]
@@ -52,7 +52,7 @@ dev = [
     "ruff==0.14.10",
     "ty>=0.0.26",
 ]
-scanner = [
+sane = [
     "python-sane>=2.9",
 ]
 plustek = [

--- a/uv.lock
+++ b/uv.lock
@@ -345,7 +345,7 @@ camera = [
 plustek = [
     { name = "pyopticfilm" },
 ]
-scanner = [
+sane = [
     { name = "python-sane" },
 ]
 
@@ -366,7 +366,7 @@ pieusb = [
 plustek = [
     { name = "pyopticfilm" },
 ]
-scanner = [
+sane = [
     { name = "python-sane" },
 ]
 
@@ -385,13 +385,13 @@ requires-dist = [
     { name = "pyqt6", specifier = "==6.11.0" },
     { name = "pyqt6-charts", specifier = "==6.11.0" },
     { name = "pyserial", specifier = ">=3.5" },
-    { name = "python-sane", marker = "extra == 'scanner'", specifier = ">=2.9" },
+    { name = "python-sane", marker = "extra == 'sane'", specifier = ">=2.9" },
     { name = "qtawesome", specifier = "==1.4.2" },
     { name = "rawpy", specifier = "==0.27.0" },
     { name = "tifffile", specifier = "==2026.6.1" },
     { name = "wgpu", specifier = "==0.31.1" },
 ]
-provides-extras = ["plustek", "scanner", "camera"]
+provides-extras = ["plustek", "sane", "camera"]
 
 [package.metadata.requires-dev]
 camera = [{ name = "gphoto2", marker = "sys_platform != 'win32'", specifier = ">=2.5" }]
@@ -404,7 +404,7 @@ dev = [
 ]
 pieusb = [{ name = "pieusb", specifier = ">=0.3.7" }]
 plustek = [{ name = "pyopticfilm", specifier = ">=1.0" }]
-scanner = [{ name = "python-sane", specifier = ">=2.9" }]
+sane = [{ name = "python-sane", specifier = ">=2.9" }]
 
 [[package]]
 name = "numba"


### PR DESCRIPTION
`scanner` stopped describing what the group holds once the Plustek and PIEUSB backends landed — it installs `python-sane` and nothing else. Renames both the optional-dependency extra and the dependency group to `sane`, matching `plustek` / `pieusb` / `camera`.

- `pyproject.toml`: `scanner` → `sane` (extra + group), `uv.lock` regenerated
- `.github/workflows/release.yml`: Windows build syncs `--no-group sane`
- `build.py`: comment names the new group
- `sane_backend.py`: the missing-SANE hints told the user to run a plain `uv sync`, which never installed `python-sane` because the group is not a default one — they now name `--group sane`
- `CONTRIBUTING.md`: SANE bullet names the group and the extra, like the Plustek one
- One unrelated ruff format reflow in `keyboard_shortcuts.py`, picked up by `make format`

`pip install negpy[scanner]` stops working. No doc or workflow ever referenced that extra, so no alias is kept.

`make all` green.
