### PR TITLE
fix(analysis): clear stale interactive flag so Negative Peek's histogram resyncs

### DIFF
--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -4005,6 +4005,11 @@ class AppController(QObject):
             self.state.last_metrics["content_rect"] = None
             self.state.last_metrics["splash"] = False
             self.state.last_metrics["proof"] = False
+            # A prior interactive/peek render (e.g. Flat Peek, which renders with
+            # readback_metrics=False) can leave this stale True, which makes
+            # right_panel's _update_analysis mistake this settled frame for a
+            # mid-gesture one and skip the histogram refresh.
+            self.state.last_metrics["interactive"] = False
         self.image_updated.emit()
 
     def toggle_negative_peek(self, force: Optional[bool] = None) -> None:

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -2570,6 +2570,15 @@ class TestNegativePeekColor(unittest.TestCase):
 
         np.testing.assert_allclose(with_wb, without_wb, atol=1e-5)
 
+    def test_the_peek_clears_a_stale_interactive_flag(self):
+        """Flat Peek renders with readback_metrics=False, which tags its metrics
+        interactive; switching straight to Negative Peek must not inherit that flag,
+        or right_panel's analysis-chart refresh mistakes the settled peek frame for a
+        mid-gesture one and never re-syncs the histogram."""
+        self.controller.state.last_metrics["interactive"] = True
+        metrics = self._paint(self.D3300)
+        self.assertFalse(metrics["interactive"])
+
 
 class TestCompareFlatPeekInteraction(unittest.TestCase):
     """Before/After and flat-peek are mutually exclusive overlays; a geometry op must


### PR DESCRIPTION
## Summary
- Flat Peek renders with `readback_metrics=False`, which tags that render's metrics `interactive=True`.
- `_paint_negative_peek()` never reset that flag, so switching straight from Flat Peek to Negative Peek left it `True`.
- `right_panel.py`'s analysis-chart refresh (`_update_analysis`) treats `interactive=True` as a mid-gesture frame and skips the histogram/curve resync — so the chart visually stayed on Flat Peek's display after switching to Negative Peek.
- Fix: `_paint_negative_peek()` now clears `last_metrics["interactive"]` alongside the other fields it already resets on every peek paint.

## Test plan
- [x] Added `test_the_peek_clears_a_stale_interactive_flag` in `tests/test_controller.py`, reproducing the stale-flag scenario directly.
- [x] `make lint`, `make type`, full `pytest` pass (two pre-existing failures unrelated to this change: missing optional `pyopticfilm` scanner dependency).
- [x] Verified live with a driver script exercising the real controller/widget objects: before the fix, the chart's display-mode fields (`_channel_density`/`_show_print`) were unchanged after Flat → Negative Peek; after the fix they correctly flip to the per-channel density view.

https://claude.ai/code/session_01Gm4QojV2apRRPd4HcBBzY2