### PR TITLE
Round to nearest when quantising, instead of truncating

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Unreleased
+
+- Fix: **Exports are no longer half a level too dark.** Converting the finished float image to 8- or 16-bit truncated toward zero instead of rounding to nearest, so every sample landed on the level below whenever it fell between two — a systematic 0.196% darkening of full scale at 8-bit, with half of all pixels one level off, on every export and on the canvas itself. The two greyscale conversions in the same module had always rounded, so a black-and-white export was already correct while a colour one was not. Both now round, and the print-layout path uses the same shared conversion rather than a second copy of it. Re-exported files will differ from old ones by up to one level, which is the point.
+
 ## 0.52.0
 
 - New: **Contrast Mask** — the darkroom's unsharp mask in the Tone panel: a blurred low-gamma sandwich that compresses or opens the global range while fine detail passes through. Works both ways, and its reach is drawn as a violet band on the H&D chart.

--- a/negpy/kernel/image/logic.py
+++ b/negpy/kernel/image/logic.py
@@ -27,7 +27,11 @@ def _get_luminance_jit(img: np.ndarray) -> np.ndarray:
 @njit(cache=True, fastmath=True)
 def _to_uint16_jit(img: np.ndarray) -> np.ndarray:
     """
-    Scale to uint16 (clips & handles NaNs).
+    Scale to uint16 (rounds to nearest, clips & handles NaNs).
+
+    The +0.5 rounds. A bare cast truncates toward zero, which biases every sample down by
+    half a level and doubles the quantisation error: the error distribution runs [-1, 0]
+    instead of [-0.5, +0.5]. The luma kernels below have always rounded; these did not.
     """
     res = np.empty_like(img, dtype=np.uint16)
     img_flat = img.reshape(-1)
@@ -38,7 +42,7 @@ def _to_uint16_jit(img: np.ndarray) -> np.ndarray:
         if np.isnan(val):
             v = 0.0
         else:
-            v = val * 65535.0
+            v = val * 65535.0 + 0.5
 
         if v < 0.0:
             v = 0.0
@@ -52,7 +56,7 @@ def _to_uint16_jit(img: np.ndarray) -> np.ndarray:
 @njit(cache=True, fastmath=True)
 def _to_uint8_jit(img: np.ndarray) -> np.ndarray:
     """
-    Scale to uint8 (clips & handles NaNs).
+    Scale to uint8 (rounds to nearest, clips & handles NaNs). See _to_uint16_jit.
     """
     res = np.empty_like(img, dtype=np.uint8)
     img_flat = img.reshape(-1)
@@ -63,7 +67,7 @@ def _to_uint8_jit(img: np.ndarray) -> np.ndarray:
         if np.isnan(val):
             v = 0.0
         else:
-            v = val * 255.0
+            v = val * 255.0 + 0.5
 
         if v < 0.0:
             v = 0.0

--- a/negpy/services/export/print.py
+++ b/negpy/services/export/print.py
@@ -6,7 +6,7 @@ from negpy.domain.models import ExportConfig, AspectRatio, ExportResolutionMode
 from negpy.features.finish.models import FinishConfig
 from negpy.features.toning.logic import apply_chemical_toning, apply_split_toning
 from negpy.features.toning.models import ToningConfig
-from negpy.kernel.image.logic import working_oetf_decode
+from negpy.kernel.image.logic import float_to_uint8, working_oetf_decode
 
 
 class PrintService:
@@ -42,7 +42,9 @@ class PrintService:
         result_np, content_rect = PrintService.apply_layout(
             img_np, config, border_size=border_size_cm, border_color=border_color_hex, finish=finish
         )
-        result_uint8 = (np.clip(result_np, 0, 1) * 255).astype(np.uint8)
+        # The shared quantiser, not a bare cast: it rounds, clips and handles NaN, and a
+        # second implementation here is how this path came to truncate while the rest rounded.
+        result_uint8 = float_to_uint8(result_np)
         return Image.fromarray(result_uint8), content_rect
 
     @staticmethod

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -18,7 +18,8 @@ def test_float_to_uint8() -> None:
     res = float_to_uint8(img)
     assert res.dtype == np.uint8
     assert res[0, 0] == 0
-    assert res[0, 1] == 127
+    # 0.5 * 255 = 127.5, which rounds to 128. This asserted 127 while the kernel truncated.
+    assert res[0, 1] == 128
     assert res[0, 2] == 255
     assert res[1, 0] == 255  # Clamped
     assert res[1, 1] == 0  # Clamped
@@ -29,7 +30,8 @@ def test_float_to_uint16() -> None:
     res = float_to_uint16(img)
     assert res.dtype == np.uint16
     assert res[0, 0] == 0
-    assert res[0, 1] == 32767
+    # 0.5 * 65535 = 32767.5 -> 32768 rounded; 32767 was the truncated value.
+    assert res[0, 1] == 32768
     assert res[0, 2] == 65535
 
 

--- a/tests/test_image_processor.py
+++ b/tests/test_image_processor.py
@@ -12,7 +12,8 @@ def test_image_service_buffer_to_pil_8bit() -> None:
     img = service.buffer_to_pil(buffer, settings, bit_depth=8)
     assert img.mode == "RGB"
     assert img.size == (1, 1)
-    assert img.getpixel((0, 0)) == (0, 127, 255)
+    # 0.5 -> 128: the quantiser rounds now rather than truncating.
+    assert img.getpixel((0, 0)) == (0, 128, 255)
 
 
 def test_image_service_buffer_to_pil_16bit_bw() -> None:

--- a/tests/test_quantisation.py
+++ b/tests/test_quantisation.py
@@ -1,0 +1,72 @@
+"""Quantisation rounds to nearest rather than truncating.
+
+A bare cast to uint truncates toward zero, so every sample lands half a level low: the
+error runs [-1, 0] instead of [-0.5, +0.5]. That is a 0.196% darkening of full scale at
+8 bits, on every pixel of every export and of the canvas itself. The two greyscale kernels
+in the same module have always rounded — these two had not, so a B&W export was correct
+while a colour one was not.
+"""
+
+import numpy as np
+import pytest
+
+from negpy.kernel.image.logic import float_to_uint8, float_to_uint16, float_to_uint_luma
+
+RNG = np.random.default_rng(0)
+SAMPLE = RNG.random((64, 64, 3)).astype(np.float32)
+
+
+@pytest.mark.parametrize("fn,scale", [(float_to_uint8, 255.0), (float_to_uint16, 65535.0)])
+def test_matches_round_to_nearest_exactly(fn, scale):
+    got = fn(SAMPLE).astype(np.float64)
+    assert np.array_equal(got, np.rint(SAMPLE.astype(np.float64) * scale))
+
+
+@pytest.mark.parametrize("fn,scale", [(float_to_uint8, 255.0), (float_to_uint16, 65535.0)])
+def test_no_systematic_bias(fn, scale):
+    """The regression this guards: a -0.5 level DC offset across the whole image."""
+    err = fn(SAMPLE).astype(np.float64) - SAMPLE.astype(np.float64) * scale
+    assert abs(err.mean()) < 0.01, f"mean quantisation error {err.mean():+.4f} levels — truncating?"
+    assert np.abs(err).max() <= 0.5 + 1e-6, "error must stay within half a level"
+
+
+@pytest.mark.parametrize("fn,scale", [(float_to_uint8, 255.0), (float_to_uint16, 65535.0)])
+def test_endpoints_and_midpoint(fn, scale):
+    out = fn(np.array([[[0.0, 1.0, 0.5]]], dtype=np.float32)).ravel()
+    assert out[0] == 0
+    assert out[1] == scale, "1.0 must reach full scale, not fall a level short"
+    assert out[2] == round(scale * 0.5)
+
+
+@pytest.mark.parametrize("fn", [float_to_uint8, float_to_uint16])
+def test_nan_and_out_of_range_are_still_clamped(fn):
+    """Rounding must not reintroduce wraparound at the ends."""
+    out = fn(np.array([[[np.nan, -1.0, 2.0]]], dtype=np.float32)).ravel()
+    assert out[0] == 0 and out[1] == 0
+    assert out[2] == np.iinfo(fn(np.zeros((1, 1, 3), np.float32)).dtype).max
+
+
+def test_every_quantiser_in_the_module_rounds():
+    """All four, held to the same rule. 0.25 is exact in float32 and 0.25*255 = 63.75, so
+    rounding gives 64 and truncating gives 63 — the two are distinguishable.
+
+    The greyscale kernels are fed a 2-D luminance plane directly: computing luma from three
+    channels first accumulates its own float32 error, which is a separate question from how
+    the result is quantised (a 0.5 grey lands a hair under 0.5 that way, and lands on 127).
+    """
+    rgb = np.full((4, 4, 3), 0.25, dtype=np.float32)
+    plane = np.full((4, 4), 0.25, dtype=np.float32)
+    assert int(float_to_uint8(rgb)[0, 0, 0]) == 64
+    assert int(float_to_uint16(rgb)[0, 0, 0]) == round(0.25 * 65535)
+    assert int(float_to_uint_luma(plane, 8)[0, 0]) == 64
+    assert int(float_to_uint_luma(plane, 16)[0, 0]) == round(0.25 * 65535)
+
+
+def test_the_print_layout_path_uses_the_shared_quantiser():
+    """It had its own bare cast, which is how one path drifted from the other."""
+    import inspect
+
+    from negpy.services.export import print as print_service
+
+    src = inspect.getsource(print_service)
+    assert "astype(np.uint8)" not in src, "a second quantiser here will drift from the shared one"


### PR DESCRIPTION
**Summary:** every 8- and 16-bit export was half a level too dark, because the float-to-int conversion truncated instead of rounding. Four lines of arithmetic; the two greyscale conversions in the same module had always rounded, so black-and-white exports were already correct while colour ones were not.

`_to_uint8_jit` and `_to_uint16_jit` cast with `np.uint8(v)`, which truncates toward zero. Every sample therefore lands on the level below whenever it falls between two: the quantisation error runs [-1, 0] instead of [-0.5, +0.5], which is a -0.5 level DC bias and twice the RMS error. Measured on random data: mean error -0.4999 levels, 50% of all pixels one level off, a systematic 0.196% darkening of full scale at 8 bits.

It lands on every 8-bit export -- JPEG, PNG, WebP, thumbnails -- and on `converters.py`, which is the canvas itself. At 16 bits the same half level is 0.0008% of scale and matters only in principle. Quantisation runs after `working_oetf_encode`, so the bias is in gamma-encoded space and is roughly uniform across the tone scale rather than concentrated anywhere.

That this was an oversight rather than a trade-off is settled by the same module: `_float_to_uint8_luma_jit` and its 16-bit twin have always done `v = lum * scale + 0.5`. Four near-identical loops, two rounding and two not, so a black-and-white export was correct while a colour one was half a level dark. Both now match `np.rint` exactly, verified across the range and at the endpoints, with NaN and out-of-range clamping unchanged.

`services/export/print.py` had its own bare cast and now calls the shared quantiser; a second implementation is how the two drifted apart in the first place, and a test now fails if one reappears there.

Three existing tests asserted the truncated values (127 for 0.5, 32767 for 0.5). They were encoding the bug; updated with the arithmetic spelled out.

Dithering is deliberately not included here. It addresses banding rather than bias, needs a decision about whether the canvas gets it too, and is worth landing separately.