### PR TITLE
feat(updates): add a manual update check next to the version

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -49,7 +49,7 @@ Both side panels can be narrowed to give the canvas more room. As the controls p
 
 ## 2. Film strip (left panel)
 
-The header shows the NegPy logo and version. When a newer release is out, a green **⬇ Update Available** line appears under it; click it to read what changed and let NegPy install it ([§15](#15-updating-negpy)). The chevron at the header's top-right folds the branding away to give the frames more room.
+The header shows the NegPy logo and version. The **↻** button beside the version number asks GitHub for a newer release on demand; it becomes a green **⬇** when one is out. When a newer release is out, a green **⬇ Update Available** line also appears under the version; click either to read what changed and let NegPy install it ([§15](#15-updating-negpy)). The chevron at the header's top-right folds the branding away to give the frames more room.
 
 Below the header: the toolbar, the search box, and two collapsible sections. **Library** holds the folders your scans live in; **Film Strip** holds the frames you have open. Click either heading to fold it away; the one still open takes the whole panel. NegPy remembers which were open.
 
@@ -850,6 +850,8 @@ If NegPy crashes on launch or has rendering glitches, you can force backend sett
 ## 15. Updating NegPy
 
 NegPy asks GitHub for the newest release once at startup. If there is one, a green **⬇ Update Available: vX.Y.Z** line appears under the logo in the left panel. Click it to open the update window with the release notes, the download size and one button.
+
+To check yourself, press the **↻** button next to the version number in the left panel's header. If nothing is new, NegPy says so; if something is, the button turns into a green **⬇** and the update window opens.
 
 **Install Update** downloads the build that matches how *this* copy was installed, then closes NegPy, installs it over the old version, and reopens on the new one. You do not download, uninstall or reinstall anything by hand. Nothing is replaced until NegPy has exited, so a failed download or a refused permission prompt leaves your working install exactly as it was.
 

--- a/negpy/desktop/view/sidebar/header.py
+++ b/negpy/desktop/view/sidebar/header.py
@@ -10,6 +10,7 @@ from PyQt6.QtCore import Qt, QSize, pyqtSignal
 from PyQt6.QtGui import QPixmap
 
 from negpy.desktop.controller import AppController
+from negpy.desktop.view.shortcut_registry import tooltip_with_shortcut
 from negpy.desktop.view.styles.theme import THEME
 from negpy.kernel.system.paths import get_resource_path
 from negpy.kernel.system.version import get_app_version
@@ -24,6 +25,7 @@ class SidebarHeader(QWidget):
     """
 
     expanded_changed = pyqtSignal(bool)
+    check_requested = pyqtSignal()
 
     def __init__(self, controller: AppController, expanded: bool = True):
         super().__init__()
@@ -80,9 +82,44 @@ class SidebarHeader(QWidget):
         self.ver_label = QLabel(f"v{get_app_version()}")
         self.ver_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.ver_label.setStyleSheet(f"font-size: 14px; color: {THEME.text_secondary}; font-weight: bold;")
-        body_layout.addWidget(self.ver_label)
+
+        self.update_button = QToolButton()
+        self.update_button.setAutoRaise(True)
+        self.update_button.setIconSize(QSize(12, 12))
+        self.update_button.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.update_button.setStyleSheet("QToolButton { border: none; background: transparent; padding: 0px; }")
+        self.update_button.clicked.connect(self.check_requested)
+
+        version_row = QHBoxLayout()
+        version_row.setContentsMargins(0, 0, 0, 0)
+        version_row.setSpacing(4)
+        version_row.addStretch()
+        version_row.addWidget(self.ver_label)
+        version_row.addWidget(self.update_button)
+        version_row.addStretch()
+        body_layout.addLayout(version_row)
+
+        self.set_update_state(False)
 
         layout.addWidget(self.body)
+
+    def set_update_state(self, available: bool) -> None:
+        """Swap the version button between "check now" and "an update is waiting"."""
+        if available:
+            self.update_button.setIcon(qta.icon("fa5s.download", color=THEME.status_success))
+            self.update_button.setToolTip("An update is ready — click to install it")
+        else:
+            self.update_button.setIcon(qta.icon("fa5s.sync-alt", color=THEME.text_muted))
+            self.update_button.setToolTip(tooltip_with_shortcut("Check for updates", "check_for_updates"))
+        self.update_button.setEnabled(True)
+
+    def set_checking(self) -> None:
+        """Disable the button while a check runs: each click starts its own thread.
+
+        ``set_update_state`` re-enables it once the answer is in.
+        """
+        self.update_button.setEnabled(False)
+        self.update_button.setToolTip("Checking…")
 
     def is_expanded(self) -> bool:
         return self.toggle_button.isChecked()

--- a/negpy/desktop/view/sidebar/session_panel.py
+++ b/negpy/desktop/view/sidebar/session_panel.py
@@ -39,6 +39,7 @@ class SessionPanel(QWidget):
         persisted = repo.get_global_setting("section_expanded_app_header")
         self.header = SidebarHeader(self.controller, expanded=bool(persisted) if persisted is not None else True)
         self.header.expanded_changed.connect(lambda v: repo.save_global_setting("section_expanded_app_header", v))
+        self.header.check_requested.connect(self.check_for_updates)
         layout.addWidget(self.header)
 
         self.update_label = QLabel("")
@@ -111,6 +112,7 @@ class SessionPanel(QWidget):
         if info is None:
             return
         self.update_info = info
+        self.header.set_update_state(True)
         self.update_label.setText(
             f'<a href="#update" style="color:{THEME.status_success}; text-decoration:none;">⬇ Update Available: v{info.version}</a>'
         )
@@ -132,10 +134,12 @@ class SessionPanel(QWidget):
         if self.update_info is not None:
             self.show_update_dialog()
             return
+        self.header.set_checking()
         start_update_check(self._on_manual_check)
 
     def _on_manual_check(self, info: Optional[UpdateInfo]) -> None:
         if info is None:
+            self.header.set_update_state(False)
             QMessageBox.information(self, "NegPy", f"NegPy {get_app_version()} is up to date.")
             return
         self._on_update_checked(info)

--- a/tests/test_session_panel.py
+++ b/tests/test_session_panel.py
@@ -220,3 +220,30 @@ def test_the_window_stays_shut_while_the_running_version_is_current(panel, monke
     )
 
     panel.show_update_dialog()
+
+
+def test_the_version_button_runs_a_check(panel, monkeypatch):
+    started = []
+    monkeypatch.setattr("negpy.desktop.view.sidebar.session_panel.start_update_check", lambda cb: started.append(cb))
+
+    panel.header.update_button.click()
+
+    assert started
+    assert not panel.header.update_button.isEnabled()  # no second thread while one runs
+
+
+def test_the_version_button_returns_to_check_when_nothing_is_new(panel, monkeypatch):
+    monkeypatch.setattr("PyQt6.QtWidgets.QMessageBox.information", lambda *a, **k: None)
+    panel.header.set_checking()
+
+    panel._on_manual_check(None)
+
+    assert panel.header.update_button.isEnabled()
+    assert "Check for updates" in panel.header.update_button.toolTip()
+
+
+def test_the_version_button_offers_the_update_once_one_is_found(panel):
+    panel._on_update_checked(_update())
+
+    assert "update" in panel.header.update_button.toolTip().lower()
+    assert panel.header.update_button.isEnabled()


### PR DESCRIPTION
## What

The release check ran once per app launch. If nothing was new, there was no visible way to ask again — `check_for_updates()` existed but only behind an *unbound* keyboard shortcut.

A small button now sits beside the version number in the sidebar header:

- **↻** (muted) — nothing new is known; click to ask GitHub. NegPy reports "up to date" when there is nothing.
- **⬇** (green) — an update was found; click to open the update window.

The button disables itself while a check runs, because every click starts its own `UpdateCheckWorker` thread.

The green **⬇ Update Available: vX.Y.Z** banner stays as it was — it names the version, the button is the control.

## Changes

- `header.py` — `update_button` next to `ver_label`, `check_requested` signal, `set_update_state()` / `set_checking()`.
- `session_panel.py` — wires the signal to the existing `check_for_updates()`; both the startup and the manual path already route through `_on_update_checked`, so the button follows both.
- Tooltip goes through `tooltip_with_shortcut("Check for updates", "check_for_updates")`, so a key the user assigns shows up there. The registry entry already existed.
- `docs/USER_GUIDE.md` — §2 header and §15 Updating NegPy.

## Tests

3 new tests in `tests/test_session_panel.py`: the button starts a check and locks out a second one, it returns to the check state when nothing is new, and it offers the update once one is found.

`make all` green — 4214 passed, lint and ty clean.