### PR TITLE
refactor(ui): remove the Save Edits action

### DIFF
--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -2555,11 +2555,6 @@ class AppController(QObject):
         if geom.crop_from_auto:
             self.request_render()
 
-    def save_current_edits(self) -> None:
-        if self.state.current_file_hash:
-            self.session.update_config(self.state.config, persist=True)
-            self._update_thumbnail_from_state()
-
     def clear_retouch(self) -> None:
         from negpy.desktop.view.confirm import confirm_clear_heals
 

--- a/negpy/desktop/view/canvas/toolbar.py
+++ b/negpy/desktop/view/canvas/toolbar.py
@@ -372,11 +372,6 @@ class ActionToolbar(QWidget):
         self._ov_flip_v_action.setToolTip(tooltip_with_shortcut("Flip Vertical", "flip_v"))
         overflow_menu.addSeparator()
 
-        # Edits auto-save to the DB and surface in History, so an explicit Save lives here in the
-        # overflow rather than the main toolbar.
-        save_action = overflow_menu.addAction(qta.icon("fa5s.save", color=icon_color), "Save Edits", self.controller.save_current_edits)
-        save_action.setToolTip("Write the current edit to the database now (edits also auto-save)")
-        overflow_menu.addSeparator()
         self._action_copy = overflow_menu.addAction(
             qta.icon("fa5s.copy", color=icon_color), "Copy Settings  Ctrl+C", self.session.copy_settings
         )

--- a/tests/test_thumbnail_attribution_fallback.py
+++ b/tests/test_thumbnail_attribution_fallback.py
@@ -1,6 +1,6 @@
 """A render whose frame is no longer open must not be filed under whatever is selected now.
 
-`_update_thumbnail_from_state` runs on file switch, on save, and after an export — not only
+`_update_thumbnail_from_state` runs on file switch and after an export — not only
 from the render that produced the buffer. So `state.last_metrics` can hold a render whose
 frame has since left `uploaded_files`: opening a different folder replaces the list, and a
 merge or unmerge swaps frames for a composite. Resolving that by falling back to


### PR DESCRIPTION
Edits autosave to the database on every change, so an explicit Save Edits command only duplicated what already happened.

Drops the overflow-menu entry and `AppController.save_current_edits`. Thumbnail refresh still runs on file switch and after an export.