### PR TITLE
fix(thumbnails): use inspect.iscoroutinefunction, not the asyncio alias

### DIFF
--- a/negpy/services/assets/thumbnails.py
+++ b/negpy/services/assets/thumbnails.py
@@ -1,4 +1,5 @@
 import asyncio
+import inspect
 from typing import Optional, Any, List, Dict, Tuple
 from PIL import Image
 import rawpy
@@ -47,7 +48,7 @@ async def generate_batch_thumbnails(
             )
             completed += 1
             if progress_callback:
-                if asyncio.iscoroutinefunction(progress_callback):
+                if inspect.iscoroutinefunction(progress_callback):
                     await progress_callback(completed, f_info["name"])
                 else:
                     progress_callback(completed, f_info["name"])


### PR DESCRIPTION
`asyncio.iscoroutinefunction` is deprecated and slated for removal in Python 3.16. `_stream_thumbnails` calls it once per file to decide whether `progress_callback` needs awaiting, so a 23-file batch emits 23 DeprecationWarnings today and the path stops working on 3.16.

`inspect.iscoroutinefunction` is the documented replacement. I checked they agree rather than assuming it is a drop-in, across a plain function, an `async def`, bound sync and async methods, a lambda, `functools.partial` of each, and callable objects with sync and async `__call__`:

```
disagreements on 3.13: 0
disagreements on 3.14: 0
```

`asyncio` stays imported; the module still uses `Semaphore` and `gather`.

Before and after, running the affected file with deprecations promoted to errors:

```
-W error::DeprecationWarning
  before: 2 failed, 5 passed
  after:  7 passed
```

Full suite on Windows 11, Python 3.14.7, your `[dev]` group: `4553 passed, 10 skipped`. The 2 failures are the `test_backend_registry.py` plustek cases needing the optional extra, which fail identically without this change. `ruff check` and `ruff format --check` clean.

Found by running the suite; the warning surfaces on any batch that streams thumbnails.
