### PR TITLE
fix(test): compare toast height against a one-word toast, not lineSpacing

### DIFF
--- a/tests/test_hud_toast.py
+++ b/tests/test_hud_toast.py
@@ -10,6 +10,7 @@ from negpy.desktop.view.canvas.hud import _TOAST_WIDTH_RATIO, CanvasHud
 
 LONG = "Nikon High Efficiency (HE) raw — NegPy cannot decode this format. Re-shoot as Lossless Compressed, or convert to DNG."
 SHORT = "merging exposures"
+ONE_WORD = "rendering"
 
 
 def _hud(qapp, width=1400, height=900):
@@ -42,10 +43,15 @@ def test_a_long_message_wraps_rather_than_truncating(qapp):
 def test_a_short_message_keeps_its_natural_width(qapp):
     """The floor must not inflate an ordinary toast into a banner."""
     hud = _hud(qapp)
+    # Compared against a word that cannot wrap, not a font metric: a toast's height also carries
+    # the padding and the border the stylesheet gives it.
+    hud.showMessage(ONE_WORD, 3000)
+    hud.toast.adjustSize()
+    one_line = hud.toast.height()
     hud.showMessage(SHORT, 3000)
     hud.toast.adjustSize()
     assert hud.toast.width() < int(hud.width() * _TOAST_WIDTH_RATIO), "a short toast should not fill the cap"
-    assert hud.toast.height() <= hud.toast.fontMetrics().lineSpacing() * 2
+    assert hud.toast.height() <= one_line, "a short toast should stay on one line"
 
 
 def test_it_fits_before_the_hud_has_ever_been_resized(qapp):


### PR DESCRIPTION
`test_a_short_message_keeps_its_natural_width` bounds the toast height by `fontMetrics().lineSpacing() * 2`, but the height also carries what the stylesheet gives it. `_TOAST_QSS` adds `padding: 7px 18px` and a 1px border, so 16px vertical that the font metric knows nothing about.

That makes the bound sensitive to font registration order. Without qtawesome's icon fonts, lineSpacing is 18, the one-line label is 31 and the bound is 36. With them registered, lineSpacing drops to 16 while the label grows to 33, so the bound falls to 32 and the assertion fails. The file passes alone and fails after any test that pulls qtawesome in.

This is the thirteenth item from #835, the one left undiagnosed there as "order-dependent Qt state, listed for completeness". #840 fixed the twelve deterministic failures and did not scope this one.

The fix compares the short toast against a one-word toast measured the same way instead of against a font metric. I did not compare it against the wrapped `LONG` toast, which is the more obvious reference but is weaker than what it replaces: mutating `setMinimumWidth(min(cap, one_line))` to `setMinimumWidth(0)`, which is the exact inflation this test exists to catch, folds both toasts together and that comparison passes at `51 < 87`. A one-word toast cannot wrap, so it still catches the mutant at `assert 49 <= 31`.

Before: `pytest tests/test_altprocess_sidebar.py tests/test_hud_toast.py` fails here with `assert 33 <= (16 * 2)`, while `pytest tests/test_hud_toast.py` alone passes. After: both orders pass. Full suite on the branch is 4231 passed, 9 skipped, 11 deselected, 0 failed.

I could only run this on Windows, so the numbers above are from that machine and CI is the authority for Linux.
