### PR TITLE
Fix/filmstrip slide thumbnails

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -160,7 +160,7 @@ Narrow the panel and the toolbar buttons that no longer fit move into a **»** m
 
 ### Triage (culling the roll)
 
-Thumbnails are positives from the start. A frame you have not opened yet is inverted straight from its preview — a quick per-channel job, not the full pipeline — so the sheet reads as photographs while you cull rather than as a strip of orange negatives. Open a frame and its thumbnail is replaced by the real render, matching the canvas exactly. Transparencies are left alone, being positives already.
+Thumbnails are positives from the start. A frame you have not opened yet is inverted straight from its preview — a quick per-channel job, not the full pipeline — so the sheet reads as photographs while you cull rather than as a strip of orange negatives. Open a frame and its thumbnail is replaced by the real render, matching the canvas exactly. Transparencies are left alone, being positives already: a frame whose film process you have already set (or that you have opened once, which saves the autodetected one) is taken at its word, and only a frame nothing has decided yet is guessed at from its preview.
 
 Right-click a thumbnail (or use keyboard shortcuts) to mark frames while you review the sheet:
 

--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -717,7 +717,11 @@ class AppController(QObject):
                 return
             self._thumb_requested = [asset_thumbnail_key(f) for f in missing]
             self.set_status("GENERATING THUMBNAILS...")
-            self.thumbnail_requested.emit(missing)
+            # Copies, carrying each frame's stored film process: the source decode cannot
+            # tell a slide from a negative reliably, and inverting one that is already a
+            # positive is what put negatives in the filmstrip. Copies because these dicts
+            # cross to a worker thread, and uploaded_files must not grow a stale mode.
+            self.thumbnail_requested.emit([{**f, "process_mode": self.session.stored_process_mode(f)} for f in missing])
 
     def clear_thumbnail_cache(self) -> None:
         """Drops cached thumbnails on disk and in memory, then regenerates loaded ones."""

--- a/negpy/desktop/session.py
+++ b/negpy/desktop/session.py
@@ -1013,6 +1013,27 @@ class DesktopSessionManager(QObject):
         config, _ = self._hydrate_asset_config(asset)
         return config
 
+    def stored_process_mode(self, asset: dict) -> str:
+        """The film process already decided for an asset, or "" when nothing has decided.
+
+        A composite's inherited mode, else a saved edit's. Deliberately not the sticky
+        global: that is a guess about the next file, and a caller asking this question
+        wants to know whether an answer exists, not to be handed the last roll's default.
+
+        Cheaper than config_for_asset on purpose — the filmstrip asks it once per frame of
+        a roll, and a full hydration would read every sticky global that many times.
+        """
+        if asset.get("process_mode"):
+            return str(asset["process_mode"])
+        saved = load_or_promote(
+            self.repo,
+            asset["hash"],
+            asset["path"],
+            half=int(asset.get("half") or 0),
+            composite=bool(asset.get("hdr_paths") or asset.get("stitch_paths")),
+        )
+        return str(saved.process.process_mode) if saved is not None else ""
+
     def select_file(self, index: int, selection_override: Optional[List[int]] = None) -> None:
         """
         Changes active file and hydrates state from repository.

--- a/negpy/desktop/view/keyboard_shortcuts.py
+++ b/negpy/desktop/view/keyboard_shortcuts.py
@@ -121,9 +121,7 @@ class ShortcutManager:
             "flip_v": lambda: toolbar.flip("vertical"),
             "lock_bounds_toggle": lambda: controls.process_sidebar.lock_bounds_btn.toggle(),
             "scan_setup": lambda: controls.sensor_sidebar.scan_setup_btn.click(),
-            "scan_prescan": (
-                lambda: right.scan_sidebar.prescan_btn.click() if getattr(right, "scan_sidebar", None) is not None else None
-            ),
+            "scan_prescan": (lambda: right.scan_sidebar.prescan_btn.click() if getattr(right, "scan_sidebar", None) is not None else None),
             "mode_color_negative": lambda: controls.process_sidebar.mode_btns[0].click(),
             "mode_bw_negative": lambda: controls.process_sidebar.mode_btns[1].click(),
             "mode_transparency": lambda: controls.process_sidebar.mode_btns[2].click(),

--- a/negpy/services/assets/thumbnails.py
+++ b/negpy/services/assets/thumbnails.py
@@ -42,6 +42,7 @@ async def generate_batch_thumbnails(
                 f_info.get("blue_path") or "",
                 tuple(f_info["crop_rect"]) if f_info.get("crop_rect") else None,
                 float(f_info.get("gutter_thickness") or 0.0),
+                str(f_info.get("process_mode") or ""),
             )
             completed += 1
             if progress_callback:
@@ -79,9 +80,11 @@ def thumbnail_cache_key(file_hash: str, is_triplet: bool) -> str:
     rendered positive is what makes the filmstrip match the canvas.
 
     The version suffix retires caches written before the batch path inverted negatives;
-    without it an existing library keeps serving its stored negatives forever."""
+    without it an existing library keeps serving its stored negatives forever. v3 retires
+    the ones written before the batch path read the frame's saved film process, which is
+    where a slide got cached as an inverted negative."""
     base = f"{file_hash}-rgb" if is_triplet else file_hash
-    return f"{base}-v2"
+    return f"{base}-v3"
 
 
 def _fast_demosaic(raw: Any) -> np.ndarray:
@@ -159,9 +162,15 @@ def decode_source_image(file_path: str, green_path: str = "", blue_path: str = "
         return img
 
 
-def preview_positive(img: Image.Image) -> Image.Image:
+def preview_positive(img: Image.Image, process_mode: str = "") -> Image.Image:
     """Invert a negative preview so the filmstrip reads as photographs before a frame
     has ever been opened.
+
+    ``process_mode`` is the frame's *stored* film process; it decides outright, and the
+    heuristic runs only when nothing has decided yet. Detection here reads an 8-bit
+    preview — for a slide that is an already-positive embedded JPEG, and warm content
+    trips the orange-mask test into calling it a negative, which is how a transparency
+    reached the filmstrip inverted while the canvas rendered it right.
 
     Deliberately not the pipeline: per-channel log-density bounds over an 8-bit preview,
     with no config to key on. It is a placeholder that get_rendered_thumbnail supersedes
@@ -172,7 +181,9 @@ def preview_positive(img: Image.Image) -> Image.Image:
 
     arr = np.asarray(img.convert("RGB"), dtype=np.uint8)
     linear = srgb_to_linear(uint8_to_float32(arr))
-    if detect_process_mode(linear) is ProcessMode.E6:
+    # ProcessMode("") would resolve to C41 via _missing_, so an unknown mode must not reach it.
+    mode = ProcessMode(process_mode) if process_mode else detect_process_mode(linear)
+    if mode is ProcessMode.E6:
         return img
 
     # A lone narrowband exposure carries its picture in one channel; the other two hold
@@ -202,6 +213,7 @@ def get_thumbnail_worker(
     blue_path: str = "",
     crop_rect: Optional[tuple[float, float, float, float]] = None,
     gutter_thickness: float = 0.0,
+    process_mode: str = "",
 ) -> Optional[Image.Image]:
     """
     Checks cache -> extracts/renders -> resize.
@@ -223,7 +235,7 @@ def get_thumbnail_worker(
 
             img = Image.fromarray(slice_half(np.asarray(img), half, split_x, crop_rect=crop_rect, gutter_thickness=gutter_thickness))
 
-        square_img: Image.Image = prepare_thumbnail(preview_positive(img), ts)
+        square_img: Image.Image = prepare_thumbnail(preview_positive(img, process_mode), ts)
 
         if asset_store:
             asset_store.save_thumbnail(cache_key, square_img)

--- a/tests/test_thumbnail_positive.py
+++ b/tests/test_thumbnail_positive.py
@@ -58,6 +58,37 @@ class TestPreviewPositive(unittest.TestCase):
 
         self.assertTrue(np.array_equal(np.asarray(result), arr))
 
+    def test_stored_transparency_beats_the_heuristic(self):
+        """The reported bug: a warm slide reads as an orange mask, so detection called it a
+        negative and the filmstrip inverted it while the canvas rendered it right."""
+        warm = np.zeros((64, 64, 3), dtype=np.uint8)
+        warm[:, :] = (200, 120, 50)
+        warm[:32, :] = (90, 50, 20)
+        slide = Image.fromarray(warm)
+
+        self.assertFalse(np.array_equal(np.asarray(preview_positive(slide)), warm))
+        self.assertTrue(np.array_equal(np.asarray(preview_positive(slide, "Transparency")), warm))
+
+    def test_stored_negative_is_inverted_without_detection(self):
+        """A stored mode decides outright, so a negative the heuristic would have read as a
+        slide is still inverted."""
+        rng = np.random.default_rng(3)
+        arr = rng.integers(0, 256, (64, 64, 3), dtype=np.uint8)
+
+        result = preview_positive(Image.fromarray(arr), "Color Negative")
+
+        self.assertFalse(np.array_equal(np.asarray(result), arr))
+
+    def test_unknown_mode_falls_back_to_detection(self):
+        """An empty mode must not resolve to C41 through ProcessMode._missing_ — a frame
+        nothing has decided yet still gets the heuristic."""
+        self.assertTrue(
+            np.array_equal(
+                np.asarray(preview_positive(_orange_mask_negative(), "")),
+                np.asarray(preview_positive(_orange_mask_negative())),
+            )
+        )
+
     def test_cache_key_retires_stored_negatives(self):
         """A library scanned before this change must not keep serving its negatives."""
         self.assertNotEqual(thumbnail_cache_key("abc", False), "abc")

--- a/tests/test_thumbnail_process_mode.py
+++ b/tests/test_thumbnail_process_mode.py
@@ -1,0 +1,79 @@
+"""The filmstrip must not guess a frame's film process when the frame already knows it.
+
+A slide reached the filmstrip inverted while the canvas rendered it as a positive: the
+batch path re-detected the mode from an 8-bit preview, and a warm slide reads as an orange
+mask. The stored mode is the answer the canvas uses, so the filmstrip uses it too.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from negpy.desktop.controller import AppController
+from negpy.desktop.session import DesktopSessionManager
+
+SLIDE = {"name": "a.nef", "path": "/f/a.nef", "hash": "hash-a"}
+FRESH = {"name": "b.nef", "path": "/f/b.nef", "hash": "hash-b"}
+
+
+def _controller(stored: dict):
+    c = MagicMock()
+    c.state.uploaded_files = [dict(SLIDE), dict(FRESH)]
+    c.state.thumbnails = {}
+    c._begin_batch.return_value = 1
+    c.session.stored_process_mode = lambda asset: stored.get(asset["hash"], "")
+    return c
+
+
+def _emitted(controller) -> list:
+    controller.thumbnail_requested.emit.assert_called_once()
+    return controller.thumbnail_requested.emit.call_args.args[0]
+
+
+class BatchRequest(unittest.TestCase):
+    def test_stored_mode_rides_along(self):
+        controller = _controller({"hash-a": "Transparency"})
+
+        AppController.generate_missing_thumbnails(controller)
+
+        modes = {f["hash"]: f["process_mode"] for f in _emitted(controller)}
+        self.assertEqual(modes, {"hash-a": "Transparency", "hash-b": ""})
+
+    def test_the_session_assets_are_not_touched(self):
+        """The dicts cross to a worker thread, and a mode written back here would outlive
+        the frame's own settings."""
+        controller = _controller({"hash-a": "Transparency"})
+
+        AppController.generate_missing_thumbnails(controller)
+
+        self.assertFalse(any("process_mode" in f for f in controller.state.uploaded_files))
+        self.assertIsNot(_emitted(controller)[0], controller.state.uploaded_files[0])
+
+
+class StoredMode(unittest.TestCase):
+    def test_a_composite_uses_the_mode_it_inherited(self):
+        session = MagicMock()
+        asset = {**SLIDE, "process_mode": "Transparency", "hdr_paths": ("/f/x.nef",)}
+
+        with patch("negpy.desktop.session.load_or_promote") as load:
+            self.assertEqual(DesktopSessionManager.stored_process_mode(session, asset), "Transparency")
+            load.assert_not_called()
+
+    def test_a_saved_edit_answers(self):
+        session = MagicMock()
+        saved = MagicMock()
+        saved.process.process_mode = "Transparency"
+
+        with patch("negpy.desktop.session.load_or_promote", return_value=saved):
+            self.assertEqual(DesktopSessionManager.stored_process_mode(session, dict(SLIDE)), "Transparency")
+
+    def test_an_undecided_frame_answers_nothing(self):
+        """Not the sticky global: that is a guess about the next file, and the caller wants
+        to know whether an answer exists at all."""
+        session = MagicMock()
+
+        with patch("negpy.desktop.session.load_or_promote", return_value=None):
+            self.assertEqual(DesktopSessionManager.stored_process_mode(session, dict(FRESH)), "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Some transparencies appeared in the filmstrip as inverted negatives, then
switched to positives the moment they were clicked. The batch thumbnail path
re-detected the film process from an 8-bit preview instead of reading the mode
the frame already had, and that heuristic is being asked a question it cannot
answer: for a slide the preview is an already-positive embedded JPEG, and warm
content (sunset, skin, autumn) trips detect_process_mode's red-over-blue
orange-mask test into calling it a negative. It was then inverted, while the
canvas — which reads the saved mode — rendered it correctly.

The stored mode now decides outright, and detection runs only for a frame
nothing has decided yet, which is the case it was written for. The mode comes
from DesktopSessionManager.stored_process_mode: a composite's inherited mode,
else a saved edit's, deliberately never the sticky global, since that is a guess
about the next file rather than an answer about this one. It is a single DB read
per frame rather than a full hydration, because the filmstrip asks once per
frame of a roll.

The cache key goes to v3. Without it an existing library keeps serving the
inverted slides it has already stored, exactly as v2 retired the pre-inversion
caches; the cost is one regeneration pass per library.