### PR TITLE
fix(capture): stop trusting a generic white level for ETTR clipping

### DIFF
--- a/negpy/infrastructure/capture/raw_demosaic.py
+++ b/negpy/infrastructure/capture/raw_demosaic.py
@@ -14,7 +14,44 @@ its own verification); it is NOT covered here.
 
 from __future__ import annotations
 
+from typing import Optional, Sequence
+
 import numpy as np
+
+
+def _linearity_limit(raw, positions: Optional[Sequence[int]] = None) -> int:
+    """The camera's calibrated linear-range ceiling (raw ADC scale), not the format's generic max.
+
+    `white_level` is the format's theoretical max code value; `camera_white_level_per_channel` is
+    the manufacturer's own calibration of where the sensor stops responding linearly, often lower
+    (a Nikon D800: 15311 vs a generic 16383). Trusting the generic number lets already non-linear
+    or clipped photosites read as clean. Falls back to `white_level` where a body carries no
+    calibrated table. `positions` restricts the minimum to specific CFA channel indices; None
+    takes it across all of them.
+    """
+    generic = int(raw.white_level or 0)
+    per_channel = raw.camera_white_level_per_channel
+    if not per_channel:
+        return generic
+    values = [per_channel[j] for j in positions] if positions is not None else per_channel
+    calibrated = int(min(values))
+    # A calibrated limit can't legitimately exceed the format's own ADC ceiling; a body
+    # reporting one anyway is bad metadata, not a wider range.
+    return min(calibrated, generic) if generic > 0 else calibrated
+
+
+def _user_sat(raw) -> Optional[int]:
+    """`_linearity_limit`, converted to the post-black-subtraction scale `postprocess()` wants.
+
+    `user_sat` is compared after LibRaw subtracts the black level from every photosite, so the
+    raw-scale limit must be corrected by the same amount or every body with a non-zero black
+    level is silently under-scaled (invisible on a body whose black level happens to be 0).
+    """
+    limit = _linearity_limit(raw)
+    if limit <= 0:
+        return None
+    black = min(raw.black_level_per_channel or [0])
+    return max(1, limit - black)
 
 
 def linear_demosaic(path: str, half_size: bool = False) -> np.ndarray:
@@ -44,6 +81,11 @@ def linear_demosaic(path: str, half_size: bool = False) -> np.ndarray:
             # substitution and makes the demosaiced scale a fixed multiple of the raw counts, which is
             # what a meter measuring absolute light requires and what CLIP_CEILING assumes.
             adjust_maximum_thr=0.0,
+            # Pin the scale reference to the camera's calibrated linearity limit (see
+            # `_user_sat`), not LibRaw's generic ADC ceiling — otherwise a body whose real
+            # limit sits below the format max reports up to 65535 for photosites that are
+            # already non-linear or clipped, and CLIP_CEILING never sees it.
+            user_sat=_user_sat(raw),
             use_camera_wb=False,
             user_wb=[1, 1, 1, 1],
             output_bps=16,
@@ -55,28 +97,66 @@ def linear_demosaic(path: str, half_size: bool = False) -> np.ndarray:
     return np.asarray(rgb)
 
 
-def raw_channel_clip_fraction(path: str, channel_index: int, roi, saturation_margin: int = 16) -> float:
-    """Fraction of *raw Bayer* photosites for one channel that are clipped, inside the ROI.
+#: Window below the ROI's own maximum searched for a saturation plateau, and the run of bins
+#: immediately above a candidate peak compared against it for density. A real pileup is denser by
+#: an order of magnitude or more; a clean sensor's falling tail never clears this ratio (verified
+#: down to a 4-count read-noise sigma). Both are counts, so they hold regardless of what the raw
+#: format's own ceiling is — this path needs no white level at all.
+_PLATEAU_WINDOW = 256
+_PLATEAU_NEIGHBOR_BINS = 8
+_PLATEAU_DENSITY_RATIO = 6.0
+_MIN_PLATEAU_SITES = 4  # a plateau is a pile, never a handful of photosites on a small ROI
 
-    A demosaiced channel can read below saturation while its source photosites are already at
-    the sensor ceiling — interpolation averages a clipped site with clean neighbours and hides
-    it. Metering the raw sites (before demosaic/color) catches that, which matters for ETTR
-    where the base is deliberately exposed near the ceiling. `roi` is any object with a
+
+def _plateau_clip_fraction(values: np.ndarray, dark_frame_guard: int) -> float:
+    """Fraction of photosites pinned on a saturation plateau, found from the data's shape alone.
+
+    A sensor can saturate below the white level its metadata publishes — or on a body with no
+    metadata at all. Saturation still has a shape: photosites pile up against the highest level
+    the sensor reaches, while noise above that pile falls off smoothly. The pile is not always the
+    ROI's own maximum — a handful of noise-elevated sites (dust, a hot pixel, ordinary shot noise)
+    routinely sit a few dozen counts above the true plateau, so anchoring on `values.max()` itself
+    can land in that sparse tail and miss the pile beneath it. Scanning the top `_PLATEAU_WINDOW`
+    counts for the densest bin, rather than assuming the maximum sample instead, finds it either
+    way. `dark_frame_guard` (typically the raw white level, loosely, or 0 to skip the guard) keeps
+    a frame nowhere near saturation from having its noise floor mistaken for a plateau.
+    """
+    top = int(values.max())
+    if dark_frame_guard > 0 and top * 2 < dark_frame_guard:
+        return 0.0
+    lo = max(0, top - _PLATEAU_WINDOW)
+    counts = np.bincount(values[values >= lo] - lo, minlength=_PLATEAU_WINDOW + 1)
+    peak_bin = int(np.argmax(counts))
+    peak = int(counts[peak_bin])
+    if peak < _MIN_PLATEAU_SITES:
+        return 0.0
+    neighbors = counts[peak_bin + 1 : peak_bin + 1 + _PLATEAU_NEIGHBOR_BINS]
+    neighbor_density = float(neighbors.mean()) if neighbors.size else 0.0
+    if peak < _PLATEAU_DENSITY_RATIO * max(neighbor_density, 1.0):
+        return 0.0
+    anchor = lo + peak_bin
+    return float(np.count_nonzero(values >= anchor)) / values.size
+
+
+def raw_channel_clip_fraction(path: str, channel_index: int, roi, saturation_margin: int = 16) -> float:
+    """Fraction of *raw Bayer* photosites for one channel at or beyond saturation, inside the ROI
+    — "clipped" for ETTR purposes even where it is a soft, non-linear rolloff rather than a hard
+    ADC ceiling.
+
+    A demosaiced channel can read clean while its source photosites are already past that point —
+    interpolation averages a bad site with clean neighbours and hides it. Metering the raw sites
+    (before demosaic/color) catches that, which matters for ETTR where the base is deliberately
+    exposed near the ceiling. Two independent signals are combined by `max()`, so either one alone
+    can flag clipping the other misses, never suppress it: the camera's calibrated linearity limit
+    (`_linearity_limit`, when the body publishes one) and a shape-based plateau detector
+    (`_plateau_clip_fraction`) that needs no metadata at all. `roi` is any object with a
     `.pixels(w, h)` method (duck-typed to avoid an infra→services import). channel_index: R=0,
-    G=1, B=2. Returns 0.0 if the channel/white level can't be resolved."""
+    G=1, B=2. Returns 0.0 if the channel can't be resolved."""
     import rawpy
 
     with rawpy.imread(path) as raw:
         img = raw.raw_image_visible
         colors = raw.raw_colors_visible
-        # No white level means no raw refinement, though the demosaiced clip guard still runs.
-        # Never guess img.max() instead: that is an image-dependent reference, the same failure
-        # class as adjust_maximum_thr, and on a uniform base the guess sits inside the noise. The
-        # quieter the sensor, the more photosites land within `saturation_margin` of their own
-        # maximum and read as heavy clipping on a frame that clips nowhere.
-        white = int(raw.white_level or 0)
-        if white <= 0:
-            return 0.0
         letter = "RGB"[channel_index]
         desc = raw.color_desc.decode("ascii", errors="ignore")  # e.g. "RGBG": 0=R,1=G,2=B,3=G
         wanted = [j for j, c in enumerate(desc) if c.upper() == letter]
@@ -88,5 +168,14 @@ def raw_channel_clip_fraction(path: str, channel_index: int, roi, saturation_mar
         mask = np.isin(colors[y0:y1, x0:x1], wanted)
         if not mask.any():
             return 0.0
-        threshold = max(0, white - saturation_margin)
-        return float(np.mean(sub_img[mask] >= threshold))
+        values = sub_img[mask]
+
+        by_limit = 0.0
+        # raw_image_visible is absolute ADC counts (black not subtracted), matching the limit's scale.
+        limit = _linearity_limit(raw, wanted)
+        if limit > 0:
+            threshold = max(0, limit - saturation_margin)
+            by_limit = float(np.mean(values >= threshold))
+
+        by_plateau = _plateau_clip_fraction(values, int(raw.white_level or 0))
+        return max(by_limit, by_plateau)

--- a/negpy/infrastructure/capture/raw_demosaic.py
+++ b/negpy/infrastructure/capture/raw_demosaic.py
@@ -138,20 +138,22 @@ def _plateau_clip_fraction(values: np.ndarray, dark_frame_guard: int) -> float:
     return float(np.count_nonzero(values >= anchor)) / values.size
 
 
-def raw_channel_clip_fraction(path: str, channel_index: int, roi, saturation_margin: int = 16) -> float:
-    """Fraction of *raw Bayer* photosites for one channel at or beyond saturation, inside the ROI
-    — "clipped" for ETTR purposes even where it is a soft, non-linear rolloff rather than a hard
-    ADC ceiling.
+def raw_channel_clip_fraction(path: str, channel_index: int, roi, saturation_margin: int = 16) -> tuple[float, float]:
+    """Fraction of *raw Bayer* photosites for one channel past two independent points, inside the
+    ROI: (linearity_fraction, plateau_fraction).
 
-    A demosaiced channel can read clean while its source photosites are already past that point —
-    interpolation averages a bad site with clean neighbours and hides it. Metering the raw sites
+    A demosaiced channel can read clean while its source photosites are already past either point
+    — interpolation averages a bad site with clean neighbours and hides it. Metering the raw sites
     (before demosaic/color) catches that, which matters for ETTR where the base is deliberately
-    exposed near the ceiling. Two independent signals are combined by `max()`, so either one alone
-    can flag clipping the other misses, never suppress it: the camera's calibrated linearity limit
-    (`_linearity_limit`, when the body publishes one) and a shape-based plateau detector
-    (`_plateau_clip_fraction`) that needs no metadata at all. `roi` is any object with a
+    exposed near the ceiling. The two are semantically different and must not be merged into one
+    number here: `linearity_fraction` (`_linearity_limit`, when the body publishes a calibrated
+    ceiling) can overstate real clipping — a body's calibrated ceiling is often a conservative
+    linearity limit, not where it actually saturates, so a channel legitimately using the top of
+    its range reads as partly "past" it. `plateau_fraction` (`_plateau_clip_fraction`) finds the
+    true saturation pile from the data's shape, needs no metadata, and is what should gate a hard
+    abort; the caller is expected to budget the two separately. `roi` is any object with a
     `.pixels(w, h)` method (duck-typed to avoid an infra→services import). channel_index: R=0,
-    G=1, B=2. Returns 0.0 if the channel can't be resolved."""
+    G=1, B=2. Returns (0.0, 0.0) if the channel can't be resolved."""
     import rawpy
 
     with rawpy.imread(path) as raw:
@@ -161,21 +163,21 @@ def raw_channel_clip_fraction(path: str, channel_index: int, roi, saturation_mar
         desc = raw.color_desc.decode("ascii", errors="ignore")  # e.g. "RGBG": 0=R,1=G,2=B,3=G
         wanted = [j for j, c in enumerate(desc) if c.upper() == letter]
         if not wanted:
-            return 0.0
+            return 0.0, 0.0
         h, w = img.shape[:2]
         x0, y0, x1, y1 = roi.pixels(w, h)
         sub_img = img[y0:y1, x0:x1]
         mask = np.isin(colors[y0:y1, x0:x1], wanted)
         if not mask.any():
-            return 0.0
+            return 0.0, 0.0
         values = sub_img[mask]
 
-        by_limit = 0.0
+        linearity_fraction = 0.0
         # raw_image_visible is absolute ADC counts (black not subtracted), matching the limit's scale.
         limit = _linearity_limit(raw, wanted)
         if limit > 0:
             threshold = max(0, limit - saturation_margin)
-            by_limit = float(np.mean(values >= threshold))
+            linearity_fraction = float(np.mean(values >= threshold))
 
-        by_plateau = _plateau_clip_fraction(values, int(raw.white_level or 0))
-        return max(by_limit, by_plateau)
+        plateau_fraction = _plateau_clip_fraction(values, int(raw.white_level or 0))
+        return linearity_fraction, plateau_fraction

--- a/negpy/services/capture/calibration.py
+++ b/negpy/services/capture/calibration.py
@@ -45,10 +45,10 @@ logger = get_logger(__name__)
 # limit, not the format's generic ADC max. This holds only because `linear_demosaic`
 # pins adjust_maximum_thr=0.0 and passes user_sat from the body's own calibration table
 # (see `_linearity_limit`/`_user_sat`) instead of the frame's own brightest pixel or
-# LibRaw's generic white_level. The raw Bayer plane is checked separately by
-# raw_channel_clip_fraction, on the same calibrated reference, which also catches bad
-# photosites the demosaic averages away. This ceiling is only a fast secondary guard on
-# the normalised scale.
+# LibRaw's generic white_level. Because this ceiling is itself linearity-anchored, a
+# check against it feeds MAX_LINEARITY_FRACTION, not MAX_CLIP_FRACTION — the raw Bayer
+# plane's shape-based plateau check is what owns that stricter budget (both live in
+# raw_channel_clip_fraction, kept separate on purpose).
 CLIP_CEILING = 65535
 # A demosaiced pixel this close to the ceiling counts as clipped. The margin absorbs
 # demosaic interpolation and read noise just below saturation.
@@ -64,8 +64,19 @@ PWM_MAX_SAFE = 250
 TARGET_FRACTION = 0.9  # expose the film base to 90 % of the usable range
 MIN_SIGNAL = 10.0  # counts; below this the channel read no real signal
 # ETTR meters p99.9, so the base can read on-target while a sliver clips. The base is the
-# whitepoint (blackpoint after inversion) and must stay just below clipping.
+# whitepoint (blackpoint after inversion) and must stay just below clipping. This budgets
+# genuine, physically-lost data — the shape-based plateau detector, which finds the true
+# saturation pile from the data itself. See MAX_LINEARITY_FRACTION for the separate,
+# looser budget a body's (often conservative) calibrated linearity limit is held to.
 MAX_CLIP_FRACTION = 0.002
+# A calibrated linearity limit (camera_white_level_per_channel) is often conservative: a
+# body can keep responding, usefully if non-linearly, well above it before it actually
+# saturates. Photosites past the limit are not lost data the way a plateau is, so this
+# budget is an order of magnitude looser than MAX_CLIP_FRACTION — wide enough to absorb a
+# clean channel's ordinary tail into that non-linear-but-still-usable region, tight enough
+# that a channel genuinely run too far into it still aborts rather than trusting a `k`
+# measurement taken off a non-linear response.
+MAX_LINEARITY_FRACTION = 0.02
 # A channel this far under target is under-exposed from any cause: a maxed LED at the
 # slowest shutter, or a clip guard that pulled the LED down hard. Aborts the run as
 # "under". A smaller undershoot still counts as on-target.
@@ -308,7 +319,8 @@ class ChannelCalibration:
     shutter: str  # solved camera shutter label (shared across channels)
     signal: float  # measured base p99.9 at the solved settings
     target: int  # target signal
-    clip_fraction: float = 0.0  # fraction of base pixels at/above saturation (ETTR keeps this ~0)
+    clip_fraction: float = 0.0  # fraction of base pixels genuinely lost to the plateau (ETTR keeps this ~0)
+    linearity_fraction: float = 0.0  # fraction past the (often conservative) calibrated linearity limit
 
 
 @dataclass(frozen=True)
@@ -396,15 +408,16 @@ class CalibrationService:
         camera: Camera,
         demosaic: DemosaicFn,
         *,
-        source_clip: Optional[Callable[[str, int, Roi], float]] = None,
+        source_clip: Optional[Callable[[str, int, Roi], tuple[float, float]]] = None,
         sleep: Callable[[float], None] = time.sleep,
         settle_s: float = 0.4,
     ) -> None:
         self._light = light
         self._camera = camera
         self._demosaic = demosaic
-        # (path, channel_index, roi) -> raw-Bayer source-clip fraction. None = the rawpy
-        # default; tests inject a stub so the hardware-free path never touches rawpy.
+        # (path, channel_index, roi) -> raw-Bayer (linearity_fraction, plateau_fraction).
+        # None = the rawpy default; tests inject a stub so the hardware-free path never
+        # touches rawpy.
         self._source_clip = source_clip
         self._sleep = sleep
         self._settle_s = settle_s
@@ -438,13 +451,16 @@ class CalibrationService:
             if progress is not None:
                 progress(_floor[0], msg)
 
-        def _shoot(i: int, ch, level: int, shutter: str) -> tuple[float, float]:
-            """Light channel `ch` at `level`, capture at `shutter`, meter → (base p99.9, clip)."""
+        def _shoot(i: int, ch, level: int, shutter: str) -> tuple[float, float, float]:
+            """Light channel `ch` at `level`, capture at `shutter`, meter → (base p99.9,
+            linearity_clip, plateau_clip). The demosaiced check joins the linearity budget: its
+            ceiling is itself scaled from the calibrated linearity limit via user_sat."""
             self._light.set_color(*ch.rgb(level))
             self._sleep(self._settle_s)
             img, written = self._capture(scratch_path, shutter=shutter)
-            clip = max(clip_fraction(img[..., i], roi), self._source_clip_fraction(written, i, roi))
-            return meter_base(img[..., i], roi), clip
+            source_linearity, source_plateau = self._source_clip_fraction(written, i, roi)
+            linearity_clip = max(clip_fraction(img[..., i], roi), source_linearity)
+            return meter_base(img[..., i], roi), linearity_clip, source_plateau
 
         try:
             # --- Phase 2: measure the response k per channel (adaptive probe) ------------------
@@ -489,11 +505,13 @@ class CalibrationService:
         raises RuntimeError (that is a broken setup — lens cap, dead LED, ROI off the base)."""
         level, shutter = start_level, start_shutter
         for _ in range(_MAX_PROBE_STEPS):
-            signal, clip = shoot(i, ch, level, shutter)
+            signal, linearity_clip, plateau_clip = shoot(i, ch, level, shutter)
             # Halve/double the exposure per step, moving the shutter first and dropping to the
             # LED only at the ladder end. A 1-stop step cannot jump the measurable window, so
             # it never overshoots from clipping to no-signal.
-            if clip > MAX_CLIP_FRACTION or signal >= SATURATION_VALUE:  # too bright → halve exposure
+            if (
+                linearity_clip > MAX_LINEARITY_FRACTION or plateau_clip > MAX_CLIP_FRACTION or signal >= SATURATION_VALUE
+            ):  # too bright → halve exposure
                 faster = _nearest_by_seconds(shutter_seconds(shutter) * 0.5, candidates)
                 if shutter_seconds(faster) < shutter_seconds(shutter):
                     shutter = faster
@@ -528,28 +546,33 @@ class CalibrationService:
         """Capture at the solved settings, one proportional trim, then a clip guard. Returns the
         channel calibration with a graceful status (never raises on a physical limit)."""
         tol = 0.05 * T
-        measured, clip = shoot(i, ch, level, shutter)
-        if clip <= MAX_CLIP_FRACTION and abs(measured - T) > tol:
+
+        def _in_budget(linearity_clip: float, plateau_clip: float) -> bool:
+            return linearity_clip <= MAX_LINEARITY_FRACTION and plateau_clip <= MAX_CLIP_FRACTION
+
+        measured, linearity_clip, plateau_clip = shoot(i, ch, level, shutter)
+        if _in_budget(linearity_clip, plateau_clip) and abs(measured - T) > tol:
             level = correct_led_level(level, measured, T)
-            measured, clip = shoot(i, ch, level, shutter)
-        # Clip guard: pull the LED down until the base sits below clipping. p99.9 can read
+            measured, linearity_clip, plateau_clip = shoot(i, ch, level, shutter)
+        # Clip guard: pull the LED down until the base sits below both budgets. p99.9 can read
         # on-target while the top 0.1 % saturates. A dense base overshoots, so iterate and
         # re-measure, bounded by _MAX_CLIP_GUARD_STEPS to keep the capture budget hard.
         for _ in range(_MAX_CLIP_GUARD_STEPS):
-            if clip <= MAX_CLIP_FRACTION or level <= PWM_MIN:
+            if _in_budget(linearity_clip, plateau_clip) or level <= PWM_MIN:
                 break
             level = max(PWM_MIN, int(round(level * 0.85)))
-            measured, clip = shoot(i, ch, level, shutter)
+            measured, linearity_clip, plateau_clip = shoot(i, ch, level, shutter)
 
-        status = _channel_status(measured, clip, T)
+        status = _channel_status(measured, linearity_clip, plateau_clip, T)
         logger.info(
-            "calibrated %s → level %d, shutter %s (target %d, got %.0f, clip %.3f%%, %s)",
+            "calibrated %s → level %d, shutter %s (target %d, got %.0f, linearity %.3f%%, plateau %.3f%%, %s)",
             ch.letter,
             level,
             shutter,
             T,
             measured,
-            clip * 100,
+            linearity_clip * 100,
+            plateau_clip * 100,
             status,
         )
         if status != "target":
@@ -563,23 +586,26 @@ class CalibrationService:
             shutter=shutter,
             signal=measured,
             target=T,
-            clip_fraction=clip,
+            clip_fraction=plateau_clip,
+            linearity_fraction=linearity_clip,
         )
 
-    def _source_clip_fraction(self, path: str, channel_index: int, roi: Roi) -> float:
-        """Raw-Bayer source clip for one channel (catches clipped photosites the demosaic hides)."""
+    def _source_clip_fraction(self, path: str, channel_index: int, roi: Roi) -> tuple[float, float]:
+        """Raw-Bayer source clip for one channel: (linearity_fraction, plateau_fraction) — kept
+        separate because they budget differently, see raw_channel_clip_fraction."""
         if self._source_clip is not None:
-            measured = float(self._source_clip(path, channel_index, roi))
+            linearity, plateau = self._source_clip(path, channel_index, roi)
         else:
             from negpy.infrastructure.capture.raw_demosaic import raw_channel_clip_fraction
 
             try:
-                measured = raw_channel_clip_fraction(path, channel_index, roi)
+                linearity, plateau = raw_channel_clip_fraction(path, channel_index, roi)
             except Exception as exc:
                 raise RuntimeError(f"calibration failed: raw source-clip check failed for {path}") from exc
-        if not np.isfinite(measured):
+        linearity, plateau = float(linearity), float(plateau)
+        if not (np.isfinite(linearity) and np.isfinite(plateau)):
             raise RuntimeError(f"calibration failed: non-finite raw source-clip measurement for {path}")
-        return measured
+        return linearity, plateau
 
     def _capture(self, path: str, shutter: Optional[str]) -> tuple[np.ndarray, str]:
         """Capture, decode, and report *where the file landed* (the camera names it after its own
@@ -588,12 +614,12 @@ class CalibrationService:
         return self._demosaic(written), written
 
 
-def _channel_status(measured: float, clip: float, target: int) -> str:
+def _channel_status(measured: float, linearity_clip: float, plateau_clip: float, target: int) -> str:
     """Per-channel verdict from the *measured signal*, not the level — the verify's abort input.
-    'over' if the base still clips; 'under' if it is materially below target from any cause — a
-    maxed LED at the slowest shutter, OR a clip-guard that pulled the LED well below PWM_MAX; else
-    'target' (a small clip-guard undershoot within the margin stays 'target')."""
-    if clip > MAX_CLIP_FRACTION:
+    'over' if the base is past either budget; 'under' if it is materially below target from any
+    cause — a maxed LED at the slowest shutter, OR a clip-guard that pulled the LED well below
+    PWM_MAX; else 'target' (a small clip-guard undershoot within the margin stays 'target')."""
+    if plateau_clip > MAX_CLIP_FRACTION or linearity_clip > MAX_LINEARITY_FRACTION:
         return "over"
     if measured < (1.0 - MAX_TARGET_UNDER_FRACTION) * target:
         return "under"

--- a/negpy/services/capture/calibration.py
+++ b/negpy/services/capture/calibration.py
@@ -40,13 +40,15 @@ from negpy.kernel.system.logging import get_logger
 
 logger = get_logger(__name__)
 
-# The decode normalises the camera white level to full 16-bit, so the *demosaiced*
-# saturation point is camera-independent (65535). This holds only because
-# `linear_demosaic` pins adjust_maximum_thr=0.0. On LibRaw's default the reference
-# becomes the frame's own brightest pixel and no two shots are comparable. The
-# camera-SPECIFIC raw white level is checked separately by raw_channel_clip_fraction,
-# which also catches clipped photosites the demosaic averages away. This ceiling is
-# only a fast secondary guard on the normalised scale.
+# The decode normalises the camera's calibrated linearity limit to full 16-bit, so the
+# *demosaiced* ceiling is camera-independent (65535) while still landing on the real
+# limit, not the format's generic ADC max. This holds only because `linear_demosaic`
+# pins adjust_maximum_thr=0.0 and passes user_sat from the body's own calibration table
+# (see `_linearity_limit`/`_user_sat`) instead of the frame's own brightest pixel or
+# LibRaw's generic white_level. The raw Bayer plane is checked separately by
+# raw_channel_clip_fraction, on the same calibrated reference, which also catches bad
+# photosites the demosaic averages away. This ceiling is only a fast secondary guard on
+# the normalised scale.
 CLIP_CEILING = 65535
 # A demosaiced pixel this close to the ceiling counts as clipped. The margin absorbs
 # demosaic interpolation and read noise just below saturation.

--- a/tests/test_capture_calibration.py
+++ b/tests/test_capture_calibration.py
@@ -14,6 +14,7 @@ import pytest
 
 from negpy.services.capture.calibration import (
     MAX_CLIP_FRACTION,
+    MAX_LINEARITY_FRACTION,
     PWM_MAX,
     PWM_MAX_SAFE,
     PWM_MIN,
@@ -163,10 +164,21 @@ def test_channel_status_is_measured_based_not_level_based():
     # materially under target — that must read "under", not "target". The status keys off the
     # measured signal, not the level.
     T = target_signal()
-    assert _channel_status(T, 0.0, T) == "target"
-    assert _channel_status(0.85 * T, 0.0, T) == "target"  # small undershoot within the margin
-    assert _channel_status(0.5 * T, 0.0, T) == "under"  # materially under (level irrelevant here)
-    assert _channel_status(T, 0.01, T) == "over"  # still clipping → over
+    assert _channel_status(T, 0.0, 0.0, T) == "target"
+    assert _channel_status(0.85 * T, 0.0, 0.0, T) == "target"  # small undershoot within the margin
+    assert _channel_status(0.5 * T, 0.0, 0.0, T) == "under"  # materially under (level irrelevant here)
+    assert _channel_status(T, 0.0, 0.01, T) == "over"  # plateau clip → over
+    assert _channel_status(T, 0.05, 0.0, T) == "over"  # linearity fraction well over its own budget → over
+
+
+def test_channel_status_gives_the_linearity_limit_its_own_looser_budget():
+    # A body's calibrated linearity limit routinely undershoots where it actually saturates, so a
+    # clean channel with an ordinary tail past that limit must not read "over" the way real
+    # (plateau) clipping does — that was the false-abort risk a shared budget created.
+    T = target_signal()
+    assert _channel_status(T, MAX_CLIP_FRACTION, 0.0, T) == "target"  # at the strict budget, fine here
+    assert _channel_status(T, MAX_LINEARITY_FRACTION * 0.5, 0.0, T) == "target"
+    assert _channel_status(T, MAX_LINEARITY_FRACTION * 1.5, 0.0, T) == "over"
 
 
 def test_spread_stops():
@@ -273,8 +285,8 @@ def _make_demosaic(light, camera, *, k_scale=1.0, level_cap=None, sliver=0):
 
 
 def _service(light, cam, **demo):
-    # source_clip stubbed to 0 → the hardware-free path never touches rawpy.
-    return CalibrationService(light, cam, _make_demosaic(light, cam, **demo), source_clip=lambda *_a: 0.0, sleep=lambda _s: None)
+    # source_clip stubbed to (0.0, 0.0) → the hardware-free path never touches rawpy.
+    return CalibrationService(light, cam, _make_demosaic(light, cam, **demo), source_clip=lambda *_a: (0.0, 0.0), sleep=lambda _s: None)
 
 
 def _calibrate(service, roi=Roi(0, 0, 1, 1)):
@@ -360,9 +372,13 @@ def test_calibrate_raises_only_when_a_channel_has_no_signal_at_all():
 
 def test_calibrate_clip_guard_pulls_the_led_down_below_clipping():
     # A bright sliver clips at the solved level; the guard lowers the LED until the base is clean.
+    # This drives the demosaiced clip_fraction() check, which now feeds the linearity budget (its
+    # ceiling is itself linearity-anchored via user_sat) — sized above MAX_LINEARITY_FRACTION, not
+    # the stricter MAX_CLIP_FRACTION, so the guard has something to actually pull down here.
     light, cam = FakeLight(), FakeCamera()
-    result = _calibrate(_service(light, cam, sliver=40))
+    result = _calibrate(_service(light, cam, sliver=400))
     for ch in result.channels.values():
+        assert ch.linearity_fraction <= MAX_LINEARITY_FRACTION
         assert ch.clip_fraction <= MAX_CLIP_FRACTION
 
 
@@ -372,6 +388,41 @@ def test_calibrate_measures_spread_matching_the_channel_responses():
     # log2(760/250) ≈ 1.60 — the value that confirms one shutter can serve all three (< 2.7).
     assert result.spread_stops == pytest.approx(1.60, abs=0.05)
     assert result.spread_stops < 2.7
+
+
+# ---- linearity limit vs. plateau: separately budgeted --------------------
+
+
+def test_calibrate_survives_a_raw_source_reading_past_only_the_linearity_limit():
+    # A body's calibrated linearity limit routinely undershoots true saturation, so a channel
+    # sitting past it while never actually piling up must not false-abort a clean run (the bug a
+    # shared budget created — see discussion #906 / PR #931 review).
+    light, cam = FakeLight(), FakeCamera()
+    service = CalibrationService(
+        light,
+        cam,
+        _make_demosaic(light, cam),
+        source_clip=lambda *_a: (MAX_LINEARITY_FRACTION * 0.5, 0.0),  # linearity only, no plateau
+        sleep=lambda _s: None,
+    )
+    result = _calibrate(service)
+    assert set(result.channels) == {"R", "G", "B"}  # completed without aborting
+
+
+def test_calibrate_still_aborts_on_a_genuine_plateau_reading():
+    # The plateau signal alone must still gate a hard abort — the split loosens the linearity
+    # budget, it does not weaken real-clipping detection.
+    light, cam = FakeLight(), FakeCamera()
+    service = CalibrationService(
+        light,
+        cam,
+        _make_demosaic(light, cam),
+        source_clip=lambda *_a: (0.0, MAX_CLIP_FRACTION * 2),  # plateau only, over its own budget
+        sleep=lambda _s: None,
+    )
+    with pytest.raises(CalibrationExposureError) as e:
+        _calibrate(service)
+    assert e.value.status == "over"
 
 
 # ---- source-clip guard (fail-closed) --------------------------------------
@@ -385,7 +436,7 @@ def test_source_clip_reads_the_file_the_camera_actually_wrote():
 
     def record(path, _channel, _roi):
         seen.append(path)
-        return 0.0
+        return 0.0, 0.0
 
     service = CalibrationService(light, cam, _make_demosaic(light, cam), source_clip=record, sleep=lambda _s: None)
     _calibrate(service)
@@ -407,7 +458,7 @@ def test_calibrate_fails_closed_when_the_raw_clip_check_errors(monkeypatch):
 
 def test_calibrate_fails_closed_on_a_nonfinite_raw_clip_measurement():
     light, cam = FakeLight(), FakeCamera()
-    service = CalibrationService(light, cam, _make_demosaic(light, cam), source_clip=lambda *_a: np.nan, sleep=lambda _s: None)
+    service = CalibrationService(light, cam, _make_demosaic(light, cam), source_clip=lambda *_a: (np.nan, np.nan), sleep=lambda _s: None)
     with pytest.raises(RuntimeError, match="non-finite raw source-clip"):
         _calibrate(service)
 

--- a/tests/test_capture_raw_demosaic.py
+++ b/tests/test_capture_raw_demosaic.py
@@ -9,6 +9,9 @@ from negpy.infrastructure.capture.raw_demosaic import linear_demosaic, raw_chann
 class _FakeRaw:
     raw_type = rawpy.RawType.Flat
     raw_pattern = np.zeros((6, 6), dtype=np.uint8)
+    white_level = 16383
+    camera_white_level_per_channel = None  # most bodies: no calibrated table
+    black_level_per_channel = [0, 0, 0, 0]
 
     def __enter__(self):
         return self
@@ -33,14 +36,34 @@ class _FakeBayer:
 
     color_desc = b"RGBG"
 
-    def __init__(self, white_level, base=3000.0, sigma=4.0, clipped_rows=0):
+    def __init__(self, white_level, base=3000.0, sigma=4.0, clipped_rows=0, camera_white_level=None):
         self.white_level = white_level
+        # A body without a calibrated saturation table (most of them): None, same as rawpy.
+        self.camera_white_level_per_channel = [camera_white_level] * 4 if camera_white_level is not None else None
         rng = np.random.default_rng(7)
         img = base + rng.normal(0.0, sigma, (64, 64))
         if clipped_rows:  # pin some photosites to the ceiling — genuine clipping
             img[:clipped_rows] = 16383
         self.raw_image_visible = img.astype(np.uint16)
         self.raw_colors_visible = np.zeros((64, 64), dtype=np.uint8)  # every site is "R"
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        pass
+
+
+class _FakeBayerFromValues:
+    """A single-column Bayer sensor whose R-channel raw values are exactly the array given."""
+
+    color_desc = b"RGBG"
+
+    def __init__(self, values, white_level, camera_white_level=None):
+        self.white_level = white_level
+        self.camera_white_level_per_channel = [camera_white_level] * 4 if camera_white_level is not None else None
+        self.raw_image_visible = np.asarray(values, dtype=np.uint16).reshape(-1, 1)
+        self.raw_colors_visible = np.zeros((len(values), 1), dtype=np.uint8)  # every site is "R"
 
     def __enter__(self):
         return self
@@ -73,6 +96,85 @@ def test_linear_demosaic_pins_the_scale_to_the_white_level(monkeypatch):
     assert seen["adjust_maximum_thr"] == 0.0
 
 
+def test_linear_demosaic_pins_the_scale_to_the_camera_calibrated_limit(monkeypatch):
+    # A Nikon D800 reports a generic white_level of 16383 but a calibrated
+    # camera_white_level_per_channel of 15311 — the sensor goes non-linear below the
+    # format's nominal ADC max. Trusting the generic number lets already non-linear
+    # photosites land at ~93 % of the demosaiced scale instead of 100 %, so CLIP_CEILING
+    # never sees them (issue #906). user_sat must carry the calibrated value through.
+    seen = {}
+
+    class _Spy(_FakeRaw):
+        white_level = 16383
+        camera_white_level_per_channel = [15311, 15311, 15311, 15311]
+
+        def postprocess(self, **kwargs):
+            seen.update(kwargs)
+            return super().postprocess(**kwargs)
+
+    monkeypatch.setattr(rawpy, "imread", lambda _path: _Spy())
+    linear_demosaic("frame.NEF")
+    assert seen["user_sat"] == 15311
+
+
+def test_linear_demosaic_falls_back_to_the_generic_white_level_without_a_calibrated_table(monkeypatch):
+    # Most bodies carry no camera_white_level_per_channel table at all — user_sat must
+    # still be set from *something*, not silently omitted.
+    seen = {}
+
+    class _Spy(_FakeRaw):
+        white_level = 16383
+        camera_white_level_per_channel = None
+
+        def postprocess(self, **kwargs):
+            seen.update(kwargs)
+            return super().postprocess(**kwargs)
+
+    monkeypatch.setattr(rawpy, "imread", lambda _path: _Spy())
+    linear_demosaic("frame.NEF")
+    assert seen["user_sat"] == 16383
+
+
+def test_linear_demosaic_corrects_user_sat_for_a_nonzero_black_level(monkeypatch):
+    # `user_sat` is compared AFTER LibRaw subtracts the black level from every photosite.
+    # A D800's black level happens to be 0, which hid this: on a Fuji/Sony/Canon body with
+    # a real black level, passing the raw-scale limit unmodified silently under-scales the
+    # whole decode and pushes ETTR's exposure the wrong way.
+    seen = {}
+
+    class _Spy(_FakeRaw):
+        white_level = 16383
+        camera_white_level_per_channel = None
+        black_level_per_channel = [1020, 1020, 1020, 1020]
+
+        def postprocess(self, **kwargs):
+            seen.update(kwargs)
+            return super().postprocess(**kwargs)
+
+    monkeypatch.setattr(rawpy, "imread", lambda _path: _Spy())
+    linear_demosaic("frame.RAF")
+    assert seen["user_sat"] == 16383 - 1020
+
+
+def test_linear_demosaic_clamps_a_calibrated_limit_that_exceeds_the_format_ceiling(monkeypatch):
+    # A calibrated linearity limit can't legitimately exceed the format's own ADC ceiling —
+    # a body reporting one anyway is bad metadata, not a wider range, and must not widen
+    # what CLIP_CEILING accepts as clean.
+    seen = {}
+
+    class _Spy(_FakeRaw):
+        white_level = 16383
+        camera_white_level_per_channel = [20000, 20000, 20000, 20000]
+
+        def postprocess(self, **kwargs):
+            seen.update(kwargs)
+            return super().postprocess(**kwargs)
+
+    monkeypatch.setattr(rawpy, "imread", lambda _path: _Spy())
+    linear_demosaic("frame.NEF")
+    assert seen["user_sat"] == 16383
+
+
 def test_raw_clip_returns_zero_when_the_body_reports_no_white_level(monkeypatch):
     # The documented contract ("Returns 0.0 if the channel/white level can't be resolved") — the code
     # used to guess img.max() instead, an image-dependent reference (the adjust_maximum_thr failure
@@ -90,3 +192,73 @@ def test_raw_clip_still_catches_genuine_clipping(monkeypatch):
     # And a clean frame with a proper white level reads ~0, not noise-tail false positives.
     monkeypatch.setattr(rawpy, "imread", lambda _path: _FakeBayer(white_level=16383))
     assert raw_channel_clip_fraction("x.ARW", 0, _FullRoi()) == 0.0
+
+
+def test_raw_clip_uses_the_calibrated_ceiling_when_the_body_reports_a_higher_generic_one(monkeypatch):
+    # A D800-shaped body: generic white_level is 16383, the real calibrated ceiling is
+    # 15311. A base exposed to just under the *real* ceiling is genuinely clipped, but
+    # reads clean against the generic one (issue #906) — this must be caught.
+    monkeypatch.setattr(
+        rawpy,
+        "imread",
+        lambda _path: _FakeBayer(white_level=16383, base=15320.0, sigma=4.0, camera_white_level=15311),
+    )
+    assert raw_channel_clip_fraction("x.NEF", 0, _FullRoi()) > 0.9
+
+    # The same photosites, checked against the generic ceiling alone, would have read as clean —
+    # this is exactly what let the old code pass a clipped base as "on target".
+    monkeypatch.setattr(
+        rawpy,
+        "imread",
+        lambda _path: _FakeBayer(white_level=16383, base=15320.0, sigma=4.0, camera_white_level=None),
+    )
+    assert raw_channel_clip_fraction("x.NEF", 0, _FullRoi()) == 0.0
+
+
+def test_raw_clip_plateau_survives_a_noise_tail_above_the_pile(monkeypatch):
+    # Real sensor data: a hard pileup at the true saturation point, with a sparse scatter of
+    # noise-elevated photosites (dust, a hot pixel, ordinary shot noise) sitting up to a few
+    # dozen counts above it. Anchoring on the ROI's own maximum lands in that scatter and misses
+    # the pile beneath it; scanning the top window for the densest bin does not.
+    rng = np.random.default_rng(3)
+    pile = np.full(5000, 15778, dtype=np.int64)
+    tail = 15779 + rng.integers(0, 50, size=40)
+    below = np.clip(14000 + rng.normal(0, 200, size=2000), 0, None).astype(np.int64)
+    values = np.concatenate([pile, tail, below])
+    monkeypatch.setattr(
+        rawpy,
+        "imread",
+        lambda _path: _FakeBayerFromValues(values, white_level=16383, camera_white_level=None),
+    )
+    frac = raw_channel_clip_fraction("x.NEF", 0, _FullRoi())
+    assert frac > 0.6  # the pile is ~71 % of the ROI; a max()-anchored window would report 0
+
+
+def test_raw_clip_plateau_needs_no_white_level_at_all(monkeypatch):
+    # The shape-based path exists specifically for a body with no usable ceiling metadata, so it
+    # must not be gated behind one.
+    rng = np.random.default_rng(5)
+    pile = np.full(500, 12000, dtype=np.int64)
+    below = np.clip(8000 + rng.normal(0, 100, size=2000), 0, None).astype(np.int64)
+    values = np.concatenate([pile, below])
+    monkeypatch.setattr(
+        rawpy,
+        "imread",
+        lambda _path: _FakeBayerFromValues(values, white_level=None, camera_white_level=None),
+    )
+    frac = raw_channel_clip_fraction("x.NEF", 0, _FullRoi())
+    assert frac > 0.15  # found from shape alone, roughly pile / total
+
+
+def test_raw_clip_plateau_does_not_false_positive_on_a_quiet_clean_base(monkeypatch):
+    # An ETTR base sitting close to but under saturation, at realistic read noise, must not
+    # false-positive: its own maximum is a noise excursion held by a handful of photosites, and
+    # the falling tail below it never clears the plateau's density-ratio gate.
+    rng = np.random.default_rng(11)
+    values = np.clip(15000 + rng.normal(0.0, 4.0, size=20000), 0, None).astype(np.int64)
+    monkeypatch.setattr(
+        rawpy,
+        "imread",
+        lambda _path: _FakeBayerFromValues(values, white_level=16383, camera_white_level=None),
+    )
+    assert raw_channel_clip_fraction("x.NEF", 0, _FullRoi()) == 0.0

--- a/tests/test_capture_raw_demosaic.py
+++ b/tests/test_capture_raw_demosaic.py
@@ -176,34 +176,43 @@ def test_linear_demosaic_clamps_a_calibrated_limit_that_exceeds_the_format_ceili
 
 
 def test_raw_clip_returns_zero_when_the_body_reports_no_white_level(monkeypatch):
-    # The documented contract ("Returns 0.0 if the channel/white level can't be resolved") — the code
-    # used to guess img.max() instead, an image-dependent reference (the adjust_maximum_thr failure
-    # class). On a uniform base the guess sits inside the noise, so the quieter the sensor the more
-    # photosites read as clipped (~40 % at σ=4 DN): the probe then halves a frame that clips nowhere.
+    # The documented contract ("Returns (0.0, 0.0) if the channel/limit can't be resolved") — the
+    # code used to guess img.max() instead, an image-dependent reference (the adjust_maximum_thr
+    # failure class). On a uniform base the guess sits inside the noise, so the quieter the sensor
+    # the more photosites read as clipped: the probe then halves a frame that clips nowhere.
     monkeypatch.setattr(rawpy, "imread", lambda _path: _FakeBayer(white_level=None))
-    assert raw_channel_clip_fraction("x.ARW", 0, _FullRoi()) == 0.0
+    linearity, plateau = raw_channel_clip_fraction("x.ARW", 0, _FullRoi())
+    assert linearity == 0.0
+    assert plateau == 0.0
 
 
 def test_raw_clip_still_catches_genuine_clipping(monkeypatch):
-    # The positive path must survive the contract fix: photosites at the ceiling are reported.
+    # The positive path must survive the contract fix: photosites at the ceiling are reported by
+    # both signals — genuinely pinned rows are past the linearity limit AND form a real plateau.
     monkeypatch.setattr(rawpy, "imread", lambda _path: _FakeBayer(white_level=16383, clipped_rows=8))
-    frac = raw_channel_clip_fraction("x.ARW", 0, _FullRoi())
-    assert frac > 0.1  # 8 of 64 rows pinned to the ceiling
+    linearity, plateau = raw_channel_clip_fraction("x.ARW", 0, _FullRoi())
+    assert linearity > 0.1  # 8 of 64 rows pinned to the ceiling
+    assert plateau > 0.1
     # And a clean frame with a proper white level reads ~0, not noise-tail false positives.
     monkeypatch.setattr(rawpy, "imread", lambda _path: _FakeBayer(white_level=16383))
-    assert raw_channel_clip_fraction("x.ARW", 0, _FullRoi()) == 0.0
+    linearity, plateau = raw_channel_clip_fraction("x.ARW", 0, _FullRoi())
+    assert linearity == 0.0
+    assert plateau == 0.0
 
 
 def test_raw_clip_uses_the_calibrated_ceiling_when_the_body_reports_a_higher_generic_one(monkeypatch):
-    # A D800-shaped body: generic white_level is 16383, the real calibrated ceiling is
-    # 15311. A base exposed to just under the *real* ceiling is genuinely clipped, but
-    # reads clean against the generic one (issue #906) — this must be caught.
+    # A D800-shaped body: generic white_level is 16383, the real calibrated ceiling is 15311. A
+    # base exposed to just under the *real* ceiling reads past the linearity limit, but reads
+    # clean against the generic one alone (issue #906) — this must be caught. It is an ordinary
+    # exposed base, not a real pileup, so the plateau signal correctly stays quiet either way.
     monkeypatch.setattr(
         rawpy,
         "imread",
         lambda _path: _FakeBayer(white_level=16383, base=15320.0, sigma=4.0, camera_white_level=15311),
     )
-    assert raw_channel_clip_fraction("x.NEF", 0, _FullRoi()) > 0.9
+    linearity, plateau = raw_channel_clip_fraction("x.NEF", 0, _FullRoi())
+    assert linearity > 0.9
+    assert plateau == 0.0
 
     # The same photosites, checked against the generic ceiling alone, would have read as clean —
     # this is exactly what let the old code pass a clipped base as "on target".
@@ -212,7 +221,8 @@ def test_raw_clip_uses_the_calibrated_ceiling_when_the_body_reports_a_higher_gen
         "imread",
         lambda _path: _FakeBayer(white_level=16383, base=15320.0, sigma=4.0, camera_white_level=None),
     )
-    assert raw_channel_clip_fraction("x.NEF", 0, _FullRoi()) == 0.0
+    linearity, _plateau = raw_channel_clip_fraction("x.NEF", 0, _FullRoi())
+    assert linearity == 0.0
 
 
 def test_raw_clip_plateau_survives_a_noise_tail_above_the_pile(monkeypatch):
@@ -230,8 +240,8 @@ def test_raw_clip_plateau_survives_a_noise_tail_above_the_pile(monkeypatch):
         "imread",
         lambda _path: _FakeBayerFromValues(values, white_level=16383, camera_white_level=None),
     )
-    frac = raw_channel_clip_fraction("x.NEF", 0, _FullRoi())
-    assert frac > 0.6  # the pile is ~71 % of the ROI; a max()-anchored window would report 0
+    _linearity, plateau = raw_channel_clip_fraction("x.NEF", 0, _FullRoi())
+    assert plateau > 0.6  # the pile is ~71 % of the ROI; a max()-anchored window would report 0
 
 
 def test_raw_clip_plateau_needs_no_white_level_at_all(monkeypatch):
@@ -246,8 +256,9 @@ def test_raw_clip_plateau_needs_no_white_level_at_all(monkeypatch):
         "imread",
         lambda _path: _FakeBayerFromValues(values, white_level=None, camera_white_level=None),
     )
-    frac = raw_channel_clip_fraction("x.NEF", 0, _FullRoi())
-    assert frac > 0.15  # found from shape alone, roughly pile / total
+    linearity, plateau = raw_channel_clip_fraction("x.NEF", 0, _FullRoi())
+    assert linearity == 0.0  # no white level at all → the linearity signal has nothing to check
+    assert plateau > 0.15  # found from shape alone, roughly pile / total
 
 
 def test_raw_clip_plateau_does_not_false_positive_on_a_quiet_clean_base(monkeypatch):
@@ -261,4 +272,6 @@ def test_raw_clip_plateau_does_not_false_positive_on_a_quiet_clean_base(monkeypa
         "imread",
         lambda _path: _FakeBayerFromValues(values, white_level=16383, camera_white_level=None),
     )
-    assert raw_channel_clip_fraction("x.NEF", 0, _FullRoi()) == 0.0
+    linearity, plateau = raw_channel_clip_fraction("x.NEF", 0, _FullRoi())
+    assert linearity == 0.0
+    assert plateau == 0.0


### PR DESCRIPTION
## The bug

Discussion #906: narrowband camera-scan calibration was letting a genuinely clipped
channel pass as on-target, producing punchier/more-contrasty trichrome merges than a
white-light scan of the same film.

`raw_channel_clip_fraction` and `linear_demosaic` compared raw sensor values against
rawpy's generic `white_level` (a Nikon D800 publishes 16383), instead of the body's own
calibrated ceiling (`camera_white_level_per_channel` = 15311). Verified against the
reporter's own files: this let a fully saturated green channel read 0.000% clipped and
pass calibration's 0.2% clip-fraction budget.

## The fix

- `_linearity_limit()`: reads the camera's calibrated ceiling when available, falls back
  to the generic one, clamps a bogus calibrated value to the format's own ADC max.
- `_user_sat()`: the same limit, corrected for LibRaw's black-level subtraction, so
  `postprocess(user_sat=...)` scales correctly on any body (not just this D800, whose
  black level happens to be 0 and hid the issue during initial testing).
- `_plateau_clip_fraction()`: a second, independent, metadata-free check — finds
  saturation by density shape (the densest bin in a search window near the ROI's own
  ceiling) rather than assuming the ROI's maximum sample sits on the plateau, since real
  sensor noise routinely scatters a few photosites above it.

`raw_channel_clip_fraction` returns the two signals separately, budgeted differently
(update from review, see below) — the plateau detector, which finds true saturation from
the data's shape, keeps the strict `MAX_CLIP_FRACTION` (0.2%) budget; the linearity-limit
checks (raw and demosaiced) get a new, order-of-magnitude looser `MAX_LINEARITY_FRACTION`
(2%), since a calibrated linearity limit is often conservative and a clean channel's
ordinary tail past it isn't lost data the way a plateau is.

**Side effect worth calling out explicitly** (flagged by @light-sntchr below): the
black-level-corrected `user_sat` changes ETTR exposure targeting on *any* body that
publishes a calibrated ceiling below its ADC max, not only the D800 case this PR fixes.
On a Sony a7C II (white=16383, calibrated=15360, black=512) this scales every
measurement ~1.069x, landing the ETTR target lower in raw terms with more headroom — a
beneficial direction, but a distinct effect from the clipping-fraction fix, not merely a
side effect of it.

Related to #931, which independently diagnosed the same discussion and proposed a
metadata-free shape detector. We found its `values.max()`-anchored window misses the
real pileup at realistic calibration ROI sizes/positions (including the default centered
crosshair) when the ROI's noise ceiling sits above the true plateau — left a comment
there with details. This PR folds a corrected version of that idea in alongside the
ceiling fix.

## Verification

Against the reporter's real Nikon D800 files (`260819_Frame023_{R,G,B}.nef`), whole-frame
(not the production ROI, which reads more extreme). "Within budget" means the check would
let calibration proceed; "over budget" means it correctly aborts as clipped:

| channel | linearity fraction | plateau fraction |
|---|---|---|
| red | 0.550% — within budget (2%) | 0.145% — within budget (0.2%) |
| green | 33.4% — **over budget**, correctly rejected | 31.2% — **over budget**, correctly rejected |
| blue | 0.198% — within budget (2%) | 0.010% — within budget (0.2%) |

Blue's linearity reading (0.198%) used to sit right against the old shared 0.2% budget —
one noisy run from a false abort on a clean channel. It now passes comfortably. Green is
genuinely blown out and is correctly still rejected by both signals — this fix loosens
the budget only for clean channels near a conservative linearity limit, not for real
clipping, which is what the PR exists to catch in the first place.

`make all` clean. Full suite: 4562 passed, 2 pre-existing failures unrelated to this
change (missing optional `pyopticfilm` dependency for the Plustek flatbed backend,
present on `main` before this change too).

## Resolved from review

@light-sntchr's two points from the earlier review are both addressed: the `user_sat`
side effect is now called out explicitly above, and the linearity-limit/plateau
conflation is fixed by giving them separate budgets as described.
