### PR TITLE
Report an unusable user directory instead of aborting on it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,8 +20,8 @@ appimagetool-x86_64.AppImage
 # user settings
 user/
 debug/
-# per-developer make settings (NEGPY_USER_DIR, ...)
-.env.local
+# per-developer make settings (NEGPY_USER_DIR, ...), and the copies made while editing it
+.env.local*
 
 # Virtual Environment
 venv/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,8 +64,14 @@ Set `NEGPY_USER_DIR` to an absolute path. The `Makefile` reads an optional, giti
 NEGPY_USER_DIR = $(HOME)/negpy-devhome
 ```
 
-`make run` then uses that directory, and creates it if it is missing. `~` is not
-expanded — use `$(HOME)` or a full path. Without the file, nothing changes.
+`make run` then uses that directory, and creates it if it is missing. Without the file,
+nothing changes.
+
+Write `$(HOME)`, not `~` or `$HOME`: make leaves `~` alone, and reads `$HOME` as the
+variable `H` followed by `OME`. Either one resolves to a path inside the checkout, so
+make stops and tells you when the value is not absolute. Note that the path must also
+be right for the platform — `/home/you/...` is a Linux path, and macOS puts your home
+under `/Users/you`.
 
 To start again with no saved edits and no caches:
 

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,15 @@ UV = uv run
 -include .env.local
 export NEGPY_USER_DIR
 
+# A value that is not absolute means make did not expand what was written: it leaves ~
+# alone, and reads $HOME as the variable H followed by "OME". Either one quietly puts the
+# development user directory inside the checkout, so stop here with the correction.
+ifneq ($(NEGPY_USER_DIR),)
+ifneq ($(patsubst /%,,$(NEGPY_USER_DIR)),)
+$(error NEGPY_USER_DIR is "$(NEGPY_USER_DIR)", which is not an absolute path. make does not expand ~ or $$HOME in .env.local — write $$(HOME)/your-dir, or a full path)
+endif
+endif
+
 # Default target
 .PHONY: all
 all: format lint type test

--- a/negpy/desktop/main.py
+++ b/negpy/desktop/main.py
@@ -79,7 +79,15 @@ def _install_exception_hook() -> None:
             return
         logger.critical("Unhandled exception", exc_info=(exc_type, exc_value, exc_tb))
         try:
-            from PyQt6.QtWidgets import QMessageBox
+            from PyQt6.QtWidgets import QApplication, QMessageBox
+
+            # Startup work runs before QApplication exists, and constructing a widget
+            # without one makes Qt call qFatal() — an abort at the C level, with no Python
+            # exception to catch, that buries the real failure under a complaint about
+            # widgets. Print the traceback instead; there is no UI to notify yet.
+            if QApplication.instance() is None:
+                sys.__excepthook__(exc_type, exc_value, exc_tb)
+                return
 
             QMessageBox.critical(
                 None,
@@ -92,6 +100,37 @@ def _install_exception_hook() -> None:
             logger.warning("could not show the error dialog", exc_info=True)
 
     sys.excepthook = _hook
+
+
+class UserDirectoryError(Exception):
+    """NegPy has nowhere to keep its databases, caches and presets.
+
+    Raised instead of the bare OSError so the startup path can say which directory it
+    could not create and what to do about it, rather than aborting on a makedirs
+    traceback the user cannot act on (issue #651).
+    """
+
+    def __init__(self, failed_dir: str, cause: OSError) -> None:
+        self.failed_dir = failed_dir
+        env_override = os.environ.get("NEGPY_USER_DIR")
+        lines = [
+            "NegPy could not create the directory it keeps its data in:",
+            f"    {failed_dir}",
+            f"    {cause.strerror or cause} (errno {cause.errno})",
+        ]
+        if env_override:
+            lines += [
+                "",
+                f"NEGPY_USER_DIR is set to {env_override!r}, which is where that path comes from.",
+                "It must be an absolute path on this machine that you can write to. If it came",
+                "from .env.local, note that make does not expand ~ or $HOME — use $(HOME).",
+            ]
+        else:
+            lines += [
+                "",
+                "Set NEGPY_USER_DIR to a directory you can write to, to start somewhere else.",
+            ]
+        super().__init__("\n".join(lines))
 
 
 def _bootstrap_environment() -> None:
@@ -108,7 +147,10 @@ def _bootstrap_environment() -> None:
         APP_CONFIG.default_export_dir,
     ]
     for d in dirs:
-        os.makedirs(d, exist_ok=True)
+        try:
+            os.makedirs(d, exist_ok=True)
+        except OSError as e:
+            raise UserDirectoryError(d, e) from e
     CrosstalkProfiles.ensure_user_dir()
     GearProfiles.ensure_user_dir()
 
@@ -158,7 +200,16 @@ def main() -> None:
 
         apply_override(override_cfg, APP_CONFIG)
 
-        _bootstrap_environment()
+        try:
+            _bootstrap_environment()
+        except UserDirectoryError as e:
+            # Nothing works without this directory, so stop here with an explanation
+            # rather than carry a traceback into a startup that can only fail again on
+            # the first database write. One line for the log, which may itself be
+            # unwritable here; the full text to stderr, since the log handler repeats it.
+            logger.critical("User directory unusable: %s", e.failed_dir)
+            print(f"\n{e}\n", file=sys.stderr)
+            sys.exit(1)
 
         # Storage (sqlite, no Qt dependency), created before QApplication so the saved UI scale
         # can be applied through QT_SCALE_FACTOR, which Qt reads only at startup.

--- a/negpy/kernel/system/paths.py
+++ b/negpy/kernel/system/paths.py
@@ -45,7 +45,9 @@ def get_default_user_dir() -> str:
     """Resolve the user directory, defaulting to Documents/NegPy with platform-native detection."""
     env_path = os.getenv("NEGPY_USER_DIR")
     if env_path:
-        return os.path.abspath(env_path)
+        # expanduser before abspath: a bare "~/dev" would otherwise become a literal "~"
+        # directory under the working directory, silently, and the app would run out of it.
+        return os.path.abspath(os.path.expanduser(env_path))
 
     docs_dir: Optional[Path] = None
 

--- a/tests/test_startup_user_dir.py
+++ b/tests/test_startup_user_dir.py
@@ -1,0 +1,89 @@
+"""Startup must survive a user directory it cannot create.
+
+Everything NegPy keeps — databases, caches, presets, logs — lives under one directory,
+and it is created before QApplication exists. A path that cannot be made (a Linux-style
+/home/... on macOS, an unlinked OneDrive Documents on Windows, issue #651) used to abort
+the process: the exception hook tried to raise a QMessageBox with no application object,
+Qt called qFatal(), and the real cause was buried under "Must construct a QApplication
+before a QWidget".
+"""
+
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+from negpy.desktop.main import UserDirectoryError, _bootstrap_environment, _install_exception_hook
+
+
+class TestBootstrapReportsAnUnusableDirectory(unittest.TestCase):
+    def _raise_makedirs(self, errno, strerror, failing):
+        def fake(path, exist_ok=False):
+            if path == failing:
+                raise OSError(errno, strerror, path)
+
+        return fake
+
+    def test_it_names_the_directory_and_the_reason(self):
+        with patch("negpy.desktop.main.BASE_USER_DIR", "/home/nobody/NegPy-dev"):
+            with patch("os.makedirs", self._raise_makedirs(45, "Operation not supported", "/home/nobody/NegPy-dev")):
+                with self.assertRaises(UserDirectoryError) as caught:
+                    _bootstrap_environment()
+
+        message = str(caught.exception)
+        self.assertEqual(caught.exception.failed_dir, "/home/nobody/NegPy-dev")
+        self.assertIn("/home/nobody/NegPy-dev", message)
+        self.assertIn("Operation not supported", message)
+        self.assertIn("45", message)
+
+    def test_it_points_at_the_override_when_one_is_set(self):
+        with patch.dict(os.environ, {"NEGPY_USER_DIR": "/home/nobody/NegPy-dev"}):
+            with patch("negpy.desktop.main.BASE_USER_DIR", "/home/nobody/NegPy-dev"):
+                with patch("os.makedirs", self._raise_makedirs(45, "Operation not supported", "/home/nobody/NegPy-dev")):
+                    with self.assertRaises(UserDirectoryError) as caught:
+                        _bootstrap_environment()
+
+        message = str(caught.exception)
+        self.assertIn("NEGPY_USER_DIR", message)
+        self.assertIn("$(HOME)", message, "the .env.local correction is the actionable part")
+
+    def test_a_directory_that_can_be_made_raises_nothing(self):
+        with patch("os.makedirs"), patch("negpy.desktop.main.CrosstalkProfiles"), patch("negpy.desktop.main.GearProfiles"):
+            _bootstrap_environment()
+
+
+class TestExceptionHookBeforeQApplication(unittest.TestCase):
+    """A widget without a QApplication aborts the process, so the hook must not build one."""
+
+    def setUp(self):
+        self._saved_hook = sys.excepthook
+        self.addCleanup(lambda: setattr(sys, "excepthook", self._saved_hook))
+
+    def _fire(self):
+        _install_exception_hook()
+        try:
+            raise RuntimeError("boom")
+        except RuntimeError:
+            sys.excepthook(*sys.exc_info())
+
+    def test_no_dialog_is_built_with_no_application(self):
+        box = MagicMock()
+        with patch("PyQt6.QtWidgets.QMessageBox", box), patch("PyQt6.QtWidgets.QApplication") as app:
+            app.instance.return_value = None
+            with patch("sys.__excepthook__") as fallback:
+                self._fire()
+
+        box.critical.assert_not_called()
+        fallback.assert_called_once()
+
+    def test_the_dialog_is_still_shown_once_the_app_is_up(self):
+        box = MagicMock()
+        with patch("PyQt6.QtWidgets.QMessageBox", box), patch("PyQt6.QtWidgets.QApplication") as app:
+            app.instance.return_value = object()
+            self._fire()
+
+        box.critical.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_user_dir_resolution.py
+++ b/tests/test_user_dir_resolution.py
@@ -42,6 +42,16 @@ def test_env_override_wins(monkeypatch, tmp_path):
     assert get_default_user_dir() == os.path.abspath(str(tmp_path / "custom"))
 
 
+def test_env_override_expands_a_leading_tilde(monkeypatch, tmp_path):
+    """Without expansion "~/dev" becomes a literal "~" directory under the working
+    directory — the app runs, out of a folder inside the checkout."""
+    home = tmp_path / "home"
+    monkeypatch.setattr(os.path, "expanduser", lambda p: p.replace("~", str(home), 1) if p.startswith("~") else p)
+    monkeypatch.setenv("NEGPY_USER_DIR", "~/negpy-devhome")
+
+    assert get_default_user_dir() == str(home / "negpy-devhome")
+
+
 def test_broken_documents_falls_back_to_home(monkeypatch, tmp_path):
     home = tmp_path / "home"
     home.mkdir()


### PR DESCRIPTION
Everything NegPy keeps lives under one directory, created before QApplication exists. A path that cannot be made — a Linux-style /home/... on macOS, an unlinked OneDrive Documents on Windows — aborted the process: the exception hook tried to raise a QMessageBox with no application object, so Qt called qFatal() and killed it at the C level, burying the cause under "Must construct a QApplication before a QWidget".

The hook now falls back to the default excepthook when no QApplication exists, and _bootstrap_environment raises UserDirectoryError naming the directory, the errno, and what to change. Startup prints that and exits 1.

Two ways of writing NEGPY_USER_DIR also failed silently. A leading ~ was never expanded, so "~/dev" became a literal "~" directory inside the working directory and the app ran out of it; get_default_user_dir now expands it. And make reads $HOME in .env.local as the variable H followed by "OME", which is equally silent — the Makefile now stops when the value is not absolute, with the correction. CONTRIBUTING covers both, and .gitignore's .env.local pattern widens to catch the copies made while editing it.

I think this should fix #651 