### PR TITLE
Peek the negative as loaded

### DIFF
--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -305,6 +305,11 @@ When the render intent is **Linear**, the entire darkroom pipeline is bypassed. 
 
 **The JPEG XL path carries none of this.** `_write_jxl()` and `_write_ir_jxl()` take no metadata parameters at all: no description, no XMP, no Make/Model/DateTime, and critically no record of whether ICE was applied. A linear JXL file has zero processing history baked in, and the only indirect signal is the IR sidecar's presence, whose absence could mean either "no IR channel" or "ICE consumed it". `imagecodecs.jpegxl_encode()` has no parameter for this, though libjxl's box API (Exif and XMP boxes) and the reference `cjxl` CLI (`-x exif=`, `-x xmp=`) both support it. Closing this gap needs the same encoder rework as the ICC limitation above, not a small patch.
 
+### Peek Negative
+**Code**: `AppController.toggle_negative_peek` / `_paint_negative_peek`
+
+The canvas equivalent of Linear Output, and not a pipeline stage of its own. The decoded source buffer (`AppState.preview_raw`, pre-bake, so before flat-field, sensor unmix and every defect repair) runs through `GeometryProcessor` and `CropProcessor`, the same two the base and crop stages use, so the frame keeps the user's rotation, flip, straighten, keystone and crop. It then takes `working_oetf_encode`, a display encode rather than an edit, since a linear buffer would otherwise show as near-black. Everything between those two is skipped: nothing is inverted, metered or normalized, so the negative is on screen as the loader read it. `content_rect` is cleared, no border stage having run. The buffer is in camera or scanner primaries, so it is marked `splash` and the working-to-display matrix and the soft proof are left off. The state is transient, mutually exclusive with the flat peek and the before/after split, and any render with no config override drops it.
+
 ---
 
 ## 4. Local Contrast (CLAHE)

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -20,7 +20,11 @@ This guide is for new users. It explains what each control does and when to reac
 
 The canvas toolbar's **◑** button (or `\`) splits the canvas in two. Left of the divider is the auto baseline: the same frame with the same film process, crop and rotation, but with every creative control (exposure, tone, Lab, dodge/burn, toning, retouch and finishing) back at its default. Right of it is your edit. Drag the divider to move the split, or grab its knob in the middle.
 
-The split stays up while you work, so a slider moves the after side against a fixed reference. Press `\` again, or move to another frame, to close it. Peek Flat Scan and the test strip take the canvas over, so they close it too.
+The split stays up while you work, so a slider moves the after side against a fixed reference. Press `\` again, or move to another frame, to close it. Peek Negative, Peek Flat Scan and the test strip take the canvas over, so they close it too.
+
+### Peek Negative
+
+The canvas toolbar's film button (or `N`) shows the scan as it was loaded: the negative, un-inverted, with no metering, no film-base normalization and none of your edits. Use it to judge the scan rather than the print — whether the frame is thin or dense, what colour the mask really is, whether the scanner clipped. It changes nothing and closes as soon as you touch a control. Your crop, rotation and flip still apply, so the frame stays where you put it. Because it is the file's own numbers, it gets no colour management or soft proof, so expect the raw orange cast rather than an accurate one.
 
 ### The workflow (and the order things happen)
 
@@ -544,7 +548,7 @@ Two conventions are worth knowing, both borrowed from the darkroom rather than f
 
 A mask with a local **Grade** also carries the grade it actually prints at, not the trim: a burn of +1.00 st at −20 R on a frame graded R115 is written `Burn +1 @ R95`, and a grade-only mask reads `Grade @ R95`.
 
-Every mask is on the map, including ones whose outline you hid with the eye: that eye is there to unclutter editing, and a printing record that quietly omits a burn would be wrong. The overlay steps aside while a test strip, the flat peek, the before/after baseline, or the crop and analysis tools own the canvas. Both the preview and its export live in the Export tab's **Printing Notes** section.
+Every mask is on the map, including ones whose outline you hid with the eye: that eye is there to unclutter editing, and a printing record that quietly omits a burn would be wrong. The overlay steps aside while a test strip, either peek, the before/after baseline, or the crop and analysis tools own the canvas. Both the preview and its export live in the Export tab's **Printing Notes** section.
 
 ---
 

--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -12,6 +12,7 @@ from PyQt6.QtGui import QIcon, QPixmap
 from PyQt6.QtWidgets import QCheckBox, QMessageBox
 
 from negpy.kernel.system.text import count_of, plural
+from negpy.kernel.image.logic import working_oetf_encode
 from negpy.desktop.converters import ImageConverter
 from negpy.desktop.render_memo import RenderMemo
 from negpy.desktop.session import (
@@ -104,6 +105,8 @@ from negpy.features.geometry.logic import (
     has_manual_crop,
 )
 from negpy.features.geometry.models import FINE_ROTATION_LIMIT, AutocropMode
+from negpy.features.geometry.processor import CropProcessor, GeometryProcessor
+from negpy.domain.interfaces import PipelineContext
 from negpy.features.lab.models import LabConfig
 from negpy.features.local.models import LocalAdjustmentsConfig
 from negpy.features.process.models import ProcessConfig, ProcessMode, invalidate_local_bounds, scan_setup_values
@@ -310,6 +313,7 @@ class AppController(QObject):
     flat_output_changed = pyqtSignal(bool)
     linear_output_changed = pyqtSignal(bool)
     flat_peek_changed = pyqtSignal(bool)
+    negative_peek_changed = pyqtSignal(bool)
     zoom_requested = pyqtSignal(float)
     zoom_changed = pyqtSignal(float)
     _render_cleanup_requested = pyqtSignal(object)  # texture to spare, or None
@@ -1503,6 +1507,9 @@ class AppController(QObject):
         self.state.preview_ir = None
         self.state.has_ir = False
         self.state.original_res = (0, 0)
+        if self.state.negative_peek:
+            self.state.negative_peek = False
+            self.negative_peek_changed.emit(False)
 
         pending_import = self._pending_capture_imports.pop(_capture_import_key(file_path), None)
         if pending_import is not None and pending_import.process_mode is not None:
@@ -3720,6 +3727,9 @@ class AppController(QObject):
         if config_override is None and self.state.flat_peek:
             self.state.flat_peek = False
             self.flat_peek_changed.emit(False)
+        if config_override is None and self.state.negative_peek:
+            self.state.negative_peek = False
+            self.negative_peek_changed.emit(False)
 
         # The strip's patches were printed from the config as it stood, so once the edit
         # moves they prove something else. Drop them, which also cancels a strip still
@@ -3840,6 +3850,9 @@ class AppController(QObject):
             if self.state.flat_peek:
                 self.state.flat_peek = False
                 self.flat_peek_changed.emit(False)
+            if self.state.negative_peek:
+                self.state.negative_peek = False
+                self.negative_peek_changed.emit(False)
             # Same reason the strip and the peek are exclusive: both want the canvas.
             self._clear_test_strip()
             self.state.compare_mode = True
@@ -3854,7 +3867,9 @@ class AppController(QObject):
         out of flat-peek; a plain request_render() would exit it. The compare split
         survives a plain render, and its baseline half re-captures on the key change.
         """
-        if self.state.flat_peek:
+        if self.state.negative_peek:
+            self._paint_negative_peek()
+        elif self.state.flat_peek:
             self.request_render(readback_metrics=False, config_override=flat_master_config(self.state.config))
         else:
             self.request_render()
@@ -3916,6 +3931,9 @@ class AppController(QObject):
 
         if target:
             self.exit_compare()
+            if self.state.negative_peek:
+                self.state.negative_peek = False
+                self.negative_peek_changed.emit(False)
             self._clear_test_strip()
 
         self.state.flat_peek = target
@@ -3923,6 +3941,67 @@ class AppController(QObject):
 
         if target:
             self.request_render(readback_metrics=False, config_override=flat_master_config(self.state.config))
+        else:
+            self.request_render()
+
+    def _paint_negative_peek(self) -> None:
+        """Put the decoded source on the canvas: un-inverted, un-normalized, no tone edits.
+
+        Geometry is the one thing the peek does apply, through the same two processors
+        the base and crop stages use, so the negative sits at the orientation and
+        framing the user set. Everything after it is skipped: no metering, no
+        inversion, no look. Only the working OETF follows, or a linear buffer shows as
+        near-black. The source is in camera primaries, so it is marked splash to keep
+        the working-to-display matrix and the proof out of it, and content_rect is
+        cleared because no border stage ran to inset the picture.
+        """
+        source = self.state.preview_raw
+        if source is None:
+            return
+        geometry = self.state.config.geometry
+        flatfield = self.state.config.flatfield
+        original = self.state.original_res if any(self.state.original_res) else source.shape[:2]
+        context = PipelineContext(
+            original_size=(original[0], original[1]),
+            scale_factor=max(original) / float(APP_CONFIG.preview_render_size),
+            process_mode=self.state.config.process.process_mode,
+            # Mirrors request_render: the crop tool frames against the uncropped frame.
+            crop_preview_full=self.state.active_tool in (ToolMode.CROP_MANUAL, ToolMode.ANALYSIS_DRAW),
+            wants_uv_grid=False,
+        )
+        img = GeometryProcessor(geometry, flatfield.k1 if flatfield.apply else 0.0).process(source, context)
+        if not context.crop_preview_full:
+            img = CropProcessor(geometry).process(img, context)
+        with self.state.metrics_lock:
+            self.state.last_metrics["base_positive"] = working_oetf_encode(img)
+            self.state.last_metrics["content_rect"] = None
+            self.state.last_metrics["splash"] = True
+        self.image_updated.emit()
+
+    def toggle_negative_peek(self, force: Optional[bool] = None) -> None:
+        """Show the negative as it was loaded, without changing the saved edit.
+
+        ``force`` sets an explicit state; otherwise toggles. Mutually exclusive with
+        the before/after compare view and the flat peek.
+        """
+        if self.state.preview_raw is None:
+            return
+        target = (not self.state.negative_peek) if force is None else force
+        if target == self.state.negative_peek:
+            return
+
+        if target:
+            self.exit_compare()
+            if self.state.flat_peek:
+                self.state.flat_peek = False
+                self.flat_peek_changed.emit(False)
+            self._clear_test_strip()
+
+        self.state.negative_peek = target
+        self.negative_peek_changed.emit(target)
+
+        if target:
+            self._paint_negative_peek()
         else:
             self.request_render()
 
@@ -4746,7 +4825,11 @@ class AppController(QObject):
             self._gpu_fallback_notified = True
             self.set_status("GPU acceleration failed — using CPU", 5000)
 
-        self.image_updated.emit()
+        # A render already in flight when the peek went on would otherwise repaint over it.
+        if self.state.negative_peek:
+            self._paint_negative_peek()
+        else:
+            self.image_updated.emit()
 
         # By reference, because display buffers are read-only downstream. After the repaint:
         # overwriting an entry frees the texture the canvas has just stopped sampling.

--- a/negpy/desktop/session.py
+++ b/negpy/desktop/session.py
@@ -199,6 +199,8 @@ class AppState:
     flat_output: bool = False
     # Transient: preview is currently peeking the flat render (not persisted).
     flat_peek: bool = False
+    # Transient: preview is showing the decoded source as loaded, un-inverted.
+    negative_peek: bool = False
 
     # Linear Output: export the loader's raw decoded buffer as an untagged 16-bit TIFF.
     linear_output: bool = False

--- a/negpy/desktop/view/canvas/overlay.py
+++ b/negpy/desktop/view/canvas/overlay.py
@@ -687,7 +687,11 @@ class CanvasOverlay(QWidget):
             self._draw_dust_overlay(painter)
 
         # Crop/analysis modes show the uncropped frame, so the boxes wouldn't line up.
-        content_aligned = not self.state.flat_peek and self._tool_mode not in (ToolMode.CROP_MANUAL, ToolMode.ANALYSIS_DRAW)
+        content_aligned = (
+            not self.state.flat_peek
+            and not self.state.negative_peek
+            and self._tool_mode not in (ToolMode.CROP_MANUAL, ToolMode.ANALYSIS_DRAW)
+        )
         if self.state.test_strip and content_aligned:
             # Takes the content rect over from the zone grid: both would claim it.
             self._draw_test_strip(painter)

--- a/negpy/desktop/view/canvas/toolbar.py
+++ b/negpy/desktop/view/canvas/toolbar.py
@@ -161,6 +161,16 @@ class ActionToolbar(QWidget):
             tooltip_with_shortcut("Peek flat scan — temporarily show the flat master (does not change your edit)", "toggle_flat_peek")
         )
 
+        self.btn_negative_peek = QToolButton()
+        self.btn_negative_peek.setCheckable(True)
+        self.btn_negative_peek.setIcon(qta.icon("fa5s.film", color=icon_color))
+        self.btn_negative_peek.setToolTip(
+            tooltip_with_shortcut(
+                "Peek negative — show the source as it was loaded, un-inverted and unedited, at your crop and rotation (no colour management)",
+                "toggle_negative_peek",
+            )
+        )
+
         self.btn_zones = QToolButton()
         self.btn_zones.setCheckable(True)
         self.btn_zones.setIcon(qta.icon("mdi.grid", color=icon_color))
@@ -252,6 +262,14 @@ class ActionToolbar(QWidget):
         self._ov_flat_peek_action.setCheckable(True)
         self._ov_flat_peek_action.setToolTip(
             tooltip_with_shortcut("Peek flat scan — temporarily show the flat master (does not change your edit)", "toggle_flat_peek")
+        )
+        self._ov_negative_peek_action = overflow_menu.addAction(qta.icon("fa5s.film", color=icon_color), "Peek Negative")
+        self._ov_negative_peek_action.setCheckable(True)
+        self._ov_negative_peek_action.setToolTip(
+            tooltip_with_shortcut(
+                "Peek negative — show the source as it was loaded, un-inverted and unedited, at your crop and rotation (no colour management)",
+                "toggle_negative_peek",
+            )
         )
         self._ov_zones_action = overflow_menu.addAction(qta.icon("mdi.grid", color=icon_color), "Zone Overlay")
         self._ov_zones_action.setCheckable(True)
@@ -384,6 +402,7 @@ class ActionToolbar(QWidget):
             self.btn_zoom_original,
             self.btn_hq,
             self.btn_compare,
+            self.btn_negative_peek,
             self.btn_zones,
             self.btn_loupe,
             self.btn_overflow,
@@ -423,13 +442,14 @@ class ActionToolbar(QWidget):
         row_layout.addWidget(self.btn_undo)
         row_layout.addWidget(self.btn_redo)
         row_layout.addWidget(self.btn_compare)
+        row_layout.addWidget(self.btn_negative_peek)
         row_layout.addWidget(self.btn_zones)
         row_layout.addWidget(self.btn_loupe)
         row_layout.addWidget(self.btn_overflow)
         row_layout.addWidget(self.btn_toggle_right)
 
         # Overflow groups for responsive resize (first listed = first collapsed).
-        self._ov_view_toggles: list = [self.btn_compare, self.btn_zones, self.btn_loupe]
+        self._ov_view_toggles: list = [self.btn_compare, self.btn_negative_peek, self.btn_zones, self.btn_loupe]
         self._ov_undo_redo: list = [self._sep3, self.btn_undo, self.btn_redo]
         self._ov_zoom_extra: list = [self.btn_zoom_fit, self.btn_zoom_original]
         self._ov_hq_group: list = [self.btn_hq, self._sep2]
@@ -466,6 +486,12 @@ class ActionToolbar(QWidget):
         self._ov_flat_peek_action.setChecked(active)
         self._ov_flat_peek_action.blockSignals(False)
 
+    def _on_negative_peek_changed(self, active: bool) -> None:
+        for widget in (self.btn_negative_peek, self._ov_negative_peek_action):
+            widget.blockSignals(True)
+            widget.setChecked(active)
+            widget.blockSignals(False)
+
     def _connect_signals(self) -> None:
         self.btn_prev.clicked.connect(self.session.prev_file)
         self.btn_next.clicked.connect(self.session.next_file)
@@ -487,6 +513,9 @@ class ActionToolbar(QWidget):
         self.controller.compare_changed.connect(self._ov_compare_action.setChecked)
         self.btn_flat_peek.toggled.connect(lambda checked: self.controller.toggle_flat_peek(force=checked))
         self.controller.flat_peek_changed.connect(self._on_flat_peek_changed)
+        self.btn_negative_peek.toggled.connect(lambda checked: self.controller.toggle_negative_peek(force=checked))
+        self._ov_negative_peek_action.triggered.connect(lambda checked: self.controller.toggle_negative_peek(force=checked))
+        self.controller.negative_peek_changed.connect(self._on_negative_peek_changed)
         self.btn_zones.toggled.connect(lambda checked: self.controller.toggle_zones_overlay(force=checked))
         self._ov_zones_action.triggered.connect(lambda checked: self.controller.toggle_zones_overlay(force=checked))
         self.controller.zones_overlay_changed.connect(self._on_zones_changed)
@@ -731,6 +760,7 @@ class ActionToolbar(QWidget):
         self._ov_compare_action.setChecked(state.compare_mode)
         self.btn_flat_peek.setChecked(state.flat_peek)
         self._ov_flat_peek_action.setChecked(state.flat_peek)
+        self._on_negative_peek_changed(state.negative_peek)
         self._on_zones_changed(state.zones_overlay)
         self._on_grain_focuser_changed(state.grain_focuser)
 

--- a/negpy/desktop/view/keyboard_shortcuts.py
+++ b/negpy/desktop/view/keyboard_shortcuts.py
@@ -141,6 +141,7 @@ class ShortcutManager:
             "local_gradient": lambda: _toggle_tool_button(self.window, "tone", controls.local_sidebar.gradient_btn),
             "analysis_draw": lambda: _toggle_tool_button(self.window, "setup", controls.process_sidebar.analysis_region_btn),
             "toggle_flat_peek": controller.toggle_flat_peek,
+            "toggle_negative_peek": controller.toggle_negative_peek,
             "toggle_zones": controller.toggle_zones_overlay,
             "toggle_test_strip": controller.toggle_test_strip,
             "toggle_ring_around": controller.toggle_ring_around,

--- a/negpy/desktop/view/shortcut_registry.py
+++ b/negpy/desktop/view/shortcut_registry.py
@@ -53,6 +53,7 @@ REGISTRY: dict[str, ShortcutEntry] = {
     "local_gradient": ShortcutEntry("", "Toggle dodge & burn card-edge mask draw", "Tools"),
     "analysis_draw": ShortcutEntry("Shift+R", "Toggle analysis region draw", "Tools"),
     "toggle_flat_peek": ShortcutEntry("|", "Peek flat scan (digital intermediate)", "Tools"),
+    "toggle_negative_peek": ShortcutEntry("N", "Peek negative (source as loaded)", "Tools"),
     "toggle_zones": ShortcutEntry("Shift+Z", "Adams zone overlay", "Tools"),
     "toggle_test_strip": ShortcutEntry("Shift+T", "Density × grade test strip", "Tools"),
     "toggle_ring_around": ShortcutEntry("Shift+F", "Color ring-around (M/Y filtration)", "Tools"),

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -2531,6 +2531,117 @@ class TestCompareFlatPeekInteraction(unittest.TestCase):
         _, kwargs = rr.call_args
         self.assertIsNone(kwargs.get("config_override"))
 
+    def test_negative_peek_paints_the_source_with_only_the_oetf(self):
+        import numpy as np
+
+        from negpy.kernel.image.logic import working_oetf_encode
+
+        source = np.linspace(0.0, 1.0, 8 * 8 * 3, dtype=np.float32).reshape(8, 8, 3)
+        self.controller.state.preview_raw = source
+        painted: list = []
+        self.controller.image_updated.connect(lambda: painted.append(True))
+
+        self.controller.toggle_negative_peek(force=True)
+
+        self.assertTrue(self.controller.state.negative_peek)
+        self.assertTrue(painted)
+        metrics = self.controller.state.last_metrics
+        np.testing.assert_allclose(metrics["base_positive"], working_oetf_encode(source))
+        # Camera primaries, so the working-to-display matrix and the proof stay out.
+        self.assertTrue(metrics["splash"])
+
+    def test_leaving_the_negative_peek_re_renders_the_edit(self):
+        self.controller.state.negative_peek = True
+        with patch.object(self.controller, "request_render") as rr:
+            self.controller.toggle_negative_peek(force=False)
+        self.assertFalse(self.controller.state.negative_peek)
+        rr.assert_called_once()
+
+    def test_negative_peek_needs_a_loaded_source(self):
+        self.controller.state.preview_raw = None
+        seen: list = []
+        self.controller.negative_peek_changed.connect(seen.append)
+        self.controller.toggle_negative_peek(force=True)
+        self.assertFalse(self.controller.state.negative_peek)
+        self.assertEqual(seen, [])
+
+    def test_the_two_peeks_are_mutually_exclusive(self):
+        self.controller.state.flat_peek = True
+        self.controller.toggle_negative_peek(force=True)
+        self.assertTrue(self.controller.state.negative_peek)
+        self.assertFalse(self.controller.state.flat_peek)
+
+        with patch.object(self.controller, "request_render"):
+            self.controller.toggle_flat_peek(force=True)
+        self.assertTrue(self.controller.state.flat_peek)
+        self.assertFalse(self.controller.state.negative_peek)
+
+    def test_enabling_compare_clears_an_active_negative_peek(self):
+        self.controller.state.negative_peek = True
+        seen: list = []
+        self.controller.negative_peek_changed.connect(seen.append)
+        with patch.object(self.controller, "request_render"):
+            self.controller.toggle_compare()
+        self.assertTrue(self.controller.state.compare_mode)
+        self.assertFalse(self.controller.state.negative_peek)
+        self.assertIn(False, seen)
+
+    def test_the_negative_peek_takes_the_geometry(self):
+        import numpy as np
+        from dataclasses import replace
+
+        # Landscape, so a quarter turn is visible in the shape alone.
+        source = np.random.default_rng(0).random((6, 10, 3), dtype=np.float32)
+        self.controller.state.preview_raw = source
+        geo = replace(self.controller.state.config.geometry, rotation=1, crop_rect=(0.0, 0.0, 0.5, 1.0))
+        self.controller.state.config = replace(self.controller.state.config, geometry=geo)
+
+        self.controller.toggle_negative_peek(force=True)
+
+        painted = self.controller.state.last_metrics["base_positive"]
+        # Quarter turn swaps the axes, then the crop keeps the left half of the width.
+        self.assertEqual(painted.shape, (10, 3, 3))
+        # No border stage ran, so nothing may claim the frame is inset.
+        self.assertIsNone(self.controller.state.last_metrics["content_rect"])
+
+    def test_the_crop_tool_peeks_the_uncropped_frame(self):
+        import numpy as np
+        from dataclasses import replace
+
+        from negpy.desktop.session import ToolMode
+
+        source = np.zeros((6, 10, 3), dtype=np.float32)
+        self.controller.state.preview_raw = source
+        geo = replace(self.controller.state.config.geometry, crop_rect=(0.0, 0.0, 0.5, 1.0))
+        self.controller.state.config = replace(self.controller.state.config, geometry=geo)
+        self.controller.state.active_tool = ToolMode.CROP_MANUAL
+
+        self.controller.toggle_negative_peek(force=True)
+
+        # Framing a crop against a pre-cropped frame would be impossible.
+        self.assertEqual(self.controller.state.last_metrics["base_positive"].shape, (6, 10, 3))
+
+    def test_any_plain_render_leaves_the_negative_peek(self):
+        self.controller.state.negative_peek = True
+        seen: list = []
+        self.controller.negative_peek_changed.connect(seen.append)
+        with patch.object(self.controller, "_dispatch_pending_render"):
+            self.controller.request_render()
+        self.assertFalse(self.controller.state.negative_peek)
+        self.assertIn(False, seen)
+
+    def test_rerender_active_view_keeps_the_negative_peek(self):
+        import numpy as np
+
+        self.controller.state.preview_raw = np.zeros((8, 8, 3), dtype=np.float32)
+        self.controller.state.negative_peek = True
+        with patch.object(self.controller, "request_render") as rr:
+            self.controller.rerender_active_view()
+        # A geometry op must not drop the peek, and the peek is not a render.
+        rr.assert_not_called()
+        self.assertTrue(self.controller.state.negative_peek)
+        self.assertIn("base_positive", self.controller.state.last_metrics)
+
 
 class TestClearThumbnailCache(unittest.TestCase):
     """'Clear Thumbnails' has to drop the disk cache and the in-memory icons, then refill."""

--- a/tests/test_interactive_decoupling.py
+++ b/tests/test_interactive_decoupling.py
@@ -90,6 +90,7 @@ class TestSettleOnlyWorkIsSkipped(unittest.TestCase):
                 last_metrics={},
                 current_file_hash="h1",
                 compare_mode=False,
+                negative_peek=False,
             ),
             image_updated=MagicMock(),
             _update_thumbnail_from_state=MagicMock(),

--- a/tests/test_navigate_back_memo.py
+++ b/tests/test_navigate_back_memo.py
@@ -45,6 +45,7 @@ def _stub(memo, **overrides):
             last_metrics={},
             current_file_hash="h1",
             compare_mode=False,
+            negative_peek=False,
         ),
         image_updated=MagicMock(),
         _update_thumbnail_from_state=MagicMock(),


### PR DESCRIPTION
## Why

Every canvas view is a print. The base stage converts the linear source to normalized log density and the exposure transfer curve (`features/exposure/transfer.py`) inverts it; Peek Flat Scan inverts too, since `RenderIntent.FLAT` only drops the creative stages. So there was no way to look at the negative itself.

When a conversion looks wrong, the first question is whether the *scan* is wrong — thin or dense frame, what colour the mask really is, whether the scanner clipped. Answering it meant exporting a Linear Output TIFF and opening it elsewhere.

## What

A **Peek Negative** toggle: toolbar button, overflow entry, `N`. It paints `AppState.preview_raw` — un-inverted, un-metered, un-normalized, none of the tone edits — and returns to the normal render when turned off.

Geometry is the one thing it does apply, through `GeometryProcessor` and `CropProcessor`, the same two the base and crop stages use, so the frame keeps its rotation, flip, straighten, keystone and crop. The crop tool is the exception and peeks the uncropped frame, mirroring `request_render`, or there would be nothing to frame a crop against.

Only `working_oetf_encode` follows. That is a display encode rather than an edit — a linear buffer would otherwise show as near-black.

## Approach

Not a pipeline change and not a `config_override` render. No config expresses "do not invert", and adding a `RenderIntent` would mean the CPU engine, the WGSL shaders and a parity test for a diagnostic that needs none of them. This follows the splash path (`_on_splash_preview`) instead: write the buffer into `last_metrics["base_positive"]`, mark it `splash`, emit `image_updated`.

Two consequences worth calling out:

- **Marked `splash`**, so the working-to-display matrix and the soft proof stay off it. The buffer is in camera/scanner primaries, not the working space; expect the raw orange cast rather than an accurate one.
- **`content_rect` cleared.** It marks the picture area inside a border/mat, and no finish stage ran, so leaving the previous render's value would inset the frame wrongly once a border is on.

The state is transient, mutually exclusive with the flat peek and the before/after split, and any render with no config override drops it.

## Verification

`make all` green. Nine controller tests added, plus `negative_peek=False` on three `SimpleNamespace` state stubs that model `AppState`.

Driven headless against `samples/20260619SP_EKTAR100_120_1_09_ME_4000PPI.tif`, peek vs. print at each geometry setting:

```
[no geometry] peek (1600,1184) == print,  corr -0.978
[rotate CCW]  peek (1184,1600) == print,  corr -0.978
[rotate 180]  peek (1600,1184) == print,  corr -0.978
[flip H]      peek (1600,1184) == print,  corr -0.978
[crop half]   peek (800,592) — exactly the 0.25-0.75 box
[crop tool]   peek uncropped (1600,1184)
```

The strong negative correlation is the point: same picture, inverted. Also confirmed the orange mask reads in the raw negative (R=0.416, G=0.243, B=0.164) and that any edit drops the peek. Colour Negative and B&W Negative give identical peek buffers, as they must — the peek sits upstream of the pipeline, so process mode cannot reach it.

## One unrelated observation

While checking the crop case I found the CPU and GPU engines disagree on a `crop_rect` set directly on the config:

```
gpu=True   with-crop (1600,1184)   <- uncropped
gpu=False  with-crop (800,592)     <- cropped
```

Still uncropped on the GPU after a fresh load with the crop already in the config, so it is not stale cache in the harness. It may be that poking `crop_rect` programmatically is not the supported path and the real crop tool sets state the GPU keys on. Pre-existing and untouched by this PR; the peek follows the CPU engine, which is the parity reference. Flagging it rather than chasing it here.

## Docs

`docs/USER_GUIDE.md` gets the panel prose; `docs/PIPELINE.md` records that the peek is not a stage of its own and what it skips.