### PR TITLE
Drop stale per-frame bounds when a triplet is assembled

### DIFF
--- a/negpy/desktop/session.py
+++ b/negpy/desktop/session.py
@@ -11,7 +11,8 @@ from negpy.desktop.settings_catalog import apply_selected_fields
 from negpy.desktop.view.canvas.crop_guides import CropGuide
 from negpy.domain.models import ExportPreset, WorkspaceConfig
 from negpy.features.exposure.models import apply_targets
-from negpy.features.rgbscan.models import RgbScanConfig
+from negpy.features.process.models import invalidate_local_bounds
+from negpy.features.rgbscan.models import RgbScanConfig, is_rgb_triplet
 from negpy.features.hdr.logic import resolve_anchor, seed_shadow_density
 from negpy.features.hdr.models import ANCHOR_EV_UNSET, HdrConfig, hdr_frame_paths
 from negpy.features.stitch.models import StitchConfig
@@ -432,15 +433,37 @@ def _source_effective_bounds(process) -> Optional[tuple]:
     return None
 
 
+def _triplet_composition(config: RgbScanConfig) -> tuple:
+    """Which exposures the assembled source takes its channels from; () when not a triplet.
+
+    `align` is excluded on purpose: sub-pixel registration cannot move a whole-frame
+    percentile, so it must not cost a re-analysis.
+    """
+    return (config.green_path, config.blue_path) if is_rgb_triplet(config) else ()
+
+
 def resolve_asset_rgbscan(params: WorkspaceConfig, asset: dict) -> WorkspaceConfig:
     """Overlay a frame's own RGB-scan triplet paths (from the asset dict) onto its export
     params — the authoritative source select_file uses. A non-triplet frame gets rgbscan
-    reset so a batch frame never inherits the currently-open frame's leaked/stale triplet."""
+    reset so a batch frame never inherits the currently-open frame's leaked/stale triplet.
+
+    A triplet keeps the red exposure's content hash (it *is* that asset, with green/blue
+    riding along), so it loads the lone red exposure's saved edit — including per-frame
+    bounds measured when green and blue held nothing but sensor leak. Applying those to a
+    three-band composite puts its real G/B densities above their ceils and inverts both to
+    black, leaving a solid red frame. So a change of composition drops the bounds and the
+    stretch re-derives from the assembled source. Stitch and HDR need no such guard: they
+    get a fresh hash, so they never inherit a member's bounds.
+    """
     green, blue = asset.get("green_path"), asset.get("blue_path")
     if green and blue:
         align = bool(asset.get("align", params.rgbscan.align))
-        return replace(params, rgbscan=RgbScanConfig(enabled=True, green_path=green, blue_path=blue, align=align))
-    return replace(params, rgbscan=RgbScanConfig())
+        resolved = RgbScanConfig(enabled=True, green_path=green, blue_path=blue, align=align)
+    else:
+        resolved = RgbScanConfig()
+    if _triplet_composition(resolved) == _triplet_composition(params.rgbscan):
+        return replace(params, rgbscan=resolved)
+    return replace(params, rgbscan=resolved, process=replace(params.process, **invalidate_local_bounds(params.process)))
 
 
 def resolve_asset_process_mode(params: WorkspaceConfig, asset: dict) -> WorkspaceConfig:

--- a/tests/test_rgbscan.py
+++ b/tests/test_rgbscan.py
@@ -233,6 +233,71 @@ def test_resolve_asset_rgbscan_resets_when_not_triplet():
     assert out.rgbscan == RgbScanConfig()
 
 
+def _with_bounds(config, **rgbscan_kwargs):
+    return replace(
+        config,
+        rgbscan=RgbScanConfig(**rgbscan_kwargs) if rgbscan_kwargs else RgbScanConfig(),
+        process=replace(config.process, local_floors=(-1.3, -1.4, -1.5), local_ceils=(-0.2, -0.3, -0.4)),
+    )
+
+
+def test_resolve_asset_rgbscan_drops_bounds_when_becoming_a_triplet():
+    """The lone red exposure's bounds measured G/B on sensor leak alone; on the composite
+    they invert both channels to black and leave a solid red frame."""
+    from negpy.desktop.session import resolve_asset_rgbscan
+
+    lone = _with_bounds(WorkspaceConfig())
+    out = resolve_asset_rgbscan(lone, {"path": "/r", "green_path": "/g", "blue_path": "/b"})
+    assert out.process.is_local_initialized is False
+
+
+def test_resolve_asset_rgbscan_drops_bounds_when_leaving_a_triplet():
+    from negpy.desktop.session import resolve_asset_rgbscan
+
+    triplet = _with_bounds(WorkspaceConfig(), enabled=True, green_path="/g", blue_path="/b")
+    out = resolve_asset_rgbscan(triplet, {"path": "/r"})
+    assert out.process.is_local_initialized is False
+
+
+def test_resolve_asset_rgbscan_drops_bounds_when_members_change():
+    from negpy.desktop.session import resolve_asset_rgbscan
+
+    triplet = _with_bounds(WorkspaceConfig(), enabled=True, green_path="/g", blue_path="/b")
+    out = resolve_asset_rgbscan(triplet, {"path": "/r", "green_path": "/g2", "blue_path": "/b2"})
+    assert out.process.is_local_initialized is False
+
+
+def test_resolve_asset_rgbscan_keeps_bounds_on_unchanged_composition():
+    """Reopening the same triplet must not throw away its analysis, and align is not a
+    composition change."""
+    from negpy.desktop.session import resolve_asset_rgbscan
+
+    triplet = _with_bounds(WorkspaceConfig(), enabled=True, green_path="/g", blue_path="/b")
+    out = resolve_asset_rgbscan(triplet, {"path": "/r", "green_path": "/g", "blue_path": "/b", "align": False})
+    assert out.process.local_floors == triplet.process.local_floors
+    assert out.process.local_ceils == triplet.process.local_ceils
+    assert out.rgbscan.align is False
+
+
+def test_resolve_asset_rgbscan_keeps_bounds_on_a_plain_frame():
+    """The overwhelmingly common case: no triplet either side, nothing to invalidate."""
+    from negpy.desktop.session import resolve_asset_rgbscan
+
+    plain = _with_bounds(WorkspaceConfig())
+    out = resolve_asset_rgbscan(plain, {"path": "/r"})
+    assert out.process.local_floors == plain.process.local_floors
+
+
+def test_resolve_asset_rgbscan_respects_locked_bounds():
+    """lock_bounds is the user pinning the stretch by hand; invalidate_local_bounds no-ops."""
+    from negpy.desktop.session import resolve_asset_rgbscan
+
+    lone = _with_bounds(WorkspaceConfig())
+    lone = replace(lone, process=replace(lone.process, lock_bounds=True))
+    out = resolve_asset_rgbscan(lone, {"path": "/r", "green_path": "/g", "blue_path": "/b"})
+    assert out.process.local_floors == lone.process.local_floors
+
+
 def test_thumbnail_cache_key_namespaces_triplets():
     """Batch and rendered paths must derive the same triplet key so they share a cache slot."""
     from negpy.services.assets.thumbnails import thumbnail_cache_key


### PR DESCRIPTION
Turning on RGB-triplet mode rendered a solid red frame. An assembled triplet reuses the red exposure's content hash, so it loaded that lone exposure's saved edit — including per-frame normalization bounds measured when green and blue held nothing but sensor leak. Those bounds sit ~1 log-density too low, so the composite's real G/B densities land above their ceils, invert to black, and only red survives.

resolve_asset_rgbscan now drops local_floors/local_ceils when the channel composition changes: entering a triplet, leaving one, or swapping members. An unchanged triplet keeps its analysis, and align stays out of the comparison because a sub-pixel shift cannot move a whole-frame percentile. lock_bounds still wins, through invalidate_local_bounds.

Stitch and HDR need no equivalent guard: they get a fresh content hash, so they never inherit a member's bounds.

Toggling Linear RAW appeared to fix the frame only because it invalidates the same bounds as a side effect, which is why the broken state never came back.

The trichrome unmix is not the cause, but it makes the same failure worse: it clips the two empty channels to exactly zero, driving their bounds to -4.4.

Fixes #853 