### PR TITLE
feat(metadata): add developer and scan-setup presets

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -822,9 +822,10 @@ Archival metadata for the **original analog capture** (camera, lens, film, proce
 
 **Analog Gear** (searchable; type in any field to filter the library):
 
-*   **Preset**: a reusable camera, lens and film combination. **Clear** empties the gear selections.
+*   **Preset**: a reusable camera, lens and film combination. **Clear** empties the gear selections. A preset may also name a developer and a scan setup; those two slots apply only when the preset sets them, so a gear pick never wipes chemistry you chose by hand.
+*   **Process & Scan preset**: a reusable developer and scan-setup pair, for a roll processed and digitized the same way each time. It owns both slots, so an empty slot clears the matching pick. **Clear** empties both.
 *   **Camera / Lens / Film stock**: pick from your library. Empty means not set.
-*   **Manage…**: edit cameras, lenses, film stocks and presets. Starter data seeds into `~/NegPy/gear/` on first launch.
+*   **Manage…**: edit cameras, lenses, film stocks, developers, scan setups and both kinds of preset. Starter data seeds into `~/NegPy/gear/` on first launch.
 
 **Capture:**
 
@@ -834,12 +835,12 @@ Archival metadata for the **original analog capture** (camera, lens, film, proce
 **Process:**
 
 *   **Format**: `35mm`, `120`, `4×5`, `8×10`, `110`, or `Other` with a free-text field.
-*   **Developer**: for example `D-76 1+1`.
+*   **Developer**: pick a saved recipe — chemistry, dilution, time, temperature, process (`B&W`, `C-41`, `E-6`, `ECN-2`, `Other`) and lab — or type the text yourself, for example `D-76 1+1`. Picking a recipe fills the text field; what you type afterwards wins and survives later gear changes.
 *   **Push / Pull**: `Push +3` … `Normal` … `Pull -3`.
 
 **Scanning:**
 
-*   **Scanning**: scan method or notes. EXIF `Software` is always `NegPy`.
+*   **Scanning**: pick a saved scan setup — method (`Copy stand`, `Flatbed`, `Film scanner`, `Drum`, `Lab scan`, `Other`), device, light source, holder and software — or type the method or notes yourself. It fills the text field the same way the developer does. EXIF `Software` is always `NegPy`.
 *   **Roll / Frame**: Scanlight capture roll name and frame number, stamped automatically on capture and editable here. Available in export filename templates as `{{ roll }}` and `{{ frame }}`, and written to XMP as `negpy:CaptureRoll` and `negpy:CaptureFrame` when set. Not the Roll Analysis normalization name.
 
 **Exposure**: optional original shutter, aperture and ISO. Click the lock to edit a free-text string, for example `1/125s f/2.8 ISO 400`.

--- a/gear/developers.json
+++ b/gear/developers.json
@@ -1,0 +1,76 @@
+[
+  {
+    "id": "dev-d76-stock",
+    "displayName": "D-76 stock",
+    "developer": "Kodak D-76",
+    "dilution": "stock",
+    "time": "8:00",
+    "temperatureC": 20,
+    "process": "B&W",
+    "notes": "Fine grain, full film speed."
+  },
+  {
+    "id": "dev-d76-1plus1",
+    "displayName": "D-76 1+1",
+    "developer": "Kodak D-76",
+    "dilution": "1+1",
+    "time": "11:00",
+    "temperatureC": 20,
+    "process": "B&W",
+    "notes": "One-shot dilution, finer grain and a little more sharpness."
+  },
+  {
+    "id": "dev-hc110-b",
+    "displayName": "HC-110 dil. B",
+    "developer": "Kodak HC-110",
+    "dilution": "dil. B",
+    "time": "6:00",
+    "temperatureC": 20,
+    "process": "B&W"
+  },
+  {
+    "id": "dev-xtol-1plus1",
+    "displayName": "XTOL 1+1",
+    "developer": "Kodak XTOL",
+    "dilution": "1+1",
+    "time": "9:45",
+    "temperatureC": 20,
+    "process": "B&W"
+  },
+  {
+    "id": "dev-rodinal-1plus50",
+    "displayName": "Rodinal 1+50",
+    "developer": "Rodinal",
+    "dilution": "1+50",
+    "time": "13:00",
+    "temperatureC": 20,
+    "process": "B&W",
+    "notes": "High acutance, visible grain."
+  },
+  {
+    "id": "dev-c41-lab",
+    "displayName": "C-41 (lab)",
+    "developer": "C-41",
+    "time": "3:15",
+    "temperatureC": 37.8,
+    "process": "C-41",
+    "notes": "Standard colour negative process."
+  },
+  {
+    "id": "dev-e6-lab",
+    "displayName": "E-6 (lab)",
+    "developer": "E-6",
+    "temperatureC": 38,
+    "process": "E-6",
+    "notes": "Standard reversal process."
+  },
+  {
+    "id": "dev-ecn2",
+    "displayName": "ECN-2",
+    "developer": "ECN-2",
+    "time": "3:00",
+    "temperatureC": 41.1,
+    "process": "ECN-2",
+    "notes": "Motion-picture negative process, for Vision3 and similar."
+  }
+]

--- a/gear/process_scan_presets.json
+++ b/gear/process_scan_presets.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": "psp-d76-copystand",
+    "displayName": "D-76 1+1 / Copy stand",
+    "developerId": "dev-d76-1plus1",
+    "scanSetupId": "scan-copystand-scanlight"
+  },
+  {
+    "id": "psp-c41-copystand",
+    "displayName": "C-41 lab / Copy stand",
+    "developerId": "dev-c41-lab",
+    "scanSetupId": "scan-copystand-scanlight"
+  },
+  {
+    "id": "psp-hc110-opticfilm",
+    "displayName": "HC-110 B / OpticFilm 8200i",
+    "developerId": "dev-hc110-b",
+    "scanSetupId": "scan-opticfilm-8200i"
+  }
+]

--- a/gear/scan_setups.json
+++ b/gear/scan_setups.json
@@ -1,0 +1,38 @@
+[
+  {
+    "id": "scan-copystand-scanlight",
+    "displayName": "Copy stand + Scanlight",
+    "method": "Copy stand",
+    "lightSource": "NegPy Scanlight narrowband RGB"
+  },
+  {
+    "id": "scan-copystand-white",
+    "displayName": "Copy stand + white LED",
+    "method": "Copy stand",
+    "lightSource": "White LED panel"
+  },
+  {
+    "id": "scan-opticfilm-8200i",
+    "displayName": "Plustek OpticFilm 8200i SE",
+    "method": "Film scanner",
+    "device": "Plustek OpticFilm 8200i SE"
+  },
+  {
+    "id": "scan-coolscan-v",
+    "displayName": "Nikon Coolscan V ED",
+    "method": "Film scanner",
+    "device": "Nikon Coolscan V ED"
+  },
+  {
+    "id": "scan-flatbed-v850",
+    "displayName": "Epson V850",
+    "method": "Flatbed",
+    "device": "Epson Perfection V850 Pro"
+  },
+  {
+    "id": "scan-lab",
+    "displayName": "Lab scan",
+    "method": "Lab scan",
+    "notes": "Scanned by the lab that processed the roll."
+  }
+]

--- a/negpy/desktop/view/sidebar/metadata.py
+++ b/negpy/desktop/view/sidebar/metadata.py
@@ -98,6 +98,17 @@ class MetadataSidebar(BaseSidebar):
         preset_row.addWidget(self.preset_clear_btn)
         gear.addLayout(preset_row)
 
+        ps_row = QHBoxLayout()
+        ps_row.setSpacing(THEME.space_sm)
+        gear.addWidget(field_label("Process & Scan preset"))
+        self.process_scan_combo = SearchableGearCombo(placeholder="Search process & scan presets…")
+        self.process_scan_combo.setToolTip("Reusable developer + scan setup combination. Click and type to search.")
+        ps_row.addWidget(self.process_scan_combo, 1)
+        self.process_scan_clear_btn = QPushButton("Clear")
+        self.process_scan_clear_btn.setToolTip("Clear process & scan preset selection")
+        ps_row.addWidget(self.process_scan_clear_btn)
+        gear.addLayout(ps_row)
+
         gear.addWidget(field_label("Camera"))
         self.camera_combo = SearchableGearCombo(placeholder="Search cameras…")
         self.camera_combo.setToolTip("Original film camera body. Click and type to search.")
@@ -115,7 +126,7 @@ class MetadataSidebar(BaseSidebar):
 
         self.manage_btn = QPushButton(" Manage…")
         self.manage_btn.setIcon(qta.icon("fa5s.cog", color=THEME.text_primary))
-        self.manage_btn.setToolTip("Edit cameras, lenses, film stocks, and gear presets")
+        self.manage_btn.setToolTip("Edit cameras, lenses, film stocks, developers, scan setups and presets")
         gear.addWidget(self.manage_btn)
         controls.addWidget(self._card("Analog Gear", "gear", gear_body, "fa5s.camera-retro"))
 
@@ -161,6 +172,9 @@ class MetadataSidebar(BaseSidebar):
         proc.addWidget(self.format_other_edit)
 
         proc.addWidget(field_label("Developer"))
+        self.developer_combo = SearchableGearCombo(placeholder="Search developers…")
+        self.developer_combo.setToolTip("Saved development recipe. Click and type to search; the field below stays editable.")
+        proc.addWidget(self.developer_combo)
         self.developer_edit = QLineEdit()
         self.developer_edit.setPlaceholderText("e.g. D-76 1+1")
         self.developer_edit.setText(conf.developer)
@@ -177,6 +191,9 @@ class MetadataSidebar(BaseSidebar):
         # ── SCANNING ─────────────────────────────────────────────────────
         scan_body, scan = self._card_body()
         scan.addWidget(field_label("Scanning"))
+        self.scan_setup_combo = SearchableGearCombo(placeholder="Search scan setups…")
+        self.scan_setup_combo.setToolTip("Saved digitization rig. Click and type to search; the field below stays editable.")
+        scan.addWidget(self.scan_setup_combo)
         self.scanning_edit = QLineEdit()
         self.scanning_edit.setPlaceholderText("e.g. DSLR copy-stand scan")
         self.scanning_edit.setText(conf.scanning)
@@ -323,6 +340,10 @@ class MetadataSidebar(BaseSidebar):
         self.camera_combo.selection_changed.connect(self._on_gear_changed)
         self.lens_combo.selection_changed.connect(self._on_gear_changed)
         self.film_stock_combo.selection_changed.connect(self._on_gear_changed)
+        self.developer_combo.selection_changed.connect(self._on_gear_changed)
+        self.scan_setup_combo.selection_changed.connect(self._on_gear_changed)
+        self.process_scan_combo.selection_changed.connect(self._on_process_scan_preset_changed)
+        self.process_scan_clear_btn.clicked.connect(self._on_process_scan_preset_clear)
         self.manage_btn.clicked.connect(self._open_gear_library)
 
         self.capture_date_edit.textChanged.connect(self._on_capture_date_changed)
@@ -412,6 +433,30 @@ class MetadataSidebar(BaseSidebar):
                 lambda stock: stock.resolved_display_name,
             )
 
+        if should_refresh(self.process_scan_combo):
+            self.process_scan_combo.blockSignals(True)
+            self.process_scan_combo.set_gear_items(
+                library.process_scan_presets,
+                conf.process_scan_preset_id or "",
+                lambda p: p.display_name or "Unnamed preset",
+                library,
+            )
+            self.process_scan_combo.blockSignals(False)
+
+        if should_refresh(self.developer_combo):
+            self.developer_combo.set_gear_items(
+                library.developers,
+                conf.developer_id or "",
+                lambda recipe: recipe.resolved_display_name,
+            )
+
+        if should_refresh(self.scan_setup_combo):
+            self.scan_setup_combo.set_gear_items(
+                library.scan_setups,
+                conf.scan_setup_id or "",
+                lambda rig: rig.resolved_display_name,
+            )
+
     def _on_preset_changed(self, _preset_id: str = "") -> None:
         preset_id = self.preset_combo.selected_id()
         if not preset_id:
@@ -444,9 +489,33 @@ class MetadataSidebar(BaseSidebar):
         )
         self._apply_metadata_config(cleared)
 
+    def _on_process_scan_preset_changed(self, _preset_id: str = "") -> None:
+        preset_id = self.process_scan_combo.selected_id()
+        if not preset_id:
+            return
+        self._flush_pending_edits()
+        new_meta = metadata_from_gear(
+            self.state.config.metadata,
+            self._gear_library,
+            process_scan_preset_id=preset_id,
+        )
+        self._apply_metadata_config(new_meta)
+
+    def _on_process_scan_preset_clear(self) -> None:
+        cleared = replace(
+            self.state.config.metadata,
+            process_scan_preset_id="",
+            developer_id="",
+            scan_setup_id="",
+            developer="",
+            scanning="",
+        )
+        self._apply_metadata_config(cleared)
+
     def _on_gear_changed(self, *_args) -> None:
         sender = self.sender()
         kwargs: dict = {}
+        self._flush_pending_edits()
         if sender is self.camera_combo:
             kwargs["gear_preset_id"] = ""
             kwargs["camera_id"] = self.camera_combo.selected_id()
@@ -456,6 +525,12 @@ class MetadataSidebar(BaseSidebar):
         elif sender is self.film_stock_combo:
             kwargs["gear_preset_id"] = ""
             kwargs["film_stock_id"] = self.film_stock_combo.selected_id()
+        elif sender is self.developer_combo:
+            kwargs["process_scan_preset_id"] = ""
+            kwargs["developer_id"] = self.developer_combo.selected_id()
+        elif sender is self.scan_setup_combo:
+            kwargs["process_scan_preset_id"] = ""
+            kwargs["scan_setup_id"] = self.scan_setup_combo.selected_id()
         else:
             return
 
@@ -464,9 +539,10 @@ class MetadataSidebar(BaseSidebar):
             self._gear_library,
             **kwargs,
         )
-        self.preset_combo.blockSignals(True)
-        self.preset_combo.set_selected_id("")
-        self.preset_combo.blockSignals(False)
+        cleared = self.process_scan_combo if "process_scan_preset_id" in kwargs else self.preset_combo
+        cleared.blockSignals(True)
+        cleared.set_selected_id("")
+        cleared.blockSignals(False)
         self._apply_metadata_config(new_meta, refresh_combos=False)
 
     def _apply_metadata_config(self, new_meta, *, refresh_combos: bool = True) -> None:
@@ -492,6 +568,12 @@ class MetadataSidebar(BaseSidebar):
         self._gear_library = GearProfiles.load_library()
         self._refresh_gear_combos()
         self._schedule_preview()
+
+    def _flush_pending_edits(self) -> None:
+        """Write typed-but-unsaved fields to the config, so a library pick builds on them."""
+        self.update_timer.stop()
+        self._persist_all_metadata_settings()
+        self._dirty = False
 
     def _mark_dirty(self) -> None:
         self._dirty = True
@@ -618,6 +700,9 @@ class MetadataSidebar(BaseSidebar):
             camera_id=self.camera_combo.selected_id(),
             lens_id=self.lens_combo.selected_id(),
             film_stock_id=self.film_stock_combo.selected_id(),
+            process_scan_preset_id=self.process_scan_combo.selected_id(),
+            developer_id=self.developer_combo.selected_id(),
+            scan_setup_id=self.scan_setup_combo.selected_id(),
             format=fmt,
             format_other=self.format_other_edit.text().strip() if fmt == "Other" else "",
             developer=self.developer_edit.text().strip(),
@@ -720,6 +805,9 @@ class MetadataSidebar(BaseSidebar):
             camera_id=self.camera_combo.selected_id(),
             lens_id=self.lens_combo.selected_id(),
             film_stock_id=self.film_stock_combo.selected_id(),
+            process_scan_preset_id=self.process_scan_combo.selected_id(),
+            developer_id=self.developer_combo.selected_id(),
+            scan_setup_id=self.scan_setup_combo.selected_id(),
             format=fmt,
             format_other=self.format_other_edit.text().strip() if fmt == "Other" else "",
             developer=self.developer_edit.text().strip(),

--- a/negpy/desktop/view/widgets/gear_library_dialog.py
+++ b/negpy/desktop/view/widgets/gear_library_dialog.py
@@ -27,12 +27,17 @@ from negpy.desktop.view.widgets.searchable_gear_combo import SearchableGearCombo
 from negpy.features.metadata.gear_logic import matches_gear_filter
 from negpy.features.metadata.gear_models import (
     Camera,
+    DeveloperRecipe,
+    DevProcess,
     FilmColorType,
     FilmFormat,
     FilmStock,
     GearLibrary,
     GearPreset,
     Lens,
+    ProcessScanPreset,
+    ScanMethod,
+    ScanSetup,
 )
 from negpy.services.assets.gear import GearProfiles
 
@@ -40,21 +45,30 @@ _CATEGORIES = [
     ("cameras", "Cameras"),
     ("lenses", "Lenses"),
     ("film_stocks", "Film Stocks"),
+    ("developers", "Developers"),
+    ("scan_setups", "Scan Setups"),
     ("gear_presets", "Gear Presets"),
+    ("process_scan_presets", "Process & Scan"),
 ]
 
 _CATEGORY_FIELDS: dict[str, frozenset[str]] = {
     "cameras": frozenset({"display_name", "make", "model", "notes"}),
     "lenses": frozenset({"display_name", "make", "lens_model", "focal", "aperture", "notes"}),
     "film_stocks": frozenset({"display_name", "manufacturer", "stock_name", "iso", "format", "color_type", "notes"}),
-    "gear_presets": frozenset({"display_name", "preset_camera", "preset_lens", "preset_film", "notes"}),
+    "developers": frozenset({"display_name", "developer", "dilution", "dev_time", "temperature", "dev_process", "lab", "notes"}),
+    "scan_setups": frozenset({"display_name", "scan_method", "device", "light_source", "holder", "software", "notes"}),
+    "gear_presets": frozenset({"display_name", "preset_camera", "preset_lens", "preset_film", "preset_developer", "preset_scan", "notes"}),
+    "process_scan_presets": frozenset({"display_name", "preset_developer", "preset_scan", "notes"}),
 }
 
 _CATEGORY_SEARCH_PLACEHOLDER = {
     "cameras": "Search cameras…",
     "lenses": "Search lenses…",
     "film_stocks": "Search film stocks…",
+    "developers": "Search developers…",
+    "scan_setups": "Search scan setups…",
     "gear_presets": "Search presets…",
+    "process_scan_presets": "Search process & scan presets…",
 }
 
 
@@ -167,9 +181,33 @@ class GearLibraryDialog(QDialog):
         self.color_combo = QComboBox()
         self.color_combo.addItems([e.value for e in FilmColorType])
         self.notes_edit = QLineEdit()
+        self.developer_edit = QLineEdit()
+        self.developer_edit.setPlaceholderText("e.g. D-76")
+        self.dilution_edit = QLineEdit()
+        self.dilution_edit.setPlaceholderText("e.g. 1+1")
+        self.dev_time_edit = QLineEdit()
+        self.dev_time_edit.setPlaceholderText("e.g. 9:30, or stand 60 min")
+        self.temperature_spin = QDoubleSpinBox()
+        self.temperature_spin.setRange(0, 60)
+        self.temperature_spin.setDecimals(1)
+        self.temperature_spin.setSuffix(" °C")
+        self.dev_process_combo = QComboBox()
+        self.dev_process_combo.addItems([e.value for e in DevProcess])
+        self.lab_edit = QLineEdit()
+        self.lab_edit.setPlaceholderText("Commercial lab, when not self-developed")
+        self.scan_method_combo = QComboBox()
+        self.scan_method_combo.addItems([e.value for e in ScanMethod])
+        self.device_edit = QLineEdit()
+        self.device_edit.setPlaceholderText("e.g. Sony A7RIV + 90mm macro")
+        self.light_source_edit = QLineEdit()
+        self.light_source_edit.setPlaceholderText("e.g. NegPy Scanlight narrowband")
+        self.holder_edit = QLineEdit()
+        self.software_edit = QLineEdit()
         self.preset_camera_combo = SearchableGearCombo(placeholder="Search cameras…")
         self.preset_lens_combo = SearchableGearCombo(placeholder="Search lenses…")
         self.preset_film_combo = SearchableGearCombo(placeholder="Search film stocks…")
+        self.preset_developer_combo = SearchableGearCombo(placeholder="Search developers…")
+        self.preset_scan_combo = SearchableGearCombo(placeholder="Search scan setups…")
 
         for w in (
             self.display_name_edit,
@@ -178,6 +216,14 @@ class GearLibraryDialog(QDialog):
             self.lens_model_edit,
             self.manufacturer_edit,
             self.stock_name_edit,
+            self.developer_edit,
+            self.dilution_edit,
+            self.dev_time_edit,
+            self.lab_edit,
+            self.device_edit,
+            self.light_source_edit,
+            self.holder_edit,
+            self.software_edit,
             self.notes_edit,
         ):
             w.textChanged.connect(self._on_form_changed)
@@ -189,6 +235,11 @@ class GearLibraryDialog(QDialog):
         self.preset_camera_combo.selection_changed.connect(self._on_form_changed)
         self.preset_lens_combo.selection_changed.connect(self._on_form_changed)
         self.preset_film_combo.selection_changed.connect(self._on_form_changed)
+        self.temperature_spin.valueChanged.connect(self._on_form_changed)
+        self.dev_process_combo.currentIndexChanged.connect(self._on_form_changed)
+        self.scan_method_combo.currentIndexChanged.connect(self._on_form_changed)
+        self.preset_developer_combo.selection_changed.connect(self._on_form_changed)
+        self.preset_scan_combo.selection_changed.connect(self._on_form_changed)
 
         self.form_panel = QWidget()
         self.form_layout = QFormLayout(self.form_panel)
@@ -205,9 +256,22 @@ class GearLibraryDialog(QDialog):
         self._register_form_row("iso", "ISO", self.iso_spin)
         self._register_form_row("format", "Format", self.format_combo)
         self._register_form_row("color_type", "Color type", self.color_combo)
+        self._register_form_row("developer", "Developer", self.developer_edit)
+        self._register_form_row("dilution", "Dilution", self.dilution_edit)
+        self._register_form_row("dev_time", "Time", self.dev_time_edit)
+        self._register_form_row("temperature", "Temperature", self.temperature_spin)
+        self._register_form_row("dev_process", "Process", self.dev_process_combo)
+        self._register_form_row("lab", "Lab", self.lab_edit)
+        self._register_form_row("scan_method", "Method", self.scan_method_combo)
+        self._register_form_row("device", "Device", self.device_edit)
+        self._register_form_row("light_source", "Light source", self.light_source_edit)
+        self._register_form_row("holder", "Holder", self.holder_edit)
+        self._register_form_row("software", "Software", self.software_edit)
         self._register_form_row("preset_camera", "Camera", self.preset_camera_combo)
         self._register_form_row("preset_lens", "Lens", self.preset_lens_combo)
         self._register_form_row("preset_film", "Film stock", self.preset_film_combo)
+        self._register_form_row("preset_developer", "Developer", self.preset_developer_combo)
+        self._register_form_row("preset_scan", "Scan setup", self.preset_scan_combo)
         self._register_form_row("notes", "Notes", self.notes_edit)
 
         right_layout.addWidget(self.form_panel)
@@ -241,7 +305,13 @@ class GearLibraryDialog(QDialog):
             return self._library.lenses
         if self._category == "film_stocks":
             return self._library.film_stocks
-        return self._library.gear_presets
+        if self._category == "developers":
+            return self._library.developers
+        if self._category == "scan_setups":
+            return self._library.scan_setups
+        if self._category == "gear_presets":
+            return self._library.gear_presets
+        return self._library.process_scan_presets
 
     def _set_current_items(self, items: list) -> None:
         if self._category == "cameras":
@@ -250,8 +320,14 @@ class GearLibraryDialog(QDialog):
             self._library.lenses = items
         elif self._category == "film_stocks":
             self._library.film_stocks = items
-        else:
+        elif self._category == "developers":
+            self._library.developers = items
+        elif self._category == "scan_setups":
+            self._library.scan_setups = items
+        elif self._category == "gear_presets":
             self._library.gear_presets = items
+        else:
+            self._library.process_scan_presets = items
 
     def _item_label(self, item) -> str:
         if isinstance(item, Camera):
@@ -260,7 +336,9 @@ class GearLibraryDialog(QDialog):
             return item.resolved_display_name
         if isinstance(item, FilmStock):
             return item.resolved_display_name
-        if isinstance(item, GearPreset):
+        if isinstance(item, (DeveloperRecipe, ScanSetup)):
+            return item.resolved_display_name
+        if isinstance(item, (GearPreset, ProcessScanPreset)):
             return item.display_name or "Unnamed preset"
         return str(item)
 
@@ -291,7 +369,7 @@ class GearLibraryDialog(QDialog):
             selected_id = all_items[self._selected_idx].id
 
         query = self.item_search.text().strip()
-        lib = self._library if self._category == "gear_presets" else None
+        lib = self._library if self._category in ("gear_presets", "process_scan_presets") else None
         visible = [item for item in all_items if matches_gear_filter(item, query, lib)]
 
         self._list_items = visible
@@ -323,6 +401,8 @@ class GearLibraryDialog(QDialog):
         camera_id: str = "",
         lens_id: str = "",
         film_id: str = "",
+        developer_id: str = "",
+        scan_setup_id: str = "",
     ) -> None:
         self.preset_camera_combo.set_gear_items(
             self._library.cameras,
@@ -338,6 +418,16 @@ class GearLibraryDialog(QDialog):
             self._library.film_stocks,
             film_id,
             lambda stock: stock.resolved_display_name,
+        )
+        self.preset_developer_combo.set_gear_items(
+            self._library.developers,
+            developer_id,
+            lambda recipe: recipe.resolved_display_name,
+        )
+        self.preset_scan_combo.set_gear_items(
+            self._library.scan_setups,
+            scan_setup_id,
+            lambda rig: rig.resolved_display_name,
         )
 
     def _on_item_changed(self, row: int) -> None:
@@ -384,11 +474,41 @@ class GearLibraryDialog(QDialog):
                 if idx >= 0:
                     self.color_combo.setCurrentIndex(idx)
                 self.notes_edit.setText(item.notes)
+            elif isinstance(item, DeveloperRecipe):
+                self.display_name_edit.setText(item.display_name)
+                self.developer_edit.setText(item.developer)
+                self.dilution_edit.setText(item.dilution)
+                self.dev_time_edit.setText(item.time)
+                self.temperature_spin.setValue(item.temperature_c or 0)
+                idx = self.dev_process_combo.findText(item.process.value)
+                if idx >= 0:
+                    self.dev_process_combo.setCurrentIndex(idx)
+                self.lab_edit.setText(item.lab)
+                self.notes_edit.setText(item.notes)
+            elif isinstance(item, ScanSetup):
+                self.display_name_edit.setText(item.display_name)
+                idx = self.scan_method_combo.findText(item.method.value)
+                if idx >= 0:
+                    self.scan_method_combo.setCurrentIndex(idx)
+                self.device_edit.setText(item.device)
+                self.light_source_edit.setText(item.light_source)
+                self.holder_edit.setText(item.holder)
+                self.software_edit.setText(item.software)
+                self.notes_edit.setText(item.notes)
             elif isinstance(item, GearPreset):
                 self._refresh_preset_combos(
                     camera_id=item.camera_id,
                     lens_id=item.lens_id,
                     film_id=item.film_stock_id,
+                    developer_id=item.developer_id,
+                    scan_setup_id=item.scan_setup_id,
+                )
+                self.display_name_edit.setText(item.display_name)
+                self.notes_edit.setText(item.notes)
+            elif isinstance(item, ProcessScanPreset):
+                self._refresh_preset_combos(
+                    developer_id=item.developer_id,
+                    scan_setup_id=item.scan_setup_id,
                 )
                 self.display_name_edit.setText(item.display_name)
                 self.notes_edit.setText(item.notes)
@@ -405,12 +525,21 @@ class GearLibraryDialog(QDialog):
                 self.lens_model_edit,
                 self.manufacturer_edit,
                 self.stock_name_edit,
+                self.developer_edit,
+                self.dilution_edit,
+                self.dev_time_edit,
+                self.lab_edit,
+                self.device_edit,
+                self.light_source_edit,
+                self.holder_edit,
+                self.software_edit,
                 self.notes_edit,
             ):
                 w.clear()
             self.focal_spin.setValue(0)
             self.aperture_spin.setValue(0)
             self.iso_spin.setValue(100)
+            self.temperature_spin.setValue(0)
         finally:
             self._updating = False
 
@@ -440,11 +569,35 @@ class GearLibraryDialog(QDialog):
             item.format = FilmFormat(self.format_combo.currentText())
             item.color_type = FilmColorType(self.color_combo.currentText())
             item.notes = self.notes_edit.text().strip()
+        elif isinstance(item, DeveloperRecipe):
+            item.display_name = self.display_name_edit.text().strip()
+            item.developer = self.developer_edit.text().strip()
+            item.dilution = self.dilution_edit.text().strip()
+            item.time = self.dev_time_edit.text().strip()
+            item.temperature_c = self.temperature_spin.value() or None
+            item.process = DevProcess(self.dev_process_combo.currentText())
+            item.lab = self.lab_edit.text().strip()
+            item.notes = self.notes_edit.text().strip()
+        elif isinstance(item, ScanSetup):
+            item.display_name = self.display_name_edit.text().strip()
+            item.method = ScanMethod(self.scan_method_combo.currentText())
+            item.device = self.device_edit.text().strip()
+            item.light_source = self.light_source_edit.text().strip()
+            item.holder = self.holder_edit.text().strip()
+            item.software = self.software_edit.text().strip()
+            item.notes = self.notes_edit.text().strip()
         elif isinstance(item, GearPreset):
             item.display_name = self.display_name_edit.text().strip()
             item.camera_id = self.preset_camera_combo.selected_id()
             item.lens_id = self.preset_lens_combo.selected_id()
             item.film_stock_id = self.preset_film_combo.selected_id()
+            item.developer_id = self.preset_developer_combo.selected_id()
+            item.scan_setup_id = self.preset_scan_combo.selected_id()
+            item.notes = self.notes_edit.text().strip()
+        elif isinstance(item, ProcessScanPreset):
+            item.display_name = self.display_name_edit.text().strip()
+            item.developer_id = self.preset_developer_combo.selected_id()
+            item.scan_setup_id = self.preset_scan_combo.selected_id()
             item.notes = self.notes_edit.text().strip()
 
         items[self._selected_idx] = item
@@ -462,8 +615,14 @@ class GearLibraryDialog(QDialog):
             item = Lens(lens_model="New lens")
         elif self._category == "film_stocks":
             item = FilmStock(stock_name="New stock")
-        else:
+        elif self._category == "developers":
+            item = DeveloperRecipe(developer="New developer")
+        elif self._category == "scan_setups":
+            item = ScanSetup(display_name="New scan setup")
+        elif self._category == "gear_presets":
             item = GearPreset(display_name="New preset")
+        else:
+            item = ProcessScanPreset(display_name="New preset")
         items = list(self._current_items())
         items.append(item)
         self._set_current_items(items)

--- a/negpy/features/metadata/gear_logic.py
+++ b/negpy/features/metadata/gear_logic.py
@@ -5,10 +5,31 @@ from __future__ import annotations
 from dataclasses import replace
 from typing import Optional, Union
 
-from negpy.features.metadata.gear_models import Camera, FilmStock, GearLibrary, GearPreset, Lens
+from negpy.features.metadata.gear_models import (
+    Camera,
+    DeveloperRecipe,
+    FilmStock,
+    GearLibrary,
+    GearPreset,
+    Lens,
+    ProcessScanPreset,
+    ScanSetup,
+)
 from negpy.features.metadata.models import MetadataConfig
 
-GearItem = Union[Camera, Lens, FilmStock, GearPreset]
+GearItem = Union[Camera, Lens, FilmStock, DeveloperRecipe, ScanSetup, GearPreset, ProcessScanPreset]
+
+
+def _process_scan_search_parts(item: Union[GearPreset, ProcessScanPreset], library: GearLibrary) -> list[str]:
+    """Searchable text contributed by a preset's developer and scan-setup slots."""
+    parts: list[str] = []
+    dev = library.get_developer(item.developer_id)
+    rig = library.get_scan_setup(item.scan_setup_id)
+    if dev:
+        parts.extend([dev.resolved_display_name, dev.developer, dev.lab])
+    if rig:
+        parts.extend([rig.resolved_display_name, rig.method.value, rig.device])
+    return parts
 
 
 def gear_search_text(item: GearItem, library: Optional[GearLibrary] = None) -> str:
@@ -33,6 +54,28 @@ def gear_search_text(item: GearItem, library: Optional[GearLibrary] = None) -> s
             item.format.value,
             item.color_type.value,
         ]
+    elif isinstance(item, DeveloperRecipe):
+        parts = [
+            item.display_name,
+            item.developer,
+            item.dilution,
+            item.time,
+            item.process.value,
+            item.lab,
+            item.notes,
+        ]
+        if item.temperature_c is not None:
+            parts.append(f"{item.temperature_c:g}")
+    elif isinstance(item, ScanSetup):
+        parts = [
+            item.display_name,
+            item.method.value,
+            item.device,
+            item.light_source,
+            item.holder,
+            item.software,
+            item.notes,
+        ]
     elif isinstance(item, GearPreset):
         parts = [item.display_name, item.notes]
         if library is not None:
@@ -45,6 +88,11 @@ def gear_search_text(item: GearItem, library: Optional[GearLibrary] = None) -> s
                 parts.extend([lens.resolved_display_name, lens.make, lens.lens_model])
             if stock:
                 parts.extend([stock.resolved_display_name, stock.manufacturer, stock.stock_name])
+            parts.extend(_process_scan_search_parts(item, library))
+    elif isinstance(item, ProcessScanPreset):
+        parts = [item.display_name, item.notes]
+        if library is not None:
+            parts.extend(_process_scan_search_parts(item, library))
 
     return " ".join(p.strip() for p in parts if p and str(p).strip()).lower()
 
@@ -64,7 +112,11 @@ def metadata_from_gear(
     camera_id: Optional[str] = None,
     lens_id: Optional[str] = None,
     film_stock_id: Optional[str] = None,
+    process_scan_preset_id: Optional[str] = None,
+    developer_id: Optional[str] = None,
+    scan_setup_id: Optional[str] = None,
     clear_preset: bool = False,
+    clear_process_scan_preset: bool = False,
 ) -> MetadataConfig:
     """Build updated MetadataConfig from gear library selections.
 
@@ -77,9 +129,23 @@ def metadata_from_gear(
     else:
         preset_id = config.gear_preset_id
 
+    if clear_process_scan_preset:
+        ps_preset_id = ""
+    elif process_scan_preset_id is not None:
+        ps_preset_id = process_scan_preset_id
+    else:
+        ps_preset_id = config.process_scan_preset_id
+
     cam_id = config.camera_id if camera_id is None else camera_id
     lens_id_val = config.lens_id if lens_id is None else lens_id
     film_id = config.film_stock_id if film_stock_id is None else film_stock_id
+    dev_id = config.developer_id if developer_id is None else developer_id
+    rig_id = config.scan_setup_id if scan_setup_id is None else scan_setup_id
+
+    # The free-text fields are re-derived on a deliberate pick only. An id merely
+    # carried over from the config leaves whatever the user typed in place.
+    derive_developer = bool(developer_id)
+    derive_scanning = bool(scan_setup_id)
 
     if preset_id:
         preset = library.get_gear_preset(preset_id)
@@ -88,6 +154,20 @@ def metadata_from_gear(
             cam_id = preset.camera_id
             lens_id_val = preset.lens_id
             film_id = preset.film_stock_id
+            # Chemistry and rig are additive here, so a gear pick never wipes them.
+            # Only the Process & Scan preset owns those two slots outright.
+            derive_developer = derive_developer or bool(preset.developer_id)
+            derive_scanning = derive_scanning or bool(preset.scan_setup_id)
+            dev_id = preset.developer_id or dev_id
+            rig_id = preset.scan_setup_id or rig_id
+
+    if ps_preset_id:
+        ps_preset = library.get_process_scan_preset(ps_preset_id)
+        if ps_preset:
+            derive_developer = True
+            derive_scanning = True
+            dev_id = ps_preset.developer_id
+            rig_id = ps_preset.scan_setup_id
 
     camera_make = ""
     camera_model = ""
@@ -100,6 +180,8 @@ def metadata_from_gear(
     film_iso: Optional[int] = None
     film_format = config.format
     film_color_type = ""
+    developer = config.developer
+    scanning = config.scanning
 
     if cam_id:
         cam = library.get_camera(cam_id)
@@ -124,12 +206,27 @@ def metadata_from_gear(
             film_format = stock.format.value
             film_color_type = stock.color_type.value
 
+    if dev_id and (derive_developer or not config.developer.strip()):
+        recipe = library.get_developer(dev_id)
+        if recipe:
+            developer = recipe.full_developer_label
+
+    if rig_id and (derive_scanning or not config.scanning.strip()):
+        rig = library.get_scan_setup(rig_id)
+        if rig:
+            scanning = rig.full_scan_label
+
     return replace(
         config,
         gear_preset_id=preset_id,
         camera_id=cam_id,
         lens_id=lens_id_val,
         film_stock_id=film_id,
+        process_scan_preset_id=ps_preset_id,
+        developer_id=dev_id,
+        scan_setup_id=rig_id,
+        developer=developer,
+        scanning=scanning,
         camera_make=camera_make,
         camera_model=camera_model,
         lens_make=lens_make,

--- a/negpy/features/metadata/gear_models.py
+++ b/negpy/features/metadata/gear_models.py
@@ -1,4 +1,4 @@
-"""Domain models for the analog gear library (cameras, lenses, film stocks, presets)."""
+"""Domain models for the analog gear library (cameras, lenses, film stocks, chemistry, rigs, presets)."""
 
 from __future__ import annotations
 
@@ -50,6 +50,56 @@ class FilmColorType(str, Enum):
             "BlackAndWhiteNegative": cls.BW_NEGATIVE,
             "ColorSlide": cls.COLOR_SLIDE,
             "BlackAndWhiteSlide": cls.BW_SLIDE,
+        }
+        return legacy.get(value, cls.OTHER)
+
+    def to_storage(self) -> str:
+        return self.value
+
+
+class DevProcess(str, Enum):
+    BW = "B&W"
+    C41 = "C-41"
+    E6 = "E-6"
+    ECN2 = "ECN-2"
+    OTHER = "Other"
+
+    @classmethod
+    def from_storage(cls, value: str) -> "DevProcess":
+        """Parse a process string from gear JSON (native value or legacy alias)."""
+        if value in {e.value for e in cls}:
+            return cls(value)
+        legacy = {
+            "BlackAndWhite": cls.BW,
+            "BW": cls.BW,
+            "C41": cls.C41,
+            "E6": cls.E6,
+            "ECN2": cls.ECN2,
+        }
+        return legacy.get(value, cls.OTHER)
+
+    def to_storage(self) -> str:
+        return self.value
+
+
+class ScanMethod(str, Enum):
+    COPY_STAND = "Copy stand"
+    FLATBED = "Flatbed"
+    FILM_SCANNER = "Film scanner"
+    DRUM = "Drum"
+    LAB = "Lab scan"
+    OTHER = "Other"
+
+    @classmethod
+    def from_storage(cls, value: str) -> "ScanMethod":
+        """Parse a scan-method string from gear JSON (native value or legacy alias)."""
+        if value in {e.value for e in cls}:
+            return cls(value)
+        legacy = {
+            "CopyStand": cls.COPY_STAND,
+            "DSLR": cls.COPY_STAND,
+            "FilmScanner": cls.FILM_SCANNER,
+            "Lab": cls.LAB,
         }
         return legacy.get(value, cls.OTHER)
 
@@ -215,12 +265,145 @@ class FilmStock:
 
 
 @dataclass
+class DeveloperRecipe:
+    """A development recipe: chemistry, dilution and the conditions it was run at."""
+
+    id: str = field(default_factory=_new_id)
+    display_name: str = ""
+    developer: str = ""
+    dilution: str = ""
+    time: str = ""
+    temperature_c: Optional[float] = None
+    process: DevProcess = DevProcess.BW
+    lab: str = ""
+    notes: str = ""
+    is_bundled: bool = False
+
+    @property
+    def resolved_display_name(self) -> str:
+        if self.display_name.strip():
+            return self.display_name.strip()
+        name = " ".join(p for p in (self.developer.strip(), self.dilution.strip()) if p)
+        return name or self.lab.strip() or "Unnamed developer"
+
+    @property
+    def full_developer_label(self) -> str:
+        """The metadata string: ``D-76 1+1, 9:30 @ 20 °C``."""
+        head = " ".join(p for p in (self.developer.strip(), self.dilution.strip()) if p)
+        if not head:
+            head = self.display_name.strip()
+        tail: list[str] = []
+        if self.time.strip():
+            tail.append(self.time.strip())
+        if self.temperature_c is not None:
+            tail.append(f"{self.temperature_c:g} °C")
+        conditions = " @ ".join(tail) if len(tail) == 2 else (tail[0] if tail else "")
+        parts = [p for p in (head, conditions) if p]
+        label = ", ".join(parts)
+        if self.lab.strip():
+            label = f"{label} ({self.lab.strip()})" if label else self.lab.strip()
+        return label
+
+    def to_dict(self) -> dict[str, Any]:
+        d: dict[str, Any] = {
+            "id": self.id,
+            "displayName": self.display_name,
+            "developer": self.developer,
+            "dilution": self.dilution or None,
+            "time": self.time or None,
+            "process": self.process.to_storage(),
+            "lab": self.lab or None,
+            "notes": self.notes or None,
+        }
+        if self.temperature_c is not None:
+            d["temperatureC"] = self.temperature_c
+        return d
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "DeveloperRecipe":
+        temp = data.get("temperatureC", data.get("temperature_c"))
+        proc_raw = data.get("process", "B&W")
+        proc = proc_raw if isinstance(proc_raw, DevProcess) else DevProcess.from_storage(str(proc_raw))
+        return cls(
+            id=str(data.get("id") or _new_id()),
+            display_name=str(data.get("displayName") or data.get("display_name") or ""),
+            developer=str(data.get("developer") or ""),
+            dilution=str(data.get("dilution") or ""),
+            time=str(data.get("time") or ""),
+            temperature_c=float(temp) if temp is not None else None,
+            process=proc,
+            lab=str(data.get("lab") or ""),
+            notes=str(data.get("notes") or ""),
+        )
+
+
+@dataclass
+class ScanSetup:
+    """A digitization rig: how the frame was scanned, and with what."""
+
+    id: str = field(default_factory=_new_id)
+    display_name: str = ""
+    method: ScanMethod = ScanMethod.COPY_STAND
+    device: str = ""
+    light_source: str = ""
+    holder: str = ""
+    software: str = ""
+    notes: str = ""
+    is_bundled: bool = False
+
+    @property
+    def resolved_display_name(self) -> str:
+        if self.display_name.strip():
+            return self.display_name.strip()
+        if self.device.strip():
+            return f"{self.method.value} — {self.device.strip()}"
+        return self.method.value
+
+    @property
+    def full_scan_label(self) -> str:
+        """The metadata string: ``Copy stand — Sony A7RIV, Scanlight narrowband``."""
+        detail = ", ".join(p for p in (self.device.strip(), self.light_source.strip(), self.holder.strip(), self.software.strip()) if p)
+        if detail:
+            return f"{self.method.value} — {detail}"
+        return self.method.value
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "displayName": self.display_name,
+            "method": self.method.to_storage(),
+            "device": self.device or None,
+            "lightSource": self.light_source or None,
+            "holder": self.holder or None,
+            "software": self.software or None,
+            "notes": self.notes or None,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "ScanSetup":
+        method_raw = data.get("method", "Copy stand")
+        method = method_raw if isinstance(method_raw, ScanMethod) else ScanMethod.from_storage(str(method_raw))
+        return cls(
+            id=str(data.get("id") or _new_id()),
+            display_name=str(data.get("displayName") or data.get("display_name") or ""),
+            method=method,
+            device=str(data.get("device") or ""),
+            light_source=str(data.get("lightSource") or data.get("light_source") or ""),
+            holder=str(data.get("holder") or ""),
+            software=str(data.get("software") or ""),
+            notes=str(data.get("notes") or ""),
+        )
+
+
+@dataclass
 class GearPreset:
     id: str = field(default_factory=_new_id)
     display_name: str = ""
     camera_id: str = ""
     lens_id: str = ""
     film_stock_id: str = ""
+    developer_id: str = ""
+    scan_setup_id: str = ""
     notes: str = ""
     is_bundled: bool = False
 
@@ -231,6 +414,8 @@ class GearPreset:
             "cameraId": self.camera_id or None,
             "lensId": self.lens_id or None,
             "filmStockId": self.film_stock_id or None,
+            "developerId": self.developer_id or None,
+            "scanSetupId": self.scan_setup_id or None,
             "notes": self.notes or None,
         }
 
@@ -242,6 +427,39 @@ class GearPreset:
             camera_id=str(data.get("cameraId") or data.get("camera_id") or ""),
             lens_id=str(data.get("lensId") or data.get("lens_id") or ""),
             film_stock_id=str(data.get("filmStockId") or data.get("film_stock_id") or ""),
+            developer_id=str(data.get("developerId") or data.get("developer_id") or ""),
+            scan_setup_id=str(data.get("scanSetupId") or data.get("scan_setup_id") or ""),
+            notes=str(data.get("notes") or ""),
+        )
+
+
+@dataclass
+class ProcessScanPreset:
+    """A development recipe paired with the rig it was scanned on."""
+
+    id: str = field(default_factory=_new_id)
+    display_name: str = ""
+    developer_id: str = ""
+    scan_setup_id: str = ""
+    notes: str = ""
+    is_bundled: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "displayName": self.display_name,
+            "developerId": self.developer_id or None,
+            "scanSetupId": self.scan_setup_id or None,
+            "notes": self.notes or None,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "ProcessScanPreset":
+        return cls(
+            id=str(data.get("id") or _new_id()),
+            display_name=str(data.get("displayName") or data.get("display_name") or ""),
+            developer_id=str(data.get("developerId") or data.get("developer_id") or ""),
+            scan_setup_id=str(data.get("scanSetupId") or data.get("scan_setup_id") or ""),
             notes=str(data.get("notes") or ""),
         )
 
@@ -253,7 +471,10 @@ class GearLibrary:
     cameras: list[Camera] = field(default_factory=list)
     lenses: list[Lens] = field(default_factory=list)
     film_stocks: list[FilmStock] = field(default_factory=list)
+    developers: list[DeveloperRecipe] = field(default_factory=list)
+    scan_setups: list[ScanSetup] = field(default_factory=list)
     gear_presets: list[GearPreset] = field(default_factory=list)
+    process_scan_presets: list[ProcessScanPreset] = field(default_factory=list)
 
     def get_camera(self, camera_id: str) -> Optional[Camera]:
         return next((c for c in self.cameras if c.id == camera_id), None)
@@ -264,5 +485,14 @@ class GearLibrary:
     def get_film_stock(self, film_stock_id: str) -> Optional[FilmStock]:
         return next((f for f in self.film_stocks if f.id == film_stock_id), None)
 
+    def get_developer(self, developer_id: str) -> Optional[DeveloperRecipe]:
+        return next((d for d in self.developers if d.id == developer_id), None)
+
+    def get_scan_setup(self, scan_setup_id: str) -> Optional[ScanSetup]:
+        return next((s for s in self.scan_setups if s.id == scan_setup_id), None)
+
     def get_gear_preset(self, preset_id: str) -> Optional[GearPreset]:
         return next((p for p in self.gear_presets if p.id == preset_id), None)
+
+    def get_process_scan_preset(self, preset_id: str) -> Optional[ProcessScanPreset]:
+        return next((p for p in self.process_scan_presets if p.id == preset_id), None)

--- a/negpy/features/metadata/models.py
+++ b/negpy/features/metadata/models.py
@@ -73,6 +73,9 @@ class MetadataConfig:
     camera_id: str = ""
     lens_id: str = ""
     film_stock_id: str = ""
+    process_scan_preset_id: str = ""
+    developer_id: str = ""
+    scan_setup_id: str = ""
 
     # Structured gear fields (resolved from library or manual)
     camera_make: str = ""

--- a/negpy/services/assets/gear.py
+++ b/negpy/services/assets/gear.py
@@ -1,4 +1,4 @@
-"""JSON-backed gear library (cameras, lenses, film stocks, gear presets)."""
+"""JSON-backed gear library (cameras, lenses, film stocks, chemistry, rigs, presets)."""
 
 from __future__ import annotations
 
@@ -8,10 +8,13 @@ from typing import TypeVar
 
 from negpy.features.metadata.gear_models import (
     Camera,
+    DeveloperRecipe,
     FilmStock,
     GearLibrary,
     GearPreset,
     Lens,
+    ProcessScanPreset,
+    ScanSetup,
 )
 from negpy.kernel.system.config import APP_CONFIG
 from negpy.kernel.system.paths import get_resource_path
@@ -21,7 +24,10 @@ T = TypeVar("T")
 _CAMERAS_FILE = "cameras.json"
 _LENSES_FILE = "lenses.json"
 _FILM_STOCKS_FILE = "film_stocks.json"
+_DEVELOPERS_FILE = "developers.json"
+_SCAN_SETUPS_FILE = "scan_setups.json"
 _GEAR_PRESETS_FILE = "gear_presets.json"
+_PROCESS_SCAN_PRESETS_FILE = "process_scan_presets.json"
 
 
 class GearProfiles:
@@ -83,7 +89,10 @@ class GearProfiles:
             cameras=GearProfiles._load_merged(_CAMERAS_FILE, Camera),
             lenses=GearProfiles._load_merged(_LENSES_FILE, Lens),
             film_stocks=GearProfiles._load_merged(_FILM_STOCKS_FILE, FilmStock),
+            developers=GearProfiles._load_merged(_DEVELOPERS_FILE, DeveloperRecipe),
+            scan_setups=GearProfiles._load_merged(_SCAN_SETUPS_FILE, ScanSetup),
             gear_presets=GearProfiles._load_merged(_GEAR_PRESETS_FILE, GearPreset),
+            process_scan_presets=GearProfiles._load_merged(_PROCESS_SCAN_PRESETS_FILE, ProcessScanPreset),
         )
 
     @staticmethod
@@ -99,15 +108,30 @@ class GearProfiles:
         GearProfiles._write_list(os.path.join(GearProfiles._gear_dir(), _FILM_STOCKS_FILE), film_stocks)
 
     @staticmethod
+    def save_developers(developers: list[DeveloperRecipe]) -> None:
+        GearProfiles._write_list(os.path.join(GearProfiles._gear_dir(), _DEVELOPERS_FILE), developers)
+
+    @staticmethod
+    def save_scan_setups(scan_setups: list[ScanSetup]) -> None:
+        GearProfiles._write_list(os.path.join(GearProfiles._gear_dir(), _SCAN_SETUPS_FILE), scan_setups)
+
+    @staticmethod
     def save_gear_presets(presets: list[GearPreset]) -> None:
         GearProfiles._write_list(os.path.join(GearProfiles._gear_dir(), _GEAR_PRESETS_FILE), presets)
+
+    @staticmethod
+    def save_process_scan_presets(presets: list[ProcessScanPreset]) -> None:
+        GearProfiles._write_list(os.path.join(GearProfiles._gear_dir(), _PROCESS_SCAN_PRESETS_FILE), presets)
 
     @staticmethod
     def save_library(library: GearLibrary) -> None:
         GearProfiles.save_cameras([c for c in library.cameras if not c.is_bundled])
         GearProfiles.save_lenses([lens for lens in library.lenses if not lens.is_bundled])
         GearProfiles.save_film_stocks([f for f in library.film_stocks if not f.is_bundled])
+        GearProfiles.save_developers([d for d in library.developers if not d.is_bundled])
+        GearProfiles.save_scan_setups([s for s in library.scan_setups if not s.is_bundled])
         GearProfiles.save_gear_presets([p for p in library.gear_presets if not p.is_bundled])
+        GearProfiles.save_process_scan_presets([p for p in library.process_scan_presets if not p.is_bundled])
 
     @staticmethod
     def ensure_user_dir() -> None:

--- a/tests/metadata/test_developer_scan_presets.py
+++ b/tests/metadata/test_developer_scan_presets.py
@@ -1,0 +1,186 @@
+"""Tests for developer recipes, scan setups and the Process & Scan preset."""
+
+import os
+
+import pytest
+
+from negpy.features.metadata.gear_logic import gear_search_text, matches_gear_filter, metadata_from_gear
+from negpy.features.metadata.gear_models import (
+    DeveloperRecipe,
+    DevProcess,
+    GearLibrary,
+    GearPreset,
+    ProcessScanPreset,
+    ScanMethod,
+    ScanSetup,
+)
+from negpy.features.metadata.models import MetadataConfig
+from negpy.features.metadata.payload import build_metadata_payload, has_capture_gear
+from negpy.services.assets.gear import GearProfiles
+
+
+@pytest.fixture
+def gear_dir(tmp_path, monkeypatch):
+    monkeypatch.setattr("negpy.services.assets.gear.APP_CONFIG.gear_dir", str(tmp_path))
+    monkeypatch.setattr("negpy.services.assets.gear.get_resource_path", lambda _: str(tmp_path / "_no_bundled"))
+    return str(tmp_path)
+
+
+@pytest.fixture
+def library():
+    return GearLibrary(
+        developers=[
+            DeveloperRecipe(id="d1", developer="D-76", dilution="1+1", time="9:30", temperature_c=20),
+            DeveloperRecipe(id="d2", developer="HC-110", dilution="dil. B", time="6:00"),
+        ],
+        scan_setups=[
+            ScanSetup(id="s1", device="Sony A7RIV", light_source="Scanlight narrowband"),
+            ScanSetup(id="s2", method=ScanMethod.FLATBED, device="Epson V850"),
+        ],
+        process_scan_presets=[ProcessScanPreset(id="ps1", display_name="Home B&W", developer_id="d1", scan_setup_id="s1")],
+    )
+
+
+def test_developer_label_renders_chemistry_and_conditions():
+    recipe = DeveloperRecipe(developer="D-76", dilution="1+1", time="9:30", temperature_c=20)
+
+    assert recipe.full_developer_label == "D-76 1+1, 9:30 @ 20 °C"
+    assert recipe.resolved_display_name == "D-76 1+1"
+
+
+def test_developer_label_omits_missing_parts():
+    assert DeveloperRecipe(developer="HC-110", dilution="dil. B").full_developer_label == "HC-110 dil. B"
+    assert DeveloperRecipe(developer="C-41", lab="Carmencita").full_developer_label == "C-41 (Carmencita)"
+    assert DeveloperRecipe(developer="Rodinal", time="13:00").full_developer_label == "Rodinal, 13:00"
+
+
+def test_scan_label_renders_method_and_rig():
+    rig = ScanSetup(device="Sony A7RIV", light_source="Scanlight narrowband")
+
+    assert rig.full_scan_label == "Copy stand — Sony A7RIV, Scanlight narrowband"
+    assert ScanSetup(method=ScanMethod.FLATBED).full_scan_label == "Flatbed"
+
+
+def test_enums_fall_back_to_other_on_unknown_storage_value():
+    assert DevProcess.from_storage("C41") is DevProcess.C41
+    assert DevProcess.from_storage("Caffenol") is DevProcess.OTHER
+    assert ScanMethod.from_storage("CopyStand") is ScanMethod.COPY_STAND
+    assert ScanMethod.from_storage("Contact print") is ScanMethod.OTHER
+
+
+def test_round_trip_through_json(gear_dir):
+    saved = GearLibrary(
+        developers=[DeveloperRecipe(id="d1", developer="XTOL", dilution="1+1", time="9:45", temperature_c=20)],
+        scan_setups=[ScanSetup(id="s1", method=ScanMethod.DRUM, device="Howtek 4500")],
+        process_scan_presets=[ProcessScanPreset(id="ps1", display_name="Archive", developer_id="d1", scan_setup_id="s1")],
+    )
+
+    GearProfiles.save_library(saved)
+    loaded = GearProfiles.load_library()
+
+    assert os.path.isfile(os.path.join(gear_dir, "developers.json"))
+    assert loaded.developers[0].full_developer_label == "XTOL 1+1, 9:45 @ 20 °C"
+    assert loaded.scan_setups[0].method is ScanMethod.DRUM
+    assert loaded.process_scan_presets[0].developer_id == "d1"
+
+
+def test_selecting_a_developer_fills_the_text_field(library):
+    applied = metadata_from_gear(MetadataConfig(), library, developer_id="d1")
+
+    assert applied.developer_id == "d1"
+    assert applied.developer == "D-76 1+1, 9:30 @ 20 °C"
+
+
+def test_selecting_a_scan_setup_fills_the_text_field(library):
+    applied = metadata_from_gear(MetadataConfig(), library, scan_setup_id="s2")
+
+    assert applied.scan_setup_id == "s2"
+    assert applied.scanning == "Flatbed — Epson V850"
+
+
+def test_process_scan_preset_sets_both_slots(library):
+    applied = metadata_from_gear(MetadataConfig(), library, process_scan_preset_id="ps1")
+
+    assert applied.developer_id == "d1"
+    assert applied.scan_setup_id == "s1"
+    assert applied.developer == "D-76 1+1, 9:30 @ 20 °C"
+    assert applied.scanning == "Copy stand — Sony A7RIV, Scanlight narrowband"
+
+
+def test_gear_preset_developer_slot_is_additive(library):
+    """An empty gear-preset slot must not wipe a developer picked by hand."""
+    library.gear_presets = [GearPreset(id="p1", display_name="Bodies only")]
+    picked = metadata_from_gear(MetadataConfig(), library, developer_id="d1")
+
+    applied = metadata_from_gear(picked, library, gear_preset_id="p1")
+
+    assert applied.developer_id == "d1"
+    assert applied.developer == "D-76 1+1, 9:30 @ 20 °C"
+
+
+def test_gear_preset_slot_applies_when_set(library):
+    library.gear_presets = [GearPreset(id="p1", display_name="Full kit", developer_id="d2", scan_setup_id="s2")]
+
+    applied = metadata_from_gear(MetadataConfig(), library, gear_preset_id="p1")
+
+    assert applied.developer == "HC-110 dil. B, 6:00"
+    assert applied.scanning == "Flatbed — Epson V850"
+
+
+def test_process_scan_preset_is_authoritative_over_its_slots(library):
+    library.process_scan_presets = [ProcessScanPreset(id="ps2", display_name="Dev only", developer_id="d2")]
+    picked = metadata_from_gear(MetadataConfig(), library, scan_setup_id="s1")
+
+    applied = metadata_from_gear(picked, library, process_scan_preset_id="ps2")
+
+    assert applied.developer_id == "d2"
+    assert applied.scan_setup_id == ""
+
+
+def test_typed_override_survives_an_unrelated_gear_change(library):
+    picked = metadata_from_gear(MetadataConfig(), library, developer_id="d1")
+    edited = picked.__class__(**{**picked.__dict__, "developer": "D-76 1+1, stand 20 min"})
+
+    applied = metadata_from_gear(edited, library, camera_id="")
+
+    assert applied.developer == "D-76 1+1, stand 20 min"
+
+
+def test_empty_id_leaves_the_text_alone(library):
+    config = MetadataConfig(developer="Caffenol-C", scanning="Phone snap")
+
+    applied = metadata_from_gear(config, library, developer_id="", scan_setup_id="")
+
+    assert applied.developer == "Caffenol-C"
+    assert applied.scanning == "Phone snap"
+
+
+def test_search_text_covers_the_new_item_types(library):
+    recipe = library.developers[0]
+    rig = library.scan_setups[0]
+
+    assert matches_gear_filter(recipe, "d-76")
+    assert matches_gear_filter(recipe, "20")
+    assert matches_gear_filter(rig, "scanlight")
+    assert matches_gear_filter(rig, "copy stand")
+    assert not matches_gear_filter(rig, "drum")
+
+
+def test_preset_search_text_includes_linked_labels(library):
+    text = gear_search_text(library.process_scan_presets[0], library)
+
+    assert "d-76" in text
+    assert "sony a7riv" in text
+
+
+def test_chemistry_alone_does_not_claim_the_scanner_exif(library):
+    """Developer and rig are not capture gear, so they must not strip scan EXIF."""
+    config = metadata_from_gear(MetadataConfig(), library, process_scan_preset_id="ps1")
+
+    assert has_capture_gear(config) is False
+
+    payload = build_metadata_payload(config, library)
+
+    assert payload.exif_flags.strip_scan_residuals is False
+    assert payload.developer == "D-76 1+1, 9:30 @ 20 °C"
+    assert payload.scan_method == "Copy stand — Sony A7RIV, Scanlight narrowband"

--- a/tests/test_metadata_sidebar.py
+++ b/tests/test_metadata_sidebar.py
@@ -17,7 +17,12 @@ from PyQt6.QtWidgets import QApplication, QCheckBox, QLabel
 from conftest import FakeController
 from negpy.desktop.view.sidebar import metadata as metadata_module
 from negpy.desktop.view.sidebar.metadata import MetadataSidebar
-from negpy.features.metadata.gear_models import GearLibrary
+from negpy.features.metadata.gear_models import (
+    DeveloperRecipe,
+    GearLibrary,
+    ProcessScanPreset,
+    ScanSetup,
+)
 
 if not QApplication.instance():
     _app = QApplication(sys.argv)
@@ -198,3 +203,80 @@ class TestPlaceButtons:
             assert button.text() == ""
             assert button.icon().isNull() is False
             assert button.toolTip() != ""
+
+
+class TestDeveloperAndScanCombos:
+    @pytest.fixture
+    def stocked(self, sidebar: MetadataSidebar, monkeypatch) -> MetadataSidebar:
+        library = GearLibrary(
+            developers=[DeveloperRecipe(id="d1", developer="D-76", dilution="1+1", time="9:30", temperature_c=20)],
+            scan_setups=[ScanSetup(id="s1", device="Sony A7RIV", light_source="Scanlight narrowband")],
+            process_scan_presets=[ProcessScanPreset(id="ps1", display_name="Home B&W", developer_id="d1", scan_setup_id="s1")],
+        )
+        monkeypatch.setattr(metadata_module.GearProfiles, "load_library", staticmethod(lambda: library))
+        sidebar._refresh_gear_combos(force=True)
+        return sidebar
+
+    def test_picking_a_developer_fills_the_text_field(self, stocked: MetadataSidebar) -> None:
+        stocked.developer_combo.set_selected_id("d1")
+        stocked.developer_combo.selection_changed.emit("d1")
+
+        assert stocked.state.config.metadata.developer_id == "d1"
+        assert stocked.developer_edit.text() == "D-76 1+1, 9:30 @ 20 °C"
+
+    def test_picking_a_scan_setup_fills_the_text_field(self, stocked: MetadataSidebar) -> None:
+        stocked.scan_setup_combo.set_selected_id("s1")
+        stocked.scan_setup_combo.selection_changed.emit("s1")
+
+        assert stocked.state.config.metadata.scan_setup_id == "s1"
+        assert stocked.scanning_edit.text() == "Copy stand — Sony A7RIV, Scanlight narrowband"
+
+    def test_process_scan_preset_sets_both_cards(self, stocked: MetadataSidebar) -> None:
+        stocked.process_scan_combo.set_selected_id("ps1")
+        stocked.process_scan_combo.selection_changed.emit("ps1")
+
+        assert stocked.developer_edit.text() == "D-76 1+1, 9:30 @ 20 °C"
+        assert stocked.scanning_edit.text() == "Copy stand — Sony A7RIV, Scanlight narrowband"
+
+    def test_a_manual_pick_clears_only_the_process_scan_preset(self, stocked: MetadataSidebar) -> None:
+        """Chemistry and gear own separate presets, so one must not clear the other."""
+        _set_metadata(stocked, gear_preset_id="p1")
+        stocked.process_scan_combo.set_selected_id("ps1")
+        stocked.process_scan_combo.selection_changed.emit("ps1")
+
+        stocked.developer_combo.set_selected_id("d1")
+        stocked.developer_combo.selection_changed.emit("d1")
+
+        assert stocked.state.config.metadata.process_scan_preset_id == ""
+        assert stocked.state.config.metadata.gear_preset_id == "p1"
+
+    def test_clear_empties_both_slots(self, stocked: MetadataSidebar) -> None:
+        stocked.process_scan_combo.set_selected_id("ps1")
+        stocked.process_scan_combo.selection_changed.emit("ps1")
+
+        stocked._on_process_scan_preset_clear()
+
+        conf = stocked.state.config.metadata
+        assert (conf.process_scan_preset_id, conf.developer_id, conf.scan_setup_id) == ("", "", "")
+        assert conf.developer == ""
+        assert conf.scanning == ""
+
+    def test_a_pick_during_the_save_delay_keeps_both_edits(self, stocked: MetadataSidebar) -> None:
+        """Typing then picking inside the debounce window must lose neither."""
+        stocked.capture_roll_edit.setText("Roll007")
+
+        stocked.developer_combo.set_selected_id("d1")
+        stocked.developer_combo.selection_changed.emit("d1")
+
+        conf = stocked.state.config.metadata
+        assert conf.capture_roll == "Roll007"
+        assert conf.developer == "D-76 1+1, 9:30 @ 20 °C"
+
+    def test_a_typed_override_survives_a_later_camera_pick(self, stocked: MetadataSidebar) -> None:
+        stocked.developer_combo.set_selected_id("d1")
+        stocked.developer_combo.selection_changed.emit("d1")
+        stocked.developer_edit.setText("D-76 1+1, stand 20 min")
+
+        stocked.camera_combo.selection_changed.emit("")
+
+        assert stocked.state.config.metadata.developer == "D-76 1+1, stand 20 min"


### PR DESCRIPTION
## What

The gear library covered camera, lens and film stock, but **Developer** and **Scanning** were plain free-text fields retyped for every roll. This adds two library item types and a preset that pairs them.

- **`DeveloperRecipe`** — developer, dilution, time, temperature, process (`B&W` / `C-41` / `E-6` / `ECN-2` / `Other`), lab. Renders `D-76 1+1, 9:30 @ 20 °C`.
- **`ScanSetup`** — method (`Copy stand` / `Flatbed` / `Film scanner` / `Drum` / `Lab scan` / `Other`), device, light source, holder, software. Renders `Copy stand — Sony A7RIV, Scanlight narrowband`.
- **`GearPreset`** gains `developer_id` / `scan_setup_id`, and a new **`ProcessScanPreset`** pairs the two on its own.

Both labels feed the existing `MetadataConfig.developer` / `.scanning` strings, so EXIF `UserComment` and XMP `negpy:Developer` / `negpy:ScanMethod` output is unchanged. Finer-grained XMP tags (`negpy:DeveloperDilution` and friends) are deliberately left for a follow-up, once this is tested.

No pipeline involvement — `docs/PIPELINE.md` is untouched.

## Why

A roll is developed and scanned the same way far more often than it is shot with the same body. Retyping `HC-110 dil. B, 6:00` per frame was the last hand-typed step in the Metadata panel.

## Reviewer notes

**Two ownership rules are the interesting part of the diff**, both tested:

1. A **gear preset's** chemistry/rig slots are *additive* — they apply only when set, so picking a camera preset never wipes a developer chosen by hand. Only the **Process & Scan preset** owns those two slots outright (an empty slot clears). This intentionally departs from the existing "preset is authoritative" rule for camera/lens/film, which is unchanged.
2. The free-text fields stay editable as overrides. Derivation keys off a *deliberate pick*, not off the stored id, so editing an unrelated field never overwrites what you typed. `_flush_pending_edits()` also means typing in one field and picking from a combo inside the 500 ms debounce window loses neither.

`has_capture_gear()` is deliberately **not** extended: a developer choice is not capture gear and must not trigger overwriting the scanner's EXIF.

`settings_catalog.py` is deliberately unchanged — it syncs resolved values, not library ids (`camera_id` is absent there too), and the `Developer` / `Scanning` rows already exist, so the new fields get the same treatment as camera/lens/film. Happy to add the ids if you'd rather they sync.

## Bundled data

`gear/developers.json` (8), `gear/scan_setups.json` (6), `gear/process_scan_presets.json` (3). The whole `gear/` directory already ships via `build.py`, so packaging needed no change. No migration entry is needed — added fields default cleanly and old saves carry empty ids.

## Testing

`make format`, `make lint`, `make type` all clean. **4561 tests pass** (baseline 4554; +23 new — 16 in `tests/metadata/test_developer_scan_presets.py`, 7 in `tests/test_metadata_sidebar.py`), covering label rendering, JSON round-trip, enum fallback on unknown stored values, both ownership rules above, the debounce-window case, and that chemistry alone does not claim the scanner's EXIF.

The Manage dialog was additionally smoke-tested offscreen: all seven categories show exactly their intended field sets, and edits write through to the model and the list label.

`docs/USER_GUIDE.md` §12 updated; `docs/CHANGELOG.md` left alone per the repo convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)