### PR TITLE
Render a half-frame scan as a diptych once the split is turned off

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -85,6 +85,8 @@ Toolbar buttons, left to right:
 *   **Hot Folder**: watches the current folder and auto-loads new files as they appear, which is handy when a scanner or tethering app drops files into a directory. While it is on, the "Working…" import popup stays hidden so each new frame does not raise a window; the status line over the canvas still reports the import.
 *   **RGB Scan**: treats the folder as red/green/blue exposure triplets and assembles each frame from three shots, for narrowband trichrome scanning. Right-click a frame → **Edit RGB Triplet…** to assign the three files by hand. An assembled frame carries the three-dot badge described under [Triage](#triage-culling-the-roll).
 *   **Half Frame**: splits each scan into two frames, for half-frame cameras. Each half is edited and metered separately and badged with which half it is. Enabling it opens a rectangle editor on the current scan: drag the green box to crop (everything outside is discarded), drag the orange line to set the split, and use **Cut thickness** to discard a band centred on the split, which is the physical black separator between the two exposures. The setting is saved and applied to every half-frame split from then on, whatever the scans were acquired with (SANE scanner, camera copy-stand, or folder import). **Adjust Half Frame**, beside Half Frame, re-opens the editor. Auto-detection of the gutter still seeds the initial split position.
+
+    Turning Half Frame off does not lose the work: each half keeps its own edit. The scan comes back as one frame carrying both, a **diptych** — half 1 rendered with its own edit, half 2 with its own, joined side by side at the original spacing, with the cut band as a black gap. It carries the both-sides-filled split badge and exports as one file named `<name>-DIPTYCH`. A diptych's controls panel is disabled, because the edits belong to the halves: turn Half Frame back on to change either one. A scan where only one half was worked on uses that half's edit for both sides. The filmstrip thumbnail and contact-sheet tile still show the plain whole scan, so a diptych's thumbnail does not match what it exports. An export size set as a long edge applies to each half, so a diptych comes out about twice that wide.
 *   **Apply (clone)**: copy the current frame's settings to selected frames or the whole roll. You choose which aspects in a dialog; crop and rotation are always per-image.
 *   **Sheet filter** (funnel): show *All frames*, *Keepers only*, or *Hide rejected*.
 *   **Sort**: by Name or Date, ascending or descending.
@@ -194,6 +196,7 @@ The bottom-left badge is grey, not red, because it reports what the frame *is* r
 | Three stacked bars | a merged bracket ([§Merging](#merging-bracketed-exposures-hdr)) |
 | Three red/green/blue dots | an RGB-scan triplet |
 | A split rectangle, one side filled | one half of a half-frame scan; the filled side is which half |
+| A split rectangle, both sides filled | a diptych: the whole scan, each half with its own edit |
 
 Hover any thumbnail and the tooltip says the same thing in words, with the frame count: *HDR merge of 5 exposures*, *Stitched composite of 3 frames*.
 

--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -66,7 +66,7 @@ from negpy.domain.models import (
     preset_from_export_config,
     resolve_preset_export,
 )
-from negpy.services.assets.half_frame import base_hash, half_hash, half_of
+from negpy.services.assets.half_frame import base_hash, diptych_configs, half_hash, half_of
 from negpy.services.assets.sidecar import load_or_promote, write_sidecar
 from negpy.features.exposure.analysis import (
     RING_GRID,
@@ -357,6 +357,7 @@ class AppController(QObject):
         self.session = session_manager
         self.state: AppState = session_manager.state
         self._thumb_config: Optional[WorkspaceConfig] = None
+        self._active_diptych_memo: tuple[str, Optional[tuple[dict, tuple[WorkspaceConfig, WorkspaceConfig]]]] = ("", None)
         self._first_render_t0: Optional[float] = None
         self._export_start_time = 0.0
         self._export_failures = 0
@@ -1091,6 +1092,7 @@ class AppController(QObject):
         """Persist the half-frame toggle and re-discover already-loaded assets so the
         mode splits/collapses frames in place (not only on the next folder load)."""
         self.session.repo.save_global_setting("half_frame_mode", bool(enabled))
+        self._active_diptych_memo = ("", None)
         files = self.session.state.uploaded_files
         if not files:
             return
@@ -1162,10 +1164,25 @@ class AppController(QObject):
         self.status_progress_requested.emit(current, total)
         self.batch_progress.emit(current, total, name)
 
+    def _mark_diptychs(self, assets: List[Dict]) -> None:
+        """Flag whole-frame scans that already carry the two halves' edits.
+
+        One query for the whole roll, at discovery, so every later reader — the filmstrip
+        badge, the read-only panel, the exporter — finds the answer on the asset dict.
+        """
+        whole = [a for a in assets if not a.get("half") and a.get("hash") and "#" not in a["hash"]]
+        if not whole:
+            return
+        found = self.session.repo.load_file_settings_many([half_hash(a["hash"], n) for a in whole for n in (1, 2)])
+        for a in whole:
+            a["diptych"] = half_hash(a["hash"], 1) in found or half_hash(a["hash"], 2) in found
+
     def _on_discovery_finished(self, valid_assets: List[Dict]) -> None:
         """
         Adds discovered assets to the session and starts thumbnail generation.
         """
+        self._mark_diptychs(valid_assets)
+        self._active_diptych_memo = ("", None)
         ended_batch = self._end_batch("discovery")
         if not ended_batch and self._active_batch is None:
             # Preserve the completion signal for direct invocations and late
@@ -1279,6 +1296,53 @@ class AppController(QObject):
     def _active_half(self) -> Optional[tuple[int, float, tuple[float, float, float, float] | None, float]]:
         """(half, split_x, crop_rect, gutter_thickness) of the active asset, or None for whole-frame."""
         return self._half_slice_for_asset(self.state.current_file_path, self.state.current_file_hash)
+
+    def active_diptych(self) -> Optional[tuple[dict, tuple[WorkspaceConfig, WorkspaceConfig]]]:
+        """(asset with the split geometry, half configs) for the active scan, or None.
+
+        Memoized per hash: it is read on every render, and the halves' edits can only
+        change while half-frame mode is on, where the active asset is a half instead.
+        """
+        file_hash = self.state.current_file_hash or ""
+        if self._active_diptych_memo[0] != file_hash:
+            asset = next((a for a in self.state.uploaded_files if a.get("hash") == file_hash), None)
+            resolved = None
+            if asset is not None:
+                info, pair = self._diptych_task(asset)
+                resolved = (info, pair) if pair is not None else None
+            self._active_diptych_memo = (file_hash, resolved)
+        return self._active_diptych_memo[1]
+
+    def diptych_pair(self, file_info: dict) -> Optional[tuple[WorkspaceConfig, WorkspaceConfig]]:
+        """The two halves' saved edits for a whole-frame scan, or None.
+
+        Half-frame mode being off is implied: with it on the assets already *are* halves,
+        which `half` on the asset dict reports.
+        """
+        if file_info.get("half") or file_info.get("diptych") is False:
+            return None
+        return diptych_configs(self.session.repo, file_info.get("hash"))
+
+    def _diptych_task(self, file_info: dict) -> tuple[dict, Optional[tuple[WorkspaceConfig, WorkspaceConfig]]]:
+        """(asset dict with the split geometry stamped on, half configs) for a diptych.
+
+        A whole-frame asset never went through `_expand_half_frames`, so the split comes
+        from the saved profile — the same one the halves were cut with.
+        """
+        pair = self.diptych_pair(file_info)
+        if pair is None:
+            return file_info, None
+        profile = self.half_frame_profile() or {}
+        raw_rect = profile.get("crop_rect")
+        return (
+            {
+                **file_info,
+                "split_x": float(profile.get("split_x") or 0.5),
+                "crop_rect": tuple(float(v) for v in raw_rect) if raw_rect else None,
+                "gutter_thickness": float(profile.get("gutter_thickness") or 0.0),
+            },
+            pair,
+        )
 
     def _render_memo_key(self, config: Optional[WorkspaceConfig] = None) -> str:
         """Identity of everything that shapes the displayed render of the current
@@ -1436,6 +1500,13 @@ class AppController(QObject):
         hdr = self.state.config.hdr
         flatfield = self.state.config.flatfield
         half_info = self._active_half()
+        if half_info is None:
+            dip = self.active_diptych()
+            if dip is not None:
+                # half 0: cropped to the rect, still whole. The render worker splits it, so
+                # both halves come off one decode.
+                info = dip[0]
+                half_info = (0, info["split_x"], info["crop_rect"], info["gutter_thickness"])
         self.preview_load_requested.emit(
             PreviewLoadTask(
                 file_path=file_path,
@@ -3618,6 +3689,7 @@ class AppController(QObject):
         if config_override is None and not ephemeral and not crop_preview_full and not interactive:
             memo_key = self._render_memo_key()
 
+        dip = self.active_diptych()
         task = RenderTask(
             buffer=preview_raw,
             config=config_override if config_override is not None else self.state.config,
@@ -3635,6 +3707,9 @@ class AppController(QObject):
             wants_thumbnail=(not interactive and not ephemeral and config_override is None and self.state.config is not self._thumb_config),
             cam_xyz=self.state.preview_cam_xyz,
             camera_wb=self.state.preview_camera_wb,
+            diptych=dip[1] if dip is not None else None,
+            split_x=dip[0]["split_x"] if dip is not None else 0.5,
+            gutter_thickness=dip[0]["gutter_thickness"] if dip is not None else 0.0,
         )
 
         if self._is_rendering:
@@ -3822,6 +3897,9 @@ class AppController(QObject):
         source_exif=None,
         metadata_config=None,
     ) -> List[ExportTask]:
+        file_info, diptych = self._diptych_task(file_info)
+        if diptych is not None:
+            bounds_override = None  # the active frame's bounds belong to a half, not to the pair
         tasks = []
         for preset in presets:
             task_params, export_settings = resolve_preset_export(preset, params)
@@ -3836,6 +3914,7 @@ class AppController(QObject):
                     source_exif=source_exif,
                     metadata_config=metadata_config,
                     working_color_space=self.state.workspace_color_space,
+                    diptych=diptych,
                 )
             )
         return tasks
@@ -4038,8 +4117,10 @@ class AppController(QObject):
                 "hash": self.state.current_file_hash,
             }
 
+        file_info, diptych = self._diptych_task(file_info)
+
         bounds_override = None
-        if file_info.get("hash") == self.state.current_file_hash:
+        if diptych is None and file_info.get("hash") == self.state.current_file_hash:
             with self.state.metrics_lock:
                 bounds_override = self.state.last_metrics.get("log_bounds")
 
@@ -4054,6 +4135,7 @@ class AppController(QObject):
                     source_exif=source_exif,
                     metadata_config=self.state.config.metadata,
                     working_color_space=self.state.workspace_color_space,
+                    diptych=diptych,
                 )
             ]
         )
@@ -4110,8 +4192,10 @@ class AppController(QObject):
             if flat:
                 final_export = flat_export_config(final_export)
 
+            file_info, diptych = self._diptych_task(f)
+
             bounds_override = None
-            if f["hash"] == self.state.current_file_hash:
+            if diptych is None and f["hash"] == self.state.current_file_hash:
                 with self.state.metrics_lock:
                     bounds_override = self.state.last_metrics.get("log_bounds")
 
@@ -4120,7 +4204,7 @@ class AppController(QObject):
 
             tasks.append(
                 ExportTask(
-                    file_info=f,
+                    file_info=file_info,
                     params=params,
                     export_settings=preset_from_export_config(final_export),
                     gpu_enabled=self.state.gpu_enabled,
@@ -4128,6 +4212,7 @@ class AppController(QObject):
                     source_exif=source_exif,
                     metadata_config=metadata_config,
                     working_color_space=self.state.workspace_color_space,
+                    diptych=diptych,
                 )
             )
 
@@ -4567,7 +4652,9 @@ class AppController(QObject):
         # its own: they are not this frame's bounds. Nor from a mid-gesture frame, which
         # measured the proxy rather than the real buffer. A render of another file was
         # already dropped above.
-        if metrics.get("ephemeral") or metrics.get("interactive"):
+        # A diptych's bounds were measured on one half, under that half's edit; writing them
+        # onto the whole-frame config would file a half's measurement as the scan's.
+        if metrics.get("ephemeral") or metrics.get("interactive") or metrics.get("diptych"):
             return
         src = metrics.get("source_hash")
         if src is not None and src != self.state.current_file_hash:

--- a/negpy/desktop/session.py
+++ b/negpy/desktop/session.py
@@ -241,8 +241,8 @@ def _asset_mtime(asset: Dict[str, Any]) -> float:
 
 
 def composite_kind(asset: Dict[str, Any]) -> str:
-    """Which multi-file construction an asset is: stitch, hdr, rgb, half, or "" for a
-    plain frame.
+    """Which multi-file construction an asset is: stitch, hdr, rgb, half, diptych, or "" for
+    a plain frame.
 
     Order is load-bearing: a stitch of triplets also carries the primary part's
     green/blue pair (``controller._on_stitch_registered``), so it must be tested first.
@@ -255,6 +255,8 @@ def composite_kind(asset: Dict[str, Any]) -> str:
         return "rgb"
     if asset.get("half"):
         return "half"
+    if asset.get("diptych"):
+        return "diptych"
     return ""
 
 
@@ -269,6 +271,8 @@ def composite_summary(asset: Dict[str, Any]) -> str:
         return "RGB-scan triplet"
     if kind == "half":
         return f"Half-frame split ({int(asset['half'])} of 2)"
+    if kind == "diptych":
+        return "Diptych — both halves, each with its own edit"
     return ""
 
 

--- a/negpy/desktop/view/sidebar/controls_panel.py
+++ b/negpy/desktop/view/sidebar/controls_panel.py
@@ -121,6 +121,7 @@ class ControlsPanel(QWidget):
         super().__init__()
         self.controller = controller
         self._last_histogram_buf = None
+        self._read_only = False
 
         self._init_ui()
         self._connect_signals()
@@ -716,10 +717,27 @@ class ControlsPanel(QWidget):
             )
         )
 
+    _DIPTYCH_HINT = "Diptych — the edits live on the halves. Turn Half Frame on to edit either one."
+
+    def _set_read_only(self, read_only: bool) -> None:
+        """A diptych renders from the two halves' own configs, so this panel drives nothing.
+
+        Announced on the transition rather than as a tooltip: Qt gives no tooltip to a
+        disabled widget.
+        """
+        if read_only == self._read_only:
+            return
+        self._read_only = read_only
+        for page in self.pages:
+            page["widget"].setEnabled(not read_only)
+        if read_only:
+            self.controller.set_status(self._DIPTYCH_HINT, 6000)
+
     def _sync_all_sidebars(self) -> None:
         """Force all sidebar panels to update their widgets from current AppState."""
         from negpy.features.process.models import ProcessMode
 
+        self._set_read_only(self.controller.active_diptych() is not None)
         self.color_section.setVisible(self.controller.state.config.process.process_mode != ProcessMode.BW)
         self.process_sidebar.sync_ui()
         self.roll_sidebar.sync_ui()

--- a/negpy/desktop/view/sidebar/files.py
+++ b/negpy/desktop/view/sidebar/files.py
@@ -136,6 +136,10 @@ class _ThumbnailDelegate(QStyledItemDelegate):
         elif kind == "half":  # a split frame, this asset's own half filled
             painter.drawRect(QRect(cx - 6, cy - 4, 12, 8))
             painter.fillRect(QRect(cx - 5 if half == 1 else cx + 1, cy - 3, 5, 7), self._COMPOSITE_GLYPH)
+        elif kind == "diptych":  # the same split frame with both halves filled
+            painter.drawRect(QRect(cx - 6, cy - 4, 12, 8))
+            for left in (cx - 5, cx + 1):
+                painter.fillRect(QRect(left, cy - 3, 5, 7), self._COMPOSITE_GLYPH)
 
     def paint(self, painter: QPainter, option: QStyleOptionViewItem, index: QModelIndex) -> None:
         file_info = index.data(Qt.ItemDataRole.UserRole) or {}

--- a/negpy/desktop/workers/export.py
+++ b/negpy/desktop/workers/export.py
@@ -36,6 +36,9 @@ class ExportTask:
     source_exif: Optional[dict] = None
     metadata_config: Optional[MetadataConfig] = None
     working_color_space: str = WORKING_COLOR_SPACE
+    # The two halves' own edits, for a whole-frame scan that was worked on split.
+    # Set means one file holding both frames; `params` is then only a naming/metadata carrier.
+    diptych: Optional[tuple[WorkspaceConfig, WorkspaceConfig]] = None
 
 
 @dataclass(frozen=True)
@@ -95,7 +98,7 @@ def resolve_export_naming(task: ExportTask) -> tuple[str, str, str]:
         border_size=task.params.finish.border_size,
         half=int(task.file_info.get("half") or 0),
         metadata=task.metadata_config,
-        composite="HDR" if frames else "",
+        composite="DIPTYCH" if task.diptych else ("HDR" if frames else ""),
     )
     return out_dir, filename, ext
 
@@ -158,6 +161,7 @@ class ExportWorker(QObject):
                     split_x=float(task.file_info.get("split_x") or 0.5),
                     crop_rect=tuple(task.file_info["crop_rect"]) if task.file_info.get("crop_rect") else None,
                     gutter_thickness=float(task.file_info.get("gutter_thickness") or 0.0),
+                    diptych=task.diptych,
                 )
 
                 if not bits:

--- a/negpy/desktop/workers/render.py
+++ b/negpy/desktop/workers/render.py
@@ -59,6 +59,11 @@ class RenderTask:
     cam_xyz: Optional[list] = None
     # As-shot WB multipliers, needed only when the buffer was decoded without WB.
     camera_wb: Optional[list] = None
+    # Half-frame diptych: `buffer` is the whole cropped scan and these two configs render
+    # its halves, which are then joined. `config` is unused then — the halves own the edit.
+    diptych: Optional[tuple[WorkspaceConfig, WorkspaceConfig]] = None
+    split_x: float = 0.5
+    gutter_thickness: float = 0.0
 
 
 @dataclass(frozen=True)
@@ -211,6 +216,46 @@ class RenderWorker(QObject):
         """Full teardown of processing resources."""
         self._processor.destroy_all()
 
+    def _render_diptych(self, task: RenderTask, pipeline_source_hash: str) -> tuple[np.ndarray, dict]:
+        """Render the scan's two halves with their own configs and join them.
+
+        Each half is sliced before the pipeline, so its normalization sees the pixels it
+        was edited on — the same reason the half-frame preview slices pre-downsample. The
+        halves get distinct pipeline hashes or they share the stage cache and the second
+        render comes back as the first. Metrics are half 1's, marked so the controller
+        does not write those bounds back to the whole-frame edit.
+        """
+        from negpy.services.assets.half_frame import gap_px, half_hash, join_halves, slice_half
+
+        assert task.diptych is not None
+        rendered = []
+        for n, config in ((1, task.diptych[0]), (2, task.diptych[1])):
+            buffer = np.ascontiguousarray(slice_half(task.buffer, n, task.split_x, gutter_thickness=task.gutter_thickness))
+            ir = None
+            if task.ir_buffer is not None:
+                ir = np.ascontiguousarray(slice_half(task.ir_buffer, n, task.split_x, gutter_thickness=task.gutter_thickness))
+            out, metrics = self._processor.run_pipeline(
+                buffer,
+                config,
+                half_hash(pipeline_source_hash, n),
+                render_size_ref=task.preview_size,
+                prefer_gpu=task.gpu_enabled,
+                readback_metrics=task.readback_metrics and n == 1,
+                ir_buffer=ir,
+                crop_preview_full=task.crop_preview_full,
+                cam_xyz=task.cam_xyz,
+                camera_wb=task.camera_wb,
+            )
+            if isinstance(out, GPUTexture):
+                out = np.ascontiguousarray(out.readback()[:, :, :3])
+            rendered.append((out, metrics))
+
+        (left, metrics), (right, _) = rendered
+        metrics["diptych"] = True
+        # Half 1's GPU histogram describes half 1; let `process` bin the joined image instead.
+        metrics.pop("histogram_raw", None)
+        return join_halves(left, right, gap_px(left.shape[1], right.shape[1], task.gutter_thickness)), metrics
+
     @pyqtSlot(RenderTask)
     def process(self, task: RenderTask) -> None:
         """Executes the rendering pipeline for a single frame."""
@@ -218,18 +263,21 @@ class RenderWorker(QObject):
             # The splash shares the file's source_hash but is the embedded JPEG, not the linear
             # decode, so isolate its cache identity and it cannot leak into the real render.
             pipeline_source_hash = task.source_hash + ("\x00splash" if task.ephemeral else "")
-            result, metrics = self._processor.run_pipeline(
-                task.buffer,
-                task.config,
-                pipeline_source_hash,
-                render_size_ref=task.preview_size,
-                prefer_gpu=task.gpu_enabled,
-                readback_metrics=task.readback_metrics,
-                ir_buffer=task.ir_buffer,
-                crop_preview_full=task.crop_preview_full,
-                cam_xyz=task.cam_xyz,
-                camera_wb=task.camera_wb,
-            )
+            if task.diptych is not None:
+                result, metrics = self._render_diptych(task, pipeline_source_hash)
+            else:
+                result, metrics = self._processor.run_pipeline(
+                    task.buffer,
+                    task.config,
+                    pipeline_source_hash,
+                    render_size_ref=task.preview_size,
+                    prefer_gpu=task.gpu_enabled,
+                    readback_metrics=task.readback_metrics,
+                    ir_buffer=task.ir_buffer,
+                    crop_preview_full=task.crop_preview_full,
+                    cam_xyz=task.cam_xyz,
+                    camera_wb=task.camera_wb,
+                )
 
             # CPU renders have no in-shader histogram; bin the float output here.
             if task.readback_metrics and "histogram_raw" not in metrics and isinstance(result, np.ndarray):

--- a/negpy/services/assets/half_frame.py
+++ b/negpy/services/assets/half_frame.py
@@ -17,6 +17,10 @@ logger = get_logger(__name__)
 
 _SEP = "#"
 
+# The inter-frame gap in a joined diptych, in output space. Black is what the gap between
+# two exposures looks like once rendered; swap for the finish border colour if wanted.
+_GAP_FILL = 0.0
+
 
 def half_hash(file_hash: str, half: int) -> str:
     return f"{file_hash}{_SEP}{half}"
@@ -48,7 +52,7 @@ def slice_half(
     crop_rect: Optional[tuple[float, float, float, float]] = None,
     gutter_thickness: float = 0.0,
 ) -> np.ndarray:
-    """View of one half of a decoded buffer.
+    """View of one half of a decoded buffer; ``half=0`` crops only, without splitting.
 
     The scan is first cropped to ``crop_rect`` (normalized x1,y1,x2,y2; None =
     full frame), then split at the normalized gutter ``split_x`` relative to the
@@ -67,6 +71,8 @@ def slice_half(
         if cx2 <= cx1 or cy2 <= cy1:
             return a[:, :1]
         a = a[cy1:cy2, cx1:cx2]
+    if not half:
+        return a
     w = a.shape[1]
     xs = min(max(int(round(w * split_x)), 1), w - 1)
     if gutter_thickness > 0:
@@ -81,14 +87,15 @@ def slice_half(
 
 
 def slice_for_asset(buf: np.ndarray, file_info: Dict[str, Any]) -> np.ndarray:
-    """Apply the asset's half slice; no-op for whole-frame assets.
+    """Apply the asset's half slice; no-op for whole-frame assets without a crop rect.
 
     Recognizes an optional ``crop_rect`` (normalized x1,y1,x2,y2) and
     ``gutter_thickness`` (normalized fraction of the cropped width) set by the
-    half-frame rectangle editor.
+    half-frame rectangle editor. A whole-frame asset that carries a crop rect is a
+    diptych: cropped to the rect, still whole, split later per half.
     """
     half = int(file_info.get("half") or 0)
-    if not half:
+    if not half and not file_info.get("crop_rect"):
         return buf
     raw_rect = file_info.get("crop_rect")
     crop_rect = tuple(float(v) for v in raw_rect) if isinstance(raw_rect, (tuple, list)) else None
@@ -99,6 +106,63 @@ def slice_for_asset(buf: np.ndarray, file_info: Dict[str, Any]) -> np.ndarray:
         crop_rect=crop_rect,
         gutter_thickness=float(file_info.get("gutter_thickness") or 0.0),
     )
+
+
+def gap_px(left_width: int, right_width: int, gutter_thickness: float) -> int:
+    """Width of the diptych gap, from the two rendered halves.
+
+    Derived from the halves rather than from the source: an export can resize, so the
+    discarded band's pixel count on the scan is not the gap's pixel count on the output.
+    ``gutter_thickness`` is a fraction of the cropped scan width, of which the two halves
+    hold the remaining ``1 - gutter_thickness``.
+    """
+    if gutter_thickness <= 0 or gutter_thickness >= 1:
+        return 0
+    return int(round((left_width + right_width) * gutter_thickness / (1.0 - gutter_thickness)))
+
+
+def _pad_height(a: np.ndarray, height: int) -> np.ndarray:
+    pad = height - a.shape[0]
+    if pad <= 0:
+        return a
+    top = pad // 2
+    return np.pad(a, ((top, pad - top), (0, 0)) + ((0, 0),) * (a.ndim - 2), constant_values=_GAP_FILL)
+
+
+def join_halves(left: np.ndarray, right: np.ndarray, gap: int = 0) -> np.ndarray:
+    """Join two rendered halves side by side, with a ``gap``-wide band where the gutter was.
+
+    The gap is filled rather than copied from the scan: the source gutter is
+    scene-linear negative data, so pasting it in gives a bright bar, and running the
+    pipeline on a thin dark strip renormalizes it into noise.
+
+    Unequal heights (a per-half crop aspect or border) are centre-padded, never
+    resampled — an export must not resize pixels the pipeline already sized.
+    """
+    height = max(left.shape[0], right.shape[0])
+    parts = [_pad_height(left, height)]
+    if gap > 0:
+        parts.append(np.full((height, gap) + left.shape[2:], _GAP_FILL, dtype=left.dtype))
+    parts.append(_pad_height(right, height))
+    return np.ascontiguousarray(np.concatenate(parts, axis=1))
+
+
+def diptych_configs(repo: Any, file_hash: Optional[str]) -> Optional[tuple[Any, Any]]:
+    """The two halves' saved edits for a whole-frame scan, or None when it has none.
+
+    A half with no saved edit takes its sibling's, so a scan where only one side was
+    worked on still renders as a consistent pair. Any ``#``-suffixed hash is rejected:
+    a half is not a diptych, and a composite's base is its reference frame, whose half
+    edits are not the composite's.
+    """
+    if not file_hash or _SEP in file_hash:
+        return None
+    keys = [half_hash(file_hash, 1), half_hash(file_hash, 2)]
+    found = repo.load_file_settings_many(keys)
+    first, second = found.get(keys[0]), found.get(keys[1])
+    if first is None and second is None:
+        return None
+    return (first or second, second or first)
 
 
 def detect_split_x(buf: np.ndarray) -> float:

--- a/negpy/services/rendering/image_processor.py
+++ b/negpy/services/rendering/image_processor.py
@@ -774,6 +774,90 @@ class ImageProcessor:
             ir_full = np.ascontiguousarray(slice_half(ir_full, half, split_x, crop_rect=crop_rect, gutter_thickness=gutter_thickness))
         return f32_buffer, ir_full
 
+    def _render_export_buffer(
+        self,
+        file_path: str,
+        params: WorkspaceConfig,
+        export_settings,  # ExportConfig or ExportPreset
+        source_hash: str,
+        metrics: Optional[Dict[str, Any]] = None,
+        prefer_gpu: bool = True,
+        bounds_override: Optional[Any] = None,
+        half: int = 0,
+        split_x: float = 0.5,
+        crop_rect: Optional[tuple[float, float, float, float]] = None,
+        gutter_thickness: float = 0.0,
+    ) -> Tuple[np.ndarray, str]:
+        """Full-res render of one frame; returns the float buffer and its color space."""
+        # Ensure both GPU and CPU paths use the same export settings.
+        params = dc_replace(params, export=export_settings)
+
+        f32_buffer, ir_full, source_cs = self._load_source_f32(file_path, params)
+        f32_buffer, ir_full = self._slice_half_source(
+            f32_buffer, ir_full, half, split_x, crop_rect=crop_rect, gutter_thickness=gutter_thickness
+        )
+        target_cs = export_settings.export_color_space
+        if target_cs == ColorSpace.SAME_AS_SOURCE.value:
+            target_cs = source_cs
+        color_space = str(target_cs)
+
+        detect_key = (
+            source_hash
+            + flatfield_token(params.flatfield)
+            + rgbscan_token(params.rgbscan)
+            + stitch_token(params.stitch)
+            + hdr_token(params.hdr)
+            + linear_raw_token(params.process, params.exposure.render_intent)
+            + sensor_token(params.process)
+            + ir_bake_token(params.retouch, ir_full is not None)
+            + manual_bake_token(params.retouch)
+        )
+        f32_buffer, _, _, ir_routed = self._ir_bake(f32_buffer, ir_full, params, detect_key)
+        orig_ret = params.retouch
+        detected, hair_masks = self._detect_luma(params, f32_buffer, detect_key)
+        f32_buffer = self._luma_bake(f32_buffer, detected, detect_key + hair_bake_token(orig_ret))
+        f32_buffer, manual_routed = self._manual_bake(f32_buffer, params, detect_key)
+        extra = [m for m in (ir_routed, manual_routed) if m is not None]
+        if extra:
+            hair_masks = hair_masks + extra
+        if hair_masks:
+            f32_buffer = self._hair_inpaint(f32_buffer, hair_masks, detect_key + hair_bake_token(orig_ret))
+
+        h_raw, w_raw = f32_buffer.shape[:2]
+        export_scale = max(h_raw, w_raw) / float(APP_CONFIG.preview_render_size)
+
+        if self._is_flat(params):
+            prefer_gpu = False
+
+        if prefer_gpu and self.engine_gpu:
+            buffer, _gpu_metrics = self.engine_gpu.process(
+                f32_buffer,
+                params,
+                scale_factor=export_scale,
+                bounds_override=bounds_override,
+                readback_metrics=False,
+                cam_xyz=self._cam_xyz_by_path.get(file_path, (None, None))[0],
+                camera_wb=self._cam_xyz_by_path.get(file_path, (None, None))[1],
+            )
+        else:
+            buffer, _ = self.run_pipeline(
+                f32_buffer,
+                params,
+                source_hash,
+                render_size_ref=float(APP_CONFIG.preview_render_size),
+                metrics=metrics or {"log_bounds": bounds_override} if bounds_override else metrics,
+                prefer_gpu=False,
+                wants_uv_grid=False,
+                skip_flatfield=True,  # f32_buffer already flat-fielded by _load_source_f32
+                cam_xyz=self._cam_xyz_by_path.get(file_path, (None, None))[0],
+                camera_wb=self._cam_xyz_by_path.get(file_path, (None, None))[1],
+            )
+            buffer = self._apply_scaling_and_border_f32(buffer, params, params.export)
+            # Release full-res arrays pinned in the CPU stage cache.
+            self.engine_cpu.cache.clear()
+
+        return buffer, color_space
+
     def process_export(
         self,
         file_path: str,
@@ -788,76 +872,49 @@ class ImageProcessor:
         split_x: float = 0.5,
         crop_rect: Optional[tuple[float, float, float, float]] = None,
         gutter_thickness: float = 0.0,
+        diptych: Optional[Tuple[WorkspaceConfig, WorkspaceConfig]] = None,
     ) -> Tuple[Optional[bytes], str]:
-        """Performs high-resolution export with color management."""
+        """Performs high-resolution export with color management.
+
+        ``diptych`` renders the scan's two halves with their own configs and joins them
+        back into the original geometry. Each half is sliced before the pipeline, so its
+        normalization sees the same pixels the user edited it on. ``params`` is unused
+        then — the halves own the edit. One encode, so no double compression.
+        """
         try:
-            # Ensure both GPU and CPU paths use the same export settings.
-            params = dc_replace(params, export=export_settings)
+            if diptych is not None:
+                from negpy.services.assets.half_frame import gap_px, half_hash, join_halves
 
-            f32_buffer, ir_full, source_cs = self._load_source_f32(file_path, params)
-            f32_buffer, ir_full = self._slice_half_source(
-                f32_buffer, ir_full, half, split_x, crop_rect=crop_rect, gutter_thickness=gutter_thickness
-            )
-            target_cs = export_settings.export_color_space
-            if target_cs == ColorSpace.SAME_AS_SOURCE.value:
-                target_cs = source_cs
-            color_space = str(target_cs)
-
-            detect_key = (
-                source_hash
-                + flatfield_token(params.flatfield)
-                + rgbscan_token(params.rgbscan)
-                + stitch_token(params.stitch)
-                + hdr_token(params.hdr)
-                + linear_raw_token(params.process, params.exposure.render_intent)
-                + sensor_token(params.process)
-                + ir_bake_token(params.retouch, ir_full is not None)
-                + manual_bake_token(params.retouch)
-            )
-            f32_buffer, _, _, ir_routed = self._ir_bake(f32_buffer, ir_full, params, detect_key)
-            orig_ret = params.retouch
-            detected, hair_masks = self._detect_luma(params, f32_buffer, detect_key)
-            f32_buffer = self._luma_bake(f32_buffer, detected, detect_key + hair_bake_token(orig_ret))
-            f32_buffer, manual_routed = self._manual_bake(f32_buffer, params, detect_key)
-            extra = [m for m in (ir_routed, manual_routed) if m is not None]
-            if extra:
-                hair_masks = hair_masks + extra
-            if hair_masks:
-                f32_buffer = self._hair_inpaint(f32_buffer, hair_masks, detect_key + hair_bake_token(orig_ret))
-
-            h_raw, w_raw = f32_buffer.shape[:2]
-            export_scale = max(h_raw, w_raw) / float(APP_CONFIG.preview_render_size)
-
-            if self._is_flat(params):
-                prefer_gpu = False
-
-            if prefer_gpu and self.engine_gpu:
-                buffer, gpu_metrics = self.engine_gpu.process(
-                    f32_buffer,
-                    params,
-                    scale_factor=export_scale,
-                    bounds_override=bounds_override,
-                    readback_metrics=False,
-                    cam_xyz=self._cam_xyz_by_path.get(file_path, (None, None))[0],
-                    camera_wb=self._cam_xyz_by_path.get(file_path, (None, None))[1],
-                )
+                rendered = [
+                    self._render_export_buffer(
+                        file_path,
+                        cfg,
+                        export_settings,
+                        half_hash(source_hash, n),
+                        prefer_gpu=prefer_gpu,
+                        half=n,
+                        split_x=split_x,
+                        crop_rect=crop_rect,
+                        gutter_thickness=gutter_thickness,
+                    )
+                    for n, cfg in ((1, diptych[0]), (2, diptych[1]))
+                ]
+                (left, color_space), (right, _) = rendered
+                buffer = join_halves(left, right, gap_px(left.shape[1], right.shape[1], gutter_thickness))
             else:
-                buffer, _ = self.run_pipeline(
-                    f32_buffer,
+                buffer, color_space = self._render_export_buffer(
+                    file_path,
                     params,
+                    export_settings,
                     source_hash,
-                    render_size_ref=float(APP_CONFIG.preview_render_size),
-                    metrics=metrics or {"log_bounds": bounds_override} if bounds_override else metrics,
-                    prefer_gpu=False,
-                    wants_uv_grid=False,
-                    skip_flatfield=True,  # f32_buffer already flat-fielded by _load_source_f32
-                    cam_xyz=self._cam_xyz_by_path.get(file_path, (None, None))[0],
-                    camera_wb=self._cam_xyz_by_path.get(file_path, (None, None))[1],
+                    metrics=metrics,
+                    prefer_gpu=prefer_gpu,
+                    bounds_override=bounds_override,
+                    half=half,
+                    split_x=split_x,
+                    crop_rect=crop_rect,
+                    gutter_thickness=gutter_thickness,
                 )
-                buffer = self._apply_scaling_and_border_f32(buffer, params, params.export)
-                # Release full-res arrays pinned in the CPU stage cache.
-                self.engine_cpu.cache.clear()
-
             return self._encode_export(buffer, export_settings, color_space, working_color_space)
 
         except Exception as e:

--- a/tests/test_export_flush.py
+++ b/tests/test_export_flush.py
@@ -44,6 +44,7 @@ def test_request_export_calls_flush_export_ui():
     )
     controller._ensure_valid_export_path = MagicMock(return_value="C:/Exports")
     controller.effective_input_icc = MagicMock(return_value=None)
+    controller._diptych_task = lambda info: (info, None)
     controller._run_export_tasks = MagicMock()
 
     AppController.request_export(controller)

--- a/tests/test_half_frame.py
+++ b/tests/test_half_frame.py
@@ -10,8 +10,11 @@ from negpy.domain.models import ExportConfig, WorkspaceConfig
 from negpy.services.assets.half_frame import (
     base_hash,
     detect_split_x,
+    diptych_configs,
+    gap_px,
     half_hash,
     half_name,
+    join_halves,
     slice_for_asset,
     slice_half,
 )
@@ -220,3 +223,178 @@ class TestSliceHalfCropGutter:
         }
         out = slice_for_asset(buf, info)
         np.testing.assert_array_equal(out, buf[:, :40])
+
+
+class TestDiptych:
+    """Half-frame mode off: a scan that carries both halves' edits renders as one image."""
+
+    def test_half_zero_crops_without_splitting(self):
+        buf = np.arange(2 * 100 * 3, dtype=np.float32).reshape(2, 100, 3)
+        np.testing.assert_array_equal(slice_half(buf, 0, 0.5, crop_rect=(0.2, 0.0, 0.8, 1.0)), buf[:, 20:80])
+
+    def test_slice_for_asset_crops_a_whole_frame_with_a_rect(self):
+        buf = np.arange(2 * 100 * 3, dtype=np.float32).reshape(2, 100, 3)
+        info = {"split_x": 0.5, "crop_rect": (0.2, 0.0, 0.8, 1.0), "gutter_thickness": 0.2}
+        np.testing.assert_array_equal(slice_for_asset(buf, info), buf[:, 20:80])
+
+    def test_slice_for_asset_is_a_no_op_without_a_rect(self):
+        buf = np.arange(2 * 100 * 3, dtype=np.float32).reshape(2, 100, 3)
+        assert slice_for_asset(buf, {"name": "x"}) is buf
+
+    def test_gap_px_is_scale_invariant(self):
+        # 20 % gutter: the two halves hold 80 % of the width, so the gap is a quarter of them.
+        assert gap_px(40, 40, 0.2) == 20
+        assert gap_px(400, 400, 0.2) == 200
+        assert gap_px(40, 40, 0.0) == 0
+
+    def test_join_halves_geometry_and_gap(self):
+        left = np.ones((10, 6, 3), np.float32)
+        right = np.full((10, 4, 3), 0.5, np.float32)
+        out = join_halves(left, right, 3)
+        assert out.shape == (10, 13, 3)
+        np.testing.assert_array_equal(out[:, :6], left)
+        assert out[:, 6:9].max() == 0.0
+        np.testing.assert_array_equal(out[:, 9:], right)
+
+    def test_join_halves_centre_pads_unequal_heights(self):
+        left = np.ones((10, 4, 3), np.float32)
+        right = np.ones((6, 4, 3), np.float32)
+        out = join_halves(left, right, 0)
+        assert out.shape == (10, 8, 3)
+        # right sits in rows 2..8, black above and below
+        assert out[0, 4:].max() == 0.0 and out[9, 4:].max() == 0.0
+        np.testing.assert_array_equal(out[2:8, 4:], right)
+
+    def _repo(self, rows):
+        repo = MagicMock()
+        repo.load_file_settings_many.side_effect = lambda keys: {k: v for k, v in rows.items() if k in keys}
+        return repo
+
+    def test_both_halves(self):
+        a, b = WorkspaceConfig(), WorkspaceConfig()
+        pair = diptych_configs(self._repo({"h#1": a, "h#2": b}), "h")
+        assert pair == (a, b)
+
+    def test_missing_half_copies_its_sibling(self):
+        a = WorkspaceConfig()
+        assert diptych_configs(self._repo({"h#2": a}), "h") == (a, a)
+
+    def test_no_half_edits(self):
+        assert diptych_configs(self._repo({}), "h") is None
+
+    def test_a_half_is_not_a_diptych(self):
+        assert diptych_configs(self._repo({"h#1": WorkspaceConfig()}), "h#1") is None
+
+    def test_a_composite_is_not_a_diptych(self):
+        """A stitch's base is its reference frame, whose half edits are not the stitch's."""
+        assert diptych_configs(self._repo({"h#1": WorkspaceConfig()}), "h#stitch") is None
+
+    def test_export_filename_is_not_a_half(self):
+        name = render_export_filename("/x/IMG420.tif", ExportConfig(), composite="DIPTYCH")
+        assert name.endswith("IMG420-DIPTYCH") and "IMG420_1" not in name
+
+
+class TestDiptychRender:
+    """The joined render must come from two pipeline runs on two slices, not one."""
+
+    def _worker(self, out_by_hash):
+        from negpy.desktop.workers.render import RenderWorker
+
+        worker = RenderWorker.__new__(RenderWorker)
+        seen = []
+
+        def run_pipeline(buffer, config, source_hash, **kw):
+            seen.append((buffer.shape[1], config, source_hash, kw["readback_metrics"]))
+            return np.full((buffer.shape[0], buffer.shape[1], 3), out_by_hash[source_hash], np.float32), {"log_bounds": source_hash}
+
+        worker._processor = MagicMock()
+        worker._processor.run_pipeline.side_effect = run_pipeline
+        return worker, seen
+
+    def _task(self, **kw):
+        from negpy.desktop.workers.render import RenderTask
+
+        return RenderTask(
+            buffer=np.zeros((8, 100, 3), np.float32),
+            config=WorkspaceConfig(),
+            source_hash="h",
+            preview_size=1000.0,
+            diptych=(WorkspaceConfig(), WorkspaceConfig()),
+            **kw,
+        )
+
+    def test_each_half_renders_with_its_own_config(self):
+        from negpy.desktop.workers.render import RenderWorker
+
+        worker, seen = self._worker({"h#1": 0.25, "h#2": 0.75})
+        out, _ = RenderWorker._render_diptych(worker, self._task(gutter_thickness=0.2), "h")
+
+        assert [s[0] for s in seen] == [40, 40]  # 20 % gutter discarded around the split
+        assert [s[2] for s in seen] == ["h#1", "h#2"]  # distinct stage-cache identities
+        assert [s[3] for s in seen] == [True, False]  # only half 1 is metered; two writebacks would fight
+        assert out.shape == (8, 100, 3)  # gap restores the original width
+        assert out[0, 0, 0] == 0.25 and out[0, 99, 0] == 0.75 and out[0, 50, 0] == 0.0
+
+    def test_metrics_come_from_half_one_and_are_marked(self):
+        from negpy.desktop.workers.render import RenderWorker
+
+        worker, _ = self._worker({"h#1": 0.25, "h#2": 0.75})
+        _, metrics = RenderWorker._render_diptych(worker, self._task(readback_metrics=True), "h")
+        assert metrics["log_bounds"] == "h#1"
+        assert metrics["diptych"] is True
+
+
+class TestDiptychAsset:
+    """Discovery flags the scan; every later reader takes the flag off the asset dict."""
+
+    def _controller(self, rows):
+        from negpy.desktop.controller import AppController
+
+        ctrl = AppController.__new__(AppController)
+        ctrl.session = MagicMock()
+        ctrl.session.repo.load_file_settings_many.side_effect = lambda keys: {k: v for k, v in rows.items() if k in keys}
+        ctrl.session.repo.get_global_setting.return_value = {"crop_rect": [0.1, 0.0, 0.9, 1.0], "split_x": 0.4, "gutter_thickness": 0.05}
+        ctrl._active_diptych_memo = ("", None)
+        return ctrl
+
+    def test_mark_diptychs_flags_only_scans_with_half_edits(self):
+        from negpy.desktop.controller import AppController
+
+        ctrl = self._controller({"ha#2": WorkspaceConfig()})
+        assets = [
+            {"path": "/p/a.tif", "hash": "ha"},
+            {"path": "/p/b.tif", "hash": "hb"},
+            {"path": "/p/c.tif", "hash": "hc#1", "half": 1},
+        ]
+        AppController._mark_diptychs(ctrl, assets)
+        assert assets[0]["diptych"] is True
+        assert assets[1]["diptych"] is False
+        assert "diptych" not in assets[2]  # a half is never its own diptych
+
+    def test_task_stamps_the_saved_split_geometry(self):
+        from negpy.desktop.controller import AppController
+
+        cfg = WorkspaceConfig()
+        ctrl = self._controller({"ha#1": cfg, "ha#2": cfg})
+        info, pair = AppController._diptych_task(ctrl, {"path": "/p/a.tif", "hash": "ha", "diptych": True})
+        assert pair == (cfg, cfg)
+        assert info["split_x"] == 0.4
+        assert info["crop_rect"] == (0.1, 0.0, 0.9, 1.0)
+        assert info["gutter_thickness"] == 0.05
+
+    def test_a_flagged_negative_skips_the_lookup(self):
+        from negpy.desktop.controller import AppController
+
+        ctrl = self._controller({"ha#1": WorkspaceConfig()})
+        info, pair = AppController._diptych_task(ctrl, {"hash": "ha", "diptych": False})
+        assert pair is None and info["hash"] == "ha"
+        ctrl.session.repo.load_file_settings_many.assert_not_called()
+
+    def test_composite_kind_and_summary(self):
+        from negpy.desktop.session import composite_kind, composite_summary
+
+        asset = {"hash": "ha", "diptych": True}
+        assert composite_kind(asset) == "diptych"
+        assert "Diptych" in composite_summary(asset)
+        # A half still reads as a half while the mode is on.
+        assert composite_kind({"hash": "ha#1", "half": 1, "diptych": True}) == "half"


### PR DESCRIPTION
## What

Half-frame mode gives each exposure its own asset (`<hash>#1` / `#2`) and its own edit. Turning the mode off never *lost* those edits — nothing deletes the rows, and both theft guards (`load_or_promote` skipping the path fallback for a half, `load_file_settings_by_path` excluding `%#%`) keep them intact. It only made them unreachable: the whole-frame asset keys on the unsuffixed hash and came back with defaults.

A whole-frame scan that carries half edits is now a **diptych**: half 1 renders under its own config, half 2 under its own, and the two are joined back into the original geometry — one image, one export.

## How

- `services/assets/half_frame.py` — `diptych_configs` (a missing half copies its sibling), `join_halves`, `gap_px`, and `slice_half(half=0)` for crop-without-split.
- `image_processor.py` — `process_export` split at the encode seam into `_render_export_buffer` + `_encode_export`; `diptych=` renders both halves and joins them, then encodes **once**, so no double compression.
- `workers/render.py` — `RenderWorker._render_diptych`: slice, two `run_pipeline` runs, join.
- `controller.py` — `_mark_diptychs` flags the whole roll in one query at discovery; `_diptych_task` stamps the saved split profile onto the asset; wired into all three export builders and the preview/render path.
- Read-only asset: `composite_kind` → `"diptych"`, both-sides-filled split badge, controls panel disabled with a status hint. Export settings stay editable (they live outside `ControlsPanel.pages`).
- Export name: `<name>-DIPTYCH.<ext>`, reusing the existing `-HDR` composite hook.

Two details that are load-bearing rather than incidental:

- **Each half is sliced before the pipeline**, so its normalization measures the pixels it was edited on. Rendering the whole frame twice and splicing columns would meter across both exposures and drift the look away from what the user set.
- **Each half gets its own pipeline identity** (`<source_hash>#1` / `#2`), or the stage caches collide and the second render comes back as the first.

`log_bounds` writeback is suppressed for a diptych — those bounds were measured on one half, under that half's edit.

## Decisions worth a second opinion

- **The gutter is filled black, not copied from the source.** The gap keeps the cut band's *width*, so the original geometry survives. But the source gutter is scene-linear negative data: pasted in it renders as a bright bar (unexposed film base is *low* density, and the pipeline is what inverts it), and running the pipeline on a thin dark strip renormalizes it into noise. Black is what the space between two exposures looks like once rendered. `_GAP_FILL` is a module constant if the finish border colour turns out to read better.
- **Export sizing and border apply per half**, because they resolve inside the pipeline (the GPU path handles them in its own finish stage, so they cannot be deferred to the join). A long-edge-2000 diptych is two 2000 px frames side by side. Percent and native-size exports are unaffected.
- **The gate is implicit**: a scan renders as a diptych whenever `#1`/`#2` rows exist and half-frame mode is off. No new UI, but also no way to opt one scan out.
- **Unequal half heights are centre-padded, never resampled** — an export must not resize pixels the pipeline already sized.

## Not in scope

Filmstrip thumbnails and contact-sheet tiles stay whole-frame: a diptych tile costs two pipeline runs per proxy. A diptych's thumbnail therefore will not match its export. Both caveats are in `docs/USER_GUIDE.md`.

## Testing

`make lint`, `make type` clean; `uv run pytest tests` → **4183 passed, 11 skipped**.

New coverage in `tests/test_half_frame.py`: `join_halves` geometry and centre-padding, `gap_px` scale invariance, `slice_half(half=0)`, `diptych_configs` (both halves / one / neither / a half / a `#stitch` composite), the render worker using two configs on two slices with distinct hashes, metrics coming from half 1 and marked, `_mark_diptychs`, the stamped split geometry, `composite_kind`, and the export filename.

One pre-existing test needed a stub: `test_export_flush` drives `request_export` on a bare `MagicMock`, which cannot unpack the new `_diptych_task` return.

`docs/CHANGELOG.md` untouched, per repo convention.