### PR TITLE
Give Linear Output the Export panel's destination rules

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -733,6 +733,8 @@ A scrollable list of every edit step, the last 100 kept, newest on top. The curr
     *   **Apply ICE dust removal** (visible when an IR channel is available): applies IR-based dust and scratch correction to the linear output before writing. Off by default.
     *   **Corrections** (camera RAW only): three optional toggles that bake corrections into the linear output before writing. All default to off, following the raw-dump philosophy. **Apply white balance** multiplies by the as-shot WB gains. **Apply flatfield** applies the flatfield gain correction. **Apply sensor correction** applies the sensor crosstalk unmixing matrix. For stitch composites, flatfield and sensor correction are always applied per-part regardless of these toggles, because clean seams require it.
 
+    Linear Output writes where the **Destination** section says, the same as a print or flat export: folder mode, subfolder, export path and Filename Pattern all apply. `_linear` is always appended to the rendered filename, so a dump written next to its source cannot overwrite that source. Without **Overwrite**, an existing file makes the next one `_linear_2`, `_linear_3` and so on.
+
     Linear Output runs in the background like any other batch: the progress popup shows which frame is being written, **Abort** stops it after the current one, and the finish message counts any frames that failed.
 
     The output file is always written clean: no ICC profiles, no EXIF color space tags, no XMP color metadata from the source. For **TIFF**, it carries raw pixels plus device metadata (Make, Model, DateTime) from the source file, and a description recording the source format, expansion, white balance and any corrections applied, including ICE. **JPEG XL carries none of that metadata at all**: no description, no device info, no record of whether ICE ran, only the pixels and the forced color tag noted above, which also is not from the source. The format simply cannot leave it unset.
@@ -748,7 +750,7 @@ The primary **Export** action. Its chevron menu picks the scope: current frame (
 *   **Input / Output ICC**: soft-proof against, and optionally embed, an ICC profile. Output is the destination profile (default); Input treats the profile as the source, for when a scan's profile is known but untagged. Not available for JPEG XL output; see the Format note above.
 *   **Paper Aspect Ratio**: final print ratio, or *Original* (no resize).
 *   **Resolution**: *Original* (full RAW resolution), *Print* (long-edge **Size** in cm plus **DPI**), or *Pixels* (long-edge **px**; the short side follows the paper ratio).
-*   **Destination**: **Filename Pattern** (a Jinja2 template with export settings plus Metadata fields such as roll, camera and film; see [TEMPLATING.md](TEMPLATING.md)), an **Overwrite** toggle, and the output location (subfolder of source, same as source, or an absolute **Export Path** with a browse button).
+*   **Destination**: **Filename Pattern** (a Jinja2 template with export settings plus Metadata fields such as roll, camera and film; see [TEMPLATING.md](TEMPLATING.md)), an **Overwrite** toggle, and the output location (subfolder of source, same as source, or an absolute **Export Path** with a browse button). Destination applies to all three output intents: with **Linear** selected, Format, Size and Color hide (a raw dump has no use for them) and Destination stays.
 
 ### Collapsible sections
 

--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -22,7 +22,7 @@ from negpy.desktop.session import (
     resolve_asset_rgbscan,
     resolve_asset_stitch,
 )
-from negpy.desktop.workers.export import ExportTask, ExportWorker, LinearOutputTask, find_export_conflicts
+from negpy.desktop.workers.export import ExportTask, ExportWorker, LinearOutputTask, find_export_conflicts, resolve_output_dir
 from negpy.desktop.workers.render import (
     AssetDiscoveryTask,
     AssetDiscoveryWorker,
@@ -44,7 +44,7 @@ from negpy.desktop.workers.scan_worker import BatchRequest, PrescanRequest, Roll
 from negpy.desktop.workers.library import LibrarySearchTask, LibrarySearchWorker
 from negpy.desktop.workers.hdr import HdrTask, HdrWorker
 from negpy.desktop.workers.stitch import StitchTask, StitchWorker
-from negpy.features.hdr.models import ANCHOR_EV_UNSET, hdr_frame_paths, hdr_hash, hdr_name, hdr_stem
+from negpy.features.hdr.models import ANCHOR_EV_UNSET, hdr_frame_paths, hdr_hash, hdr_name
 from negpy.features.process.logic import effective_linear_raw, narrowband_profile_active
 from negpy.features.stitch.models import stitch_hash, stitch_name
 from negpy.desktop.workers.capture_worker import (
@@ -55,6 +55,7 @@ from negpy.desktop.workers.capture_worker import (
 )
 from negpy.domain.models import (
     ColorSpace,
+    ExportFormat,
     ExportPreset,
     ExportPresetOutputMode,
     ExportResolutionMode,
@@ -67,6 +68,7 @@ from negpy.domain.models import (
     resolve_preset_export,
 )
 from negpy.services.assets.half_frame import base_hash, half_hash, half_of
+from negpy.services.export.templating import render_export_filename
 from negpy.services.assets.sidecar import load_or_promote, write_sidecar
 from negpy.features.exposure.analysis import (
     RING_GRID,
@@ -1701,10 +1703,12 @@ class AppController(QObject):
     def printing_notes_target_path(self) -> Optional[str]:
         """Next free `<stem>_notes.jpg` in the export folder."""
         export_path = self._ensure_valid_export_path()
-        if not export_path or not self.state.current_file_path:
+        if export_path is None or not self.state.current_file_path:
             return None
-        if self.state.config.export.output_mode == ExportPresetOutputMode.SAME_AS_SOURCE:
-            export_path = os.path.dirname(self.state.current_file_path)
+        export_path = resolve_output_dir(
+            self.state.current_file_path,
+            preset_from_export_config(replace(self.state.config.export, export_path=export_path)),
+        )
         stem = os.path.splitext(os.path.basename(self.state.current_file_path))[0]
         os.makedirs(export_path, exist_ok=True)
         path = os.path.join(export_path, f"{stem}_notes.jpg")
@@ -3839,11 +3843,13 @@ class AppController(QObject):
     def _ensure_valid_export_path(self) -> Optional[str]:
         """
         Checks if the current export path is valid. If not, prompts the user.
-        Returns the valid path or None if the user cancelled.
+        Returns the valid path, or None if the user cancelled. The path can come back
+        empty in the source-relative modes, which do not use it — callers must test
+        `is None`, not truthiness, or an unset path silently cancels the export.
         """
         export_path = self.state.config.export.export_path
-        if self.state.config.export.output_mode == ExportPresetOutputMode.SAME_AS_SOURCE:
-            return export_path  # path irrelevant when exporting to source folder
+        if self.state.config.export.output_mode != ExportPresetOutputMode.ABSOLUTE:
+            return export_path  # path irrelevant when the destination follows the source folder
         if export_path.strip().lower() in ["export", "/export", ""]:
             from PyQt6.QtWidgets import QFileDialog
 
@@ -3905,7 +3911,7 @@ class AppController(QObject):
             return
 
         export_path = self._ensure_valid_export_path()
-        if not export_path:
+        if export_path is None:
             return
 
         if files is None:
@@ -3953,21 +3959,38 @@ class AppController(QObject):
         expansion = self.state.linear_expansion
         linear_fmt = self.state.linear_format
         out_ext = "jxl" if linear_fmt == "jxl" else "tiff"
+        # Destination and naming are the Export panel's, shared with print and flat. Only the
+        # format belongs to the Linear intent, so the ephemeral preset carries it: `{{ format }}`
+        # in a filename template has to name the file that is actually written.
+        delivery = replace(
+            preset_from_export_config(replace(self.state.config.export, export_path=export_path)),
+            export_fmt=ExportFormat.JXL if linear_fmt == "jxl" else ExportFormat.TIFF,
+        )
+        sync_metadata = self.state.config.metadata.sync_to_batch
         taken: set[str] = set()
         tasks = []
         for f in supported:
             params = self._batch_params_for(f)
             stitch = params.stitch if params.stitch.stitch_enabled else None
             frames = hdr_frame_paths(f)
+            out_dir = resolve_output_dir(f["path"], delivery)
             # Same naming rule as a normal export: the bracket's first frame, suffixed so
-            # the merge does not write over that frame's own linear output.
-            stem = f"{hdr_stem(frames)}-HDR" if frames else os.path.splitext(os.path.basename(f["path"]))[0]
-            out_path = os.path.join(export_path, f"{stem}_linear.{out_ext}")
+            # the merge does not write over that frame's own linear output. No border and no
+            # half: a linear dump is the whole decoded source, whatever the print crop says.
+            stem = render_export_filename(
+                min(frames, key=lambda p: os.path.basename(p).lower()) if frames else f["path"],
+                delivery,
+                metadata=self.state.config.metadata if sync_metadata else params.metadata,
+                composite="HDR" if frames else "",
+            )
+            # `_linear` always, on top of whatever the template rendered: without it a dump
+            # written next to its source under the default pattern overwrites that source.
+            out_path = os.path.join(out_dir, f"{stem}_linear.{out_ext}")
             counter = 2
             # `taken` as well as the disk: the whole batch is named up front, before the
             # worker writes any of it, so same-stem frames would collide.
-            while out_path in taken or os.path.exists(out_path):
-                out_path = os.path.join(export_path, f"{stem}_linear_{counter}.{out_ext}")
+            while out_path in taken or (os.path.exists(out_path) and not delivery.overwrite):
+                out_path = os.path.join(out_dir, f"{stem}_linear_{counter}.{out_ext}")
                 counter += 1
             taken.add(out_path)
             tasks.append(
@@ -4004,7 +4027,7 @@ class AppController(QObject):
             return
 
         export_path = self._ensure_valid_export_path()
-        if not export_path:
+        if export_path is None:
             return
 
         params = self.state.config
@@ -4065,7 +4088,7 @@ class AppController(QObject):
         if self._batch_busy("export"):
             return
         export_path = self._ensure_valid_export_path()
-        if not export_path:
+        if export_path is None:
             return
 
         current_export = replace(self.state.config.export, export_path=export_path)
@@ -4259,9 +4282,14 @@ class AppController(QObject):
         custom = self.state.config.export.contact_sheet_output_path.strip()
         if custom:
             return custom
-        if self.state.config.export.output_mode == ExportPresetOutputMode.SAME_AS_SOURCE:
-            return os.path.dirname(visible_files[0]["path"])
-        return self._ensure_valid_export_path()
+        export_path = self._ensure_valid_export_path()
+        if export_path is None:
+            return None
+        # The sheet covers the whole roll, so the source-relative modes follow the first frame.
+        return resolve_output_dir(
+            visible_files[0]["path"],
+            preset_from_export_config(replace(self.state.config.export, export_path=export_path)),
+        )
 
     def request_contact_sheet(self) -> None:
         """Renders all visible files small and writes darkroom contact sheet(s)."""

--- a/negpy/desktop/view/sidebar/export.py
+++ b/negpy/desktop/view/sidebar/export.py
@@ -719,7 +719,9 @@ class ExportSidebar(BaseSidebar):
         linear_on = self.intent_linear_btn.isChecked()
         if hasattr(self, "form"):
             self.form.set_flat_mode(flat_on)
-            self.form.setVisible(not linear_on)
+            # Linear keeps DESTINATION and drops the rest; set_flat_mode reruns the format
+            # rows, so the linear pass has to come second or FORMAT reappears.
+            self.form.set_linear_mode(linear_on)
         self.flat_hint_label.setVisible(flat_on)
         self.flat_peek_btn.setVisible(flat_on)
         self.linear_hint_label.setVisible(linear_on)

--- a/negpy/desktop/view/widgets/export_settings_form.py
+++ b/negpy/desktop/view/widgets/export_settings_form.py
@@ -69,6 +69,7 @@ class ExportSettingsForm(QWidget):
         super().__init__(parent)
         self._loading = False
         self._flat_mode = False
+        self._linear_mode = False
         self._init_ui()
 
     @staticmethod
@@ -168,7 +169,13 @@ class ExportSettingsForm(QWidget):
 
     # --- SIZE ----------------------------------------------------------------
 
-    def _build_size(self, root: QVBoxLayout) -> None:
+    def _build_size(self, parent: QVBoxLayout) -> None:
+        self._size_section = QWidget()
+        root = QVBoxLayout(self._size_section)
+        root.setContentsMargins(0, 0, 0, 0)
+        root.setSpacing(10)
+        parent.addWidget(self._size_section)
+
         root.addWidget(section_subheader("SIZE"))
 
         mode_row = QHBoxLayout()
@@ -236,7 +243,13 @@ class ExportSettingsForm(QWidget):
 
     # --- COLOR ---------------------------------------------------------------
 
-    def _build_color(self, root: QVBoxLayout) -> None:
+    def _build_color(self, parent: QVBoxLayout) -> None:
+        self._color_section = QWidget()
+        root = QVBoxLayout(self._color_section)
+        root.setContentsMargins(0, 0, 0, 0)
+        root.setSpacing(10)
+        parent.addWidget(self._color_section)
+
         root.addWidget(section_subheader("COLOR"))
 
         # Drop bundled profiles already backed by a color-space enum, so the ICC lists do not
@@ -463,7 +476,7 @@ class ExportSettingsForm(QWidget):
             return
         self._flat_mode = enabled
 
-        self._format_section.setVisible(True)
+        self._format_section.setVisible(not self._linear_mode)
         current = self.fmt_combo.currentData()
         self.fmt_combo.blockSignals(True)
         self.fmt_combo.clear()
@@ -488,6 +501,26 @@ class ExportSettingsForm(QWidget):
 
     def flat_mode(self) -> bool:
         return self._flat_mode
+
+    def set_linear_mode(self, enabled: bool) -> None:
+        """Toggle Linear Output export UI: hide FORMAT, SIZE and COLOR, which a raw dump
+        has no use for, and keep DESTINATION, which it needs exactly as much as print does.
+        The Linear panel owns its own format row, so FORMAT would be a second, conflicting one."""
+        enabled = bool(enabled)
+        if enabled == self._linear_mode:
+            return
+        self._linear_mode = enabled
+        self._format_section.setVisible(not enabled)
+        self._size_section.setVisible(not enabled)
+        self._color_section.setVisible(not enabled)
+        if not enabled:
+            # Restore the rows the format and size modes were hiding on their own.
+            self._on_fmt_changed()
+            self._update_mode_visibility(self._current_mode_value())
+            self._update_ratio_visibility()
+
+    def linear_mode(self) -> bool:
+        return self._linear_mode
 
     def _update_output_mode_visibility(self, mode) -> None:
         self._subfolder_container.setVisible(mode == ExportPresetOutputMode.SUBFOLDER_OF_SOURCE)

--- a/negpy/desktop/workers/export.py
+++ b/negpy/desktop/workers/export.py
@@ -69,16 +69,22 @@ _EXT = {
 }
 
 
-def resolve_export_dir(task: ExportTask) -> str:
-    """Destination folder for a task, per its output-mode rule."""
-    source_dir = os.path.dirname(task.file_info["path"])
-    output_mode = task.export_settings.output_mode
+def resolve_output_dir(source_path: str, settings: ExportPreset) -> str:
+    """Destination folder for one source file, per its output-mode rule. Linear Output
+    calls this too, so every intent answers the destination question the same way."""
+    source_dir = os.path.dirname(source_path)
+    output_mode = settings.output_mode
     if output_mode == ExportPresetOutputMode.SUBFOLDER_OF_SOURCE:
-        subfolder = task.export_settings.output_subfolder or ""
+        subfolder = settings.output_subfolder or ""
         return os.path.join(source_dir, subfolder) if subfolder else source_dir
     if output_mode == ExportPresetOutputMode.ABSOLUTE:
-        return task.export_settings.output_path or source_dir
+        return settings.output_path or source_dir
     return source_dir
+
+
+def resolve_export_dir(task: ExportTask) -> str:
+    """Destination folder for a task, per its output-mode rule."""
+    return resolve_output_dir(task.file_info["path"], task.export_settings)
 
 
 def resolve_export_naming(task: ExportTask) -> tuple[str, str, str]:

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1217,6 +1217,109 @@ class TestLinearOutputExportCurrentFile(unittest.TestCase):
         self.assertEqual(rgbscan.blue_path, "/tmp/IMG_0001_B.cr2")
 
 
+class TestLinearOutputDestination(unittest.TestCase):
+    """Regression (#859): Linear Output built its own destination — always the absolute
+    export path, always `<stem>_linear` — instead of the Export panel's destination rules.
+    Selecting "Same as source" or a filename template did nothing under the Linear intent."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.source = os.path.join(self.tmp.name, "src", "IMG_0001.dng")
+        os.makedirs(os.path.dirname(self.source))
+        open(self.source, "w").close()
+
+        self.mock_session_manager = MagicMock(spec=DesktopSessionManager)
+        self.mock_session_manager.state = AppState()
+        self.mock_session_manager.repo = MagicMock()
+        self.mock_session_manager.repo.load_file_settings.return_value = None
+        self.file_info = {"name": "IMG_0001.dng", "path": self.source, "hash": "h1"}
+        self.mock_session_manager.state.uploaded_files = [self.file_info]
+
+        with (
+            patch("negpy.desktop.controller.RenderWorker") as mock_rw_class,
+            patch("negpy.desktop.controller.PreviewManager") as mock_pm_class,
+        ):
+            mock_rw_class.return_value = MagicMock()
+            mock_pm_class.return_value = MagicMock(spec=PreviewManager)
+            mock_pm_class.return_value.load_linear_preview.return_value = (None, (0, 0), {})
+            self.controller = AppController(self.mock_session_manager)
+
+    def tearDown(self):
+        import gc
+
+        for thread in [
+            self.controller.render_thread,
+            self.controller.export_thread,
+            self.controller.thumb_thread,
+            self.controller.norm_thread,
+            self.controller.discovery_thread,
+            self.controller.preview_load_thread,
+            self.controller.scan_thread,
+        ]:
+            if thread is not None and thread.isRunning():
+                thread.quit()
+                thread.wait()
+        del self.controller
+        gc.collect()
+        self.tmp.cleanup()
+
+    def _set_export(self, **kwargs):
+        state = self.controller.state
+        state.config = replace(state.config, export=replace(state.config.export, **kwargs))
+
+    def _out_path(self, export_path="/abs/out"):
+        tasks = self.controller._linear_output_tasks([self.file_info], export_path)
+        self.assertEqual(len(tasks), 1)
+        return tasks[0].out_path
+
+    def test_same_as_source_writes_beside_the_source(self):
+        self._set_export(output_mode=ExportPresetOutputMode.SAME_AS_SOURCE)
+        self.assertEqual(self._out_path(), os.path.join(os.path.dirname(self.source), "IMG_0001_linear.tiff"))
+
+    def test_subfolder_of_source_writes_into_the_subfolder(self):
+        self._set_export(output_mode=ExportPresetOutputMode.SUBFOLDER_OF_SOURCE, output_subfolder="linear")
+        expected = os.path.join(os.path.dirname(self.source), "linear", "IMG_0001_linear.tiff")
+        self.assertEqual(self._out_path(), expected)
+
+    def test_absolute_writes_to_the_export_path(self):
+        self._set_export(output_mode=ExportPresetOutputMode.ABSOLUTE)
+        self.assertEqual(self._out_path(), os.path.join("/abs/out", "IMG_0001_linear.tiff"))
+
+    def test_filename_template_is_honoured_and_keeps_the_linear_suffix(self):
+        # The suffix is not cosmetic: without it, "same as source" plus the default pattern
+        # writes the dump over the source file it was decoded from.
+        self._set_export(
+            output_mode=ExportPresetOutputMode.ABSOLUTE,
+            filename_pattern="{{ original_name }}_{{ format }}",
+        )
+        self.assertEqual(self._out_path(), os.path.join("/abs/out", "IMG_0001_TIFF_linear.tiff"))
+
+    def test_format_variable_names_the_linear_format_not_the_print_one(self):
+        self.controller.state.linear_format = "jxl"
+        self._set_export(
+            output_mode=ExportPresetOutputMode.ABSOLUTE,
+            export_fmt=ExportFormat.JPEG,
+            filename_pattern="{{ original_name }}_{{ format }}",
+        )
+        self.assertEqual(self._out_path(), os.path.join("/abs/out", "IMG_0001_JXL_linear.jxl"))
+
+    def test_existing_file_is_renamed_unless_overwrite_is_set(self):
+        out_dir = os.path.dirname(self.source)
+        open(os.path.join(out_dir, "IMG_0001_linear.tiff"), "w").close()
+
+        self._set_export(output_mode=ExportPresetOutputMode.SAME_AS_SOURCE, overwrite=False)
+        self.assertEqual(self._out_path(), os.path.join(out_dir, "IMG_0001_linear_2.tiff"))
+
+        self._set_export(overwrite=True)
+        self.assertEqual(self._out_path(), os.path.join(out_dir, "IMG_0001_linear.tiff"))
+
+    def test_unset_export_path_does_not_cancel_a_source_relative_export(self):
+        # `not export_path` used to abort here: the source-relative modes never read the
+        # path, so an empty one made Export do nothing at all, without a message.
+        self._set_export(output_mode=ExportPresetOutputMode.SAME_AS_SOURCE, export_path="")
+        self.assertEqual(self.controller._ensure_valid_export_path(), "")
+
+
 class TestPresetExportCurrentFileTriplet(unittest.TestCase):
     """Regression: request_preset_export() (the "Export Presets" button's current-file
     scope) built a bare {path, name, hash} dict for every call, unconditionally — never

--- a/tests/test_export_settings_form.py
+++ b/tests/test_export_settings_form.py
@@ -168,6 +168,35 @@ def test_flat_mode_limits_format_choices(qapp):
     assert ExportFormat.JPEG.value in [form.fmt_combo.itemText(i) for i in range(form.fmt_combo.count())]
 
 
+def test_linear_mode_keeps_destination_and_drops_the_rest(qapp):
+    """Linear Output has no use for format, size or color, but needs the destination
+    rules as much as print does — hiding the whole form was what left it with none (#859)."""
+    form = ExportSettingsForm()
+    form.load(_values(output_mode=ExportPresetOutputMode.SUBFOLDER_OF_SOURCE))
+
+    form.set_linear_mode(True)
+    assert form.linear_mode()
+    assert form._format_section.isHidden()
+    assert form._size_section.isHidden()
+    assert form._color_section.isHidden()
+    assert not form._subfolder_container.isHidden()
+    assert not form.filename_edit.isHidden()
+
+    form.set_linear_mode(False)
+    assert not form._format_section.isHidden()
+    assert not form._size_section.isHidden()
+    assert not form._color_section.isHidden()
+
+
+def test_flat_mode_does_not_reveal_format_under_linear(qapp):
+    """Switching intents runs set_flat_mode first, which re-shows FORMAT unconditionally."""
+    form = ExportSettingsForm()
+    form.load(_values())
+    form.set_linear_mode(True)
+    form.set_flat_mode(True)
+    assert form._format_section.isHidden()
+
+
 def test_flat_mode_hides_paper_ratio_for_original(qapp):
     form = ExportSettingsForm()
     form.load(_values(export_resolution_mode=ExportResolutionMode.ORIGINAL.value))


### PR DESCRIPTION
Linear Output ignored the Destination section and always wrote <export_path>/<stem>_linear: "Same as source" and "Subfolder of source" went to the absolute path anyway, and the filename template did nothing. The Export panel hid the whole settings form under the Linear intent, so there were no destination controls to see this with either (#859).

The gap dates to the feature's first commit (6410002). Linear started with a per-export save dialog; when batch support replaced it with a write to the export folder, the replacement imitated print's outcome instead of calling print's resolver. With the default output mode (Absolute) the two agree, which is why it went unnoticed.

Linear now resolves its destination through the same code print and flat use: resolve_export_dir's body moves into resolve_output_dir(source_path, settings), and the linear task builder calls that plus render_export_filename. `_linear` is still appended to the rendered name, so a dump written next to its source cannot overwrite that source, and Overwrite is honoured in place of the automatic _2/_3 renaming. The form keeps DESTINATION visible under Linear and hides FORMAT/SIZE/COLOR, which a raw dump has no use for.

Also fixes a silent no-op: _ensure_valid_export_path returns "" in the source-relative modes, which never read the path, and every caller treated that as a cancel — an unset path made Export do nothing, without a message. Callers now test `is None`, and the printing-notes and contact-sheet paths resolve their folder through the shared helper instead of open-coding the SAME_AS_SOURCE case.

Fixes #859 