### PR TITLE
Report content_rect from the CPU engine

### DIFF
--- a/negpy/services/rendering/engine.py
+++ b/negpy/services/rendering/engine.py
@@ -252,6 +252,11 @@ class DarkroomEngine:
             # Output transform: scene-linear -> display-encoded (flat master skips this).
             current_img = ensure_image(working_oetf_encode(current_img))
 
+        # No paper layout runs here, so the whole buffer is the picture. Reported rather
+        # than left out: the controller merges each render's metrics into last_metrics, so
+        # a key only one engine writes keeps the other engine's last value.
+        context.metrics["content_rect"] = None
+
         if context.wants_uv_grid:
             try:
                 uv_grid = CoordinateMapping.create_uv_grid(

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -30,6 +30,23 @@ class TestDarkroomEngine(unittest.TestCase):
         self.assertLess(res.shape[0], 200)
         self.assertLess(res.shape[1], 200)
 
+    def test_the_engine_always_reports_content_rect(self):
+        """The controller merges each render's metrics into last_metrics, so a key only
+        the GPU engine wrote kept its stale value through a CPU render: after a switch
+        the canvas mapped picker and overlay coords through the wrong rect."""
+        from negpy.domain.interfaces import PipelineContext
+
+        engine = DarkroomEngine()
+        img = np.random.rand(100, 100, 3).astype(np.float32)
+        context = PipelineContext(scale_factor=1.0, original_size=(100, 100))
+        # A rect left behind by an earlier GPU render of a differently framed buffer.
+        context.metrics["content_rect"] = (0, 0, 999, 999)
+
+        engine.process(img, WorkspaceConfig(), source_hash="dummy", context=context)
+
+        # No paper layout runs on this path, so the whole buffer is the picture.
+        self.assertIsNone(context.metrics["content_rect"])
+
     def test_engine_caching(self):
         """Check intermediate result caching."""
         engine = DarkroomEngine()


### PR DESCRIPTION
## The bug

Only the GPU engine writes `content_rect`. `_on_render_finished` does `last_metrics.update(metrics)` — a merge, not a replace — so the key kept the previous GPU render's value straight through a CPU render.

That is harmless while the two agree, and they usually do. With a crop active they do not: the GPU crops and then upscales the cropped region to the preview render size (`gpu_engine.py:1673`), reporting a rect for the upscaled buffer, while the CPU returns native cropped pixels. Measured on `samples/20260619SP_EKTAR100_120_1_09_ME_4000PPI.tif`:

```
gpu=True   buffer (1600,1184)   content_rect (0,0,1184,1600)
gpu=False  buffer (800,592)     content_rect (0,0,1184,1600)   <- inherited, 2x the buffer
```

`main_window` passes that rect to `canvas.update_buffer` whenever no border or paper aspect is set, which is the common case — the border branch is the only one that recomputes it. `widget.py:362` `get_pixel_rgb` then maps normalized coords through the rect and clamps, so with the rect above every sample past 50% width pinned to the right edge: the white-balance picker and the colour readout sampled the wrong pixel. `overlay.py:966,1425` map overlay coordinates through the same rect.

Reachable on any GPU-to-CPU switch with a crop active, including the automatic `"GPU acceleration failed — using CPU"` fallback, not only the manual toggle.

## The fix

`DarkroomEngine.process` publishes `content_rect` too. No paper layout runs on that path — `FinishProcessor`/`apply_carrier` draw inside the frame rather than padding it — so the whole buffer is the picture and the honest report is `None`. Both engines now always write the key, so a render's metrics cannot inherit a stale one.

## Verification

`make all` green.

`tests/test_engine.py::test_the_engine_always_reports_content_rect` seeds a stale rect into the context and asserts the engine clears it. Confirmed it fails without the one-line change and passes with it.

End to end on the real app, driving the exact switch that triggered it:

```
gpu buffer=(1600, 1184) content_rect=(0, 0, 1184, 1600)
PASS GPU still publishes its layout rect
cpu buffer=(800, 592) content_rect=None
PASS CPU render clears the stale GPU content_rect
```

## Context

Found while chasing what looked like a CPU/GPU disagreement over `crop_rect`, flagged in #889. That part turned out to be a misreading on my side — both engines crop, they differ only in output resolution (correlation of the displayed picture +0.9995). This is the real defect that investigation turned up.