### PR TITLE
Let developers point builds at a separate user directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ appimagetool-x86_64.AppImage
 # user settings
 user/
 debug/
+# per-developer make settings (NEGPY_USER_DIR, ...)
+.env.local
 
 # Virtual Environment
 venv/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,41 @@ make install
 make run
 ```
 
+#### A separate user directory for development
+
+NegPy keeps its databases, caches, presets, logs and `override.toml` in one user
+directory — `Documents/NegPy` by default. If you also use NegPy for real work, point
+your development builds at a different directory, so that test edits and stale caches
+cannot touch the real one.
+
+Set `NEGPY_USER_DIR` to an absolute path. The `Makefile` reads an optional, gitignored
+`.env.local`:
+
+```make
+# .env.local
+NEGPY_USER_DIR = $(HOME)/negpy-devhome
+```
+
+`make run` then uses that directory, and creates it if it is missing. `~` is not
+expanded — use `$(HOME)` or a full path. Without the file, nothing changes.
+
+To start again with no saved edits and no caches:
+
+```bash
+make clear-devhome
+```
+
+The target deletes the whole directory after a confirmation (`FORCE=1` skips it), and
+refuses to run if `NEGPY_USER_DIR` is unset or points at the default directory. An
+`override.toml` you rely on lives in there too, so keep a copy to put back.
+
+Two things stay outside the user directory:
+
+- `.negpy` sidecars, which are written next to the source images. A sidecar written by a
+  development build is promoted into the database of whichever install opens that image
+  next. Sidecar export is off by default; if you turn it on, test against copies.
+- Exports, wherever you send them.
+
 ## 🏗️ Project Structure
 
 The codebase follows a modular architecture:
@@ -107,6 +142,7 @@ The `Makefile` is the central source of truth for developer commands and execute
 - `make format`: Auto-format code with Ruff.
 - `make all`: Run lint, type, and test in sequence.
 - `make clean`: Removes cache and build artifacts.
+- `make clear-devhome`: Deletes the development user directory (see [above](#a-separate-user-directory-for-development)).
 
 
 ## 📦 Building and Packaging

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,12 @@
 # Variables
 UV = uv run
 
+# Optional per-developer settings, not in git. The usual content is NEGPY_USER_DIR,
+# which moves the app's user directory (databases, caches, presets, logs) away from
+# the production one. Absent, everything behaves as before.
+-include .env.local
+export NEGPY_USER_DIR
+
 # Default target
 .PHONY: all
 all: format lint type test
@@ -60,6 +66,32 @@ format:
 run:
 	@echo "Starting NegPy Desktop..."
 	@$(UV) python desktop.py
+
+# Delete the development user directory, so the next run starts with no saved edits
+# and no caches. Refuses to run against the default directory: that is the real
+# install. Set NEGPY_USER_DIR (see .env.local) to a scratch path first.
+# FORCE=1 skips the confirmation.
+.PHONY: clear-devhome
+clear-devhome:
+	@dir="$$NEGPY_USER_DIR"; \
+	if [ -z "$$dir" ]; then \
+		echo "NEGPY_USER_DIR is not set — nothing to clear."; \
+		echo "Set it in .env.local to a scratch directory, then run this again."; \
+		exit 1; \
+	fi; \
+	default=$$($(UV) python -c "import os; os.environ.pop('NEGPY_USER_DIR', None); from negpy.kernel.system.paths import get_default_user_dir; print(get_default_user_dir())"); \
+	if [ "$$(cd "$$dir" 2>/dev/null && pwd)" = "$$(cd "$$default" 2>/dev/null && pwd)" ]; then \
+		echo "Refusing to clear $$dir — that is the default user directory."; \
+		exit 1; \
+	fi; \
+	if [ ! -d "$$dir" ]; then echo "$$dir does not exist — nothing to clear."; exit 0; fi; \
+	if [ "$(FORCE)" != "1" ]; then \
+		printf "Delete %s and everything in it? [y/N] " "$$dir"; \
+		read reply; \
+		case "$$reply" in [yY]*) ;; *) echo "Cancelled."; exit 1;; esac; \
+	fi; \
+	rm -rf "$$dir"; \
+	echo "Cleared $$dir"
 
 # Run against a locally built sane-backends from rohanpandula's fork: coolscan3
 # with infrared un-gated (stock compiles it out; LS-50 reports no IR channel),


### PR DESCRIPTION
Give development builds their own user directory, so that clearing test edits and caches cannot touch a NegPy install used for real work. `NEGPY_USER_DIR` already did the redirection but was documented nowhere outside a test.

The Makefile now reads an optional, gitignored `.env.local` and exports `NEGPY_USER_DIR` from it. Without that file nothing changes.

`make clear-devhome` deletes the directory after a confirmation (`FORCE=1` skips it). It refuses if the variable is unset or resolves to the default directory, which makes it impossible to delete the production one by mistake.

CONTRIBUTING.md documents the setup, and the two things that stay outside the user directory: `.negpy` sidecars, written next to the source images, and exports.