### PR TITLE
fix(export): write the IR TIFF sidecar without the source filename in its description

### DIFF
--- a/negpy/services/export/linear_output.py
+++ b/negpy/services/export/linear_output.py
@@ -941,20 +941,30 @@ def _write_tiff(
     )
 
 
-def _write_ir_tiff(ir: np.ndarray, dest, source_name: str) -> None:
+def _write_ir_tiff(ir: np.ndarray, dest) -> None:
     """Write a single-channel IR buffer as an untagged 16-bit grayscale TIFF."""
     u16 = _to_uint16_jit(np.ascontiguousarray(ir[:, :, np.newaxis] if ir.ndim == 2 else ir, dtype=np.float32))
     if u16.ndim == 3 and u16.shape[2] == 1:
         u16 = u16[:, :, 0]
-    description = f"NegPy Linear Output -- infrared channel. Source: {source_name}"
-    _tifffile.imwrite(
-        dest,
-        u16,
-        photometric="minisblack",
-        compression="zlib",
-        predictor=True,
-        description=description,
-    )
+    # No filename in the description: TIFF tag 270 is 7-bit ASCII only, and a
+    # non-ASCII source name would make imwrite raise after the header is written.
+    description = "NegPy Linear Output -- infrared channel."
+    try:
+        _tifffile.imwrite(
+            dest,
+            u16,
+            photometric="minisblack",
+            compression="zlib",
+            predictor=True,
+            description=description,
+        )
+    except Exception:
+        # The sidecar is a bonus artifact; never let it kill the export or leave
+        # a header-only stub that looks like a real file.
+        try:
+            os.unlink(dest)
+        except OSError:
+            pass
 
 
 def _write_ir_jxl(ir: np.ndarray, dest, effort: int = 7) -> None:
@@ -1094,7 +1104,7 @@ def export_linear_output(
         if output_format == "jxl":
             _write_ir_jxl(ir, f"{stem}_ir.jxl", effort=jxl_effort)
         else:
-            _write_ir_tiff(ir, f"{stem}_ir.tiff", os.path.basename(file_path))
+            _write_ir_tiff(ir, f"{stem}_ir.tiff")
 
 
 def export_linear_output_bytes(file_path: str, geometry: Optional[GeometryConfig] = None) -> tuple[bytes, str]:

--- a/tests/test_linear_output.py
+++ b/tests/test_linear_output.py
@@ -2,6 +2,7 @@
 
 import io
 import os
+import shutil
 from typing import Optional
 from unittest import mock
 
@@ -283,6 +284,20 @@ class TestExportLinearOutputJxl:
         assert os.path.exists(ir_path)
         with tifffile.TiffFile(ir_path) as tf:
             assert tf.pages[0].asarray().dtype == np.uint16
+
+    def test_ir_sidecar_survives_non_ascii_source_filename(self, tmp_path: str) -> None:
+        dng_path = _make_linearraw_dng_4ch(str(tmp_path))
+        non_ascii_path = os.path.join(str(tmp_path), "négatif_şcan.dng")
+        shutil.copyfile(dng_path, non_ascii_path)
+        out_path = os.path.join(str(tmp_path), "output.tiff")
+        export_linear_output(non_ascii_path, out_path, output_format="tiff")
+        ir_path = os.path.join(str(tmp_path), "output_ir.tiff")
+        assert os.path.exists(ir_path)
+        # More than a header-only stub, decodable, and no filename in tag 270.
+        assert os.path.getsize(ir_path) > 8
+        with tifffile.TiffFile(ir_path) as tf:
+            assert tf.pages[0].asarray().dtype == np.uint16
+            assert "négatif" not in (tf.pages[0].description or "")
 
 
 class TestExportLinearOutputBytes:


### PR DESCRIPTION
Closes #879

Implements the fix as scoped by @thetalkingdrum in the issue thread:

- `_write_ir_tiff` now writes a fixed ASCII description (`NegPy Linear Output -- infrared channel.`), matching `_write_tiff`'s fixed-string style — no filename, so tag 270 can never see non-ASCII bytes.
- The `imwrite` is wrapped in `try/except` following the `_write_tiff` extratags precedent: a sidecar failure no longer kills the export.
- On failure the partial sidecar is unlinked, so no header-only `_ir` stub is left looking like a real file.
- The `source_name` parameter is dropped; the only caller passed `os.path.basename(file_path)` purely for the description.

**Test:** `test_ir_sidecar_survives_non_ascii_source_filename` copies the 4-channel LinearRaw DNG fixture to `négatif_şcan.dng`, exports as TIFF, and asserts the sidecar exists, is larger than a bare header, decodes as uint16, and carries no filename in its description. It fails on current main with tifffile's `ValueError: TIFF strings must be 7-bit ASCII` and passes with this change.

**Testing:** full suite on Windows 11 / Python 3.13: 4259 passed, 10 skipped, 11 deselected, 0 failed (`tests/test_linear_output.py` alone: 169 passed). `ruff check` (pinned 0.14.10) clean on both changed files.

Deliberately unchanged, per the issue discussion: the `_build_xmp` gate stays `camera_wb`-only, so the filename is not relocated into XMP.
