### PR TITLE
fix(updater): make the Windows swap script survive non-ASCII paths

### DIFF
--- a/negpy/kernel/system/updater.py
+++ b/negpy/kernel/system/updater.py
@@ -258,6 +258,10 @@ def nsis_script(setup: Path, install_dir: Path, exe: Path, pid: int) -> str:
     """
     return (
         "@echo off\r\n"
+        # cmd parses a batch file in the console OEM codepage, not the UTF-8 it is written
+        # in. The staging path carries the profile name, so a non-ASCII user name garbles
+        # every path below unless the codepage switches first.
+        "chcp 65001 >nul\r\n"
         f'powershell -NoProfile -Command "try {{ Wait-Process -Id {pid} -Timeout 240 }} catch {{ }}"\r\n'
         f'start "" /wait "{setup}" /S /D={install_dir}\r\n'
         f'del /q "{setup}"\r\n'

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -226,6 +226,16 @@ def test_the_windows_script_installs_silently_over_the_current_install():
     assert r'explorer.exe "C:\Program Files\NegPy\NegPy.exe"' in script
 
 
+def test_the_windows_script_switches_cmd_to_utf8_before_the_paths():
+    """cmd parses a batch file in the OEM codepage, not the UTF-8 it is written in. The
+    staging path carries the profile name, so a non-ASCII user name garbles every path
+    unless the script switches the codepage first."""
+    script = nsis_script(Path("C:\\Users\\José\\Temp\\Setup.exe"), Path(r"C:\Program Files\NegPy"), Path(r"C:\Program Files\NegPy\NegPy.exe"), 3)
+
+    assert "chcp 65001 >nul" in script
+    assert script.index("chcp 65001") < script.index("José")
+
+
 # --- applying -------------------------------------------------------------
 
 


### PR DESCRIPTION
On Windows the in-app updater writes its swap script as a UTF-8 .bat, but cmd.exe parses a batch file in the OEM codepage. The installer is staged under %TEMP%, whose path carries the account name, so for a user whose account name has a non-ASCII character every path decodes wrong: start cannot find the installer, nothing installs, and explorer cannot relaunch the app. The update silently does nothing.

Putting chcp 65001 on the first line after @echo off fixes it: pure ASCII, so it parses the same under any codepage, and cmd reads the rest as the UTF-8 the file is written in. The POSIX scripts are untouched.

Verified on Windows 11 (OEM cp437) through a ShellExecuteW-spawned console: an accented staging path resolves the installer only with the prologue present. Every line after the chcp switch still ran, so the old pre-1903 chcp 65001 parsing regression does not bite on the Windows 10 and 11 builds NegPy targets. A full elevated install needs a signed build and admin, so this confirms the path resolution, not the install downstream.
