### PR TITLE
fix(export): apply Contrast Mask and Tilt/Swing in tiled export

### DIFF
--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -315,7 +315,7 @@ Contrast Limited Adaptive Histogram Equalization on the CIELAB $L^{\ast}$ channe
 *   **Per-pixel remap**: a smoothstep-weighted bilinear blend of the four neighbouring tile CDFs (tile centres at $(\text{pos}/\text{dims}) \cdot 8 - 0.5$, edge-clamped), then
     $$L_{final} = (1 - \alpha) \cdot L + \alpha \cdot \text{CDF}(L) \cdot 100$$
     with $\alpha$ = `clahe_strength`.
-*   The GPU keeps the CDF from the preview render and reuses it for tiled full-res export (`clahe_cdf_override`), so export tiles share one seam-free global mapping.
+*   A tiled full-res export takes the CDF from the downsampled meter render it makes of the frame and hands it to every tile (`clahe_cdf_override`), so the tiles share one seam-free global mapping.
 
 The control lives in the Lab sidebar (`lab.clahe_strength`). Defect repair happens earlier still, on the linear source (§5), so local contrast is applied to film that has already been cleaned.
 

--- a/negpy/services/rendering/gpu_engine.py
+++ b/negpy/services/rendering/gpu_engine.py
@@ -429,6 +429,7 @@ class GPUEngine:
         analysis_source_hash: Optional[str] = None,
         cam_xyz: Optional[list] = None,
         camera_wb: Optional[list] = None,
+        contrast_mask_override: Optional[Tuple[np.ndarray, float, Tuple[int, int, int, int]]] = None,
     ) -> Tuple[Any, Dict[str, Any]]:
         """
         Executes the full pipeline, returning a GPU texture and associated metrics.
@@ -436,6 +437,9 @@ class GPUEngine:
         ``local_maps`` is the pre-rasterised (h, w, 2) dodge/burn EV + local grade
         map already in the post-geometry frame; tiled export passes a per-tile slice.
         When None and masks are present, it is computed here from ``settings.local``.
+
+        ``contrast_mask_override`` is (plane, centre, printed frame in rotated pixels),
+        built once per tiled export because a tile cannot see the pre-geometry source.
         """
         if not self.gpu.is_available:
             raise RuntimeError("GPU not available")
@@ -620,46 +624,56 @@ class GPUEngine:
         mask_plane = None
         mask_centre = 0.5
         mask_key = None
-        if settings.exposure.contrast_mask != 0.0 and not tiling_mode:
-            mask_key = (analysis_key, bounds, roi, (h_rot, w_rot))
-            if self._mask_plane is None or self._mask_plane[0] != mask_key:
-                self._mask_plane = (
-                    mask_key,
-                    *contrast_mask_plane(
-                        img,
-                        bounds,
-                        unmix_m,
-                        rotation=settings.geometry.rotation,
-                        fine_rotation=settings.geometry.fine_rotation,
-                        flip_horizontal=settings.geometry.flip_horizontal,
-                        flip_vertical=settings.geometry.flip_vertical,
-                        converge_v=settings.geometry.converge_v,
-                        converge_h=settings.geometry.converge_h,
-                        distortion_k1=k1_eff,
-                        roi_norm=normalized_roi(roi, (h_rot, w_rot)),
-                    ),
-                )
-            mask_plane = self._mask_plane[1]
-            mask_centre = self._mask_plane[2]
-
         # The printed frame in rotated pixels; the shader maps the plane onto it and
         # clamps outside, which is expand_mask_plane's edge padding.
+        mask_rect = None
+        if settings.exposure.contrast_mask != 0.0:
+            if tiling_mode:
+                # A tile holds no pre-geometry source, so the caller builds the plane once
+                # for the whole export and the frame shifts into tile coords here.
+                if contrast_mask_override is not None:
+                    mask_plane, mask_centre, frame = contrast_mask_override
+                    mask_key = ("tiled",)
+                    mask_rect = (frame[0] - global_offset[0], frame[1] - global_offset[1], frame[2], frame[3])
+            else:
+                mask_key = (analysis_key, bounds, roi, (h_rot, w_rot))
+                if self._mask_plane is None or self._mask_plane[0] != mask_key:
+                    self._mask_plane = (
+                        mask_key,
+                        *contrast_mask_plane(
+                            img,
+                            bounds,
+                            unmix_m,
+                            rotation=settings.geometry.rotation,
+                            fine_rotation=settings.geometry.fine_rotation,
+                            flip_horizontal=settings.geometry.flip_horizontal,
+                            flip_vertical=settings.geometry.flip_vertical,
+                            converge_v=settings.geometry.converge_v,
+                            converge_h=settings.geometry.converge_h,
+                            distortion_k1=k1_eff,
+                            roi_norm=normalized_roi(roi, (h_rot, w_rot)),
+                        ),
+                    )
+                mask_plane = self._mask_plane[1]
+                mask_centre = self._mask_plane[2]
+                y1_m, y2_m, x1_m, x2_m = roi if roi is not None else (0, h_rot, 0, w_rot)
+                y1_m, x1_m = max(0, y1_m), max(0, x1_m)
+                y2_m, x2_m = min(h_rot, y2_m), min(w_rot, x2_m)
+                mask_rect = (x1_m, y1_m, x2_m - x1_m, y2_m - y1_m)
+
         mask_uniform = None
-        if mask_plane is not None:
-            y1_m, y2_m, x1_m, x2_m = roi if roi is not None else (0, h_rot, 0, w_rot)
-            y1_m, x1_m = max(0, y1_m), max(0, x1_m)
-            y2_m, x2_m = min(h_rot, y2_m), min(w_rot, x2_m)
-            if y2_m - y1_m < 1 or x2_m - x1_m < 1:
+        if mask_plane is not None and mask_rect is not None:
+            if mask_rect[2] < 1 or mask_rect[3] < 1:
                 mask_plane = None
             else:
                 from negpy.features.exposure.logic import contrast_mask_scale
 
                 mask_uniform = (
                     contrast_mask_scale(settings.exposure.contrast_mask, luminance_density_range(bounds)),
-                    float(x1_m),
-                    float(y1_m),
-                    float(x2_m - x1_m),
-                    float(y2_m - y1_m),
+                    float(mask_rect[0]),
+                    float(mask_rect[1]),
+                    float(mask_rect[2]),
+                    float(mask_rect[3]),
                 )
 
         # CPU meter cost, logged once per source (skips creative-slider re-renders).
@@ -813,6 +827,8 @@ class GPUEngine:
                     settings.geometry.flip_horizontal,
                     settings.geometry.flip_vertical,
                     k1_eff,
+                    settings.geometry.converge_v,
+                    settings.geometry.converge_h,
                     settings.exposure.grade,
                     orig_shape,
                     w_rot,
@@ -830,6 +846,8 @@ class GPUEngine:
                             flip_horizontal=settings.geometry.flip_horizontal,
                             flip_vertical=settings.geometry.flip_vertical,
                             distortion_k1=k1_eff,
+                            converge_v=settings.geometry.converge_v,
+                            converge_h=settings.geometry.converge_h,
                         )
                     from negpy.features.exposure.logic import local_grade_factor_map
 
@@ -1145,6 +1163,8 @@ class GPUEngine:
                     settings.geometry.flip_vertical,
                     roi,
                     k1_eff,
+                    settings.geometry.converge_v,
+                    settings.geometry.converge_h,
                 )
                 if self._uv_grid_cache is not None and self._uv_grid_cache[0] == uv_key:
                     metrics["uv_grid"] = self._uv_grid_cache[1]
@@ -1944,6 +1964,9 @@ class GPUEngine:
             img_rot = apply_fine_rotation(img_rot, settings.geometry.fine_rotation)
         if k1_eff != 0.0:
             img_rot = apply_radial_distortion(img_rot, k1_eff)
+        # Last, as in GeometryProcessor: a plane projectivity cannot be fitted to a frame
+        # that still carries barrel distortion.
+        img_rot = apply_keystone(img_rot, settings.geometry.converge_v, settings.geometry.converge_h)
 
         # Rasterise the dodge/burn EV map once at full post-geometry resolution; tiles
         # slice it directly, like IR above.
@@ -1963,25 +1986,19 @@ class GPUEngine:
                 flip_horizontal=settings.geometry.flip_horizontal,
                 flip_vertical=settings.geometry.flip_vertical,
                 distortion_k1=k1_eff,
+                converge_v=settings.geometry.converge_v,
+                converge_h=settings.geometry.converge_h,
             )
 
         preview_scale = APP_CONFIG.preview_render_size / max(h, w)
         img_small = cv2.resize(img, (int(w * preview_scale), int(h * preview_scale)))
 
-        # Reuse the CDF from the last preview render when CLAHE settings are unchanged.
-        reused_cdf: Optional[np.ndarray] = None
-        if (
-            settings.lab.clahe_strength > 0
-            and self._last_settings is not None
-            and self._last_settings.lab.clahe_strength == settings.lab.clahe_strength
-        ):
-            reused_cdf = self._readback_clahe_cdf()
+        # This render meters the whole frame for the tiles; the CLAHE CDF it leaves behind
+        # is the one they share. Taken from here rather than from the last preview, which
+        # may belong to another image or to settings the export has since moved past.
+        _, metrics_ref = self.process_to_texture(img_small, settings, scale_factor=scale_factor, cam_xyz=cam_xyz, camera_wb=camera_wb)
 
-        _, metrics_ref = self.process_to_texture(
-            img_small, settings, scale_factor=scale_factor, clahe_cdf_override=reused_cdf, cam_xyz=cam_xyz, camera_wb=camera_wb
-        )
-
-        global_cdfs = reused_cdf if reused_cdf is not None else self._readback_clahe_cdf()
+        global_cdfs = self._readback_clahe_cdf()
 
         rot = settings.geometry.rotation % 4
         w_rot, h_rot = (h, w) if rot in (1, 3) else (w, h)
@@ -2059,6 +2076,27 @@ class GPUEngine:
         if settings.exposure.auto_normalize_contrast:
             global_textural_range = measure_textural_range_from_log(_prefiltered(), None, 0.0)
 
+        global_mask = None
+        if settings.exposure.contrast_mask != 0.0:
+            global_mask = (
+                *contrast_mask_plane(
+                    img,
+                    global_bounds,
+                    unmix_m,
+                    rotation=settings.geometry.rotation,
+                    fine_rotation=settings.geometry.fine_rotation,
+                    flip_horizontal=settings.geometry.flip_horizontal,
+                    flip_vertical=settings.geometry.flip_vertical,
+                    converge_v=settings.geometry.converge_v,
+                    converge_h=settings.geometry.converge_h,
+                    distortion_k1=k1_eff,
+                    roi_norm=normalized_roi(roi, (h_rot, w_rot)),
+                ),
+                (x1, y1, crop_w, crop_h),
+            )
+            # One plane serves every tile; the first upload wins.
+            self._mask_tex_key = None
+
         paper_w, paper_h, content_w, content_h, off_x, off_y, _ = self._calculate_layout_dims(settings, crop_w, crop_h, None)
         full_source_res = np.zeros((crop_h, crop_w, 3), dtype=np.float32)
 
@@ -2109,6 +2147,7 @@ class GPUEngine:
                     local_maps=maps_tile,
                     cam_xyz=cam_xyz,
                     camera_wb=camera_wb,
+                    contrast_mask_override=global_mask,
                 )
                 full_source_res[ty : ty + th, tx : tx + tw] = self._readback_downsampled(tile_res)[oy : oy + th, ox : ox + tw]
 

--- a/tests/test_gpu_tiled_parity.py
+++ b/tests/test_gpu_tiled_parity.py
@@ -1,0 +1,128 @@
+"""Tiled export must render what the untiled preview path renders.
+
+`_process_tiled` replays geometry on the CPU and hands every global meter to the
+tiles, so a setting the replay forgets is dropped from exports only.
+"""
+
+import unittest
+from dataclasses import replace
+
+import numpy as np
+
+from negpy.domain.models import WorkspaceConfig
+from negpy.features.local.models import LocalAdjustmentsConfig, LocalMask, MaskShape
+from negpy.features.process.models import ProcessMode
+from negpy.infrastructure.gpu.device import GPUDevice
+from negpy.services.rendering.gpu_engine import GPUEngine
+
+
+def _negative(h: int, w: int) -> np.ndarray:
+    """A C-41-ish frame: a ramp plus smooth structure. Band-limited on purpose — the
+    tiles resample geometry twice where the shader samples once, so per-pixel noise
+    would swamp the parity these tests measure."""
+    yy, xx = np.mgrid[0:h, 0:w].astype(np.float32)
+    ramp = (xx / w) * 0.5 + (yy / h) * 0.25
+    blobs = 0.08 * np.sin(xx / 90.0) * np.cos(yy / 40.0) + 0.05 * np.sin((xx + yy) / 160.0)
+    img = np.empty((h, w, 3), dtype=np.float32)
+    img[..., 0] = 0.55 + ramp * 0.30 + blobs
+    img[..., 1] = 0.35 + ramp * 0.25 + blobs * 0.7
+    img[..., 2] = 0.15 + ramp * 0.20 + blobs * 0.4
+    return np.clip(img, 1e-4, 1.0)
+
+
+def _base() -> WorkspaceConfig:
+    s = WorkspaceConfig()
+    return replace(
+        s,
+        process=replace(s.process, process_mode=ProcessMode.C41),
+        export=replace(s.export, export_resolution_mode="original"),
+    )
+
+
+@unittest.skipUnless(GPUDevice.get().is_available, "GPU not available")
+class TestGpuTiledParity(unittest.TestCase):
+    def setUp(self):
+        self.engine = GPUEngine()
+        # Wider than TILE_SIZE, so the export spans more than one tile.
+        self.img = _negative(300, 2400)
+
+    def tearDown(self):
+        self.engine.destroy_all()
+
+    def _tiled(self, settings) -> np.ndarray:
+        res, _ = self.engine._process_tiled(self.img, settings, scale_factor=1.0)
+        return res
+
+    def _direct(self, settings) -> np.ndarray:
+        tex, _ = self.engine.process_to_texture(self.img, settings, scale_factor=1.0, apply_layout=False)
+        return self.engine._readback_downsampled(tex)
+
+    def _assert_parity(self, settings, msg, tol=0.0005):
+        tiled, direct = self._tiled(settings), self._direct(settings)
+        self.assertEqual(tiled.shape, direct.shape)
+        self.assertLess(float(np.abs(tiled - direct).mean()), tol, msg)
+
+    def _assert_changes_export(self, settings, msg, tol=0.01):
+        """The control must move the tiled render, or parity holds trivially."""
+        diff = float(np.abs(self._tiled(settings) - self._tiled(_base())).mean())
+        self.assertGreater(diff, tol, msg)
+
+    def test_tiled_applies_keystone(self):
+        base = _base()
+        settings = replace(base, geometry=replace(base.geometry, converge_v=8.0, converge_h=-5.0))
+        self._assert_changes_export(settings, "Tilt/Swing did nothing to the tiled export")
+        self._assert_parity(settings, "Tiled export dropped Tilt/Swing")
+
+    def test_tiled_applies_contrast_mask(self):
+        base = _base()
+        settings = replace(base, exposure=replace(base.exposure, contrast_mask=0.4))
+        self._assert_changes_export(settings, "Contrast Mask did nothing to the tiled export")
+        self._assert_parity(settings, "Tiled export dropped the Contrast Mask")
+
+    def test_tiled_local_mask_follows_keystone(self):
+        base = _base()
+        settings = replace(
+            base,
+            geometry=replace(base.geometry, converge_v=8.0),
+            local=LocalAdjustmentsConfig(
+                masks=(LocalMask(vertices=((0.25, 0.5), (0.6, 0.5)), stops=1.5, shape=MaskShape.GRADIENT),),
+            ),
+        )
+        self._assert_changes_export(settings, "The dodge/burn mask did nothing to the tiled export")
+        self._assert_parity(settings, "Tiled export placed the dodge/burn mask on an uncorrected frame")
+
+    def test_tiled_matches_untiled_with_every_stage_live(self):
+        """One frame with a control on in each stage: geometry, exposure, local, mask,
+        clahe, lab, toning and finish all have to survive the tiling."""
+        base = _base()
+        settings = replace(
+            base,
+            geometry=replace(base.geometry, rotation=1, flip_horizontal=True, fine_rotation=1.5, converge_v=6.0, converge_h=-4.0),
+            exposure=replace(base.exposure, contrast_mask=0.35, grade=140.0, wb_cyan=0.1, shadow_density=0.2),
+            local=LocalAdjustmentsConfig(
+                masks=(LocalMask(vertices=((0.3, 0.3), (0.7, 0.7)), stops=1.0, grade=15.0, shape=MaskShape.GRADIENT),),
+            ),
+            lab=replace(base.lab, saturation=1.2, clahe_strength=0.4, sharpen=0.6, glow_amount=0.3),
+            toning=replace(base.toning, selenium_strength=0.5, shadow_tint_hue=200.0, shadow_tint_strength=0.3),
+            finish=replace(base.finish, vignette_stops=0.8, vignette_size=0.4),
+        )
+        # Looser than the focused tests: the tiles share the CLAHE CDF the preview-sized
+        # meter render built, where the untiled reference builds its own at full size.
+        self._assert_parity(settings, "Tiled export diverged from the preview pipeline", tol=0.002)
+
+    def test_tiled_clahe_cdf_is_this_image(self):
+        """The tiles share one CDF. It has to come from the frame being exported, not
+        from whatever the engine rendered last."""
+        base = _base()
+        settings = replace(base, lab=replace(base.lab, clahe_strength=0.6))
+        clean = self._tiled(settings)
+
+        other = np.clip(self.img[::-1, ::-1] * 0.6 + 0.1, 1e-4, 1.0)
+        self.engine.process_to_texture(other, settings, scale_factor=1.0, apply_layout=False)
+        after = self._tiled(settings)
+
+        np.testing.assert_allclose(after, clean, atol=1e-6)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

Contrast Mask and Tilt/Swing worked in the preview and were dropped from exports.

Both live in `_process_tiled`, the path an export takes once the frame passes the tiling threshold:

- The CPU geometry replay ran rot90 → flips → fine rotation → distortion and stopped there, with no `apply_keystone`.
- The Contrast Mask was gated off in tiling mode (`and not tiling_mode`). Its plane is built from the pre-geometry source, which a tile does not hold.

## Fix

- Keystone joins the CPU replay, last, in `GeometryProcessor`'s order.
- The mask plane is built once per export and passed to each tile, which shifts the printed frame into its own coords. All tiles share one plane texture.

Two neighbours of the same bug, found while checking the rest of the settings:

- The GPU **preview** rasterised dodge/burn masks without the convergences, so a mask sat on an uncorrected frame whenever Tilt/Swing was up. Its cache key and the UV grid's key did not see them either.
- Tiled export reused the CLAHE CDF from the last preview render, keyed only on `clahe_strength` — which could belong to a different image. It now takes the CDF from the meter render it makes of the frame being exported.

## Verification

`tests/test_gpu_tiled_parity.py` renders tiled against untiled and asserts the picture matches. All five tests fail on `main` and pass here.

A per-field sweep over process / exposure / geometry / lab / toning / finish / altproc (plus B&W mode and the alt processes) shows parity at or below 2e-5 mean for every control. CLAHE stays at ~1e-3: the tiles share the CDF the preview-sized meter render built, which is the preview's own mapping. A cropped frame carries a ~0.1% metering offset from ROI rounding on the analysis downsample, unchanged by this PR.

`make all` green: 4272 passed, 11 skipped.