### PR TITLE
fix(tests): skip Plustek tests when the optional pyopticfilm driver is absent

### DIFF
--- a/tests/scanners/test_backend_registry.py
+++ b/tests/scanners/test_backend_registry.py
@@ -51,6 +51,8 @@ def test_create_backend_falls_back_from_sane_on_windows(monkeypatch):
 
 
 def test_create_plustek_backend_when_usb_available(monkeypatch):
+    pytest.importorskip("pyopticfilm")
+
     class _FakeBackend:
         pass
 
@@ -67,6 +69,8 @@ def test_create_plustek_backend_when_usb_available(monkeypatch):
 
 
 def test_create_plustek_unavailable_without_pyusb(monkeypatch):
+    pytest.importorskip("pyopticfilm")
+
     def _boom(*, calib_cache=None):
         raise ScannerUnavailable("PyUSB is required")
 

--- a/tests/scanners/test_plustek_backend.py
+++ b/tests/scanners/test_plustek_backend.py
@@ -15,15 +15,18 @@ import pytest
 
 from negpy.infrastructure.scanners.base import ScannerUnavailable, TransientScanError
 from negpy.infrastructure.scanners.params import ScanParams
-from pyopticfilm.exceptions import ScanCancelled, UsbError
-from pyopticfilm.image import ScanImage
-from pyopticfilm.usb.device import (
+from negpy.infrastructure.scanners.result import ScanResult
+
+pytest.importorskip("pyopticfilm")
+
+from negpy.infrastructure.scanners.plustek_backend import PlustekBackend  # noqa: E402
+from pyopticfilm.exceptions import ScanCancelled, UsbError  # noqa: E402
+from pyopticfilm.image import ScanImage  # noqa: E402
+from pyopticfilm.usb.device import (  # noqa: E402
     PID_OPTICFILM_8200I_SE,
     VID_PLUSTEK,
     UsbDeviceInfo,
 )
-from negpy.infrastructure.scanners.plustek_backend import PlustekBackend
-from negpy.infrastructure.scanners.result import ScanResult
 
 _NEGPY_ROOT = Path(__file__).resolve().parents[2] / "negpy"
 _ADAPTER = _NEGPY_ROOT / "infrastructure" / "scanners" / "plustek_backend.py"

--- a/tests/scanners/test_plustek_ir_alignment.py
+++ b/tests/scanners/test_plustek_ir_alignment.py
@@ -2,8 +2,11 @@
 
 import cv2
 import numpy as np
+import pytest
 
-from pyopticfilm.ir_align import align_ir_to_rgb
+pytest.importorskip("pyopticfilm")
+
+from pyopticfilm.ir_align import align_ir_to_rgb  # noqa: E402
 
 
 def _texture(h=128, w=128, seed=0):


### PR DESCRIPTION
`pytest` cannot collect the suite at all without the optional `plustek` group installed. Three test sites import `pyopticfilm` unguarded, so collection aborts with exit 2 and **zero tests run**:

```
ERROR tests/scanners/test_plustek_backend.py
ERROR tests/scanners/test_plustek_ir_alignment.py
E   ModuleNotFoundError: No module named 'pyopticfilm'
!!!!!! Interrupted: 2 errors during collection !!!!!!
2 skipped, 11 deselected, 2 errors in 18.17s
```

The `pieusb` tests already handle this: `test_pieusb_backend.py:16` calls `pytest.importorskip("pieusb")` and `test_pieusb_autoexposure.py:13` does the same. This applies that pattern to the Plustek equivalents, plus the two `test_backend_registry.py` cases whose `monkeypatch.setattr` imports `plustek_backend` by string.

`make install` and CI both use `--all-groups` / `--group plustek`, so neither sees this. It bites `pip install -e ".[dev]"` and `uv sync --group dev`, which is what `metrics.yml:55` uses. `pyopticfilm` is documented as optional in CONTRIBUTING, so a contributor without an OpticFilm 8200i has no reason to install it.

Test-only change. No product code touched.

<details>
<summary>Verified both directions on Windows 11, Python 3.13.13</summary>

Without `pyopticfilm`:

```
before:  2 skipped, 11 deselected, 2 errors    exit 2   (collection interrupted)
after:   4553 passed, 14 skipped, 11 deselected, 48 subtests passed   exit 0
```

With `pyopticfilm` 1.1.1 installed, i.e. the CI configuration:

```
4582 passed, 10 skipped, 11 deselected, 48 subtests passed   exit 0
```

The guards are inert when the driver is present: running just the four guarded tests with it installed gives `29 passed`, so nothing is silently skipped in CI.

`ruff check` and `ruff format --check` pass on all three files.

</details>
