### PR TITLE
Parallelize batch auto crop

### DIFF
--- a/negpy/desktop/workers/render.py
+++ b/negpy/desktop/workers/render.py
@@ -12,7 +12,7 @@ from negpy.domain.models import WorkspaceConfig
 from negpy.features.exposure.analysis import output_histogram, proof_grid, rotate_grid, strip_mosaic
 from negpy.features.flatfield.logic import apply_flatfield
 from negpy.features.hdr.models import HdrConfig, hdr_active
-from negpy.features.geometry.batch_autocrop import detect_crop_candidate, resolve_roll_crops
+from negpy.features.geometry.batch_autocrop import CropEvidence, detect_crop_candidate, resolve_roll_crops
 from negpy.features.process.sensor import apply_sensor_correction, effective_sensor_matrix
 from negpy.features.process.logic import effective_linear_raw
 from negpy.infrastructure.loaders.helpers import unsupported_raw_reason
@@ -942,6 +942,12 @@ class BatchAutoCropWorker(QObject):
         self.cancelled.emit()
         return True
 
+    def _cancel_requested(self, generation: int) -> bool:
+        """Peek at the cancel flag without consuming it: only the coordinating thread
+        may emit the terminal signal, so a pool worker just stops."""
+        with self._cancel_lock:
+            return generation in self._cancelled_generations
+
     def _emit_finished_unless_cancelled(self, generation: int, results: list[BatchAutoCropResult]) -> None:
         """Atomically choose the terminal signal for a generation."""
         with self._cancel_lock:
@@ -982,72 +988,80 @@ class BatchAutoCropWorker(QObject):
             )
         return slice_for_asset(raw, file_info)
 
+    def _frame_evidence(self, index: int, frame: BatchAutoCropInput, task: BatchAutoCropTask, generation: int) -> Optional[CropEvidence]:
+        """Decode and detect one frame. None when it failed or the run was cancelled."""
+        file_info = frame.file_info
+        if self._cancel_requested(generation):
+            return None
+        try:
+            raw = self._decode(frame, task.workspace_color_space)
+            if self._cancel_requested(generation):
+                return None
+
+            config = frame.config
+            corrected = apply_flatfield(raw, config.flatfield)
+            detection_geometry = replace(
+                config.geometry,
+                crop_rect=None,
+                crop_from_auto=False,
+                autocrop_offset=0,
+            )
+            context = PipelineContext(
+                original_size=(corrected.shape[1], corrected.shape[0]),
+                scale_factor=1.0,
+                process_mode=config.process.process_mode,
+            )
+            distortion_k1 = config.flatfield.k1 if config.flatfield.apply else 0.0
+            transformed = GeometryProcessor(detection_geometry, distortion_k1).process(corrected, context)
+            if self._cancel_requested(generation):
+                return None
+            return detect_crop_candidate(
+                f"{index}:{file_info.get('hash', '')}",
+                transformed,
+                target_ratio=config.geometry.autocrop_ratio,
+                rebate_trim=config.geometry.autocrop_rebate_trim,
+            )
+        except Exception:
+            if self._cancel_requested(generation):
+                return None
+            logger.exception("Auto Crop All skipped failed frame %s", file_info.get("name") or file_info.get("path") or index)
+            return None
+
     @pyqtSlot(BatchAutoCropTask)
     def process(self, task: BatchAutoCropTask) -> None:
-        """Collect frame evidence sequentially, then resolve it as one roll."""
+        """Collect frame evidence over a thread pool, then resolve it as one roll.
+
+        Frames are independent until `resolve_roll_crops`, and each is a decode the GIL is
+        not held for. Evidence is kept in frame order — it is what the roll medians and the
+        template fit see — while progress counts completions, so the bar advances out of order.
+        """
         generation = int(task.generation)
         with self._cancel_lock:
             self._active_generation = generation
         if self._emit_cancelled_if_requested(generation):
             return
         total = len(task.frames)
-        evidence = []
-        source_by_key: dict[str, BatchAutoCropInput] = {}
+
+        def _name(index: int) -> str:
+            info = task.frames[index].file_info
+            return str(info.get("name") or info.get("path") or index + 1)
 
         try:
-            for index, frame in enumerate(task.frames):
-                if self._emit_cancelled_if_requested(generation):
-                    return
-
-                current = index + 1
-                file_info = frame.file_info
-                name = str(file_info.get("name") or file_info.get("path") or current)
-                key = f"{index}:{file_info.get('hash', '')}"
-
-                try:
-                    raw = self._decode(frame, task.workspace_color_space)
-                    if self._emit_cancelled_if_requested(generation):
-                        return
-
-                    config = frame.config
-                    corrected = apply_flatfield(raw, config.flatfield)
-                    if self._emit_cancelled_if_requested(generation):
-                        return
-                    detection_geometry = replace(
-                        config.geometry,
-                        crop_rect=None,
-                        crop_from_auto=False,
-                        autocrop_offset=0,
-                    )
-                    context = PipelineContext(
-                        original_size=(corrected.shape[1], corrected.shape[0]),
-                        scale_factor=1.0,
-                        process_mode=config.process.process_mode,
-                    )
-                    distortion_k1 = config.flatfield.k1 if config.flatfield.apply else 0.0
-                    transformed = GeometryProcessor(detection_geometry, distortion_k1).process(corrected, context)
-                    if self._emit_cancelled_if_requested(generation):
-                        return
-                    candidate = detect_crop_candidate(
-                        key,
-                        transformed,
-                        target_ratio=config.geometry.autocrop_ratio,
-                        rebate_trim=config.geometry.autocrop_rebate_trim,
-                    )
-                    if self._emit_cancelled_if_requested(generation):
-                        return
-
-                    evidence.append(candidate)
-                    source_by_key[candidate.key] = frame
-                except Exception:
-                    if self._emit_cancelled_if_requested(generation):
-                        return
-                    logger.exception("Auto Crop All skipped failed frame %s", name)
-
-                self.progress.emit(current, total, name)
+            # Half the cores: each worker holds a preview-scale frame, and the detector
+            # inside it is already multi-core.
+            workers = max(1, min(APP_CONFIG.max_workers // 2, total))
+            candidates: list[Optional[CropEvidence]] = [None] * total
+            with ThreadPoolExecutor(max_workers=workers) as ex:
+                futures = {ex.submit(self._frame_evidence, i, frame, task, generation): i for i, frame in enumerate(task.frames)}
+                for done, future in enumerate(as_completed(futures), 1):
+                    index = futures[future]
+                    candidates[index] = future.result()
+                    self.progress.emit(done, total, _name(index))
 
             if self._emit_cancelled_if_requested(generation):
                 return
+            evidence = [item for item in candidates if item is not None]
+            source_by_key = {item.key: task.frames[i] for i, item in enumerate(candidates) if item is not None}
             resolved = resolve_roll_crops(evidence)
             if self._emit_cancelled_if_requested(generation):
                 return

--- a/negpy/services/rendering/preview_cache.py
+++ b/negpy/services/rendering/preview_cache.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import threading
 from dataclasses import dataclass
 from typing import Hashable, Optional
 
@@ -46,21 +47,27 @@ class _Entry:
 class PreviewBufferCache:
     """
     In-memory LRU for decoded linear preview buffers. Evicts by entry count and approximate RSS.
+
+    One manager is shared by batch workers that decode several frames at once, so every
+    public method holds the lock: the LRU list and the entry map must move together, and
+    an unguarded ``_order.remove`` raises when two threads recycle the same key.
     """
 
     def __init__(self, app_config: Optional[AppConfig] = None) -> None:
         self._app = app_config or APP_CONFIG
         self._order: list[Hashable] = []
         self._data: dict[Hashable, _Entry] = {}
+        self._lock = threading.RLock()
 
     def get(self, key: PreviewCacheKey) -> Optional[tuple[ImageBuffer, Dimensions, dict]]:
         t = key.as_tuple()
-        ent = self._data.get(t)
-        if ent is None:
-            return None
-        self._order.remove(t)
-        self._order.append(t)
-        return ent.buffer, ent.dims, ent.metadata
+        with self._lock:
+            ent = self._data.get(t)
+            if ent is None:
+                return None
+            self._order.remove(t)
+            self._order.append(t)
+            return ent.buffer, ent.dims, ent.metadata
 
     def put(self, key: PreviewCacheKey, buffer: ImageBuffer, dims: Dimensions, metadata: dict) -> None:
         t = key.as_tuple()
@@ -70,28 +77,31 @@ class PreviewBufferCache:
             # else on the way out.
             logger.debug("preview cache skip: %d B entry exceeds %d B cap", b, self._app.preview_cache_max_bytes)
             return
-        if key.full_resolution:
-            # Full-res entries get a small slot budget (default 2: the active frame plus the one
-            # navigated from, so going back is instant). Unbudgeted, HQ buffers of hundreds of MB
-            # each would evict every small preview through the byte cap.
-            limit = max(1, self._app.preview_cache_max_full_res_entries)
-            full = [k for k in self._order if isinstance(k, tuple) and k[3] and k != t]
-            for other in full[: max(0, len(full) - (limit - 1))]:  # trim oldest beyond budget
-                self._remove_key(other)
-        if t in self._data:
-            self._order.remove(t)
-        self._data[t] = _Entry(buffer=buffer, dims=dims, metadata=dict(metadata), byte_size=b)
-        self._order.append(t)
-        self._evict_if_needed()
+        with self._lock:
+            if key.full_resolution:
+                # Full-res entries get a small slot budget (default 2: the active frame plus the one
+                # navigated from, so going back is instant). Unbudgeted, HQ buffers of hundreds of MB
+                # each would evict every small preview through the byte cap.
+                limit = max(1, self._app.preview_cache_max_full_res_entries)
+                full = [k for k in self._order if isinstance(k, tuple) and k[3] and k != t]
+                for other in full[: max(0, len(full) - (limit - 1))]:  # trim oldest beyond budget
+                    self._remove_key(other)
+            if t in self._data:
+                self._order.remove(t)
+            self._data[t] = _Entry(buffer=buffer, dims=dims, metadata=dict(metadata), byte_size=b)
+            self._order.append(t)
+            self._evict_if_needed()
 
     def invalidate_path_hash(self, file_hash: str) -> None:
-        to_drop = [k for k in self._order if isinstance(k, tuple) and k and k[0] == file_hash]
-        for t in to_drop:
-            self._remove_key(t)
+        with self._lock:
+            to_drop = [k for k in self._order if isinstance(k, tuple) and k and k[0] == file_hash]
+            for t in to_drop:
+                self._remove_key(t)
 
     def clear(self) -> None:
-        self._order.clear()
-        self._data.clear()
+        with self._lock:
+            self._order.clear()
+            self._data.clear()
 
     def _remove_key(self, t: Hashable) -> None:
         self._data.pop(t, None)

--- a/tests/test_batch_autocrop_worker.py
+++ b/tests/test_batch_autocrop_worker.py
@@ -234,7 +234,9 @@ def test_batch_autocrop_per_file_failure_does_not_abort_roll(qapp, monkeypatch) 
     worker.process(_task(_input("bad", base), _input("good", base, ("good-fingerprint",))))
 
     assert len(detected) == 1
-    assert progress == [(1, 2, "bad"), (2, 2, "good")]
+    # Progress counts completions, so the frames may be named in either order.
+    assert [count for count, _total, _name in progress] == [1, 2]
+    assert sorted(name for _c, _t, name in progress) == ["bad", "good"]
     assert errors == []
     assert len(finished) == 1
     assert [result.file_info["name"] for result in finished[0]] == ["good"]

--- a/tests/test_preview_cache.py
+++ b/tests/test_preview_cache.py
@@ -204,3 +204,47 @@ def test_hdr_preview_resamples_a_rounding_difference_but_rejects_a_different_asp
         assert "differ in shape" in str(e)
     else:
         raise AssertionError("a transposed frame was silently squashed onto the reference")
+
+
+def test_preview_cache_survives_concurrent_access():
+    """Batch workers decode several frames at once against one shared manager, so the
+    LRU list and the entry map must move under a lock — unguarded, two threads recycling
+    the same key both reach `_order.remove` and the second raises ValueError."""
+    import sys
+    import threading
+
+    from negpy.kernel.system.config import APP_CONFIG
+
+    cache = PreviewBufferCache(APP_CONFIG)
+    keys = [
+        PreviewCacheKey(file_hash=f"hash-{i}", use_camera_wb=False, workspace_color_space="Adobe RGB", full_resolution=False)
+        for i in range(6)
+    ]
+    buf = np.zeros((4, 4, 3), dtype=np.float32)
+    for key in keys:
+        cache.put(key, buf, (4, 4), {})
+    errors: list[str] = []
+
+    def hammer() -> None:
+        try:
+            for _ in range(1200):
+                for key in keys:
+                    cache.get(key)
+                    cache.put(key, buf, (4, 4), {})
+        except BaseException as exc:  # noqa: BLE001 — the point is that nothing escapes
+            errors.append(repr(exc))
+
+    threads = [threading.Thread(target=hammer) for _ in range(8)]
+    switch_interval = sys.getswitchinterval()
+    sys.setswitchinterval(1e-7)  # widen the window an unguarded LRU loses in
+    try:
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+    finally:
+        sys.setswitchinterval(switch_interval)
+
+    assert errors == []
+    assert len(cache._order) == len(set(cache._order))
+    assert set(cache._order) == set(cache._data)


### PR DESCRIPTION
Auto Crop All decoded and detected one frame at a time, though frames are independent until `resolve_roll_crops` pools them into a roll. Detection now runs over a thread pool, which cuts the wait to roughly a third. Along the way this fixes a live race in the preview buffer cache that batch decoding could already hit.

### Timings

Corpus rolls, cold preview cache per run, warm OS page cache, best of two runs each, 10 cores → 5 workers:

| Roll | Frames | Before | After | Speedup |
|---|---|---|---|---|
| `2026-06-14-01-other-holder` | 17 | 11.80s | 3.52s | 3.36x |
| `2026-05-02-skewed-dark-to-edge` | 49 | 35.15s | 10.66s | 3.30x |
| `mixed-scanners-examples` | 11 | 6.82s | 1.97s | 3.46x |

Crop rects, angles and confidences come back **bit-identical** to the serial pass on every roll tested, across repeated runs in both modes. This is wall-clock only — nothing about what the detector decides changes.

The pool is sized at half the cores, because each worker holds a preview-scale frame and the detector inside it is already multi-core. Oversubscribing loses; measured on the 17-frame roll: 1 worker 11.9s, 3 → 4.5s, **5 → 3.6s**, 8 → 4.5s, 10 → 4.5s.

### The cache fix

`PreviewBufferCache` moved its LRU list and its entry map without a lock, so two threads recycling the same key both reached `_order.remove` and the second raised `ValueError: list.remove(x): x not in list`. This was already reachable on `main` — `NormalizationWorker` decodes a whole batch against one shared `PreviewManager` — and the parallel autocrop pass would have widened the window. Every public method now holds an `RLock`.

The added test reproduces it reliably with the lock removed: 8 threads over 6 keys at a 1e-7 switch interval raise out of `get` within a second, 5 runs out of 5.

### Behavior changes

- **Progress names frames in completion order** rather than roll order. The counter stays monotonic; only the label can jump around. The worker test that asserted the old ordering now asserts the counter sequence plus the set of names.
- **Cancellation lets up to 5 in-flight frames finish** instead of 1. Queued frames still exit immediately — pool workers peek at the cancel flag through a non-consuming check, leaving the terminal signal to the coordinating thread.

### Commits

- `50740cd` — `fix(preview): lock the preview buffer cache against concurrent access`
- `2b328c5` — `perf(autocrop): collect Auto Crop All evidence over a thread pool`

### Not in this PR

The same serial-decode shape exists for stitch parts (preview and full-res export) and the HDR bracket load. Those are full-res and touch export, so they carry a memory question and a byte-identical-output bar that deserve their own change. The cache lock here is the shared prerequisite, so that work sits cleanly on top.

### Testing

`make all` green — 4581 passed, 11 skipped. Timings and the identical-output check came from driving `BatchAutoCropWorker.process` directly over real corpus rolls, not from pytest.