### PR TITLE
test(export): cover ICC tagging on RGB TIFF exports

### DIFF
--- a/tests/test_export_icc.py
+++ b/tests/test_export_icc.py
@@ -115,3 +115,28 @@ def test_contact_sheet_srgb_bytes_available():
     icc = _srgb_icc_bytes()
     assert icc
     assert "sRGB" in _profile_desc(icc)
+
+
+def _tiff_icc(bits):
+    with tifffile.TiffFile(io.BytesIO(bits)) as tf:
+        tag = tf.pages[0].tags.get("InterColorProfile")
+    return bytes(tag.value) if tag else None
+
+
+@pytest.mark.parametrize("cs", [c for c in EXPORT_COLOR_SPACES if c != ColorSpace.GREYSCALE.value])
+def test_rgb_tiff_is_tagged_like_the_png(proc, cs):
+    """An RGB TIFF must carry the same profile the PNG of that edit carries.
+
+    Reported in #598: a P3 D65 TIFF arrived with no profile while the PNG of the
+    same export had one, so the file read as sRGB downstream. Only greyscale TIFF
+    was covered here, and greyscale takes a different branch in `_encode_export`,
+    so nothing pinned the RGB path.
+    """
+    buf = np.full((8, 8, 3), 0.42, dtype=np.float32)
+
+    tif_icc = _tiff_icc(_encode(proc, ExportFormat.TIFF, cs, buf.copy())[0])
+    png_icc = _pil_icc(_encode(proc, ExportFormat.PNG, cs, buf.copy())[0])
+
+    assert tif_icc, f"RGB TIFF for {cs} shipped untagged"
+    assert png_icc, f"RGB PNG for {cs} shipped untagged"
+    assert _profile_desc(tif_icc) == _profile_desc(png_icc)


### PR DESCRIPTION
`_encode_export` branches on greyscale before writing a TIFF, and only the greyscale branch was covered here. The RGB branch, which every colour-space export actually takes, had nothing pinning its ICC tag.

That is the path #598 reports: a P3 D65 TIFF arriving with no profile while the PNG of the same edit carried one, so the file read as sRGB downstream.

**#598 no longer reproduces on main.** Encoding the same buffer through `_encode_export` for every non-greyscale entry in `EXPORT_COLOR_SPACES`, the TIFF carries a profile in all six and its description matches the PNG:

```
Same as Source  TIFF A98C | PNG A98C
sRGB            TIFF sRGB | PNG sRGB
Adobe RGB       TIFF A98C | PNG A98C
ProPhoto RGB    TIFF ROMM | PNG ROMM
P3 D65          TIFF sP3  | PNG sP3
Rec 2020        TIFF 2020 | PNG 2020
```

That matches the later comment on the issue from someone who could not reproduce it either. Filed against 0.43.1, this is 0.52.0, so it looks fixed rather than absent, which is why it is worth pinning.

The test asserts both formats are tagged and that the descriptions agree. Removing `iccprofile=` from the TIFF write fails six of the new cases, so it has teeth rather than only passing today.

`tests/test_export_icc.py` 12 passed. Export suites together 200 passed. `ruff check` and `ruff format --check` clean. Windows 11, Python 3.14.7.

Referencing #598 rather than closing it, since this adds no fix.
