### PR TITLE
fix(export): clamp Linear Output's triplet merge before it can overshoot

### DIFF
--- a/negpy/services/export/linear_output.py
+++ b/negpy/services/export/linear_output.py
@@ -694,6 +694,12 @@ def _decode_camera_raw_triplet(
         return buf
 
     f32 = merge_rgb_triplet(_decode, file_path, rgbscan.green_path, rgbscan.blue_path, align=rgbscan.align)
+    # merge_rgb_triplet's alignment warp runs on this float32 buffer (unlike the main render
+    # pipeline, which merges in uint16 and gets this for free from the saturate-cast): cubic
+    # interpolation can ring past 1.0 near a sharp edge, and nothing downstream clips before the
+    # final TIFF write, so a correction applied here would multiply an out-of-range value instead
+    # of the ceiling it stands in for.
+    f32 = np.clip(f32, 0.0, 1.0)
     if geometry is not None:
         f32 = _apply_user_geometry(f32, geometry)
     return f32, None, wb, merged_meta
@@ -725,6 +731,7 @@ def _decode_stitch_part(
             return buf
 
         f32 = merge_rgb_triplet(_decode, file_path, rgbscan.green_path, rgbscan.blue_path, align=rgbscan.align)
+        f32 = np.clip(f32, 0.0, 1.0)  # see _decode_camera_raw_triplet: the warp can ring past 1.0
     else:
         f32, _, _ = _decode_camera_raw_buffer(file_path)
 

--- a/tests/test_linear_output.py
+++ b/tests/test_linear_output.py
@@ -24,6 +24,7 @@ from negpy.services.export.linear_output import (
     _SourceMeta,
     _apply_white_balance,
     _build_xmp,
+    _decode_camera_raw_triplet,
     _decode_dng,
     _default_pakon_expansion,
     _effective_expansion,
@@ -950,6 +951,29 @@ class TestTripletExport:
         with tifffile.TiffFile(out) as tf:
             arr = tf.pages[0].asarray()
             assert arr.shape == (60, 40, 3)
+
+    def test_triplet_merge_clamps_alignment_ringing(self, tmp_path: str, monkeypatch) -> None:
+        """The alignment warp is cubic interpolation on a float32 buffer here (the main render
+        pipeline gets this clamp for free from its uint16 saturate-cast; this path does not), so
+        a sharp edge near the ceiling can ring past 1.0. Nothing downstream clips before a
+        correction (flatfield, WB) would read it, so the merge itself must clamp."""
+        paths = _make_fake_camera_raws(str(tmp_path))
+        h, w = 40, 60
+        r = np.full((h, w, 3), 0.1, dtype=np.float32)
+        g = np.full((h, w, 3), 0.1, dtype=np.float32)
+        g[:, 30:, 1] = 0.999  # a sharp edge right at the ceiling
+        b = np.full((h, w, 3), 0.1, dtype=np.float32)
+        bufs = {"r": r, "g": g, "b": b}
+
+        # A real fractional shift, so the warp interpolates instead of no-op'ing.
+        monkeypatch.setattr("negpy.features.rgbscan.logic.estimate_shift", lambda ref, mov: (0.4, 0.0))
+        rgbscan = RgbScanConfig(enabled=True, green_path=paths[1], blue_path=paths[2], align=True)
+
+        with self._patch_decode(paths, bufs):
+            f32, _ir, _wb, _meta = _decode_camera_raw_triplet(paths[0], rgbscan)
+
+        assert f32.max() <= 1.0
+        assert f32.min() >= 0.0
 
     def test_no_triplet_without_rgbscan(self, tmp_path: str) -> None:
         """Without rgbscan config, camera RAW goes through the normal single-file path."""


### PR DESCRIPTION
## The bug

While investigating discussion #906 (narrowband camera-scan clipping, see #932), we found a
separate, unrelated issue: the RGB-triplet merge's alignment warp (`_align_to` in
`negpy/features/rgbscan/logic.py`, cubic interpolation) can ring past 1.0 near a sharp edge —
normal cubic-resampling behavior, not specific to NegPy.

In the main render pipeline this is harmless: it merges in uint16, so `cv2.warpAffine`'s
saturate-cast clamps any overshoot to `[0, 65535]` at the moment of the warp, before anything
else touches the data. Measured on a real triplet: negligible practical impact (0 false-clip
green pixels, 65/36.3M blue pixels affected, all already essentially at the ceiling beforehand).

Linear Output's triplet decode is different: `_decode_camera_raw_buffer` converts to float32
*before* the merge runs, so the warp operates on float32 and nothing clamps it. When flatfield
or white-balance correction is then applied to that buffer, an out-of-range value gets multiplied
by a correction gain instead of the ceiling it stands in for — only the very last step of the
whole export (`_to_uint16_jit` at TIFF-write time) ever clips it, well after the point where it
should have been pinned.

Measured on the real reporter's D800 triplet with a realistic flatfield gain map: 934 final TIFF
pixels differ from what they'd be if clamped at merge time like the main pipeline (mean diff 104
counts, max 613 counts out of 65535 — small, but real and deterministic, in an export whose whole
purpose is untouched fidelity to the sensor data).

## The fix

`np.clip(f32, 0.0, 1.0)` right after the merge, in both `_decode_camera_raw_triplet` and
`_decode_stitch_part` — matching the convention every other decode branch in this file already
follows. Added a regression test (`test_triplet_merge_clamps_alignment_ringing`) that forces a
real fractional alignment shift and a sharp near-ceiling edge, confirmed it fails without the fix
(1.0956 > 1.0) and passes with it.

## Verification

`make all` clean. Full suite: 4552 passed, 2 pre-existing failures unrelated to this change
(missing optional `pyopticfilm` dependency for the Plustek flatbed backend, present on `main`
before this change too).
