### PR TITLE
fix(thumbnails): stop the segfault and the OOM when a folder's thumbnails generate

### DIFF
--- a/negpy/infrastructure/loaders/helpers.py
+++ b/negpy/infrastructure/loaders/helpers.py
@@ -89,20 +89,22 @@ def _tiff_preview_page(file_path: str) -> Optional[Image.Image]:
     """Reduced-resolution preview page of a TIFF-based raw, or None.
 
     Page 0 holds the preview only when the full-res data sits in SubIFDs, which is how
-    DNG writers lay it out.
+    DNG writers lay it out. Scanner DNGs write that page 16-bit, so both depths count.
     """
     try:
         import tifffile
 
         with tifffile.TiffFile(file_path) as tif:
             page = tif.pages[0]
-            if not page.pages or page.dtype != np.uint8:  # type: ignore[union-attr]
+            if not page.pages or page.dtype not in (np.uint8, np.uint16):  # type: ignore[union-attr]
                 return None
             arr = page.asarray()  # type: ignore[attr-defined]
     except Exception as e:
         logger.warning(f"TIFF preview page read failed for {file_path}: {e}")
         return None
 
+    if arr.dtype == np.uint16:
+        arr = (arr >> 8).astype(np.uint8)
     return Image.fromarray(ensure_rgb(arr))
 
 

--- a/negpy/infrastructure/loaders/helpers.py
+++ b/negpy/infrastructure/loaders/helpers.py
@@ -5,10 +5,11 @@ from typing import Any, Optional, Tuple
 
 import numpy as np
 import rawpy
-from PIL import ImageCms
+from PIL import Image, ImageCms
 
 from negpy.domain.models import ColorSpace
 from negpy.infrastructure.loaders.constants import SUPPORTED_RAW_EXTENSIONS
+from negpy.kernel.image.logic import ensure_rgb
 from negpy.kernel.system.logging import get_logger
 
 logger = get_logger(__name__)
@@ -81,6 +82,50 @@ def identify_color_space_from_icc(icc_bytes: Optional[bytes]) -> Optional[str]:
         return ColorSpace.ADOBE_RGB.value
     if "srgb" in desc or "iec 61966" in desc or "iec61966" in desc:
         return ColorSpace.SRGB.value
+    return None
+
+
+def _tiff_preview_page(file_path: str) -> Optional[Image.Image]:
+    """Reduced-resolution preview page of a TIFF-based raw, or None.
+
+    Page 0 holds the preview only when the full-res data sits in SubIFDs, which is how
+    DNG writers lay it out.
+    """
+    try:
+        import tifffile
+
+        with tifffile.TiffFile(file_path) as tif:
+            page = tif.pages[0]
+            if not page.pages or page.dtype != np.uint8:  # type: ignore[union-attr]
+                return None
+            arr = page.asarray()  # type: ignore[attr-defined]
+    except Exception as e:
+        logger.warning(f"TIFF preview page read failed for {file_path}: {e}")
+        return None
+
+    return Image.fromarray(ensure_rgb(arr))
+
+
+def embedded_preview(raw: Any, file_path: str) -> Optional[Image.Image]:
+    """Embedded preview image of a raw file, or None when it has none to give.
+
+    Only a JPEG thumb is taken from libraw. For a BITMAP thumb rawpy shapes the array
+    (h, w, 3) from libraw's hardcoded colors=3 while the allocation holds only data_size
+    bytes, and rawpy exposes no data_size — a grayscale thumb is then read three times
+    past its end, which segfaults whenever the heap tail is unmapped. A TIFF-based file
+    carries that same preview as its reduced-resolution page 0, so it is read from the
+    file instead. Never touch `thumb.data` on a BITMAP thumb.
+    """
+    if not hasattr(raw, "extract_thumb"):
+        return None
+    try:
+        thumb = raw.extract_thumb()
+        if thumb.format == rawpy.ThumbFormat.JPEG:
+            return Image.open(io.BytesIO(thumb.data))
+        if thumb.format == rawpy.ThumbFormat.BITMAP:
+            return _tiff_preview_page(file_path)
+    except Exception:
+        return None
     return None
 
 

--- a/negpy/services/assets/thumbnails.py
+++ b/negpy/services/assets/thumbnails.py
@@ -224,6 +224,9 @@ def get_thumbnail_worker(
 
             img = Image.fromarray(slice_half(np.asarray(img), half, split_x, crop_rect=crop_rect, gutter_thickness=gutter_thickness))
 
+        # Shrink before the inversion, not after: preview_positive is float math over every
+        # pixel, and on a full-size decode its temporaries cost a gigabyte per worker.
+        img.thumbnail((ts, ts), Image.Resampling.LANCZOS)
         square_img: Image.Image = prepare_thumbnail(preview_positive(img, process_mode), ts)
 
         if asset_store:

--- a/negpy/services/assets/thumbnails.py
+++ b/negpy/services/assets/thumbnails.py
@@ -6,6 +6,7 @@ from negpy.kernel.system.config import APP_CONFIG
 import numpy as np
 from negpy.kernel.image.logic import apply_exif_orientation, ensure_rgb, float_to_uint8, prepare_thumbnail, srgb_to_linear, uint8_to_float32
 from negpy.infrastructure.loaders.factory import loader_factory
+from negpy.infrastructure.loaders.helpers import embedded_preview
 from negpy.infrastructure.display.color_spaces import WORKING_COLOR_SPACE
 from negpy.kernel.system.logging import get_logger
 
@@ -138,19 +139,7 @@ def decode_source_image(file_path: str, green_path: str = "", blue_path: str = "
 
     ctx_mgr, metadata = loader_factory.get_loader(file_path)
     with ctx_mgr as raw:
-        img: Optional[Image.Image] = None
-
-        if hasattr(raw, "extract_thumb"):
-            try:
-                thumb = raw.extract_thumb()
-                if thumb.format == rawpy.ThumbFormat.JPEG:
-                    import io
-
-                    img = Image.open(io.BytesIO(thumb.data))
-                elif thumb.format == rawpy.ThumbFormat.BITMAP:
-                    img = Image.fromarray(thumb.data)
-            except Exception:
-                pass
+        img: Optional[Image.Image] = embedded_preview(raw, file_path)
 
         if img is None:
             img = Image.fromarray(_fast_demosaic(raw))

--- a/negpy/services/rendering/preview_manager.py
+++ b/negpy/services/rendering/preview_manager.py
@@ -1,11 +1,9 @@
-import io
 import os
 import time
 from typing import Any, Optional, Tuple
 
 import cv2
 import numpy as np
-from PIL import Image
 
 import rawpy
 
@@ -16,6 +14,7 @@ from negpy.infrastructure.loaders.helpers import (
     NonStandardFileWrapper,
     camera_wb_multipliers,
     camera_xyz_matrix,
+    embedded_preview,
     get_best_demosaic_algorithm,
     is_xtrans,
 )
@@ -92,17 +91,10 @@ class PreviewManager:
         Returns None if a thumb cannot be extracted or converted.
         """
         t0 = time.perf_counter()
-        if not hasattr(raw, "extract_thumb"):
+        img = embedded_preview(raw, file_path)
+        if img is None:
             return None
         try:
-            thumb = raw.extract_thumb()
-            img: Optional[Image.Image] = None
-            if thumb.format == rawpy.ThumbFormat.JPEG:
-                img = Image.open(io.BytesIO(thumb.data))
-            elif thumb.format == rawpy.ThumbFormat.BITMAP:
-                img = Image.fromarray(ensure_rgb(thumb.data))
-            if img is None:
-                return None
             img = img.convert("RGB")
         except Exception:
             return None

--- a/tests/test_embedded_preview.py
+++ b/tests/test_embedded_preview.py
@@ -75,6 +75,17 @@ def test_bitmap_thumb_falls_back_to_tiff_preview_page(tmp_path):
     assert np.asarray(img).shape == (10, 16, 3)
 
 
+def test_16_bit_preview_page_is_scaled_down(tmp_path):
+    """Scanner DNGs write page 0 as uint16; rejecting it sent a whole library through the
+    half-size demosaic instead, at about a gigabyte of transients per worker."""
+    path = _dng_with_preview(tmp_path / "scan16.dng", np.full((10, 16), 0x8000, dtype=np.uint16))
+    img = embedded_preview(_Raw(_Thumb(rawpy.ThumbFormat.BITMAP)), path)
+    assert img is not None
+    arr = np.asarray(img)
+    assert arr.shape == (10, 16, 3) and arr.dtype == np.uint8
+    assert arr.max() == 0x80
+
+
 def test_plain_tiff_without_subifds_has_no_preview_page(tmp_path):
     """Page 0 is the image itself, not a preview, so nothing is offered."""
     path = str(tmp_path / "scan.tif")

--- a/tests/test_embedded_preview.py
+++ b/tests/test_embedded_preview.py
@@ -1,0 +1,90 @@
+"""Regression: a BITMAP embedded thumb must never be read.
+
+rawpy shapes a BITMAP thumb (h, w, 3) from libraw's hardcoded colors=3 while the
+allocation holds only data_size bytes, and exposes no data_size. A grayscale thumb is
+then read three times past its end, which segfaulted the app at random while a folder's
+thumbnails generated. The preview now comes from the file's own TIFF preview page.
+"""
+
+import io
+
+import numpy as np
+import tifffile
+from PIL import Image
+
+import rawpy
+from negpy.infrastructure.loaders.helpers import embedded_preview
+
+
+class _Thumb:
+    """A rawpy Thumbnail stand-in whose data raises unless a value was given."""
+
+    def __init__(self, fmt, data=None):
+        self.format = fmt
+        self._data = data
+
+    @property
+    def data(self):
+        if self._data is None:
+            raise AssertionError("BITMAP thumb data must never be read")
+        return self._data
+
+
+class _Raw:
+    def __init__(self, thumb=None, error=None):
+        self._thumb = thumb
+        self._error = error
+
+    def extract_thumb(self):
+        if self._error is not None:
+            raise self._error
+        return self._thumb
+
+
+def _jpeg_bytes(w: int = 16, h: int = 10) -> bytes:
+    buf = io.BytesIO()
+    Image.new("RGB", (w, h), (10, 20, 30)).save(buf, format="JPEG")
+    return buf.getvalue()
+
+
+def _dng_with_preview(path, preview: np.ndarray) -> str:
+    """A DNG-shaped file: reduced-resolution page 0 with the full-res data in a SubIFD."""
+    with tifffile.TiffWriter(path) as tw:
+        tw.write(preview, subifds=1, subfiletype=1)
+        tw.write(np.zeros((40, 60), dtype=np.uint16), subfiletype=0)
+    return str(path)
+
+
+def test_jpeg_thumb_is_used():
+    img = embedded_preview(_Raw(_Thumb(rawpy.ThumbFormat.JPEG, _jpeg_bytes())), "missing.nef")
+    assert img is not None
+    assert img.size == (16, 10)
+
+
+def test_bitmap_thumb_data_is_never_read(tmp_path):
+    """No preview page to fall back on -> None, and the unsafe buffer stays untouched."""
+    assert embedded_preview(_Raw(_Thumb(rawpy.ThumbFormat.BITMAP)), str(tmp_path / "gone.dng")) is None
+
+
+def test_bitmap_thumb_falls_back_to_tiff_preview_page(tmp_path):
+    """A grayscale preview page is broadened to RGB, at its own size."""
+    path = _dng_with_preview(tmp_path / "scan.dng", np.full((10, 16), 128, dtype=np.uint8))
+    img = embedded_preview(_Raw(_Thumb(rawpy.ThumbFormat.BITMAP)), path)
+    assert img is not None
+    assert img.size == (16, 10)
+    assert np.asarray(img).shape == (10, 16, 3)
+
+
+def test_plain_tiff_without_subifds_has_no_preview_page(tmp_path):
+    """Page 0 is the image itself, not a preview, so nothing is offered."""
+    path = str(tmp_path / "scan.tif")
+    tifffile.imwrite(path, np.zeros((10, 16), dtype=np.uint8))
+    assert embedded_preview(_Raw(_Thumb(rawpy.ThumbFormat.BITMAP)), path) is None
+
+
+def test_thumb_extraction_failure_returns_none():
+    assert embedded_preview(_Raw(error=RuntimeError("no thumbnail")), "missing.nef") is None
+
+
+def test_object_without_extract_thumb_returns_none():
+    assert embedded_preview(object(), "missing.dng") is None

--- a/tests/test_preview_manager_open_count.py
+++ b/tests/test_preview_manager_open_count.py
@@ -6,10 +6,12 @@ exactly once per file, even when use_splash=True triggers both a splash and a
 linear decode.
 """
 
+import io
 from unittest.mock import MagicMock, patch
 
 import numpy as np
 import rawpy
+from PIL import Image
 
 
 # ---------------------------------------------------------------------------
@@ -23,9 +25,11 @@ def _make_fake_raw(w: int = 100, h: int = 100) -> MagicMock:
     raw.sizes = MagicMock(iheight=h, iwidth=w)
     raw.postprocess.return_value = np.zeros((h, w, 3), dtype=np.uint16)
 
+    buf = io.BytesIO()
+    Image.new("RGB", (w, h), (10, 20, 30)).save(buf, format="JPEG")
     thumb = MagicMock()
-    thumb.format = rawpy.ThumbFormat.BITMAP
-    thumb.data = np.zeros((h, w, 3), dtype=np.uint8)
+    thumb.format = rawpy.ThumbFormat.JPEG
+    thumb.data = buf.getvalue()
     raw.extract_thumb.return_value = thumb
 
     # Support use as a context manager

--- a/tests/test_preview_manager_splash_grayscale.py
+++ b/tests/test_preview_manager_splash_grayscale.py
@@ -1,44 +1,51 @@
-"""Regression: grayscale (H,W,1) BITMAP thumbnails must not break splash/load.
+"""Regression: the splash must not read a BITMAP thumb's buffer.
 
-Silverfast-scanned Nikon Coolscan 5000/9000ED DNGs embed a single-channel
-grayscale thumbnail. PIL's Image.fromarray cannot map (H,W,1) uint8, which used
-to abort the whole file load with "cannot handle this data type : (1, 1, 1) |u1".
+Silverfast-scanned Nikon Coolscan 5000/9000ED DNGs embed a single-channel grayscale
+thumbnail, which libraw still reports as 3-channel. Reading it ran past the allocation
+and segfaulted at random. The splash comes from the file's TIFF preview page instead,
+and is skipped when there is none.
 """
 
 from unittest.mock import MagicMock
 
 import numpy as np
-import rawpy
+import tifffile
 
+import rawpy
 from negpy.services.rendering.preview_manager import PreviewManager
 
 
-def _make_thumb(channels: int, w: int = 64, h: int = 48) -> MagicMock:
+def _raw_with_bitmap_thumb(w: int = 64, h: int = 48) -> MagicMock:
     thumb = MagicMock()
     thumb.format = rawpy.ThumbFormat.BITMAP
-    thumb.data = np.zeros((h, w, channels), dtype=np.uint8)
+    type(thumb).data = property(lambda _self: (_ for _ in ()).throw(AssertionError("BITMAP thumb data must never be read")))
     raw = MagicMock()
     raw.sizes = MagicMock(iheight=h, iwidth=w)
     raw.extract_thumb.return_value = thumb
     return raw
 
 
-def test_grayscale_bitmap_thumb_yields_splash():
-    """A single-channel thumb is broadened to RGB instead of crashing."""
-    raw = _make_thumb(channels=1)
-    result = PreviewManager._try_splash_from_open_raw(raw, "scan.dng")
+def test_bitmap_thumb_splashes_from_the_preview_page(tmp_path):
+    """The grayscale preview page is broadened to RGB, without touching the thumb."""
+    path = str(tmp_path / "scan.dng")
+    with tifffile.TiffWriter(path) as tw:
+        tw.write(np.full((48, 64), 128, dtype=np.uint8), subifds=1, subfiletype=1)
+        tw.write(np.zeros((480, 640), dtype=np.uint16), subfiletype=0)
+
+    result = PreviewManager._try_splash_from_open_raw(_raw_with_bitmap_thumb(), path)
     assert result is not None
     buf, _dims = result
     assert buf.ndim == 3 and buf.shape[2] == 3
 
 
+def test_bitmap_thumb_without_preview_page_skips_the_splash(tmp_path):
+    """No safe preview to read -> no splash, and no crash."""
+    assert PreviewManager._try_splash_from_open_raw(_raw_with_bitmap_thumb(), str(tmp_path / "gone.dng")) is None
+
+
 def test_malformed_thumb_returns_none_not_raises():
-    """Any thumb conversion failure falls back to None (skip splash), never raises."""
+    """Any thumb extraction failure falls back to None (skip splash), never raises."""
     raw = MagicMock()
     raw.sizes = MagicMock(iheight=48, iwidth=64)
-    raw.extract_thumb.side_effect = None
-    bad = MagicMock()
-    bad.format = rawpy.ThumbFormat.BITMAP
-    bad.data = object()  # not array-like -> fromarray raises
-    raw.extract_thumb.return_value = bad
+    raw.extract_thumb.side_effect = RuntimeError("no thumbnail")
     assert PreviewManager._try_splash_from_open_raw(raw, "scan.dng") is None

--- a/tests/test_thumbnail_positive.py
+++ b/tests/test_thumbnail_positive.py
@@ -1,9 +1,11 @@
 import unittest
+from unittest.mock import patch
 
 import numpy as np
 from PIL import Image
 
-from negpy.services.assets.thumbnails import preview_positive, thumbnail_cache_key
+from negpy.kernel.system.config import APP_CONFIG
+from negpy.services.assets.thumbnails import get_thumbnail_worker, preview_positive, thumbnail_cache_key
 
 
 def _orange_mask_negative() -> Image.Image:
@@ -94,6 +96,28 @@ class TestPreviewPositive(unittest.TestCase):
         self.assertNotEqual(thumbnail_cache_key("abc", False), "abc")
         self.assertNotEqual(thumbnail_cache_key("abc", True), "abc-rgb")
         self.assertNotEqual(thumbnail_cache_key("abc", False), thumbnail_cache_key("abc", True))
+
+
+class TestThumbnailWorker(unittest.TestCase):
+    def test_inversion_runs_on_the_shrunk_image(self):
+        """preview_positive is float math over every pixel. Run on a full-size decode its
+        temporaries cost about a gigabyte per worker, which OOM-killed the app on a
+        400-frame folder with one worker per core."""
+        big = Image.fromarray(np.full((2000, 3000, 3), 128, dtype=np.uint8))
+        seen = []
+
+        def _spy(img, process_mode=""):
+            seen.append(img.size)
+            return img
+
+        with patch("negpy.services.assets.thumbnails.decode_source_image", return_value=big):
+            with patch("negpy.services.assets.thumbnails.preview_positive", side_effect=_spy):
+                thumb = get_thumbnail_worker("frame.dng", "hash")
+
+        ts = APP_CONFIG.thumbnail_size
+        self.assertEqual(len(seen), 1)
+        self.assertLessEqual(max(seen[0]), ts)
+        self.assertEqual(thumb.size, (ts, ts))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## The crash

Loading a folder of scans sometimes kills the app:

```
Fatal Python error: Segmentation fault
Current thread ...
  File "PIL/Image.py", line 960 in frombytes
  File "PIL/Image.py", line 3458 in fromarray
  File "negpy/services/assets/thumbnails.py", line 151 in decode_source_image
  File "negpy/services/assets/thumbnails.py", line 229 in get_thumbnail_worker
```

## Root cause

Not a thread race — an out-of-bounds read.

`raw.extract_thumb()` on a Coolscan DNG returns `ThumbFormat.BITMAP` with an ndarray of shape `(166, 250, 3)` = 124,500 bytes. The file's embedded preview is **grayscale**: 166×250 = 41,500 bytes.

libraw hardcodes `colors = 3` for a bitmap thumbnail and reports the real payload length only in `data_size`. rawpy builds the ndarray from `(height, width, colors)` and exposes no `data_size`, so the array covers three times its allocation and PIL reads 83,000 bytes past the end.

Verified on `raw0001.dng`: the first 41,500 bytes equal tifffile's page-0 thumbnail exactly, and the rest is heap garbage (`... 113 171 2 0` — pointer bytes). It only faults when that tail meets an unmapped page, which is why it is intermittent and why four concurrent thumbnail workers make it likely.

The same unsafe read sat on the viewer's splash path (`preview_manager.py:103`), where `ensure_rgb` passed the `(h, w, 3)` array straight through.

## The fix

A BITMAP thumb's `data` is never read again. Both call sites go through one helper, `embedded_preview(raw, file_path)`:

- JPEG thumb → used as before (a real `bytes` copy, safe).
- BITMAP thumb → falls back to `_tiff_preview_page()`, which reads the file's own reduced-resolution page 0 with tifffile (guarded on SubIFDs present and uint8).
- no thumb, or any failure → `None`; the caller falls back to the half-size demosaic (filmstrip) or skips the splash (viewer).

Reading the preview page keeps the fast path for scanner DNGs rather than paying a demosaic: 2ms for a splash, against 168ms for `postprocess(half_size=True)` on that file.

## Tests

- New `tests/test_embedded_preview.py`. The BITMAP thumb's `.data` is a property that raises, so any future read fails the suite.
- `test_preview_manager_splash_grayscale.py` covered this case on a wrong premise — it asserted rawpy hands back `(H, W, 1)`, which rawpy never does. Rewritten to assert the buffer stays untouched and the splash comes from the preview page.
- `test_preview_manager_open_count.py`'s fake thumb switched to JPEG so it still exercises the splash.

## Verification

- 290 thumbnail generations over the 29 DNGs that crashed, 4-thread pool, 10 rounds: every call returned an image, no crash, 3.9s.
- Splash on the same file: `(166, 250, 3)` in 0.002s.
- `make all` green (4209 passed), `make format` clean.

Worth reporting upstream: rawpy shapes the thumb array from `colors` while libraw hardcodes it to 3.

---

# Second commit: the OOM on a 419-frame folder

Loading a 419-frame folder then died with exit 137. The kernel log names the OOM killer, at **13.9 GB RSS**:

```
Out of memory: Killed process 359607 (python3) total-vm:23544048kB, anon-rss:13890368kB
```

Two causes, both on the thumbnail worker.

**1. The preview page was rejected for being 16-bit.** These scanner DNGs lay out page 0 as `uint16` (256×172, minisblack) with the full-res data in a SubIFD. `_tiff_preview_page` accepted only `uint8`, so all 419 frames fell through to the half-size demosaic — where the first commit's BITMAP thumb had cost nothing. Both depths are now read, scaled to 8-bit. This one is a regression from the first commit; the second cause is not.

**2. `preview_positive` ran on the full-size decode.** Its only consumer is a 256px square, but it inverted a 2526×1698 image first: `uint8 -> float32`, the sRGB decode evaluating both `np.where` branches, log density, then three `np.percentile` passes. About a gigabyte of transients per worker, and the batch runs one worker per core (16 here). The image is now shrunk before the inversion. A/B on four frames from both folders: visually identical.

## Measurements

Peak RSS sampled every 20ms:

| | peak RSS | wall |
|---|---|---|
| before | OOM-killed at 13.9 GB | — |
| preview page fixed only | 3.80 GB (16 files, 4 workers) | 6.7s |
| both fixes | **1.41 GB** (419 files, 16 workers) | 65s |
| worst case, no embedded preview at all (forced) | 3.49 GB (64 files, 16 workers) | 8.3s |

The worst case is bounded rather than growing with the file count, so a library of raws with no usable preview no longer walks into the OOM killer either.

## Tests

- `test_16_bit_preview_page_is_scaled_down` — the uint16 page is read and scaled.
- `test_inversion_runs_on_the_shrunk_image` — spies on `preview_positive` and asserts it never sees more than `thumbnail_size` pixels.

`make all` green (4211 passed).
