### PR TITLE
Start the file pickers in a folder that is related to the work

### DIFF
--- a/negpy/desktop/view/sidebar/files.py
+++ b/negpy/desktop/view/sidebar/files.py
@@ -51,6 +51,7 @@ from negpy.infrastructure.filesystem.watcher import FolderWatchService
 from negpy.infrastructure.loaders.helpers import get_supported_raw_wildcards
 from negpy.desktop.view.sidebar.library_tree import LibraryTree
 from negpy.desktop.view.widgets.collapsible import CollapsibleSection
+from negpy.desktop.view.widgets.file_dialogs import last_open_folder, pick_start_dir
 from negpy.services.assets.library import folder_counts
 
 
@@ -966,7 +967,7 @@ class FileBrowser(QWidget):
     def prompt_add_files(self) -> None:
         """Public entry point: also driven by the canvas empty state."""
         wildcards = get_supported_raw_wildcards()
-        start_dir = self.session.repo.get_global_setting("last_open_folder", "") or ""
+        start_dir = last_open_folder(self.session.repo)
         files, _ = QFileDialog.getOpenFileNames(
             self,
             "Select Images",
@@ -979,7 +980,7 @@ class FileBrowser(QWidget):
 
     def prompt_add_folder(self) -> None:
         """Public entry point: also driven by the canvas empty state."""
-        start_dir = self.session.repo.get_global_setting("last_open_folder", "") or ""
+        start_dir = last_open_folder(self.session.repo)
         folder = QFileDialog.getExistingDirectory(self, "Select Folder", start_dir)
         if folder:
             self.session.repo.save_global_setting("last_open_folder", os.path.dirname(folder))
@@ -1200,7 +1201,14 @@ class FileBrowser(QWidget):
         if not (0 <= idx < len(files)):
             return
         info = files[idx]
-        dlg = _RgbTripletDialog(self, info["path"], info.get("green_path", ""), info.get("blue_path", ""), info.get("align", True))
+        dlg = _RgbTripletDialog(
+            self,
+            info["path"],
+            info.get("green_path", ""),
+            info.get("blue_path", ""),
+            info.get("align", True),
+            start_dir=last_open_folder(self.session.repo),
+        )
         if dlg.exec():
             red, green, blue = dlg.paths()
             if red and green and blue:
@@ -1226,8 +1234,9 @@ class FileBrowser(QWidget):
 class _RgbTripletDialog(QDialog):
     """Manually assign the red/green/blue exposure files for one RGB-scan frame."""
 
-    def __init__(self, parent, red: str, green: str, blue: str, align: bool = True) -> None:
+    def __init__(self, parent, red: str, green: str, blue: str, align: bool = True, start_dir: str = "") -> None:
         super().__init__(parent)
+        self._start_dir = start_dir
         self.setWindowTitle("Edit RGB Triplet")
         layout = QVBoxLayout(self)
         self._edits: dict[str, QLineEdit] = {}
@@ -1253,7 +1262,10 @@ class _RgbTripletDialog(QDialog):
         layout.addWidget(buttons)
 
     def _browse(self, edit: QLineEdit) -> None:
-        start = os.path.dirname(edit.text()) if edit.text() else ""
+        # An empty row starts where its siblings are: the three exposures of a triplet
+        # are shot in one go and live together.
+        siblings = [self._edits[label].text() for label in ("Red", "Green", "Blue")]
+        start = pick_start_dir(edit.text(), *siblings, self._start_dir)
         path, _ = QFileDialog.getOpenFileName(self, "Select exposure", start, f"Supported Images ({get_supported_raw_wildcards()})")
         if path:
             edit.setText(path)

--- a/negpy/desktop/view/sidebar/flatfield.py
+++ b/negpy/desktop/view/sidebar/flatfield.py
@@ -15,6 +15,7 @@ from negpy.desktop.view.confirm import confirm_delete_named
 from negpy.desktop.view.sidebar.base import BaseSidebar
 from negpy.desktop.view.styles.templates import section_subheader
 from negpy.desktop.view.styles.theme import THEME
+from negpy.desktop.view.widgets.file_dialogs import last_open_folder, pick_start_dir
 from negpy.desktop.view.widgets.sliders import CompactSlider
 
 _NONE_LABEL = "— None —"
@@ -100,7 +101,8 @@ class FlatFieldSidebar(BaseSidebar):
         self.sync_ui()
 
     def _on_add(self) -> None:
-        path, _ = QFileDialog.getOpenFileName(self, "Select flat-field reference", "", _FILE_FILTER)
+        start = pick_start_dir(last_open_folder(self.controller.session.repo))
+        path, _ = QFileDialog.getOpenFileName(self, "Select flat-field reference", start, _FILE_FILTER)
         if not path:
             return
         default_name = os.path.splitext(os.path.basename(path))[0]

--- a/negpy/desktop/view/sidebar/sensor.py
+++ b/negpy/desktop/view/sidebar/sensor.py
@@ -2,6 +2,7 @@ from PyQt6.QtWidgets import QComboBox, QDialog, QHBoxLayout
 
 from negpy.desktop.view.sidebar.base import BaseSidebar
 from negpy.desktop.view.styles.templates import field_label, hint_label, section_subheader, wrap_tooltip
+from negpy.desktop.view.widgets.file_dialogs import last_open_folder
 from negpy.desktop.view.widgets.sliders import CompactSlider
 from negpy.features.process.models import ProcessMode, invalidate_local_bounds
 from negpy.features.process.sensor import unmix_block_reason
@@ -282,7 +283,7 @@ class SensorSidebar(BaseSidebar):
     def _open_sensor_calibration(self) -> None:
         from negpy.desktop.view.widgets.sensor_calibration_dialog import SensorCalibrationDialog
 
-        dlg = SensorCalibrationDialog(parent=self)
+        dlg = SensorCalibrationDialog(parent=self, start_dir=last_open_folder(self.controller.session.repo))
         dlg.profile_saved.connect(self._on_sensor_profile_saved)
         dlg.exec()
 

--- a/negpy/desktop/view/widgets/file_dialogs.py
+++ b/negpy/desktop/view/widgets/file_dialogs.py
@@ -1,0 +1,26 @@
+"""Start-directory resolution for the file pickers."""
+
+import os
+
+_LAST_OPEN_FOLDER = "last_open_folder"
+
+
+def pick_start_dir(*candidates: str) -> str:
+    """The first candidate that resolves to a directory that exists, else the home folder.
+
+    A candidate is a file or a folder path; a file gives its parent folder. Give an empty
+    string for a candidate that does not apply. Qt reads an empty start directory as the
+    process working directory, which is `/` for a bundled app, so never return one.
+    """
+    for candidate in candidates:
+        if not candidate:
+            continue
+        folder = candidate if os.path.isdir(candidate) else os.path.dirname(candidate)
+        if folder and os.path.isdir(folder):
+            return folder
+    return os.path.expanduser("~")
+
+
+def last_open_folder(repo) -> str:
+    """The folder of the most recent Add Files / Add Folder, as a picker fallback."""
+    return repo.get_global_setting(_LAST_OPEN_FOLDER, "") or ""

--- a/negpy/desktop/view/widgets/sensor_calibration_dialog.py
+++ b/negpy/desktop/view/widgets/sensor_calibration_dialog.py
@@ -21,6 +21,7 @@ from PyQt6.QtWidgets import (
 
 from negpy.kernel.system.text import plural
 from negpy.desktop.view.styles.templates import hint_label
+from negpy.desktop.view.widgets.file_dialogs import pick_start_dir
 from negpy.desktop.view.styles.theme import THEME
 from negpy.features.process.sensor import build_sensor_matrix, measure_capture
 from negpy.infrastructure.loaders.helpers import get_supported_raw_wildcards
@@ -36,8 +37,9 @@ class SensorCalibrationDialog(QDialog):
 
     profile_saved = pyqtSignal(str)
 
-    def __init__(self, parent=None) -> None:
+    def __init__(self, parent=None, start_dir: str = "") -> None:
         super().__init__(parent)
+        self._start_dir = start_dir
         self._paths = {"R": "", "G": "", "B": ""}
         self.setWindowTitle("Calibrate Sensor")
         self.resize(560, 320)
@@ -97,8 +99,11 @@ class SensorCalibrationDialog(QDialog):
         self._refresh()
 
     def _browse(self, band: str) -> None:
+        # The three bare-light exposures are shot in one go, so an empty band starts
+        # where the bands already picked are.
+        start = pick_start_dir(self._paths[band], *self._paths.values(), self._start_dir)
         path, _ = QFileDialog.getOpenFileName(
-            self, f"Select the {band} bare-light exposure", "", f"Supported Images ({get_supported_raw_wildcards()})"
+            self, f"Select the {band} bare-light exposure", start, f"Supported Images ({get_supported_raw_wildcards()})"
         )
         if path:
             self._paths[band] = path

--- a/tests/test_file_dialog_start_dir.py
+++ b/tests/test_file_dialog_start_dir.py
@@ -1,0 +1,57 @@
+import os
+from unittest.mock import MagicMock
+
+from negpy.desktop.view.widgets.file_dialogs import last_open_folder, pick_start_dir
+from negpy.infrastructure.storage.repository import StorageRepository
+
+
+def test_file_candidate_gives_its_folder(tmp_path):
+    frame = tmp_path / "red.dng"
+    frame.write_bytes(b"")
+    assert pick_start_dir(str(frame)) == str(tmp_path)
+
+
+def test_folder_candidate_is_kept(tmp_path):
+    assert pick_start_dir(str(tmp_path)) == str(tmp_path)
+
+
+def test_empty_and_missing_candidates_are_skipped(tmp_path):
+    frame = tmp_path / "green.dng"
+    frame.write_bytes(b"")
+    gone = tmp_path / "unmounted" / "blue.dng"
+    assert pick_start_dir("", str(gone), str(frame)) == str(tmp_path)
+
+
+def test_home_is_the_last_resort():
+    # Never "" — Qt reads that as the working directory, which is / for a bundled app.
+    assert pick_start_dir("", "/no/such/place") == os.path.expanduser("~")
+
+
+def test_last_open_folder_reads_the_global_setting():
+    repo = MagicMock(spec=StorageRepository)
+    repo.get_global_setting.return_value = "/scans/roll-12"
+    assert last_open_folder(repo) == "/scans/roll-12"
+
+
+def test_last_open_folder_unset_is_empty():
+    repo = MagicMock(spec=StorageRepository)
+    repo.get_global_setting.return_value = None
+    assert last_open_folder(repo) == ""
+
+
+def test_empty_triplet_row_browses_beside_the_red_frame(qapp, tmp_path, monkeypatch):
+    from negpy.desktop.view.sidebar import files as files_mod
+
+    red = tmp_path / "roll12_r.dng"
+    red.write_bytes(b"")
+    dlg = files_mod._RgbTripletDialog(None, str(red), "", "", start_dir="")
+
+    seen = {}
+
+    def fake_open(_parent, _caption, start, _filter):
+        seen["start"] = start
+        return ("", "")
+
+    monkeypatch.setattr(files_mod.QFileDialog, "getOpenFileName", fake_open)
+    dlg._browse(dlg._edits["Blue"])
+    assert seen["start"] == str(tmp_path)


### PR DESCRIPTION
Browse on an empty row of the Edit RGB Triplet dialog started at the root of the disk, because the start directory came only from the row's own (empty) text box. The three exposures of a triplet are shot in one go and live in one folder, so an empty row now starts where its siblings are.

pick_start_dir() takes candidate paths, keeps the first one that is a folder that exists (a file gives its parent), and falls back to the home folder. It never gives "", which Qt reads as the working directory — `/` for a bundled app. last_open_folder() reads the setting that Add Files and Add Folder already write.

The same start-at-the-root problem applied to the flat-field reference picker and to the three bands of the sensor calibration dialog. All of them now fall back to the last-opened folder. They read that setting but do not write it, to keep Add Files pointed at the image folder and not at a calibration folder.

Fixes #854 