### PR TITLE
Drop a render that lands after the user has left its frame

### DIFF
--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -1398,6 +1398,10 @@ class AppController(QObject):
                 self.state.last_metrics["content_rect"] = memo.get("content_rect")
                 self.state.last_metrics["splash"] = False
                 self.state.last_metrics["compare"] = False
+                # These pixels are this frame's own last render. Leaving the outgoing
+                # frame's hash next to them would file them under it on the next
+                # thumbnail refresh, which reads whatever last_metrics holds.
+                self.state.last_metrics["source_hash"] = target_hash
             self.image_updated.emit()
 
         self.state.preview_raw = None
@@ -4461,9 +4465,26 @@ class AppController(QObject):
             self._busy_toast = False
             self.set_status("")
 
+    def _renders_another_frame(self, metrics: Dict[str, Any]) -> bool:
+        """True when a render belongs to a frame that is no longer selected.
+
+        A render carries the hash it was dispatched for, and nothing cancels one that is
+        already in flight — click the next frame mid-render and it still lands. Its pixels
+        and its measurements describe the frame the user has left, so they must not reach
+        the canvas or ``last_metrics``. A task dispatched before the file had a hash
+        carries the same ``"preview"`` placeholder ``request_render`` gives it.
+        """
+        src = metrics.get("source_hash")
+        return src is not None and src != (self.state.current_file_hash or "preview")
+
     def _on_render_finished(self, _result: Any, metrics: Dict[str, Any]) -> None:
         self._is_rendering = False
         self._clear_busy_toast()
+
+        # The queue still drains — only the frame this render produced is unusable.
+        if self._renders_another_frame(metrics):
+            self._dispatch_pending_render()
+            return
 
         if self._first_render_t0 is not None and not metrics.get("ephemeral"):
             logger.info(
@@ -4516,6 +4537,10 @@ class AppController(QObject):
             # persist=False: refresh in-memory only; disk JPEG written on switch/save/export.
             self._update_thumbnail_from_state(persist=False)
 
+        self._dispatch_pending_render()
+
+    def _dispatch_pending_render(self) -> None:
+        """Start the render queued while the last one was running, if any."""
         if self._pending_render_task:
             task = self._pending_render_task
             self._pending_render_task = None
@@ -4526,15 +4551,22 @@ class AppController(QObject):
         """
         Handles late-arriving metrics and persists analysis results.
         """
+        # A render of a frame the user has left measured that frame, not this one:
+        # merging it corrupts the histogram, densitometer and UV grid until the next
+        # render replaces every key it touched.
+        if self._renders_another_frame(metrics):
+            return
+
         with self.state.metrics_lock:
             self.state.last_metrics.update(metrics)
         if "ir_degenerate" in metrics:
             self.state.ir_degenerate = bool(metrics["ir_degenerate"])
         self.metrics_available.emit(metrics)
 
-        # Do not persist bounds from a splash render, or from a render of another file
-        # arriving late after a fast switch: they are not this frame's bounds. Nor from a
-        # mid-gesture frame, which measured the proxy rather than the real buffer.
+        # Do not persist bounds from a splash render, or from a frame with no identity of
+        # its own: they are not this frame's bounds. Nor from a mid-gesture frame, which
+        # measured the proxy rather than the real buffer. A render of another file was
+        # already dropped above.
         if metrics.get("ephemeral") or metrics.get("interactive"):
             return
         src = metrics.get("source_hash")
@@ -4578,11 +4610,7 @@ class AppController(QObject):
         self.set_status(f"Failed to load file: {message}", 5000)
         self.load_failed.emit()
 
-        if self._pending_render_task:
-            task = self._pending_render_task
-            self._pending_render_task = None
-            self._is_rendering = True
-            self.render_requested.emit(task)
+        self._dispatch_pending_render()
 
     def _on_export_task_error(self, _message: str) -> None:
         self._export_failures += 1

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -396,6 +396,105 @@ class TestAppController(unittest.TestCase):
         self.controller._on_render_finished(None, {"ephemeral": True})
         self.controller._update_thumbnail_from_state.assert_not_called()
 
+    def test_render_of_a_frame_the_user_left_is_dropped(self):
+        """Switching files mid-render leaves that render in flight. When it lands it must
+        not repaint the canvas nor overwrite the new frame's metrics."""
+        import numpy as np
+
+        state = self.controller.state
+        state.current_file_path = "/tmp/B.NEF"
+        state.current_file_hash = "hB"
+        current = np.full((2, 2, 3), 0.5, dtype=np.float32)
+        state.last_metrics = {"base_positive": current, "source_hash": "hB", "log_bounds": (0.1, 0.9)}
+
+        repaints = []
+        self.controller.image_updated.connect(lambda: repaints.append(1))
+        self.controller._update_thumbnail_from_state = MagicMock()
+
+        stale = {"base_positive": np.zeros((2, 2, 3), dtype=np.float32), "source_hash": "hA", "log_bounds": (0.4, 0.4)}
+        self.controller._on_render_finished(None, stale)
+        self.controller._on_metrics_updated(stale)
+
+        self.assertEqual(repaints, [])
+        self.assertIs(state.last_metrics["base_positive"], current)
+        self.assertEqual(state.last_metrics["log_bounds"], (0.1, 0.9))
+        self.controller._update_thumbnail_from_state.assert_not_called()
+
+        # The queue still drains — a stale frame must not wedge the render loop.
+        self.assertFalse(self.controller._is_rendering)
+
+    def test_render_of_the_current_frame_still_lands(self):
+        """The guard keys on the frame, not on staleness in general: the selected frame's
+        render — and an unhashed preview's, which carries the 'preview' placeholder —
+        repaint as before."""
+        import numpy as np
+
+        state = self.controller.state
+        state.current_file_path = "/tmp/B.NEF"
+        state.current_file_hash = "hB"
+
+        repaints = []
+        self.controller.image_updated.connect(lambda: repaints.append(1))
+        self.controller._update_thumbnail_from_state = MagicMock()
+
+        self.controller._on_render_finished(None, {"base_positive": np.zeros((2, 2, 3), np.float32), "source_hash": "hB"})
+        self.assertEqual(len(repaints), 1)
+
+        state.current_file_hash = None
+        self.controller._on_render_finished(None, {"base_positive": np.zeros((2, 2, 3), np.float32), "source_hash": "preview"})
+        self.assertEqual(len(repaints), 2)
+
+        # A render with no identity at all (older callers) is not treated as stale.
+        self.controller._on_render_finished(None, {})
+        self.assertEqual(len(repaints), 3)
+
+    def test_navigate_back_paint_carries_its_own_frames_identity(self):
+        """The memo fast path paints the incoming frame's last render. Leaving the
+        outgoing frame's hash beside those pixels files them under it on the next
+        thumbnail refresh."""
+        import numpy as np
+
+        state = self.controller.state
+        state.uploaded_files = [
+            {"name": "a.dng", "path": "/tmp/a.dng", "hash": "hA"},
+            {"name": "b.dng", "path": "/tmp/b.dng", "hash": "hB"},
+        ]
+        state.current_file_path = "/tmp/a.dng"
+        state.current_file_hash = "hA"
+        state.last_metrics = {"source_hash": "hA"}
+
+        cached = np.zeros((2, 2, 3), dtype=np.float32)
+        self.controller._render_memo.store("hB", self.controller._render_memo_key(), {"base_positive": cached, "content_rect": None})
+
+        self.controller.load_file("/tmp/b.dng")
+
+        self.assertIs(state.last_metrics["base_positive"], cached)
+        self.assertEqual(state.last_metrics["source_hash"], "hB")
+
+    def test_pending_render_is_dispatched_after_a_dropped_frame(self):
+        """A render queued behind the stale one must still be started."""
+        import numpy as np
+
+        from negpy.desktop.workers.render import RenderTask
+
+        state = self.controller.state
+        state.current_file_hash = "hB"
+        queued = RenderTask(
+            buffer=np.zeros((1, 1, 3), np.float32),
+            config=WorkspaceConfig(),
+            source_hash="hB",
+            preview_size=1.0,
+        )
+        self.controller._pending_render_task = queued
+
+        dispatched = []
+        self.controller.render_requested.connect(dispatched.append)
+        self.controller._on_render_finished(None, {"source_hash": "hA"})
+
+        self.assertEqual(dispatched, [queued])
+        self.assertIsNone(self.controller._pending_render_task)
+        self.assertTrue(self.controller._is_rendering)
+
     def test_proof_active_gated_by_toggle(self):
         """proof_active() is False unless the soft-proof toggle is on, even with an
         export color space set (which always resolves an output profile)."""

--- a/tests/test_interactive_decoupling.py
+++ b/tests/test_interactive_decoupling.py
@@ -7,6 +7,7 @@ right once the gesture settles.
 """
 
 import unittest
+from functools import partial
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -93,6 +94,8 @@ class TestSettleOnlyWorkIsSkipped(unittest.TestCase):
             set_status=MagicMock(),
             render_requested=MagicMock(),
         )
+        stub._renders_another_frame = partial(AppController._renders_another_frame, stub)
+        stub._dispatch_pending_render = partial(AppController._dispatch_pending_render, stub)
         AppController._on_render_finished(stub, None, {"interactive": True, "source_hash": "h1"})
         stub._update_thumbnail_from_state.assert_not_called()
 
@@ -122,6 +125,7 @@ class TestSettleOnlyWorkIsSkipped(unittest.TestCase):
             metrics_available=MagicMock(),
             session=MagicMock(),
         )
+        stub._renders_another_frame = partial(AppController._renders_another_frame, stub)
         AppController._on_metrics_updated(stub, {"interactive": True, "log_bounds": object(), "source_hash": "h1"})
         stub.session.update_config.assert_not_called()
 

--- a/tests/test_navigate_back_memo.py
+++ b/tests/test_navigate_back_memo.py
@@ -7,6 +7,7 @@ that lets a GPU texture be retained out of the engine's pool instead.
 """
 
 import unittest
+from functools import partial
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -48,6 +49,9 @@ def _stub(memo, **overrides):
         set_status=MagicMock(),
         render_requested=MagicMock(),
     )
+    # Real, not mocked: the frame guard and the queue drain are part of what is pinned here.
+    stub._renders_another_frame = partial(AppController._renders_another_frame, stub)
+    stub._dispatch_pending_render = partial(AppController._dispatch_pending_render, stub)
     for key, value in overrides.items():
         setattr(stub, key, value)
     return stub


### PR DESCRIPTION
Switching files does not cancel a render already in flight, so a late one used to repaint the canvas and merge its measurements into last_metrics, leaving the histogram, densitometer and UV grid describing a frame the user had left until a later render happened to overwrite every key it touched.

What that looks like depends on the path. On the CPU path the buffer is a host array that survives the file switch, so the wrong frame's picture reaches the canvas. On the GPU path the file switch has already destroyed the texture, so the draw fails with a wgpu validation error and the canvas goes dark instead — silent, but the stale measurements land either way.

Both handlers now check the render's own source_hash against the selection. _on_render_finished drops such a frame before it reaches last_metrics or the canvas, and _on_metrics_updated drops its measurements; the queued render behind it is still dispatched, now through a shared _dispatch_pending_render.

The navigate-back memo had the matching gap: it painted the incoming frame's cached render but left the outgoing frame's hash beside it in last_metrics, so a thumbnail refresh in that window filed one frame's picture under another's.

Verified by driving the app over a folder of mixed scans. Cycling frames every 250 ms, three to four of every five renders landed for a frame already left; canvas grabs show the CPU path painting those, and the GPU path flickering to black. With the guard the canvas holds the last good image and settles on the right frame, and at a 3 s cadence all nineteen renders are still accepted.

Fixes #517 