### PR TITLE
Camera scanning: give the calibration lock test a shutter ladder

### DIFF
--- a/tests/test_scanlight_sidebar.py
+++ b/tests/test_scanlight_sidebar.py
@@ -231,7 +231,7 @@ def test_closing_running_calibration_waits_for_worker_terminal_signal():
     assert w._lv_target is w.lv_image
 
 
-def test_running_calibration_locks_the_window_inputs():
+def test_running_calibration_locks_the_window_inputs(monkeypatch):
     """A calibration meters a fixed base at a fixed ISO/aperture, so the film-stock name, the base
     ROI and the ISO/aperture must not change under it mid-run. They lock when it starts and unlock
     on a terminal outcome (here a cancel) so a failed run can be adjusted and retried."""
@@ -239,6 +239,8 @@ def test_running_calibration_locks_the_window_inputs():
     w._camera_verified = True
     w._light_verified = True
     w.calib_window.image._set_crosshair(0.5, 0.5)  # place the base patch so the run can start
+    # A run also needs the body's own shutter ladder; without one the start refuses (issue #768).
+    monkeypatch.setattr(w, "_settings_json", lambda: {"shutter": {"options": [{"label": "1/250"}, {"label": "1/60"}]}})
 
     w._on_calibrate_new_preset("Portra 400")
 


### PR DESCRIPTION
`test_running_calibration_locks_the_window_inputs` has been failing on main since c4ca66a (#829).

That change made `_on_calibrate_new_preset` refuse to start when the body publishes no settable shutter speeds, so a Nikon D600 gets a clear message instead of a write it silently ignores. The bare sidebar fixture publishes no ladder, so the test returns at that gate and then asserts on a run that never started.

The test now publishes a ladder, which is what a real body does.

## Scope change

This PR originally also carried a metadata-free clipping detector for discussion #906. @thetalkingdrum showed that the version here, anchored on `values.max()`, misses the pile whenever noise and PRNU scatter photosites above it, including at the default centered calibration crosshair.

I checked it with my own sweep rather than take it on faith. Over 392 ROI positions on the reporter's green frame with real saturation above 5 percent, the version here misses 22 and the one in #932 misses 1. Every one of my misses sits at x = 0.5, which is where the light is brightest, so the most photosites are driven past saturation and the spread of their individual full wells is widest. It failed worst exactly where the clipping was deepest.

#932 carries the better detector, so the detection work belongs there and this PR is reduced to the test fix. The diagnosis that started it is in the discussion and in #932's description.
