### PR TITLE
feat(macos): give NegPy a menu bar, with Window and Help

### DIFF
--- a/docs/KEYBOARD.md
+++ b/docs/KEYBOARD.md
@@ -72,3 +72,14 @@ While a test strip or ring-around is up, `[` and `]` turn that proof's ladder in
 | `Mouse Wheel` | Zoom in / out (up to 400%); **Reverse Scroll Zoom** in the toolbar **⋯** menu flips the direction |
 | `Middle Click` + `Drag` | Pan zoomed image |
 | `Left Click` + `Drag` | Pan zoomed image (when no tool is active) |
+
+## Menu bar (macOS only)
+
+NegPy has a menu bar on macOS, with a **Window** and a **Help** menu. These keys come from it. They are platform window commands, not NegPy actions, so they are fixed and do not appear in the shortcut editor.
+
+| Key | Action |
+|-----|--------|
+| `⌘ + M` | Minimize the front window |
+| `⌘ + W` | Close the front window (closing the main window quits NegPy) |
+
+Every other menu item uses the binding listed above for its action, and shows it only when that binding uses `⌘`. A shortcut bound to a plain key still works from the keyboard; the menu just does not print it, because macOS gives a menu key priority over everything and a plain `?` would fire while you type into a text box.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -45,6 +45,19 @@ A small **dot** on a panel header, and on a tab icon, means you changed somethin
 
 Both side panels can be narrowed to give the canvas more room. As the controls panel shrinks, tab icons that no longer fit move into a **»** menu at the right of the tab bar. The tab you are on always stays visible.
 
+### Menu bar (macOS)
+
+On macOS NegPy has a menu bar. Almost nothing in it is new: apart from Report an Issue, every item runs something a button, a window control or a keyboard shortcut already runs.
+
+*   **Window**: Minimize (`⌘M`), Zoom, Close (`⌘W`) and Bring All to Front, then every open NegPy window — the main window plus any live view or calibration window — with a tick against the front one. Select a name to bring that window forward. Minimize and Zoom are unavailable while a window is full screen, as elsewhere on macOS.
+*   **Help**: Take the Tour, Keyboard Shortcuts, Customize Shortcuts, the Analysis panel guide, Report an Issue (which opens the NegPy issue tracker in your browser), and Check for Updates.
+
+Full screen is macOS's own, so NegPy adds no item for it: use the green window button. macOS puts an Enter Full Screen item in the View menu of an app that has one, and NegPy's View menu comes later.
+
+A menu shows a key only when that key uses `⌘`. A shortcut bound to a plain key — `?` for Keyboard Shortcuts — still works, but a menu cannot claim it: macOS gives a menu key priority over everything, so a plain `?` in the menu would fire while you type a `?` into the film strip search box. Rebind a shortcut and its menu item follows.
+
+`⌘W` on the main window closes NegPy. Windows and Linux have no menu bar; nothing there changes.
+
 ---
 
 ## 2. Film strip (left panel)

--- a/negpy/desktop/view/keyboard_shortcuts.py
+++ b/negpy/desktop/view/keyboard_shortcuts.py
@@ -1,4 +1,5 @@
 from collections.abc import Callable
+from typing import Optional
 
 from PyQt6.QtGui import QKeySequence, QShortcut
 
@@ -194,6 +195,11 @@ class ShortcutManager:
             actions[group.dec_action] = self._slider_adjuster(getter, group.dec_action)
         return actions
 
+    def action_for(self, action_id: str) -> Optional[Callable[[], None]]:
+        """The handler a shortcut runs. The macOS menu bar dispatches through this, so a
+        menu item and its key can never drift apart."""
+        return self._actions.get(action_id)
+
     def apply_bindings(self, bindings: dict[str, str]) -> None:
         self.bindings = dict(bindings)
         set_current_bindings(self.bindings)
@@ -211,6 +217,11 @@ class ShortcutManager:
 
         self.window.controls_panel.apply_shortcut_tooltips()
         self.window.right_panel.apply_shortcut_tooltips()
+        # The macOS menu bar carries key equivalents of its own; a rebind has to reach them
+        # or the retired key keeps working from the menu.
+        menus = getattr(self.window, "mac_menus", None)
+        if menus is not None:
+            menus.sync_shortcuts()
 
     def update_bindings(self, bindings: dict[str, str]) -> None:
         save_bindings(self.window.controller.session.repo, bindings)

--- a/negpy/desktop/view/mac_menu_bar.py
+++ b/negpy/desktop/view/mac_menu_bar.py
@@ -1,0 +1,139 @@
+"""The macOS menu bar: Window and Help.
+
+Only macOS gets one. Qt hands it to the global bar there, at no cost in window space;
+Windows and Linux draw a QMenuBar inside the window, and NegPy has no use for a strip of
+chrome above the canvas. Nothing here is new functionality — every item runs something a
+button, a window control or a keyboard shortcut already runs.
+
+This is the first stage: the standard macOS window commands, which do nothing in an app
+with no menu bar, and Help. The File and View menus come later.
+
+There is no View menu, and so no Enter Full Screen item. AppKit adds one of its own to any
+menu titled View, and ours only ever appeared under it as the duplicate.
+
+**Key equivalents are only ever ⌘ combinations.** AppKit dispatches a menu key equivalent
+before Qt's shortcut machinery sees the event, so a bare-key equivalent ("?" for Keyboard
+Shortcuts) would fire while the user types into the film-strip search box, and an Option
+combination would eat the character it composes. Items bound to those keys are listed
+without a key; their QShortcut still works. ``_menu_key`` is the one place that decides.
+
+Items dispatch through ``ShortcutManager.action_for``, so a menu item and its shortcut can
+never run different code, and ``sync_shortcuts`` re-reads the bindings after a rebind.
+"""
+
+import sys
+from typing import TYPE_CHECKING, Callable, Optional
+
+from PyQt6.QtCore import QUrl
+from PyQt6.QtGui import QAction, QDesktopServices, QKeySequence
+from PyQt6.QtWidgets import QMenu, QMenuBar
+
+from negpy.desktop.view.shortcut_registry import key_for
+from negpy.desktop.view.window_menu import WindowMenu
+from negpy.kernel.system.version import ISSUES_PAGE
+
+if TYPE_CHECKING:
+    from negpy.desktop.view.main_window import MainWindow
+
+
+def _menu_key(key: str) -> QKeySequence:
+    """A menu key equivalent for ``key``, or an empty one. ⌘ combinations only — see the
+    module docstring."""
+    return QKeySequence(key) if key and "Ctrl+" in key else QKeySequence()
+
+
+class MacMenuBar(QMenuBar):
+    """The application-wide menu bar.
+
+    It has no parent, which is what makes it application-wide on macOS. A bar owned by the
+    main window is only shown while that window is in front — Qt syncs the active window's
+    bar, and the live view, the calibration window and a floating panel have none, so the
+    menus blinked out of the bar whenever one of them took focus.
+    """
+
+    def __init__(self, window: "MainWindow") -> None:
+        super().__init__(None)
+        self._window = window
+        self._keyed: list[tuple[QAction, str]] = []
+
+        # Apple's order: the app's own menus, then Window, Help.
+        self.window_menu = WindowMenu(window, self)
+        self.addMenu(self.window_menu)
+        self.help_menu = self._build_help()
+
+        self.sync_shortcuts()
+
+    # -- construction ---------------------------------------------------------------
+
+    def _menu(self, title: str) -> QMenu:
+        menu = QMenu(title, self)
+        self.addMenu(menu)
+        return menu
+
+    def _add(
+        self,
+        menu: QMenu,
+        text: str,
+        *,
+        action_id: str = "",
+        slot: Optional[Callable[[], None]] = None,
+        key: str = "",
+    ) -> QAction:
+        if slot is None:
+            slot = self._window.shortcut_manager.action_for(action_id)
+            if slot is None:
+                raise KeyError(f"No shortcut action for menu item {text!r} ({action_id!r})")
+
+        action = QAction(text, self)
+        # Window titles carry the open file's name, and Qt's macOS merge heuristic moves any
+        # item whose text looks like "about", "settings" or "quit" into the application menu.
+        # NoRole keeps every item where it was put, whatever a frame is called.
+        action.setMenuRole(QAction.MenuRole.NoRole)
+        action.triggered.connect(lambda _checked=False, run=slot: run())
+        if action_id:
+            self._keyed.append((action, action_id))
+        elif key:
+            action.setShortcut(_menu_key(key))
+        menu.addAction(action)
+        return action
+
+    def _build_help(self) -> QMenu:
+        menu = self._menu("Help")
+        self._add(menu, "Take the Tour", slot=self._window.show_tutorial)
+        self._add(menu, "Keyboard Shortcuts", action_id="show_shortcuts")
+        self._add(menu, "Customize Shortcuts…", slot=self._open_shortcut_editor)
+        self._add(menu, "Analysis Panel Guide", action_id="show_analysis_help")
+        menu.addSeparator()
+        # No registry entry: the item exists only in this bar, and a binding would advertise
+        # it in the shortcut editor and the ? overlay on Windows and Linux, where nothing
+        # can run it.
+        self._add(menu, "Report an Issue…", slot=self._report_an_issue)
+        self._add(menu, "Check for Updates…", action_id="check_for_updates")
+        return menu
+
+    # -- state ----------------------------------------------------------------------
+
+    def sync_shortcuts(self) -> None:
+        """Re-read every menu item's key from the live bindings. Called after a rebind, or
+        the retired key would keep working from the menu."""
+        for action, action_id in self._keyed:
+            action.setShortcut(_menu_key(key_for(action_id)))
+
+    # -- slots ----------------------------------------------------------------------
+
+    def _open_shortcut_editor(self) -> None:
+        self._window.shortcut_manager.open_editor(self._window)
+
+    @staticmethod
+    def _report_an_issue() -> None:
+        QDesktopServices.openUrl(QUrl(ISSUES_PAGE))
+
+
+def install_mac_menus(window: "MainWindow") -> Optional[MacMenuBar]:
+    """Give ``window`` the macOS menu bar. Returns None on every other platform, which keeps
+    its menu-bar-free layout. Call after the shortcut manager exists: the items dispatch
+    through it.
+    """
+    if sys.platform != "darwin":
+        return None
+    return MacMenuBar(window)

--- a/negpy/desktop/view/main_window.py
+++ b/negpy/desktop/view/main_window.py
@@ -23,6 +23,7 @@ from negpy.infrastructure.loaders.constants import SUPPORTED_RAW_EXTENSIONS
 from negpy.desktop.view.canvas.toolbar import ActionToolbar
 from negpy.desktop.view.canvas.widget import ImageCanvas
 from negpy.desktop.view.keyboard_shortcuts import setup_keyboard_shortcuts
+from negpy.desktop.view.mac_menu_bar import install_mac_menus
 from negpy.desktop.view.shortcut_registry import tooltip_with_shortcut
 from negpy.desktop.view.sidebar.right_panel import RightPanel
 from negpy.desktop.view.sidebar.session_panel import SessionPanel
@@ -152,6 +153,9 @@ class MainWindow(QMainWindow):
         self._init_ui()
         self._connect_signals()
         self.shortcut_manager = setup_keyboard_shortcuts(self)
+        # macOS only: the global menu bar costs no window space, and elsewhere this is a
+        # no-op. After the shortcut manager, whose actions the menu items dispatch through.
+        self.mac_menus = install_mac_menus(self)
         self._update_title()
 
         if self.controller.session.repo.get_global_setting("show_slider_values", default=False):

--- a/negpy/desktop/view/window_menu.py
+++ b/negpy/desktop/view/window_menu.py
@@ -1,0 +1,136 @@
+"""The macOS Window menu.
+
+Without a menu bar, the key equivalents AppKit takes from the standard Window menu — Cmd+M,
+Cmd+W — do nothing. That is why NegPy has a bar at all; this is one of the menus
+``mac_menu_bar`` assembles.
+
+These keys stay out of ``shortcut_registry``. They are platform window commands, not NegPy
+actions, and a native menu key equivalent silently outranks a QShortcut — so a rebindable
+copy could only ever disagree with the menu. ``MENU_KEYS`` is here so a test can prove no
+registry default collides with one.
+
+Full screen is not here. AppKit adds its own Enter Full Screen item to any menu titled
+View, so an item of ours could only ever be the second one in the menu.
+
+Qt maps the window states onto AppKit correctly, so nothing here needs Objective-C:
+``showMaximized`` leaves the NSWindow ``isZoomed``.
+"""
+
+from typing import Optional
+
+from PyQt6.QtCore import Qt
+from PyQt6.QtGui import QAction, QKeySequence
+from PyQt6.QtWidgets import QApplication, QMainWindow, QMenu, QWidget
+
+# Qt swaps Ctrl and Meta on macOS, so "Ctrl+M" is ⌘M.
+MENU_KEYS: dict[str, str] = {
+    "minimize": "Ctrl+M",
+    "close": "Ctrl+W",
+}
+
+_EXCLUDED_WINDOW_TYPES = {
+    Qt.WindowType.Popup,
+    Qt.WindowType.ToolTip,
+    Qt.WindowType.SplashScreen,
+    Qt.WindowType.Desktop,
+    Qt.WindowType.SubWindow,
+}
+
+
+def listed_windows() -> list[QWidget]:
+    """The windows the menu lists, sorted by title so the list does not reorder itself
+    between openings. Popups, tooltips and untitled windows are not windows a user can
+    choose, so they are left out."""
+    windows = [
+        widget
+        for widget in QApplication.topLevelWidgets()
+        if widget.isWindow() and widget.isVisible() and widget.windowTitle() and widget.windowType() not in _EXCLUDED_WINDOW_TYPES
+    ]
+    return sorted(windows, key=lambda widget: widget.windowTitle())
+
+
+class WindowMenu(QMenu):
+    """Minimize / Zoom / Close / Bring All to Front, then the list of open windows.
+
+    Qt parks a dummy menu on ``NSApp.windowsMenu`` to absorb AppKit's automatic window
+    list, so that list cannot be had for free — this rebuilds its own on every opening.
+    """
+
+    def __init__(self, window: QMainWindow, parent: Optional[QWidget] = None) -> None:
+        super().__init__("Window", parent if parent is not None else window)
+        self._window = window
+        self._dynamic: list[QAction] = []
+
+        self.act_minimize = self._add("Minimize", MENU_KEYS["minimize"], self._minimize)
+        self.act_zoom = self._add("Zoom", "", self._zoom)
+        self.addSeparator()
+        self.act_close = self._add("Close", MENU_KEYS["close"], self._close)
+        self.addSeparator()
+        self.act_bring_all = self._add("Bring All to Front", "", self._bring_all_to_front)
+        self._list_separator = self.addSeparator()
+
+        self.aboutToShow.connect(self.refresh)
+
+    def _add(self, text: str, key: str, slot) -> QAction:
+        action = QAction(text, self)
+        # Window titles carry the open file's name, and Qt's macOS merge heuristic moves any
+        # item whose text looks like "about", "settings" or "quit" into the application menu.
+        # NoRole keeps every item where it was put, whatever a frame is called.
+        action.setMenuRole(QAction.MenuRole.NoRole)
+        if key:
+            action.setShortcut(QKeySequence(key))
+        action.triggered.connect(slot)
+        self.addAction(action)
+        return action
+
+    def target(self) -> QWidget:
+        """The window a command acts on: the front one, which may be the live view or a
+        floating panel rather than the main window."""
+        active = QApplication.activeWindow()
+        return active if active is not None else self._window
+
+    def _minimize(self) -> None:
+        self.target().showMinimized()
+
+    def _zoom(self) -> None:
+        target = self.target()
+        target.showNormal() if target.isMaximized() else target.showMaximized()
+
+    def _close(self) -> None:
+        self.target().close()
+
+    def _bring_all_to_front(self) -> None:
+        for widget in listed_windows():
+            widget.raise_()
+        self._window.raise_()
+        self._window.activateWindow()
+
+    def refresh(self) -> None:
+        """Match the menu to the front window. macOS retires Minimize and Zoom in full
+        screen, which the front window can enter from the green button or ⌃⌘F."""
+        target = self.target()
+        full_screen = target.isFullScreen()
+        self.act_minimize.setEnabled(not full_screen)
+        self.act_zoom.setEnabled(not full_screen)
+        self._rebuild_window_list(target)
+
+    def _rebuild_window_list(self, target: QWidget) -> None:
+        for action in self._dynamic:
+            self.removeAction(action)
+        self._dynamic.clear()
+
+        for widget in listed_windows():
+            action = QAction(widget.windowTitle(), self)
+            action.setMenuRole(QAction.MenuRole.NoRole)
+            action.setCheckable(True)
+            action.setChecked(widget is target)
+            action.triggered.connect(lambda _checked, w=widget: self._raise(w))
+            self.addAction(action)
+            self._dynamic.append(action)
+
+    @staticmethod
+    def _raise(widget: QWidget) -> None:
+        if widget.isMinimized():
+            widget.showNormal()
+        widget.raise_()
+        widget.activateWindow()

--- a/negpy/kernel/system/version.py
+++ b/negpy/kernel/system/version.py
@@ -7,6 +7,7 @@ from typing import Any, Optional
 GITHUB_REPO = "marcinz606/NegPy"
 LATEST_RELEASE_API = f"https://api.github.com/repos/{GITHUB_REPO}/releases/latest"
 RELEASES_PAGE = f"https://github.com/{GITHUB_REPO}/releases"
+ISSUES_PAGE = f"https://github.com/{GITHUB_REPO}/issues/new/choose"
 USER_AGENT = "NegPy-Updater"
 
 

--- a/tests/test_mac_menu_bar.py
+++ b/tests/test_mac_menu_bar.py
@@ -1,0 +1,147 @@
+"""The macOS menu bar: built on darwin only, dispatching through the shortcut manager.
+
+The window stub carries exactly the surface MacMenuBar reaches for, so a rename in
+MainWindow shows up here rather than at runtime on someone's Mac.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from PyQt6.QtGui import QAction, QKeySequence
+from PyQt6.QtWidgets import QMainWindow, QMenu
+
+from negpy.desktop.view.mac_menu_bar import MacMenuBar, install_mac_menus
+from negpy.desktop.view.shortcut_registry import REGISTRY, default_bindings, set_current_bindings
+from negpy.desktop.view.window_menu import MENU_KEYS
+from negpy.kernel.system.version import ISSUES_PAGE
+
+
+class _FakeShortcuts:
+    """Returns a handler only for real registry ids, so a typo in a menu item's action id
+    raises while the bar is built."""
+
+    def __init__(self):
+        self.ran: list[str] = []
+
+    def action_for(self, action_id: str):
+        if action_id not in REGISTRY:
+            return None
+        return lambda: self.ran.append(action_id)
+
+    def open_editor(self, parent=None) -> None:
+        self.ran.append("open_editor")
+
+
+@pytest.fixture
+def window(qapp):
+    win = QMainWindow()
+    win.setWindowTitle("NegPy")
+    win.shortcut_manager = _FakeShortcuts()
+    win.show_tutorial = MagicMock()
+
+    set_current_bindings(default_bindings())
+    yield win
+    win.close()
+    win.deleteLater()
+
+
+@pytest.fixture
+def bar(window):
+    return MacMenuBar(window)
+
+
+def _items(menu: QMenu) -> list[QAction]:
+    return [a for a in menu.actions() if not a.isSeparator()]
+
+
+def _by_text(bar: MacMenuBar, text: str) -> QAction:
+    for action in _items(bar.help_menu):
+        if action.text() == text:
+            return action
+    raise AssertionError(f"no menu item {text!r}")
+
+
+def test_not_installed_off_macos(window):
+    with patch("negpy.desktop.view.mac_menu_bar.sys.platform", "win32"):
+        assert install_mac_menus(window) is None
+
+
+def test_menus_are_in_apple_order(window):
+    with patch("negpy.desktop.view.mac_menu_bar.sys.platform", "darwin"):
+        bar = install_mac_menus(window)
+
+    assert [action.menu().title() for action in bar.actions()] == ["Window", "Help"]
+
+
+def test_bar_has_no_parent(bar, window):
+    # A bar owned by the main window is only synced while that window is active, so the menus
+    # dropped out of the bar whenever the live view or a floating panel took focus.
+    assert bar.parent() is None
+    assert window.findChild(MacMenuBar) is None
+
+
+def test_every_item_dispatches_through_the_shortcut_manager(bar, window):
+    # Ids are validated while the bar is built (a fake handler is only returned for real
+    # registry ids), so reaching here at all proves every id exists.
+    assert {action_id for _, action_id in bar._keyed} <= set(REGISTRY)
+
+    _by_text(bar, "Keyboard Shortcuts").trigger()
+    assert window.shortcut_manager.ran == ["show_shortcuts"]
+
+
+def test_non_registry_items_run_their_own_slot(bar, window):
+    _by_text(bar, "Take the Tour").trigger()
+    window.show_tutorial.assert_called_once()
+
+    _by_text(bar, "Customize Shortcuts…").trigger()
+    assert "open_editor" in window.shortcut_manager.ran
+
+
+def test_only_command_combinations_become_key_equivalents(bar):
+    # AppKit fires a menu key equivalent before Qt sees the event, so a bare "?" would trip
+    # while typing into the search box and an Option combination would eat its character.
+    assert _by_text(bar, "Keyboard Shortcuts").shortcut().isEmpty()  # bound to "?"
+    assert _by_text(bar, "Analysis Panel Guide").shortcut().isEmpty()  # unbound
+    assert bar.window_menu.act_minimize.shortcut() == QKeySequence(MENU_KEYS["minimize"])
+
+
+def test_menu_keys_do_not_collide_with_the_registry(bar):
+    # A native menu key equivalent outranks a QShortcut without firing activatedAmbiguously,
+    # so a collision would kill a binding silently.
+    reserved = list(MENU_KEYS.values())
+    assert len({QKeySequence(k).toString() for k in reserved}) == len(reserved)
+
+    taken = {QKeySequence(k) for k in reserved}
+    clashes = [action_id for action_id, entry in REGISTRY.items() if entry.default_key and QKeySequence(entry.default_key) in taken]
+    assert clashes == []
+
+
+def test_a_rebind_reaches_the_menu(bar):
+    set_current_bindings({**default_bindings(), "show_shortcuts": "Ctrl+Shift+K", "show_analysis_help": "F8"})
+    bar.sync_shortcuts()
+
+    assert _by_text(bar, "Keyboard Shortcuts").shortcut() == QKeySequence("Ctrl+Shift+K")
+    # Rebound to a key the menu must not claim, so the item gives its key equivalent up.
+    assert _by_text(bar, "Analysis Panel Guide").shortcut().isEmpty()
+
+
+def test_no_view_menu_of_our_own(bar):
+    # AppKit adds an Enter Full Screen item to any menu titled View, so a View menu of ours
+    # holding the same item showed it twice.
+    assert "View" not in [action.menu().title() for action in bar.actions()]
+
+
+def test_report_an_issue_opens_the_tracker(bar):
+    opened = []
+    with patch("negpy.desktop.view.mac_menu_bar.QDesktopServices.openUrl", side_effect=lambda url: opened.append(url.toString())):
+        _by_text(bar, "Report an Issue…").trigger()
+
+    assert opened == [ISSUES_PAGE]
+
+
+def test_nothing_is_merged_into_the_application_menu(bar):
+    # Qt's macOS heuristic moves "about"/"settings"/"quit"-looking items into the app menu.
+    menus = [bar.window_menu, bar.help_menu]
+    roles = {a.menuRole() for menu in menus for a in _items(menu)}
+
+    assert roles == {QAction.MenuRole.NoRole}

--- a/tests/test_window_menu.py
+++ b/tests/test_window_menu.py
@@ -1,0 +1,100 @@
+"""The macOS Window menu: the window commands, and never merged into the app menu."""
+
+import pytest
+from PyQt6.QtGui import QAction, QKeySequence
+from PyQt6.QtWidgets import QMainWindow, QWidget
+
+from negpy.desktop.view.window_menu import MENU_KEYS, WindowMenu, listed_windows
+
+
+@pytest.fixture
+def window(qapp):
+    win = QMainWindow()
+    win.setWindowTitle("NegPy")
+    yield win
+    win.close()
+    win.deleteLater()
+
+
+def test_standard_items_and_keys(window):
+    menu = WindowMenu(window)
+
+    texts = [a.text() for a in menu.actions() if not a.isSeparator()]
+    assert texts[:4] == ["Minimize", "Zoom", "Close", "Bring All to Front"]
+    assert menu.act_minimize.shortcut() == QKeySequence(MENU_KEYS["minimize"])
+    assert menu.act_close.shortcut() == QKeySequence(MENU_KEYS["close"])
+
+
+def test_every_item_keeps_its_place_in_the_menu_bar(window):
+    # Qt's macOS heuristic moves "about"/"settings"/"quit"-looking items into the app menu,
+    # and window titles carry the open file's name.
+    window.setWindowTitle("NegPy — about_settings_quit.tif")
+    menu = WindowMenu(window)
+    menu.refresh()
+
+    roles = {a.menuRole() for a in menu.actions() if not a.isSeparator()}
+    assert roles == {QAction.MenuRole.NoRole}
+
+
+def test_zoom_toggles_maximized(window):
+    window.show()
+    menu = WindowMenu(window)
+
+    menu.act_zoom.trigger()
+    assert window.isMaximized()
+
+    menu.act_zoom.trigger()
+    assert not window.isMaximized()
+
+
+def test_minimize_and_zoom_retire_in_full_screen(window):
+    window.show()
+    menu = WindowMenu(window)
+
+    window.showFullScreen()
+    menu.refresh()
+    assert window.isFullScreen()
+    assert not menu.act_minimize.isEnabled()
+    assert not menu.act_zoom.isEnabled()
+
+    window.showNormal()
+    menu.refresh()
+    assert not window.isFullScreen()
+    assert menu.act_minimize.isEnabled()
+    assert menu.act_zoom.isEnabled()
+
+
+def test_window_list_names_visible_titled_windows(window, qapp):
+    window.show()
+    other = QWidget()
+    other.setWindowTitle("Live View")
+    other.show()
+    untitled = QWidget()
+    untitled.show()
+    qapp.processEvents()
+
+    try:
+        menu = WindowMenu(window)
+        menu.refresh()
+        listed = [a.text() for a in menu.actions() if a.isCheckable()]
+
+        assert "Live View" in listed
+        assert "NegPy" in listed
+        assert "" not in listed
+        assert listed == sorted(listed)
+        assert all(w.windowTitle() for w in listed_windows())
+    finally:
+        other.close()
+        untitled.close()
+
+
+def test_window_list_is_rebuilt_not_appended(window):
+    window.show()
+    menu = WindowMenu(window)
+
+    menu.refresh()
+    first = len([a for a in menu.actions() if a.isCheckable()])
+    menu.refresh()
+    menu.refresh()
+
+    assert len([a for a in menu.actions() if a.isCheckable()]) == first


### PR DESCRIPTION
AppKit takes Cmd+M and Cmd+W from the standard menu bar, so in an app that builds none they do nothing: NegPy could not be minimized or closed by keyboard, and Zoom was unreachable altogether. This is the smallest bar that fixes that, plus Help.

Window carries Minimize, Zoom, Close, Bring All to Front and the list of open windows — the main window plus any live view or calibration window — with a tick against the front one. Every command acts on the front window, whichever that is, not on the main window. Help gathers what was already scattered: the tour, the shortcut overlay and its editor, the Analysis guide and the update check, plus Report an Issue, which opens the tracker. That last one gets no shortcut registry entry: a binding would advertise it in the shortcut editor and the ? overlay on Windows and Linux, where nothing can run it.

There is no View menu and no Enter Full Screen item. AppKit adds one of its own to any menu titled View, so ours only ever appeared beneath it as a duplicate. Full screen stays the platform's: the green button, and the item macOS puts in the View menu NegPy will have later.

The bar has no parent, which is what makes it application-wide. A bar owned by the main window is only shown while that window is in front, so the menus blinked out whenever the live view or a floating panel took focus.

Items dispatch through ShortcutManager.action_for, so a menu item and its shortcut can never run different code, and a rebind reaches the menu. Only Cmd combinations become key equivalents: AppKit fires those before Qt's shortcut machinery sees the event, so a bare "?" for Keyboard Shortcuts would fire while the user types into the film-strip search box. The window keys stay out of the shortcut registry — they are platform commands, and a native key equivalent silently outranks a QShortcut, so a rebindable copy could only disagree with the menu. A test proves no registry default collides with one.

macOS only. install_mac_menus returns None elsewhere, so Windows and Linux keep their menu-bar-free layout with nothing visibly changed.

Fixes #890 