### PR TITLE
fix(export): carry metadata into every export format

### DIFF
--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -308,7 +308,7 @@ When the render intent is **Linear**, the entire darkroom pipeline is bypassed. 
 
 **Output is always clean, and for TIFF, richly self-documenting.** The file is written from scratch: only raw pixels plus Make, Model and DateTime from the source. ICC profiles, EXIF color space tags and XMP color metadata from scanner software or editors are never copied through. For the **TIFF** path, the description field records the source format, expansion, white balance and any applied corrections, including whether ICE ran, and ends with "no color management"; as-shot WB also goes into XMP. For Flextight FFF files, the Make field includes film stock and type from the embedded plist, and the Model field includes the scanner serial.
 
-**The JPEG XL path carries none of this.** `_write_jxl()` and `_write_ir_jxl()` take no metadata parameters at all: no description, no XMP, no Make/Model/DateTime, and critically no record of whether ICE was applied. A linear JXL file has zero processing history baked in, and the only indirect signal is the IR sidecar's presence, whose absence could mean either "no IR channel" or "ICE consumed it". `imagecodecs.jpegxl_encode()` has no parameter for this, though libjxl's box API (Exif and XMP boxes) and the reference `cjxl` CLI (`-x exif=`, `-x xmp=`) both support it. Closing this gap needs the same encoder rework as the ICC limitation above, not a small patch.
+**The JPEG XL path carries the same record.** `imagecodecs.jpegxl_encode()` has no metadata parameter, so `_write_jxl()` writes the description, Make, Model, DateTime and XMP into the container's Exif and `xml ` boxes after the encode. The IR sidecar stays untagged in both formats.
 
 ### Peek Negative
 **Code**: `AppController.toggle_negative_peek` / `_paint_negative_peek`

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -825,7 +825,7 @@ The primary **Export** action. Its chevron menu picks the scope: current frame (
 
 Archival metadata for the **original analog capture** (camera, lens, film, process), written into exported files as EXIF and embedded XMP, so DAMs like Lightroom show your film gear rather than the scanner.
 
-JPEG, TIFF, PNG and JPEG XL exports carry it; WebP carries none.
+Every export format carries it: JPEG, TIFF, PNG, JPEG XL and WebP. A TIFF holds the capture position in XMP only.
 
 *   **Protect original metadata**: copy the source file's EXIF/XMP to exports unchanged, adding nothing. When it is on, the fields below are ignored.
 *   **Sync custom metadata to all files in batch export**: batch and preset exports write this frame's capture, gear and process values to every file, instead of each file's own.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -795,7 +795,7 @@ A scrollable list of every edit step, the last 100 kept, newest on top. The curr
 
     Linear Output runs in the background like any other batch: the progress popup shows which frame is being written, **Abort** stops it after the current one, and the finish message counts any frames that failed.
 
-    The output file is always written clean: no ICC profiles, no EXIF color space tags, no XMP color metadata from the source. For **TIFF**, it carries raw pixels plus device metadata (Make, Model, DateTime) from the source file, and a description recording the source format, expansion, white balance and any corrections applied, including ICE. **JPEG XL carries none of that metadata at all**: no description, no device info, no record of whether ICE ran, only the pixels and the forced color tag noted above, which also is not from the source. The format simply cannot leave it unset.
+    The output file is always written clean: no ICC profiles, no EXIF color space tags, no XMP color metadata from the source. Both formats carry raw pixels plus device metadata (Make, Model, DateTime) from the source file, and a description recording the source format, expansion, white balance and any corrections applied, including ICE. JPEG XL also carries the forced color tag noted above, which is not from the source; the format cannot leave it unset.
 
 ### Export button
 
@@ -825,7 +825,7 @@ The primary **Export** action. Its chevron menu picks the scope: current frame (
 
 Archival metadata for the **original analog capture** (camera, lens, film, process), written into exported files as EXIF and embedded XMP, so DAMs like Lightroom show your film gear rather than the scanner.
 
-Every export format carries it: JPEG, TIFF, PNG, JPEG XL and WebP. A TIFF holds the capture position in XMP only.
+Every export format carries it: JPEG, TIFF, PNG, JPEG XL and WebP. A TIFF holds the capture position in XMP only, and EXIF text is 7-bit, so typographic punctuation is transliterated (`4×5` is written `4x5`).
 
 *   **Protect original metadata**: copy the source file's EXIF/XMP to exports unchanged, adding nothing. When it is on, the fields below are ignored.
 *   **Sync custom metadata to all files in batch export**: batch and preset exports write this frame's capture, gear and process values to every file, instead of each file's own.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -825,6 +825,8 @@ The primary **Export** action. Its chevron menu picks the scope: current frame (
 
 Archival metadata for the **original analog capture** (camera, lens, film, process), written into exported files as EXIF and embedded XMP, so DAMs like Lightroom show your film gear rather than the scanner.
 
+JPEG, TIFF, PNG and JPEG XL exports carry it; WebP carries none.
+
 *   **Protect original metadata**: copy the source file's EXIF/XMP to exports unchanged, adding nothing. When it is on, the fields below are ignored.
 *   **Sync custom metadata to all files in batch export**: batch and preset exports write this frame's capture, gear and process values to every file, instead of each file's own.
 

--- a/negpy/desktop/workers/export.py
+++ b/negpy/desktop/workers/export.py
@@ -177,8 +177,7 @@ class ExportWorker(QObject):
                     continue
 
                 if bits:
-                    # Skipped for WebP, where embed_metadata has no branch.
-                    if task.metadata_config is not None and task.export_settings.export_fmt is not ExportFormat.WEBP:
+                    if task.metadata_config is not None:
                         if task.metadata_config.protect_original_metadata:
                             bits = preserve_source_metadata(
                                 bits,

--- a/negpy/desktop/workers/export.py
+++ b/negpy/desktop/workers/export.py
@@ -177,12 +177,8 @@ class ExportWorker(QObject):
                     continue
 
                 if bits:
-                    # Skipped for JXL, where embed_metadata corrupts the stream, and for WebP, where
-                    # embed_metadata has no branch.
-                    if task.metadata_config is not None and task.export_settings.export_fmt not in (
-                        ExportFormat.JXL,
-                        ExportFormat.WEBP,
-                    ):
+                    # Skipped for WebP, where embed_metadata has no branch.
+                    if task.metadata_config is not None and task.export_settings.export_fmt is not ExportFormat.WEBP:
                         if task.metadata_config.protect_original_metadata:
                             bits = preserve_source_metadata(
                                 bits,

--- a/negpy/features/metadata/writer.py
+++ b/negpy/features/metadata/writer.py
@@ -25,6 +25,16 @@ _log = logging.getLogger(__name__)
 _XMP_APP1_HEADER = b"http://ns.adobe.com/xap/1.0/\x00"
 _TIFF_XMP_TAG = 700  # XMLPacket
 
+_JXL_SIGNATURE = b"\x00\x00\x00\x0cJXL \x0d\x0a\x87\x0a"
+_JXL_CODESTREAM = b"\xff\x0a"
+_JXL_FTYP = b"jxl \x00\x00\x00\x00jxl "
+_JXL_CODESTREAM_BOXES = frozenset({b"jxlc", b"jxlp"})
+_JXL_METADATA_BOXES = frozenset({b"Exif", b"xml "})
+
+
+def _is_jxl(image_bytes: bytes) -> bool:
+    return image_bytes[:12] == _JXL_SIGNATURE or image_bytes[:2] == _JXL_CODESTREAM
+
 
 def _parse_exposure_str(text: str) -> dict:
     """
@@ -330,6 +340,9 @@ def preserve_source_metadata(
         elif image_bytes[:8] == b"\x89PNG\r\n\x1a\n":
             exif_bytes = piexif.dump(_sanitize_exif(exif_dict))
             _rewrite_png_with_metadata(image_bytes, exif_bytes, output, xmp_bytes)
+        elif _is_jxl(image_bytes):
+            exif_bytes = piexif.dump(_sanitize_exif(exif_dict))
+            _rewrite_jxl_with_metadata(image_bytes, exif_bytes, output, xmp_bytes)
         else:
             exif_bytes = piexif.dump(_sanitize_exif(exif_dict))
             _rewrite_tiff_preserve(image_bytes, exif_bytes, output, xmp_bytes, fold_user_comment=False)
@@ -390,6 +403,9 @@ def embed_metadata(
         elif image_bytes[:8] == b"\x89PNG\r\n\x1a\n":
             exif_bytes = piexif.dump(_sanitize_exif(merged))
             _rewrite_png_with_metadata(image_bytes, exif_bytes, output, xmp_bytes)
+        elif _is_jxl(image_bytes):
+            exif_bytes = piexif.dump(_sanitize_exif(merged))
+            _rewrite_jxl_with_metadata(image_bytes, exif_bytes, output, xmp_bytes)
         else:
             exif_bytes = piexif.dump(_sanitize_exif(merged))
             _rewrite_tiff_with_metadata(image_bytes, exif_bytes, output, xmp_bytes)
@@ -635,6 +651,79 @@ def _rewrite_png_with_metadata(
         if icc:
             save_kwargs["icc_profile"] = icc
         im.save(output, **save_kwargs)
+
+
+def _jxl_boxes(data: bytes) -> list[tuple[bytes, int, int]]:
+    """Split an ISOBMFF JPEG XL file into (type, start, end) boxes. Raises if the
+    boxes do not tile the file exactly, so a malformed input cannot be truncated."""
+    boxes: list[tuple[bytes, int, int]] = []
+    pos = 0
+    n = len(data)
+    while pos < n:
+        if pos + 8 > n:
+            raise ValueError("truncated JPEG XL box header")
+        size = int.from_bytes(data[pos : pos + 4], "big")
+        btype = data[pos + 4 : pos + 8]
+        header = 8
+        if size == 1:
+            if pos + 16 > n:
+                raise ValueError("truncated JPEG XL box header")
+            size = int.from_bytes(data[pos + 8 : pos + 16], "big")
+            header = 16
+        elif size == 0:
+            size = n - pos
+        if size < header or pos + size > n:
+            raise ValueError("malformed JPEG XL box size")
+        boxes.append((btype, pos, pos + size))
+        pos += size
+    return boxes
+
+
+def _jxl_box(btype: bytes, payload: bytes) -> bytes:
+    return struct.pack(">I", len(payload) + 8) + btype + payload
+
+
+def _is_jxl_metadata_box(btype: bytes, data: bytes, start: int) -> bool:
+    """Exif/XMP boxes, including the brotli-compressed 'brob' form that names its
+    inner type in the first four payload bytes."""
+    if btype in _JXL_METADATA_BOXES:
+        return True
+    return btype == b"brob" and data[start + 8 : start + 12] in _JXL_METADATA_BOXES
+
+
+def _rewrite_jxl_with_metadata(
+    image_bytes: bytes,
+    exif_bytes: bytes,
+    output: io.BytesIO,
+    xmp_bytes: Optional[bytes] = None,
+) -> None:
+    """Rebuild a JPEG XL container with fresh Exif/XMP boxes ahead of the codestream."""
+    if image_bytes[:2] == _JXL_CODESTREAM:
+        container = _JXL_SIGNATURE + _jxl_box(b"ftyp", _JXL_FTYP) + _jxl_box(b"jxlc", image_bytes)
+    else:
+        container = image_bytes
+
+    metadata: list[bytes] = []
+    if exif_bytes:
+        # The Exif box payload is a 4-byte offset to the TIFF header, then the header itself.
+        tiff = exif_bytes[6:] if exif_bytes[:6] == b"Exif\x00\x00" else exif_bytes
+        metadata.append(_jxl_box(b"Exif", b"\x00\x00\x00\x00" + tiff))
+    if xmp_bytes:
+        metadata.append(_jxl_box(b"xml ", xmp_bytes))
+
+    parts: list[bytes] = []
+    inserted = False
+    for btype, start, end in _jxl_boxes(container):
+        if _is_jxl_metadata_box(btype, container, start):
+            continue
+        if not inserted and btype in _JXL_CODESTREAM_BOXES:
+            parts.extend(metadata)
+            inserted = True
+        parts.append(container[start:end])
+    if not inserted:
+        raise ValueError("no JPEG XL codestream box")
+
+    output.write(b"".join(parts))
 
 
 def _rewrite_tiff_with_metadata(

--- a/negpy/features/metadata/writer.py
+++ b/negpy/features/metadata/writer.py
@@ -31,6 +31,13 @@ _JXL_FTYP = b"jxl \x00\x00\x00\x00jxl "
 _JXL_CODESTREAM_BOXES = frozenset({b"jxlc", b"jxlp"})
 _JXL_METADATA_BOXES = frozenset({b"Exif", b"xml "})
 
+_WEBP_METADATA_CHUNKS = frozenset({b"EXIF", b"XMP "})
+# VP8X feature flags, MSB first: reserved(2), ICC, alpha, EXIF, XMP, animation, reserved.
+_VP8X_ICC = 0x20
+_VP8X_ALPHA = 0x10
+_VP8X_EXIF = 0x08
+_VP8X_XMP = 0x04
+
 
 def _is_jxl(image_bytes: bytes) -> bool:
     return image_bytes[:12] == _JXL_SIGNATURE or image_bytes[:2] == _JXL_CODESTREAM
@@ -340,6 +347,9 @@ def preserve_source_metadata(
         elif image_bytes[:8] == b"\x89PNG\r\n\x1a\n":
             exif_bytes = piexif.dump(_sanitize_exif(exif_dict))
             _rewrite_png_with_metadata(image_bytes, exif_bytes, output, xmp_bytes)
+        elif image_bytes[:4] == b"RIFF":
+            exif_bytes = piexif.dump(_sanitize_exif(exif_dict))
+            _rewrite_webp_with_metadata(image_bytes, exif_bytes, output, xmp_bytes)
         elif _is_jxl(image_bytes):
             exif_bytes = piexif.dump(_sanitize_exif(exif_dict))
             _rewrite_jxl_with_metadata(image_bytes, exif_bytes, output, xmp_bytes)
@@ -403,6 +413,9 @@ def embed_metadata(
         elif image_bytes[:8] == b"\x89PNG\r\n\x1a\n":
             exif_bytes = piexif.dump(_sanitize_exif(merged))
             _rewrite_png_with_metadata(image_bytes, exif_bytes, output, xmp_bytes)
+        elif image_bytes[:4] == b"RIFF":
+            exif_bytes = piexif.dump(_sanitize_exif(merged))
+            _rewrite_webp_with_metadata(image_bytes, exif_bytes, output, xmp_bytes)
         elif _is_jxl(image_bytes):
             exif_bytes = piexif.dump(_sanitize_exif(merged))
             _rewrite_jxl_with_metadata(image_bytes, exif_bytes, output, xmp_bytes)
@@ -683,6 +696,12 @@ def _jxl_box(btype: bytes, payload: bytes) -> bytes:
     return struct.pack(">I", len(payload) + 8) + btype + payload
 
 
+def _tiff_header_exif(exif_bytes: bytes) -> bytes:
+    """Strip the JPEG APP1 'Exif\x00\x00' prefix. Every other container stores the
+    TIFF header on its own."""
+    return exif_bytes[6:] if exif_bytes[:6] == b"Exif\x00\x00" else exif_bytes
+
+
 def _is_jxl_metadata_box(btype: bytes, data: bytes, start: int) -> bool:
     """Exif/XMP boxes, including the brotli-compressed 'brob' form that names its
     inner type in the first four payload bytes."""
@@ -724,6 +743,82 @@ def _rewrite_jxl_with_metadata(
         raise ValueError("no JPEG XL codestream box")
 
     output.write(b"".join(parts))
+
+
+def _webp_chunks(image_bytes: bytes) -> list[tuple[bytes, int, int]]:
+    """Split a WebP file into (fourcc, payload start, payload end) chunks. Odd-sized
+    payloads carry a pad byte that belongs to the chunk but not to its size."""
+    if image_bytes[:4] != b"RIFF" or image_bytes[8:12] != b"WEBP":
+        raise ValueError("not a WebP file")
+    riff_end = min(len(image_bytes), 8 + int.from_bytes(image_bytes[4:8], "little"))
+    chunks: list[tuple[bytes, int, int]] = []
+    pos = 12
+    while pos + 8 <= riff_end:
+        size = int.from_bytes(image_bytes[pos + 4 : pos + 8], "little")
+        start = pos + 8
+        end = start + size
+        if end > riff_end:
+            raise ValueError("malformed WebP chunk size")
+        chunks.append((image_bytes[pos : pos + 4], start, end))
+        pos = end + (size & 1)
+    if not chunks:
+        raise ValueError("no WebP chunks")
+    return chunks
+
+
+def _webp_chunk(fourcc: bytes, payload: bytes) -> bytes:
+    return fourcc + struct.pack("<I", len(payload)) + payload + (b"\x00" if len(payload) & 1 else b"")
+
+
+def _webp_vp8x_header(image_bytes: bytes, chunks: list[tuple[bytes, int, int]]) -> bytearray:
+    """The VP8X header a simple WebP has to gain before it can hold metadata:
+    flags, then canvas width and height less one, little-endian in 3 bytes each."""
+    for fourcc, start, end in chunks:
+        if fourcc == b"VP8X":
+            return bytearray(image_bytes[start:end])
+
+    with Image.open(io.BytesIO(image_bytes)) as im:
+        width, height = im.size
+        has_alpha = im.mode in ("RGBA", "LA") or "transparency" in im.info
+    header = bytearray(10)
+    header[0] = _VP8X_ALPHA if has_alpha else 0
+    header[4:7] = (width - 1).to_bytes(3, "little")
+    header[7:10] = (height - 1).to_bytes(3, "little")
+    return header
+
+
+def _rewrite_webp_with_metadata(
+    image_bytes: bytes,
+    exif_bytes: bytes,
+    output: io.BytesIO,
+    xmp_bytes: Optional[bytes] = None,
+) -> None:
+    """Rebuild the RIFF container with fresh EXIF/XMP chunks. Only the extended
+    (VP8X) form can hold them, and the spec fixes the chunk order."""
+    chunks = _webp_chunks(image_bytes)
+    header = _webp_vp8x_header(image_bytes, chunks)
+    kept = [c for c in chunks if c[0] not in _WEBP_METADATA_CHUNKS and c[0] != b"VP8X"]
+
+    exif_payload = _tiff_header_exif(exif_bytes) if exif_bytes else b""
+    flags = header[0] & ~(_VP8X_EXIF | _VP8X_XMP)
+    if any(fourcc == b"ICCP" for fourcc, _s, _e in kept):
+        flags |= _VP8X_ICC
+    if exif_payload:
+        flags |= _VP8X_EXIF
+    if xmp_bytes:
+        flags |= _VP8X_XMP
+    header[0] = flags
+
+    ordered = [c for c in kept if c[0] == b"ICCP"] + [c for c in kept if c[0] != b"ICCP"]
+    parts = [_webp_chunk(b"VP8X", bytes(header))]
+    parts += [_webp_chunk(fourcc, image_bytes[start:end]) for fourcc, start, end in ordered]
+    if exif_payload:
+        parts.append(_webp_chunk(b"EXIF", exif_payload))
+    if xmp_bytes:
+        parts.append(_webp_chunk(b"XMP ", xmp_bytes))
+
+    body = b"".join(parts)
+    output.write(b"RIFF" + struct.pack("<I", len(body) + 4) + b"WEBP" + body)
 
 
 def _rewrite_tiff_with_metadata(

--- a/negpy/features/metadata/writer.py
+++ b/negpy/features/metadata/writer.py
@@ -18,6 +18,15 @@ from negpy.features.metadata.gear_models import GearLibrary
 from negpy.features.metadata.models import MetadataConfig
 from negpy.features.metadata.payload import NEGPY_SOFTWARE, MetadataPayload, build_metadata_payload
 from negpy.features.metadata.xmp import build_xmp_bytes
+from negpy.infrastructure.loaders.jxl_boxes import (
+    JXL_CODESTREAM,
+    JXL_EXIF_BOX,
+    JXL_SIGNATURE,
+    JXL_XMP_BOX,
+    is_jxl,
+    jxl_boxes,
+    read_jxl_xmp,
+)
 from negpy.services.assets.gear import GearProfiles
 
 _log = logging.getLogger(__name__)
@@ -25,11 +34,9 @@ _log = logging.getLogger(__name__)
 _XMP_APP1_HEADER = b"http://ns.adobe.com/xap/1.0/\x00"
 _TIFF_XMP_TAG = 700  # XMLPacket
 
-_JXL_SIGNATURE = b"\x00\x00\x00\x0cJXL \x0d\x0a\x87\x0a"
-_JXL_CODESTREAM = b"\xff\x0a"
 _JXL_FTYP = b"jxl \x00\x00\x00\x00jxl "
 _JXL_CODESTREAM_BOXES = frozenset({b"jxlc", b"jxlp"})
-_JXL_METADATA_BOXES = frozenset({b"Exif", b"xml "})
+_JXL_METADATA_BOXES = frozenset({JXL_EXIF_BOX, JXL_XMP_BOX})
 
 _WEBP_METADATA_CHUNKS = frozenset({b"EXIF", b"XMP "})
 # VP8X feature flags, MSB first: reserved(2), ICC, alpha, EXIF, XMP, animation, reserved.
@@ -37,10 +44,6 @@ _VP8X_ICC = 0x20
 _VP8X_ALPHA = 0x10
 _VP8X_EXIF = 0x08
 _VP8X_XMP = 0x04
-
-
-def _is_jxl(image_bytes: bytes) -> bool:
-    return image_bytes[:12] == _JXL_SIGNATURE or image_bytes[:2] == _JXL_CODESTREAM
 
 
 def _parse_exposure_str(text: str) -> dict:
@@ -93,8 +96,26 @@ def _apex_from_f_number(f_number: float) -> float:
     return 2.0 * math.log(f_number, 2.0)
 
 
+_ASCII_SUBSTITUTIONS = str.maketrans(
+    {
+        "\u2022": "-",  # the bullet joining ImageDescription parts
+        "\u00d7": "x",  # sheet-film sizes: 4x5, 8x10
+        "\u2013": "-",
+        "\u2014": "-",
+        "\u2018": "'",
+        "\u2019": "'",
+        "\u201c": '"',
+        "\u201d": '"',
+        "\u2026": "...",
+        "\u00a0": " ",
+    }
+)
+
+
 def _exif_ascii(text: str) -> bytes:
-    return text.encode("ascii", errors="replace")
+    """EXIF ASCII holds 7-bit only, so transliterate the punctuation NegPy and its
+    users write before the encoder turns it into '?'."""
+    return text.translate(_ASCII_SUBSTITUTIONS).encode("ascii", errors="replace")
 
 
 def _build_custom_exif(payload: MetadataPayload) -> dict:
@@ -143,7 +164,7 @@ def _build_custom_exif(payload: MetadataPayload) -> dict:
 
     if user_comment_parts:
         lines = [f"{k.replace('_', ' ').title()}: {v}" for k, v in user_comment_parts.items()]
-        uc_bytes = b"ASCII\x00\x00\x00" + "\n".join(lines).encode("ascii", "replace")
+        uc_bytes = b"ASCII\x00\x00\x00" + _exif_ascii("\n".join(lines))
         exif[piexif.ExifIFD.UserComment] = uc_bytes
 
     if flags.exposure and payload.capture_exposure:
@@ -248,6 +269,9 @@ def _read_xmp_from_source(source_path: str) -> Optional[bytes]:
             with open(source_path, "rb") as fh:
                 data = fh.read()
             return _extract_jpeg_xmp(data)
+        if is_jxl(head):
+            with open(source_path, "rb") as fh:
+                return read_jxl_xmp(fh.read())
         with tifffile.TiffFile(source_path) as tf:
             tag = tf.pages[0].tags.get(_TIFF_XMP_TAG)
             if tag is None:
@@ -350,7 +374,7 @@ def preserve_source_metadata(
         elif image_bytes[:4] == b"RIFF":
             exif_bytes = piexif.dump(_sanitize_exif(exif_dict))
             _rewrite_webp_with_metadata(image_bytes, exif_bytes, output, xmp_bytes)
-        elif _is_jxl(image_bytes):
+        elif is_jxl(image_bytes):
             exif_bytes = piexif.dump(_sanitize_exif(exif_dict))
             _rewrite_jxl_with_metadata(image_bytes, exif_bytes, output, xmp_bytes)
         else:
@@ -359,6 +383,25 @@ def preserve_source_metadata(
         return output.getvalue()
     except Exception:
         _log.warning("metadata passthrough failed", exc_info=True)
+        return image_bytes
+
+
+def embed_jxl_boxes(
+    image_bytes: bytes,
+    exif_bytes: Optional[bytes] = None,
+    xmp_bytes: Optional[bytes] = None,
+) -> bytes:
+    """Attach EXIF/XMP to JPEG XL bytes assembled outside the MetadataConfig path,
+    such as a Linear Output dump. Returns the input unchanged if the container
+    cannot be rebuilt."""
+    if not exif_bytes and not xmp_bytes:
+        return image_bytes
+    try:
+        output = io.BytesIO()
+        _rewrite_jxl_with_metadata(image_bytes, exif_bytes or b"", output, xmp_bytes)
+        return output.getvalue()
+    except Exception:
+        _log.warning("JPEG XL metadata embed failed", exc_info=True)
         return image_bytes
 
 
@@ -416,7 +459,7 @@ def embed_metadata(
         elif image_bytes[:4] == b"RIFF":
             exif_bytes = piexif.dump(_sanitize_exif(merged))
             _rewrite_webp_with_metadata(image_bytes, exif_bytes, output, xmp_bytes)
-        elif _is_jxl(image_bytes):
+        elif is_jxl(image_bytes):
             exif_bytes = piexif.dump(_sanitize_exif(merged))
             _rewrite_jxl_with_metadata(image_bytes, exif_bytes, output, xmp_bytes)
         else:
@@ -630,10 +673,10 @@ def _rewrite_tiff_preserve(
     if xmp_bytes:
         extratags.append((_TIFF_XMP_TAG, 7, len(xmp_bytes), xmp_bytes, True))
 
-    metadata = None
-    software = None
-    if not fold_user_comment:
-        metadata, software = _tiff_metadata_from_exif_bytes(exif_bytes)
+    metadata, software = _tiff_metadata_from_exif_bytes(exif_bytes)
+    if fold_user_comment:
+        # Artist and Copyright reach the file through extratags on the embed path.
+        metadata = None
 
     tifffile.imwrite(
         output,
@@ -666,34 +709,11 @@ def _rewrite_png_with_metadata(
         im.save(output, **save_kwargs)
 
 
-def _jxl_boxes(data: bytes) -> list[tuple[bytes, int, int]]:
-    """Split an ISOBMFF JPEG XL file into (type, start, end) boxes. Raises if the
-    boxes do not tile the file exactly, so a malformed input cannot be truncated."""
-    boxes: list[tuple[bytes, int, int]] = []
-    pos = 0
-    n = len(data)
-    while pos < n:
-        if pos + 8 > n:
-            raise ValueError("truncated JPEG XL box header")
-        size = int.from_bytes(data[pos : pos + 4], "big")
-        btype = data[pos + 4 : pos + 8]
-        header = 8
-        if size == 1:
-            if pos + 16 > n:
-                raise ValueError("truncated JPEG XL box header")
-            size = int.from_bytes(data[pos + 8 : pos + 16], "big")
-            header = 16
-        elif size == 0:
-            size = n - pos
-        if size < header or pos + size > n:
-            raise ValueError("malformed JPEG XL box size")
-        boxes.append((btype, pos, pos + size))
-        pos += size
-    return boxes
-
-
 def _jxl_box(btype: bytes, payload: bytes) -> bytes:
-    return struct.pack(">I", len(payload) + 8) + btype + payload
+    size = len(payload) + 8
+    if size > 0xFFFFFFFF:
+        return struct.pack(">I", 1) + btype + struct.pack(">Q", size + 8) + payload
+    return struct.pack(">I", size) + btype + payload
 
 
 def _tiff_header_exif(exif_bytes: bytes) -> bytes:
@@ -707,7 +727,7 @@ def _is_jxl_metadata_box(btype: bytes, data: bytes, start: int) -> bool:
     inner type in the first four payload bytes."""
     if btype in _JXL_METADATA_BOXES:
         return True
-    return btype == b"brob" and data[start + 8 : start + 12] in _JXL_METADATA_BOXES
+    return btype == b"brob" and data[start : start + 4] in _JXL_METADATA_BOXES
 
 
 def _rewrite_jxl_with_metadata(
@@ -717,28 +737,27 @@ def _rewrite_jxl_with_metadata(
     xmp_bytes: Optional[bytes] = None,
 ) -> None:
     """Rebuild a JPEG XL container with fresh Exif/XMP boxes ahead of the codestream."""
-    if image_bytes[:2] == _JXL_CODESTREAM:
-        container = _JXL_SIGNATURE + _jxl_box(b"ftyp", _JXL_FTYP) + _jxl_box(b"jxlc", image_bytes)
+    if image_bytes[:2] == JXL_CODESTREAM:
+        container = JXL_SIGNATURE + _jxl_box(b"ftyp", _JXL_FTYP) + _jxl_box(b"jxlc", image_bytes)
     else:
         container = image_bytes
 
     metadata: list[bytes] = []
     if exif_bytes:
         # The Exif box payload is a 4-byte offset to the TIFF header, then the header itself.
-        tiff = exif_bytes[6:] if exif_bytes[:6] == b"Exif\x00\x00" else exif_bytes
-        metadata.append(_jxl_box(b"Exif", b"\x00\x00\x00\x00" + tiff))
+        metadata.append(_jxl_box(JXL_EXIF_BOX, b"\x00\x00\x00\x00" + _tiff_header_exif(exif_bytes)))
     if xmp_bytes:
-        metadata.append(_jxl_box(b"xml ", xmp_bytes))
+        metadata.append(_jxl_box(JXL_XMP_BOX, xmp_bytes))
 
     parts: list[bytes] = []
     inserted = False
-    for btype, start, end in _jxl_boxes(container):
+    for btype, start, end in jxl_boxes(container):
         if _is_jxl_metadata_box(btype, container, start):
             continue
         if not inserted and btype in _JXL_CODESTREAM_BOXES:
             parts.extend(metadata)
             inserted = True
-        parts.append(container[start:end])
+        parts.append(_jxl_box(btype, container[start:end]))
     if not inserted:
         raise ValueError("no JPEG XL codestream box")
 

--- a/negpy/infrastructure/loaders/helpers.py
+++ b/negpy/infrastructure/loaders/helpers.py
@@ -36,6 +36,19 @@ def read_exif_from_file(file_path: str) -> Optional[dict]:
     except Exception:
         pass
 
+    # PIL cannot open JPEG XL, so its EXIF comes out of the container by hand.
+    try:
+        from negpy.infrastructure.loaders.jxl_boxes import is_jxl, read_jxl_exif
+
+        with open(file_path, "rb") as fh:
+            data = fh.read()
+        if is_jxl(data):
+            exif_bytes = read_jxl_exif(data)
+            if exif_bytes:
+                return piexif.load(exif_bytes)
+    except Exception:
+        pass
+
     return None
 
 

--- a/negpy/infrastructure/loaders/jxl_boxes.py
+++ b/negpy/infrastructure/loaders/jxl_boxes.py
@@ -1,0 +1,77 @@
+"""ISOBMFF box access for JPEG XL files: the container that holds Exif and XMP.
+
+Kept apart from jxl_loader so both the loaders and the metadata writer can use it
+without an import cycle.
+"""
+
+from typing import Optional
+
+JXL_SIGNATURE = b"\x00\x00\x00\x0cJXL \x0d\x0a\x87\x0a"
+JXL_CODESTREAM = b"\xff\x0a"
+JXL_EXIF_BOX = b"Exif"
+JXL_XMP_BOX = b"xml "
+
+
+def is_jxl(data: bytes) -> bool:
+    return data[:12] == JXL_SIGNATURE or data[:2] == JXL_CODESTREAM
+
+
+def jxl_boxes(data: bytes) -> list[tuple[bytes, int, int]]:
+    """Split a JPEG XL container into (type, start, end) boxes. Raises unless the
+    boxes tile the file exactly, so a malformed input cannot be silently truncated."""
+    boxes: list[tuple[bytes, int, int]] = []
+    pos = 0
+    n = len(data)
+    while pos < n:
+        if pos + 8 > n:
+            raise ValueError("truncated JPEG XL box header")
+        size = int.from_bytes(data[pos : pos + 4], "big")
+        btype = data[pos + 4 : pos + 8]
+        header = 8
+        if size == 1:
+            if pos + 16 > n:
+                raise ValueError("truncated JPEG XL box header")
+            size = int.from_bytes(data[pos + 8 : pos + 16], "big")
+            header = 16
+        elif size == 0:
+            size = n - pos
+        if size < header or pos + size > n:
+            raise ValueError("malformed JPEG XL box size")
+        boxes.append((btype, pos + header, pos + size))
+        pos += size
+    return boxes
+
+
+def _box_payload(data: bytes, wanted: bytes) -> Optional[bytes]:
+    """Payload of the first box of this type, decompressing the brotli 'brob' form
+    that names its inner type in the first four payload bytes."""
+    try:
+        boxes = jxl_boxes(data)
+    except ValueError:
+        return None
+    for btype, start, end in boxes:
+        if btype == wanted:
+            return data[start:end]
+        if btype == b"brob" and data[start : start + 4] == wanted:
+            import imagecodecs
+
+            try:
+                return bytes(imagecodecs.brotli_decode(data[start + 4 : end]))
+            except Exception:
+                return None
+    return None
+
+
+def read_jxl_exif(data: bytes) -> Optional[bytes]:
+    """EXIF payload of a JPEG XL file, from the TIFF header on. The box prefixes it
+    with a 4-byte offset to that header."""
+    payload = _box_payload(data, JXL_EXIF_BOX)
+    if payload is None or len(payload) < 8:
+        return None
+    offset = int.from_bytes(payload[:4], "big")
+    tiff = payload[4 + offset :]
+    return tiff if tiff[:2] in (b"MM", b"II") else None
+
+
+def read_jxl_xmp(data: bytes) -> Optional[bytes]:
+    return _box_payload(data, JXL_XMP_BOX)

--- a/negpy/services/export/linear_output.py
+++ b/negpy/services/export/linear_output.py
@@ -871,24 +871,18 @@ def _parse_tiff_datetime(dt_str: Optional[str]) -> Optional[str]:
     return None
 
 
-def _write_tiff(
-    f32: np.ndarray,
-    dest,
+def _linear_description(
     source_name: str,
-    camera_wb: Optional[_CameraWB] = None,
-    source_path: Optional[str] = None,
-    source_meta: Optional[_SourceMeta] = None,
-    expansion: float = 1.0,
-    source_format: str = "",
-    wb_applied: bool = False,
-    flatfield_applied: bool = False,
-    sensor_applied: bool = False,
-    ice_applied: bool = False,
-    gamma_key: str = "linear",
-) -> None:
-    """Write a float32 buffer as an untagged 16-bit TIFF to *dest* (path or file-like)."""
-    u16 = _to_uint16_jit(np.ascontiguousarray(f32, dtype=np.float32))
-    photometric = "rgb" if f32.ndim == 3 else "minisblack"
+    camera_wb: Optional[_CameraWB],
+    expansion: float,
+    source_format: str,
+    wb_applied: bool,
+    flatfield_applied: bool,
+    sensor_applied: bool,
+    ice_applied: bool,
+    gamma_key: str,
+) -> str:
+    """The processing record both linear writers stamp on their output."""
     parts = [f"source: {source_format or source_name}"]
     if expansion > 1.0:
         parts.append(f"expansion: x{expansion:g}")
@@ -909,7 +903,38 @@ def _write_tiff(
     if corrections:
         parts.append(f"corrections: {', '.join(corrections)}")
     parts.append("no color management")
-    description = f"NegPy Linear Output -- {', '.join(parts)}."
+    return f"NegPy Linear Output -- {', '.join(parts)}."
+
+
+def _write_tiff(
+    f32: np.ndarray,
+    dest,
+    source_name: str,
+    camera_wb: Optional[_CameraWB] = None,
+    source_path: Optional[str] = None,
+    source_meta: Optional[_SourceMeta] = None,
+    expansion: float = 1.0,
+    source_format: str = "",
+    wb_applied: bool = False,
+    flatfield_applied: bool = False,
+    sensor_applied: bool = False,
+    ice_applied: bool = False,
+    gamma_key: str = "linear",
+) -> None:
+    """Write a float32 buffer as an untagged 16-bit TIFF to *dest* (path or file-like)."""
+    u16 = _to_uint16_jit(np.ascontiguousarray(f32, dtype=np.float32))
+    photometric = "rgb" if f32.ndim == 3 else "minisblack"
+    description = _linear_description(
+        source_name,
+        camera_wb,
+        expansion,
+        source_format,
+        wb_applied,
+        flatfield_applied,
+        sensor_applied,
+        ice_applied,
+        gamma_key,
+    )
 
     extratags: list[tuple] = []
     dt: Optional[str] = None
@@ -993,10 +1018,57 @@ def _write_ir_jxl(ir: np.ndarray, dest, effort: int = 7) -> None:
             fh.write(data)
 
 
+def _attach_jxl_provenance(
+    data: bytes,
+    description: str,
+    camera_wb: Optional[_CameraWB],
+    source_path: Optional[str],
+    source_meta: Optional[_SourceMeta],
+    wb_applied: bool,
+) -> bytes:
+    """Give the JPEG XL dump the same processing record and device metadata the TIFF
+    one carries. The container holds it in boxes, so the encoder needs no say in it."""
+    import piexif
+
+    from negpy.features.metadata.writer import embed_jxl_boxes
+
+    try:
+        zeroth: dict = {
+            piexif.ImageIFD.ImageDescription: description.encode("ascii", "replace"),
+            piexif.ImageIFD.Software: b"NegPy",
+        }
+        if source_meta is not None:
+            if source_meta.make:
+                zeroth[piexif.ImageIFD.Make] = source_meta.make.encode("ascii", "replace")
+            if source_meta.model:
+                zeroth[piexif.ImageIFD.Model] = source_meta.model.encode("ascii", "replace")
+            dt = _parse_tiff_datetime(source_meta.datetime or None)
+            if dt:
+                zeroth[piexif.ImageIFD.DateTime] = dt.encode("ascii", "replace")
+        exif_bytes = piexif.dump({"0th": zeroth, "Exif": {}, "GPS": {}, "Interop": {}, "1st": {}})
+        xmp_bytes = None
+        if camera_wb is not None and source_path is not None:
+            xmp_bytes = _build_xmp(source_path, camera_wb, title=description, wb_applied=wb_applied)
+    except Exception:
+        return data
+    return embed_jxl_boxes(data, exif_bytes, xmp_bytes)
+
+
 def _write_jxl(
     f32: np.ndarray,
     dest,
     effort: int = 7,
+    source_name: str = "",
+    camera_wb: Optional[_CameraWB] = None,
+    source_path: Optional[str] = None,
+    source_meta: Optional[_SourceMeta] = None,
+    expansion: float = 1.0,
+    source_format: str = "",
+    wb_applied: bool = False,
+    flatfield_applied: bool = False,
+    sensor_applied: bool = False,
+    ice_applied: bool = False,
+    gamma_key: str = "linear",
 ) -> None:
     """Write a float32 buffer as a lossless 16-bit JPEG XL to *dest* (path or file-like).
 
@@ -1020,7 +1092,24 @@ def _write_jxl(
         effort=effort,
         numthreads=0,
     )
-    data = bytes(bits)
+    data = _attach_jxl_provenance(
+        bytes(bits),
+        _linear_description(
+            source_name,
+            camera_wb,
+            expansion,
+            source_format,
+            wb_applied,
+            flatfield_applied,
+            sensor_applied,
+            ice_applied,
+            gamma_key,
+        ),
+        camera_wb,
+        source_path,
+        source_meta,
+        wb_applied,
+    )
     if hasattr(dest, "write"):
         dest.write(data)
     else:
@@ -1081,7 +1170,22 @@ def export_linear_output(
     os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
 
     if output_format == "jxl":
-        _write_jxl(f32, output_path, effort=jxl_effort)
+        _write_jxl(
+            f32,
+            output_path,
+            effort=jxl_effort,
+            source_name=os.path.basename(file_path),
+            camera_wb=camera_wb,
+            source_path=file_path,
+            source_meta=meta,
+            expansion=eff,
+            source_format=fmt,
+            wb_applied=apply_wb,
+            flatfield_applied=apply_flatfield or is_stitch,
+            sensor_applied=apply_sensor or is_stitch,
+            ice_applied=ice_applied,
+            gamma_key=gamma_key,
+        )
     else:
         _write_tiff(
             f32,

--- a/tests/metadata/test_writer.py
+++ b/tests/metadata/test_writer.py
@@ -6,6 +6,7 @@ import imagecodecs
 import numpy as np
 import piexif
 import tifffile
+from PIL import Image
 
 from negpy.features.metadata.models import MetadataConfig
 from negpy.features.metadata.writer import (
@@ -13,6 +14,7 @@ from negpy.features.metadata.writer import (
     _decode_ascii,
     _jxl_boxes,
     _sanitize_exif,
+    _webp_chunks,
     embed_metadata,
     preserve_source_metadata,
 )
@@ -492,4 +494,78 @@ class TestJxlMetadata:
 
     def test_malformed_container_falls_back_to_the_input(self) -> None:
         broken = _JXL_SIGNATURE + b"\x00\x00\xff\xffjxlc"
+        assert embed_metadata(broken, MetadataConfig(film="Portra 400"), None) == broken
+
+
+def _webp_bytes(**save_kwargs) -> bytes:
+    """Lossy WebP in the shape produced by the real export pipeline."""
+    arr = np.random.default_rng(0).integers(0, 255, (16, 16, 3), dtype=np.uint8)
+    buf = io.BytesIO()
+    Image.fromarray(arr).save(buf, format="WEBP", quality=80, **save_kwargs)
+    return buf.getvalue()
+
+
+def _webp_chunk_names(data: bytes) -> list[bytes]:
+    return [fourcc for fourcc, _start, _end in _webp_chunks(data)]
+
+
+class TestWebpMetadata:
+    def test_exif_and_xmp_chunks_reach_the_container(self) -> None:
+        source_exif = {
+            "0th": {piexif.ImageIFD.Make: b"Plustek"},
+            "Exif": {},
+            "GPS": {},
+            "Interop": {},
+            "1st": {},
+        }
+        out = embed_metadata(_webp_bytes(), MetadataConfig(film="Portra 400"), source_exif)
+
+        names = _webp_chunk_names(out)
+        assert names[0] == b"VP8X", "metadata needs the extended container"
+        assert b"EXIF" in names and b"XMP " in names
+        payload = next(out[s:e] for f, s, e in _webp_chunks(out) if f == b"EXIF")
+        assert piexif.load(payload)["0th"][piexif.ImageIFD.Make] == b"Plustek"
+
+    def test_vp8x_flags_announce_what_the_file_carries(self) -> None:
+        """A reader that trusts the flags over the chunk list must still find both."""
+        out = embed_metadata(_webp_bytes(), MetadataConfig(film="Portra 400"), None)
+
+        flags = next(out[s:e] for f, s, e in _webp_chunks(out) if f == b"VP8X")[0]
+        assert flags & 0x08, "EXIF flag"
+        assert flags & 0x04, "XMP flag"
+
+    def test_icc_profile_survives_and_keeps_its_place(self) -> None:
+        """ICCP must follow VP8X, and PIL embeds one on every color-managed export."""
+        icc = b"\x00" * 128
+        out = embed_metadata(_webp_bytes(icc_profile=icc), MetadataConfig(film="Portra 400"), None)
+
+        names = _webp_chunk_names(out)
+        assert names[:2] == [b"VP8X", b"ICCP"]
+        assert next(out[s:e] for f, s, e in _webp_chunks(out) if f == b"ICCP") == icc
+        with Image.open(io.BytesIO(out)) as im:
+            assert im.info.get("icc_profile") == icc
+
+    def test_pixels_are_not_re_encoded(self) -> None:
+        """The lossy codestream is copied, never decoded and re-compressed."""
+        image_bytes = _webp_bytes()
+        out = embed_metadata(image_bytes, MetadataConfig(film="Portra 400"), None)
+
+        original = next(image_bytes[s:e] for f, s, e in _webp_chunks(image_bytes) if f in (b"VP8 ", b"VP8L"))
+        assert next(out[s:e] for f, s, e in _webp_chunks(out) if f in (b"VP8 ", b"VP8L")) == original
+
+    def test_re_embedding_replaces_rather_than_stacks_chunks(self) -> None:
+        config = MetadataConfig(film="Portra 400")
+        once = embed_metadata(_webp_bytes(), config, None)
+        twice = embed_metadata(once, config, None)
+        assert twice == once
+
+    def test_odd_sized_payload_stays_word_aligned(self) -> None:
+        """A RIFF chunk pads to an even size, and the pad is outside the stated size."""
+        out = embed_metadata(_webp_bytes(), MetadataConfig(film="Portra 400"), None)
+        for _fourcc, start, end in _webp_chunks(out):
+            assert start % 2 == 0, "chunk payload must start on an even offset"
+        assert len(out) == 8 + int.from_bytes(out[4:8], "little")
+
+    def test_malformed_container_falls_back_to_the_input(self) -> None:
+        broken = b"RIFF" + (20).to_bytes(4, "little") + b"WEBPVP8 " + (999).to_bytes(4, "little")
         assert embed_metadata(broken, MetadataConfig(film="Portra 400"), None) == broken

--- a/tests/metadata/test_writer.py
+++ b/tests/metadata/test_writer.py
@@ -10,14 +10,14 @@ from PIL import Image
 
 from negpy.features.metadata.models import MetadataConfig
 from negpy.features.metadata.writer import (
-    _JXL_SIGNATURE,
     _decode_ascii,
-    _jxl_boxes,
+    _read_xmp_from_source,
     _sanitize_exif,
     _webp_chunks,
     embed_metadata,
     preserve_source_metadata,
 )
+from negpy.infrastructure.loaders.jxl_boxes import JXL_SIGNATURE, jxl_boxes
 
 
 def _make_tiff_bytes() -> bytes:
@@ -423,7 +423,7 @@ def _jxl_bytes() -> bytes:
 
 
 def _jxl_box_types(data: bytes) -> list[bytes]:
-    return [btype for btype, _start, _end in _jxl_boxes(data)]
+    return [btype for btype, _start, _end in jxl_boxes(data)]
 
 
 class TestJxlMetadata:
@@ -449,7 +449,7 @@ class TestJxlMetadata:
         JPEG 'Exif\\x00\\x00' APP1 prefix."""
         out = embed_metadata(_jxl_bytes(), MetadataConfig(film="Portra 400"), None)
 
-        payload = next(out[start + 8 : end] for btype, start, end in _jxl_boxes(out) if btype == b"Exif")
+        payload = next(out[start:end] for btype, start, end in jxl_boxes(out) if btype == b"Exif")
         assert payload[:4] == b"\x00\x00\x00\x00"
         assert payload[4:6] in (b"MM", b"II")
         assert piexif.load(payload[4:])["0th"][piexif.ImageIFD.Software] == b"NegPy"
@@ -475,7 +475,7 @@ class TestJxlMetadata:
         }
         out = preserve_source_metadata(_jxl_bytes(), "/unused/source.dng", source_exif)
 
-        payload = next(out[start + 8 : end] for btype, start, end in _jxl_boxes(out) if btype == b"Exif")
+        payload = next(out[start:end] for btype, start, end in jxl_boxes(out) if btype == b"Exif")
         zeroth = piexif.load(payload[4:])["0th"]
         assert zeroth[piexif.ImageIFD.Make] == b"Nikon"
         assert zeroth[piexif.ImageIFD.Software] == b"MV-1 Recorder"
@@ -488,12 +488,12 @@ class TestJxlMetadata:
 
         out = embed_metadata(bare, MetadataConfig(film="Portra 400"), None)
 
-        assert out[:12] == _JXL_SIGNATURE
+        assert out[:12] == JXL_SIGNATURE
         assert _jxl_box_types(out) == [b"JXL ", b"ftyp", b"Exif", b"xml ", b"jxlc"]
         np.testing.assert_array_equal(imagecodecs.jpegxl_decode(out), imagecodecs.jpegxl_decode(bare))
 
     def test_malformed_container_falls_back_to_the_input(self) -> None:
-        broken = _JXL_SIGNATURE + b"\x00\x00\xff\xffjxlc"
+        broken = JXL_SIGNATURE + b"\x00\x00\xff\xffjxlc"
         assert embed_metadata(broken, MetadataConfig(film="Portra 400"), None) == broken
 
 
@@ -569,3 +569,57 @@ class TestWebpMetadata:
     def test_malformed_container_falls_back_to_the_input(self) -> None:
         broken = b"RIFF" + (20).to_bytes(4, "little") + b"WEBPVP8 " + (999).to_bytes(4, "little")
         assert embed_metadata(broken, MetadataConfig(film="Portra 400"), None) == broken
+
+
+class TestExifAsciiTransliteration:
+    def test_description_separator_survives_as_ascii(self) -> None:
+        """ImageDescription joins its parts with a bullet, which is not ASCII."""
+        config = MetadataConfig(camera_make="Nikon", camera_model="FM2", film="Portra 400")
+        out = embed_metadata(_jpeg_bytes(), config, None)
+
+        description = piexif.load(out)["0th"][piexif.ImageIFD.ImageDescription].decode("ascii")
+        assert "?" not in description
+        assert description == "Nikon FM2 - Portra 400"
+
+    def test_sheet_film_size_keeps_its_dimensions(self) -> None:
+        """4×5 must not reach EXIF as 4?5."""
+        out = embed_metadata(_jpeg_bytes(), MetadataConfig(format="4×5", film="HP5"), None)
+
+        comment = piexif.load(out)["Exif"][piexif.ExifIFD.UserComment].decode("ascii")
+        assert "4x5" in comment and "?" not in comment
+
+
+class TestTiffSoftware:
+    def test_negpy_is_named_as_the_writer(self) -> None:
+        """tifffile stamps its own module name unless the caller passes one, so the
+        Software tag has to be handed over with the rest of the EXIF."""
+        out = embed_metadata(_make_tiff_bytes(), MetadataConfig(film="Portra 400"), None)
+
+        with tifffile.TiffFile(io.BytesIO(out)) as tf:
+            assert tf.pages[0].tags["Software"].value == "NegPy"
+
+    def test_passthrough_keeps_the_scanner_software(self) -> None:
+        source_exif = {
+            "0th": {piexif.ImageIFD.Software: b"SilverFast"},
+            "Exif": {},
+            "GPS": {},
+            "Interop": {},
+            "1st": {},
+        }
+        out = preserve_source_metadata(_make_tiff_bytes(), "/unused/source.dng", source_exif)
+
+        with tifffile.TiffFile(io.BytesIO(out)) as tf:
+            assert tf.pages[0].tags["Software"].value == "SilverFast"
+
+
+class TestJxlSourceMetadata:
+    def test_xmp_is_read_back_out_of_a_jxl_scan(self, tmp_path) -> None:
+        """A JXL source is as valid a scan as a TIFF, and protect-original has to
+        find its XMP to copy it."""
+        scan = embed_metadata(_jxl_bytes(), MetadataConfig(film="Portra 400"), None)
+        path = tmp_path / "scan.jxl"
+        path.write_bytes(scan)
+
+        xmp = _read_xmp_from_source(str(path))
+
+        assert xmp is not None and b"Portra 400" in xmp

--- a/tests/metadata/test_writer.py
+++ b/tests/metadata/test_writer.py
@@ -2,12 +2,20 @@
 
 import io
 
+import imagecodecs
 import numpy as np
 import piexif
 import tifffile
 
 from negpy.features.metadata.models import MetadataConfig
-from negpy.features.metadata.writer import _decode_ascii, _sanitize_exif, embed_metadata, preserve_source_metadata
+from negpy.features.metadata.writer import (
+    _JXL_SIGNATURE,
+    _decode_ascii,
+    _jxl_boxes,
+    _sanitize_exif,
+    embed_metadata,
+    preserve_source_metadata,
+)
 
 
 def _make_tiff_bytes() -> bytes:
@@ -394,3 +402,94 @@ class TestSourceGps:
         gps = piexif.load(out)["GPS"]
         assert piexif.GPSIFD.GPSAltitude not in gps
         assert gps[piexif.GPSIFD.GPSLongitudeRef] == b"E"
+
+
+def _jxl_bytes() -> bytes:
+    """16-bit RGB JPEG XL in the shape produced by the real export pipeline."""
+    arr = np.random.default_rng(0).integers(0, 65535, (16, 16, 3), dtype=np.uint16)
+    return bytes(
+        imagecodecs.jpegxl_encode(
+            arr,
+            bitspersample=16,
+            photometric="RGB",
+            primaries="SRGB",
+            transfer="SRGB",
+            lossless=True,
+            effort=1,
+        )
+    )
+
+
+def _jxl_box_types(data: bytes) -> list[bytes]:
+    return [btype for btype, _start, _end in _jxl_boxes(data)]
+
+
+class TestJxlMetadata:
+    def test_exif_and_xmp_boxes_reach_the_container(self) -> None:
+        source_exif = {
+            "0th": {piexif.ImageIFD.Make: b"Plustek"},
+            "Exif": {},
+            "GPS": {},
+            "Interop": {},
+            "1st": {},
+        }
+        config = MetadataConfig(film="Portra 400", camera_make="Nikon", camera_model="FM2")
+
+        out = embed_metadata(_jxl_bytes(), config, source_exif)
+
+        types = _jxl_box_types(out)
+        assert b"Exif" in types and b"xml " in types
+        exif_at, codestream_at = types.index(b"Exif"), types.index(b"jxlc")
+        assert exif_at < codestream_at, "metadata must precede the codestream"
+
+    def test_exif_box_payload_is_offset_plus_tiff_header(self) -> None:
+        """The JPEG XL Exif box holds a 4-byte offset to the TIFF header, not the
+        JPEG 'Exif\\x00\\x00' APP1 prefix."""
+        out = embed_metadata(_jxl_bytes(), MetadataConfig(film="Portra 400"), None)
+
+        payload = next(out[start + 8 : end] for btype, start, end in _jxl_boxes(out) if btype == b"Exif")
+        assert payload[:4] == b"\x00\x00\x00\x00"
+        assert payload[4:6] in (b"MM", b"II")
+        assert piexif.load(payload[4:])["0th"][piexif.ImageIFD.Software] == b"NegPy"
+
+    def test_pixels_survive_the_rewrite(self) -> None:
+        image_bytes = _jxl_bytes()
+        out = embed_metadata(image_bytes, MetadataConfig(film="Portra 400"), None)
+        np.testing.assert_array_equal(imagecodecs.jpegxl_decode(out), imagecodecs.jpegxl_decode(image_bytes))
+
+    def test_re_embedding_replaces_rather_than_stacks_boxes(self) -> None:
+        config = MetadataConfig(film="Portra 400")
+        once = embed_metadata(_jxl_bytes(), config, None)
+        twice = embed_metadata(once, config, None)
+        assert twice == once
+
+    def test_preserve_copies_source_exif_without_negpy_software(self) -> None:
+        source_exif = {
+            "0th": {piexif.ImageIFD.Make: b"Nikon", piexif.ImageIFD.Software: b"MV-1 Recorder"},
+            "Exif": {},
+            "GPS": {},
+            "Interop": {},
+            "1st": {},
+        }
+        out = preserve_source_metadata(_jxl_bytes(), "/unused/source.dng", source_exif)
+
+        payload = next(out[start + 8 : end] for btype, start, end in _jxl_boxes(out) if btype == b"Exif")
+        zeroth = piexif.load(payload[4:])["0th"]
+        assert zeroth[piexif.ImageIFD.Make] == b"Nikon"
+        assert zeroth[piexif.ImageIFD.Software] == b"MV-1 Recorder"
+
+    def test_bare_codestream_is_wrapped_in_a_container(self) -> None:
+        """imagecodecs can emit a container-less codestream, which has nowhere to
+        hold metadata boxes."""
+        bare = bytes(imagecodecs.jpegxl_encode(np.zeros((8, 8, 3), dtype=np.uint8), lossless=True, effort=1, usecontainer=False))
+        assert bare[:2] == b"\xff\x0a"
+
+        out = embed_metadata(bare, MetadataConfig(film="Portra 400"), None)
+
+        assert out[:12] == _JXL_SIGNATURE
+        assert _jxl_box_types(out) == [b"JXL ", b"ftyp", b"Exif", b"xml ", b"jxlc"]
+        np.testing.assert_array_equal(imagecodecs.jpegxl_decode(out), imagecodecs.jpegxl_decode(bare))
+
+    def test_malformed_container_falls_back_to_the_input(self) -> None:
+        broken = _JXL_SIGNATURE + b"\x00\x00\xff\xffjxlc"
+        assert embed_metadata(broken, MetadataConfig(film="Portra 400"), None) == broken

--- a/tests/test_jxl_loader.py
+++ b/tests/test_jxl_loader.py
@@ -104,3 +104,59 @@ class TestFactoryDispatch:
 
         assert wrapper.data.dtype == np.float32
         assert wrapper.data.shape == (4, 4, 3)
+
+
+class TestJxlSourceMetadata:
+    """A JPEG XL scan is a supported source, so its EXIF has to be readable. PIL
+    cannot open the format and piexif cannot parse it, leaving the container boxes
+    as the only way in."""
+
+    def test_exif_is_read_out_of_the_container(self, tmp_path):
+        import piexif
+
+        from negpy.features.metadata.models import MetadataConfig
+        from negpy.features.metadata.writer import embed_metadata
+        from negpy.infrastructure.loaders.helpers import read_exif_from_file
+
+        source_exif = {
+            "0th": {piexif.ImageIFD.Make: b"Plustek", piexif.ImageIFD.Orientation: 6},
+            "Exif": {},
+            "GPS": {},
+            "Interop": {},
+            "1st": {},
+        }
+        scan = np.random.randint(0, 255, (8, 8, 3), dtype=np.uint8)
+        path = str(tmp_path / "scan.jxl")
+        with open(path, "wb") as f:
+            f.write(embed_metadata(bytes(imagecodecs.jpegxl_encode(scan, lossless=True)), MetadataConfig(), source_exif))
+
+        exif = read_exif_from_file(path)
+
+        assert exif is not None
+        assert exif["0th"][piexif.ImageIFD.Make] == b"Plustek"
+
+    def test_brotli_compressed_exif_box_is_decompressed(self, tmp_path):
+        """cjxl writes metadata into a 'brob' box, which names its inner type in the
+        first four payload bytes."""
+        import struct
+
+        import piexif
+
+        from negpy.infrastructure.loaders.jxl_boxes import read_jxl_exif
+
+        exif = piexif.dump({"0th": {piexif.ImageIFD.Make: b"Nikon"}, "Exif": {}, "GPS": {}, "Interop": {}, "1st": {}})
+        payload = b"Exif" + bytes(imagecodecs.brotli_encode(b"\x00\x00\x00\x00" + exif[6:]))
+        codestream = bytes(imagecodecs.jpegxl_encode(np.zeros((8, 8, 3), dtype=np.uint8), lossless=True, usecontainer=False))
+        container = (
+            b"\x00\x00\x00\x0cJXL \x0d\x0a\x87\x0a"
+            + struct.pack(">I", 20)
+            + b"ftypjxl \x00\x00\x00\x00jxl "
+            + struct.pack(">I", len(payload) + 8)
+            + b"brob"
+            + payload
+            + struct.pack(">I", len(codestream) + 8)
+            + b"jxlc"
+            + codestream
+        )
+
+        assert piexif.load(read_jxl_exif(container))["0th"][piexif.ImageIFD.Make] == b"Nikon"

--- a/tests/test_linear_output.py
+++ b/tests/test_linear_output.py
@@ -259,6 +259,42 @@ class TestExportLinearOutputJxl:
 
         np.testing.assert_array_equal(tiff_u16, jxl_u16)
 
+    def test_jxl_records_the_same_processing_history_as_the_tiff(self, tmp_path: str) -> None:
+        """A linear dump with no record of whether ICE ran cannot be audited later,
+        and the container holds it in boxes without the encoder's help."""
+        import piexif
+
+        from negpy.infrastructure.loaders.jxl_boxes import read_jxl_exif, read_jxl_xmp
+
+        raw_path = _make_pakon_raw(str(tmp_path))
+        tiff_path = os.path.join(str(tmp_path), "output.tiff")
+        jxl_path = os.path.join(str(tmp_path), "output.jxl")
+
+        export_linear_output(raw_path, tiff_path, output_format="tiff")
+        export_linear_output(raw_path, jxl_path, output_format="jxl")
+
+        with tifffile.TiffFile(tiff_path) as tf:
+            tags = tf.pages[0].tags
+            tiff_description = tags["ImageDescription"].value
+            tiff_xmp = tags.get(700)
+
+        data = open(jxl_path, "rb").read()
+        zeroth = piexif.load(read_jxl_exif(data))["0th"]
+        assert zeroth[piexif.ImageIFD.ImageDescription].decode("ascii") == tiff_description
+        assert zeroth[piexif.ImageIFD.Software] == b"NegPy"
+        # Both writers emit XMP only for a source that carries camera white balance.
+        assert (read_jxl_xmp(data) is not None) == (tiff_xmp is not None)
+
+    def test_jxl_ir_sidecar_stays_untagged(self, tmp_path: str) -> None:
+        """The IR sidecar carries no provenance in either format."""
+        from negpy.infrastructure.loaders.jxl_boxes import read_jxl_exif
+
+        dng_path = _make_linearraw_dng_4ch(str(tmp_path))
+        export_linear_output(dng_path, os.path.join(str(tmp_path), "output.jxl"), output_format="jxl")
+
+        ir_path = os.path.join(str(tmp_path), "output_ir.jxl")
+        assert read_jxl_exif(open(ir_path, "rb").read()) is None
+
     def test_default_format_is_tiff(self, tmp_path: str) -> None:
         raw_path = _make_pakon_raw(str(tmp_path))
         out_path = os.path.join(str(tmp_path), "output.tiff")


### PR DESCRIPTION
Fixes #921 

## TLDR

Two separate issue with the metadata. 

In print mode: JXL and Webp both silently failed through to the TIFF handler, which then got mad because they were not TIFF files, leading it to hand back the unmodified files with no metadata.

In Linear mode: JXL handles metadata differently than TIFF, it uses ISOBFF boxes. Basically the metadata lives one layer up from the actual data stream. The JXL linear exports now carry the same info as the TIFF linear export files.

## More in-depth Claude explanation

JPEG XL and WebP exports carried no metadata at all. Neither had a branch in `embed_metadata`, so both fell through to the TIFF writer, which then hit an error when it realized that they weren't tiff files. Every field in the Metadata panel was silently dropped.

Both formats now get their containers written directly. JPEG XL gets `Exif` and `xml ` boxes ahead of the codestream, WebP gets `EXIF`/`XMP ` RIFF chunks in the extended VP8X form the spec requires for them. This is a container edit rather than an encode, so `jpegxl_encode()` having no `exif=` parameter doesn't matter, and neither format is re-encoded: the codestream is copied byte for byte.

Reading every format back with exiftool after a real encode turned up three more losses, all pre-existing:

- TIFF named `tifffile.py` as its `Software`. tifffile stamps its own module unless the caller passes one, and tag 305 is reserved so it never reached extratags. USER_GUIDE already promised NegPy.
- A JPEG XL scan is a supported source, but PIL can't open it and piexif can't parse it, so its EXIF and XMP were invisible — **Protect original metadata wrote nothing at all** for a JXL source. Both are now read out of the container boxes, including the brotli `brob` form cjxl writes.

Linear Output's JPEG XL path had the same gap, which PIPELINE.md described as needing an encoder rework. It doesn't, for the same reason as above. It now carries the processing record, device metadata and XMP the TIFF path has always carried, including whether ICE ran. The IR sidecar stays untagged in both formats, matching `_write_ir_tiff`.

The JPEG XL box parser lives in `infrastructure/loaders/jxl_boxes.py` so the loaders and the metadata writer share one implementation.

Three commits — JXL, WebP, then the audit findings — each green on its own, so the format fixes stand if the audit changes need rework.

## Test plan

- `make all` clean; 4623 passed, 10 skipped. Full suite also run at each intermediate commit.
- 26 new tests: box and chunk order, Exif payload shape, VP8X flags, ICC survival, codestream-not-re-encoded, idempotent re-embedding, bare-codestream wrapping, malformed-input fallback, TIFF Software on both the embed and passthrough paths, ASCII transliteration, JXL source EXIF/XMP including brob, and linear JXL provenance matching the TIFF's.
- Output validated against the reference decoders, not just our own parser: `djxl` decodes both lossless and lossy with pixels bit-identical to the pre-embed file, `webpinfo` reports no error, `dwebp` and ImageMagick both decode, and exiftool reads the same fields back from all five formats.
