### PR TITLE
perf(ui): resolve font stacks against installed families at startup

### DIFF
--- a/negpy/desktop/view/sidebar/metadata.py
+++ b/negpy/desktop/view/sidebar/metadata.py
@@ -16,6 +16,7 @@ from PyQt6.QtWidgets import (
 
 from negpy.desktop.view.sidebar.base import BaseSidebar
 from negpy.desktop.view.styles.templates import field_label, hint_label
+from negpy.desktop.view.styles.fonts import mono_font_family
 from negpy.desktop.view.styles.theme import THEME
 from negpy.desktop.view.widgets.collapsible import CollapsibleSection
 from negpy.desktop.view.widgets.description_fields_dialog import DescriptionFieldsDialog
@@ -748,7 +749,7 @@ class MetadataSidebar(BaseSidebar):
 
         self.preview_empty.setText("Select gear or enter process metadata to see a preview.")
         self.preview_empty.setVisible(not sections)
-        mono = f"font-family: Consolas, monospace; font-size: {THEME.font_size_xs}px;"
+        mono = f"font-family: {mono_font_family()}; font-size: {THEME.font_size_xs}px;"
 
         for title, rows in sections:
             header = QLabel(title)

--- a/negpy/desktop/view/styles/fonts.py
+++ b/negpy/desktop/view/styles/fonts.py
@@ -1,0 +1,31 @@
+"""UI and monospace font stacks resolved against the installed families.
+
+Qt gives a family name it cannot find to the alias table, and populating that
+table walks every installed font — a visible part of startup. Resolve each stack
+to a name the system has, once, and give Qt only that. Resolution needs a live
+QApplication, so it must not run at import time.
+"""
+
+from functools import lru_cache
+
+from PyQt6.QtGui import QFontDatabase
+
+UI_STACK = ("Inter", "Segoe UI", "Roboto", "Arial")
+MONO_STACK = ("Consolas", "SF Mono", "Menlo", "DejaVu Sans Mono", "Courier New")
+
+
+@lru_cache(maxsize=None)
+def _resolve(stack: tuple[str, ...], fallback: QFontDatabase.SystemFont) -> str:
+    installed = set(QFontDatabase.families())
+    for family in stack:
+        if family in installed:
+            return family
+    return QFontDatabase.systemFont(fallback).family()
+
+
+def ui_font_family() -> str:
+    return _resolve(UI_STACK, QFontDatabase.SystemFont.GeneralFont)
+
+
+def mono_font_family() -> str:
+    return _resolve(MONO_STACK, QFontDatabase.SystemFont.FixedFont)

--- a/negpy/desktop/view/styles/modern_dark.qss
+++ b/negpy/desktop/view/styles/modern_dark.qss
@@ -5,7 +5,7 @@ QMainWindow {
 QWidget {
     background-color: #0D0D0D;
     color: #D4D4D4;
-    font-family: "Inter", "Segoe UI", "Roboto", "Arial";
+    font-family: "__UI_FONT__";
     font-size: 10pt;
 }
 

--- a/negpy/desktop/view/styles/templates.py
+++ b/negpy/desktop/view/styles/templates.py
@@ -5,6 +5,7 @@ import qtawesome as qta
 from PyQt6.QtCore import QEvent
 from PyQt6.QtWidgets import QLabel, QPushButton, QWidget
 
+from negpy.desktop.view.styles.fonts import ui_font_family
 from negpy.desktop.view.styles.theme import THEME
 
 _default_btn_height: int | None = None
@@ -25,7 +26,8 @@ def load_stylesheet() -> str:
     # QSS url() cannot resolve relative paths reliably across dev and frozen runs, so bake in
     # the absolute icon path, with forward slashes for Qt.
     check_icon = get_resource_path("media/icons/checkbox_check.svg").replace("\\", "/")
-    return qss.replace("__CHECKBOX_CHECK_ICON__", check_icon)
+    qss = qss.replace("__CHECKBOX_CHECK_ICON__", check_icon)
+    return qss.replace("__UI_FONT__", ui_font_family())
 
 
 def default_button_height() -> int:

--- a/negpy/desktop/view/styles/theme.py
+++ b/negpy/desktop/view/styles/theme.py
@@ -8,8 +8,7 @@ class ThemeConfig:
     Centralized UI styling constants.
     """
 
-    # Fonts
-    font_family: str = "Inter, Segoe UI, Roboto, sans-serif"
+    # Fonts (families are resolved at runtime in styles/fonts.py)
     font_size_base: int = 13
     font_size_small: int = 12
     font_size_header: int = 14

--- a/negpy/desktop/view/widgets/contact_sheet_colors_dialog.py
+++ b/negpy/desktop/view/widgets/contact_sheet_colors_dialog.py
@@ -5,6 +5,7 @@ from PyQt6.QtCore import QPointF, Qt, QRectF, pyqtSignal
 from PyQt6.QtGui import QColor, QFont, QImage, QMouseEvent, QPainter, QPainterPath, QPen, QPixmap
 from PyQt6.QtWidgets import QDialog, QHBoxLayout, QPushButton, QVBoxLayout, QWidget
 
+from negpy.desktop.view.styles.fonts import mono_font_family
 from negpy.desktop.view.styles.theme import THEME
 
 
@@ -260,7 +261,7 @@ class _TargetRow(QWidget):
 
         # Hex readout (right-aligned, read-only)
         painter.setPen(QColor(THEME.text_secondary))
-        hex_font = QFont("Consolas, Menlo, monospace")
+        hex_font = QFont(mono_font_family())
         hex_font.setPixelSize(THEME.font_size_xs)
         painter.setFont(hex_font)
         painter.drawText(

--- a/negpy/desktop/view/widgets/shortcut_editor.py
+++ b/negpy/desktop/view/widgets/shortcut_editor.py
@@ -44,6 +44,7 @@ from negpy.desktop.view.shortcut_registry import (
 from negpy.desktop.view.widgets.collapsible import CollapsibleSection
 from negpy.desktop.view.widgets.key_sequence_edit import KeypadAwareKeySequenceEdit
 from negpy.desktop.view.widgets.shortcut_search_line_edit import ShortcutSearchLineEdit
+from negpy.desktop.view.styles.fonts import mono_font_family
 from negpy.desktop.view.styles.theme import THEME
 
 
@@ -261,7 +262,7 @@ class ShortcutEditorDialog(QDialog):
             hdr.setStyleSheet(header_style)
             grid.addWidget(hdr, 0, col)
 
-        mono = f"color: {THEME.text_secondary}; font-family: Consolas, monospace;"
+        mono = f"color: {THEME.text_secondary}; font-family: {mono_font_family()};"
         for row, editor_row in enumerate(category_editor_rows(items), start=1):
             if isinstance(editor_row, EditorRowSlider):
                 self._add_slider_row(grid, row, editor_row, mono)

--- a/negpy/desktop/view/widgets/shortcuts_overlay.py
+++ b/negpy/desktop/view/widgets/shortcuts_overlay.py
@@ -36,6 +36,7 @@ from negpy.desktop.view.shortcut_registry import (
     category_editor_rows,
     slider_step_for,
 )
+from negpy.desktop.view.styles.fonts import mono_font_family
 from negpy.desktop.view.styles.theme import THEME
 from negpy.desktop.view.widgets.collapsible import CollapsibleSection
 from negpy.desktop.view.widgets.shortcut_search_line_edit import ShortcutSearchLineEdit
@@ -253,7 +254,7 @@ class ShortcutsOverlay(QDialog):
             hdr.setStyleSheet(header_style)
             grid.addWidget(hdr, 0, col)
 
-        mono = f"color: {THEME.text_secondary}; font-family: Consolas, monospace;"
+        mono = f"color: {THEME.text_secondary}; font-family: {mono_font_family()};"
         for row, editor_row in enumerate(category_editor_rows(items), start=1):
             if isinstance(editor_row, EditorRowSlider):
                 self._add_slider_row(grid, row, editor_row, mono)
@@ -269,7 +270,7 @@ class ShortcutsOverlay(QDialog):
             background-color: {THEME.bg_header};
             border: 1px solid {THEME.border_primary};
             border-radius: 3px;
-            font-family: Consolas, monospace;
+            font-family: {mono_font_family()};
             font-size: 11px;
             padding: 2px 6px;
         """)


### PR DESCRIPTION
Every launch spent ~190 ms populating Qt's font family alias table because the stylesheet asked for "Inter" first and no machine here has it. Qt has no cheap CSS-style fallback: a family it cannot find makes it walk every installed font's localized names before falling through to the next name in the list.

Resolve each stack once, after QApplication exists, and give Qt only a name the system has. The UI stack keeps its old order, so the rendered face does not change (Arial on macOS, Segoe UI on Windows). The four "Consolas, monospace" call sites and the comma-joined QFont() in the contact-sheet dialog went through the same resolver; THEME.font_family held a second, stale copy of the stack and is gone.