### PR TITLE
perf: preview worst-case drags and export pipeline

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -19,6 +19,8 @@ on:
       - "negpy/desktop/workers/render.py"
       - "negpy/desktop/prefetch_logic.py"
       - "negpy/kernel/caching/logic.py"
+      - "negpy/services/rendering/image_processor.py"
+      - "negpy/services/rendering/gpu_engine.py"
       - "tests/metrics/**"
   pull_request:
     branches: [main]
@@ -28,6 +30,8 @@ on:
       - "negpy/desktop/workers/render.py"
       - "negpy/desktop/prefetch_logic.py"
       - "negpy/kernel/caching/logic.py"
+      - "negpy/services/rendering/image_processor.py"
+      - "negpy/services/rendering/gpu_engine.py"
       - "tests/metrics/**"
 
 concurrency:

--- a/negpy/desktop/view/sidebar/process.py
+++ b/negpy/desktop/view/sidebar/process.py
@@ -279,10 +279,10 @@ class ProcessSidebar(BaseSidebar):
         self.sync_ui()
 
     def _on_white_point_changed(self, val: float, persist: bool = True) -> None:
-        self.update_config_section("process", persist=persist, **{self._wp_field(): val})
+        self.update_config_section("process", persist=persist, readback_metrics=persist, **{self._wp_field(): val})
 
     def _on_black_point_changed(self, val: float, persist: bool = True) -> None:
-        self.update_config_section("process", persist=persist, **{self._bp_field(): val})
+        self.update_config_section("process", persist=persist, readback_metrics=persist, **{self._bp_field(): val})
 
     def _on_lock_bounds_toggled(self, checked: bool) -> None:
         self.update_config_section("process", lock_bounds=checked, persist=True, render=False)
@@ -315,6 +315,7 @@ class ProcessSidebar(BaseSidebar):
             "process",
             persist=persist,
             render=True,
+            readback_metrics=persist,
             analysis_buffer=val,
             **invalidate_local_bounds(self.state.config.process),
         )
@@ -325,6 +326,7 @@ class ProcessSidebar(BaseSidebar):
             "process",
             persist=persist,
             render=True,
+            readback_metrics=persist,
             luma_range_clip=_luma_range_slider_to_value(val),
             **invalidate_local_bounds(self.state.config.process),
         )
@@ -334,6 +336,7 @@ class ProcessSidebar(BaseSidebar):
             "process",
             persist=persist,
             render=True,
+            readback_metrics=persist,
             color_range_clip=_color_slider_to_value(val),
             **invalidate_local_bounds(self.state.config.process),
         )

--- a/negpy/desktop/view/sidebar/right_panel.py
+++ b/negpy/desktop/view/sidebar/right_panel.py
@@ -253,7 +253,6 @@ class RightPanel(QWidget):
 
     def _connect_signals(self) -> None:
         self.controller.image_updated.connect(self._update_analysis)
-        self.controller.metrics_available.connect(self._update_histograms)
         self.controller.pixel_readout_rgb.connect(self.curve_widget.set_marker)
         self.controller.densitometer_readout.connect(self._on_densitometer)
         self.controller.zone_pins_changed.connect(self._refresh_zone_placement)
@@ -399,7 +398,9 @@ class RightPanel(QWidget):
         if metrics.get("interactive"):
             return
 
-        # Histograms refresh on metrics_available, which follows every settled render.
+        # The only histogram refresh: a peek paint emits image_updated without
+        # metrics_available, so this path must cover it.
+        self._update_histograms(metrics)
         # Measured zones read through the current config, so they track every render.
         self._refresh_zone_placement()
 

--- a/negpy/desktop/view/sidebar/right_panel.py
+++ b/negpy/desktop/view/sidebar/right_panel.py
@@ -2,7 +2,7 @@ from typing import Any, Dict
 
 import numpy as np
 import qtawesome as qta
-from PyQt6.QtCore import Qt, QSize
+from PyQt6.QtCore import Qt, QSize, QTimer
 from PyQt6.QtWidgets import (
     QPushButton,
     QScrollArea,
@@ -263,8 +263,13 @@ class RightPanel(QWidget):
         self.zone_placement.apply_clicked.connect(self.controller.apply_zone_placement)
         self.zone_placement.remove_clicked.connect(self.controller.remove_zone_pin)
         self.controller.tone_drag_changed.connect(self.curve_widget.set_active_param)
-        self.controller.config_updated.connect(self.export_sidebar.sync_ui)
-        self.controller.config_updated.connect(self.metadata_sidebar.sync_ui)
+        # These two sync_ui calls scan gear/template files; never per drag tick.
+        self._sync_debounce = QTimer()
+        self._sync_debounce.setSingleShot(True)
+        self._sync_debounce.setInterval(150)
+        self._sync_debounce.timeout.connect(self.export_sidebar.sync_ui)
+        self._sync_debounce.timeout.connect(self.metadata_sidebar.sync_ui)
+        self.controller.config_updated.connect(self._sync_debounce.start)
         self.controls_panel.modified_synced.connect(self._sync_tab_edited)
 
     def _sync_tab_edited(self) -> None:
@@ -394,7 +399,7 @@ class RightPanel(QWidget):
         if metrics.get("interactive"):
             return
 
-        self._update_histograms(metrics)
+        # Histograms refresh on metrics_available, which follows every settled render.
         # Measured zones read through the current config, so they track every render.
         self._refresh_zone_placement()
 

--- a/negpy/desktop/view/sidebar/sensor.py
+++ b/negpy/desktop/view/sidebar/sensor.py
@@ -313,6 +313,7 @@ class SensorSidebar(BaseSidebar):
             "process",
             persist=persist,
             render=True,
+            readback_metrics=persist,
             crosstalk_strength=val,
             **invalidate_local_bounds(self.state.config.process),
         )
@@ -374,7 +375,7 @@ class SensorSidebar(BaseSidebar):
 
     def _on_hue_trim_changed(self, val: float, persist: bool = True) -> None:
         # Sticky on commit only, so a drag doesn't write every intermediate value.
-        self.update_config_section("process", hue_trim=val, persist=persist)
+        self.update_config_section("process", hue_trim=val, persist=persist, readback_metrics=persist)
 
     def sync_ui(self) -> None:
         conf = self.state.config.process

--- a/negpy/desktop/workers/export.py
+++ b/negpy/desktop/workers/export.py
@@ -6,7 +6,7 @@ import tempfile
 import threading
 from PyQt6.QtCore import QObject, pyqtSignal, pyqtSlot
 from negpy.domain.models import ColorSpace, WorkspaceConfig, ExportConfig, ExportFormat, ExportPreset, ExportPresetOutputMode
-from negpy.features.metadata.writer import embed_metadata, preserve_source_metadata
+from negpy.features.metadata.writer import embed_metadata, export_embed_plan, preserve_source_metadata
 from negpy.features.metadata.models import MetadataConfig
 from negpy.infrastructure.display.color_spaces import WORKING_COLOR_SPACE, ColorSpaceRegistry
 from negpy.services.rendering.image_processor import ImageProcessor
@@ -155,6 +155,16 @@ class ExportWorker(QObject):
                 name = os.path.splitext(full_name)[0]
                 self.progress.emit(i + 1, total, name)
 
+                # TIFF/PNG take the metadata at the first encode; the post-hoc
+                # rewrite re-compresses the full-res file.
+                embed_plan = None
+                if task.metadata_config is not None and task.export_settings.export_fmt in (ExportFormat.TIFF, ExportFormat.PNG):
+                    embed_plan = export_embed_plan(
+                        task.metadata_config,
+                        task.source_exif,
+                        task.file_info["path"],
+                    )
+
                 bits, status = self._processor.process_export(
                     task.file_info["path"],
                     task.params,
@@ -168,6 +178,7 @@ class ExportWorker(QObject):
                     crop_rect=tuple(task.file_info["crop_rect"]) if task.file_info.get("crop_rect") else None,
                     gutter_thickness=float(task.file_info.get("gutter_thickness") or 0.0),
                     diptych=task.diptych,
+                    embed_plan=embed_plan,
                 )
 
                 if not bits:
@@ -177,7 +188,7 @@ class ExportWorker(QObject):
                     continue
 
                 if bits:
-                    if task.metadata_config is not None:
+                    if task.metadata_config is not None and embed_plan is None:
                         if task.metadata_config.protect_original_metadata:
                             bits = preserve_source_metadata(
                                 bits,
@@ -209,18 +220,17 @@ class ExportWorker(QObject):
                         self.error.emit(str(write_err))
                         continue
 
-                # VRAM is evacuated per file. The decoded source is kept for a same-file next task, as
-                # with multi-format presets, and gc is deferred to once per batch.
+                # The engine evicts stale pool textures itself per render; the decoded
+                # source is kept until the next task needs a different file.
                 nxt = tasks[i + 1] if i + 1 < len(tasks) else None
-                self._processor.cleanup(
-                    release_source_cache=nxt is None or not _same_decode_source(task, nxt),
-                    collect=False,
-                )
+                if nxt is None or not _same_decode_source(task, nxt):
+                    self._processor.release_source_cache()
 
             self.finished.emit()
         except Exception as e:
             self.error.emit(str(e))
         finally:
+            self._processor.cleanup(release_source_cache=True, collect=False)
             gc.collect()
 
     @pyqtSlot(list)

--- a/negpy/features/exposure/normalization.py
+++ b/negpy/features/exposure/normalization.py
@@ -126,7 +126,15 @@ def _block_median_grid(img_log: ImageBuffer) -> ImageBuffer:
     grid_rows, c = hb // b, arr.shape[2]
 
     def _median(rows: np.ndarray) -> np.ndarray:
-        return np.median(rows.reshape(rows.shape[0] // b, b, wb // b, b, c), axis=(1, 3))
+        v = rows.reshape(rows.shape[0] // b, b, wb // b, b, c)
+        if b == 2:
+            # Median of 4 = (sum - min - max) / 2; strided views, no partition.
+            p00, p01, p10, p11 = v[:, 0, :, 0], v[:, 0, :, 1], v[:, 1, :, 0], v[:, 1, :, 1]
+            s = p00.astype(np.float64) + p01 + p10 + p11
+            mn = np.minimum(np.minimum(p00, p01), np.minimum(p10, p11))
+            mx = np.maximum(np.maximum(p00, p01), np.maximum(p10, p11))
+            return ((s - mn - mx) * 0.5).astype(rows.dtype, copy=False)
+        return np.median(v, axis=(1, 3))
 
     workers = min(os.cpu_count() or 1, grid_rows)
     if workers < 2 or hb * wb < _BLOCK_MEDIAN_PARALLEL_MIN_PIXELS:

--- a/negpy/features/metadata/writer.py
+++ b/negpy/features/metadata/writer.py
@@ -6,7 +6,7 @@ import logging
 import re
 import struct
 from fractions import Fraction
-from typing import Optional
+from typing import Any, Optional
 
 import piexif
 import tifffile
@@ -405,15 +405,12 @@ def embed_jxl_boxes(
         return image_bytes
 
 
-def embed_metadata(
-    image_bytes: bytes,
+def _merged_exif_and_payload(
     config: MetadataConfig,
     source_exif: Optional[dict],
     gear: Optional[GearLibrary] = None,
-) -> bytes:
-    """
-    Insert custom metadata + preserved source EXIF + XMP into exported image bytes.
-    """
+) -> tuple[dict, Any]:
+    """Source EXIF merged with the config's custom fields, plus the resolved payload."""
     payload = _resolve_payload(config, gear, source_exif)
 
     if source_exif is not None:
@@ -440,7 +437,19 @@ def embed_metadata(
     merged.setdefault("0th", {})[piexif.ImageIFD.Orientation] = 1
     if isinstance(merged.get("1st"), dict):
         merged["1st"].pop(piexif.ImageIFD.Orientation, None)
+    return merged, payload
 
+
+def embed_metadata(
+    image_bytes: bytes,
+    config: MetadataConfig,
+    source_exif: Optional[dict],
+    gear: Optional[GearLibrary] = None,
+) -> bytes:
+    """
+    Insert custom metadata + preserved source EXIF + XMP into exported image bytes.
+    """
+    merged, payload = _merged_exif_and_payload(config, source_exif, gear)
     xmp_bytes = build_xmp_bytes(payload) if payload.has_any_data() else None
 
     try:
@@ -647,6 +656,46 @@ def _tiff_metadata_from_exif_bytes(exif_bytes: bytes) -> tuple[dict | None, str 
     return (metadata or None), software
 
 
+def tiff_metadata_kwargs(exif_bytes: bytes, xmp_bytes: Optional[bytes] = None, *, fold_user_comment: bool = True) -> dict:
+    """tifffile.imwrite kwargs carrying the EXIF/XMP payload, for embedding at the
+    first encode."""
+    description, extratags = _exif_bytes_to_extratags(exif_bytes)
+    if fold_user_comment:
+        description = _fold_user_comment_into_description(description, extratags)
+    if xmp_bytes:
+        extratags.append((_TIFF_XMP_TAG, 7, len(xmp_bytes), xmp_bytes, True))
+    metadata, software = _tiff_metadata_from_exif_bytes(exif_bytes)
+    if fold_user_comment:
+        # Artist and Copyright reach the file through extratags on the embed path.
+        metadata = None
+    return {"description": description or "", "metadata": metadata, "software": software, "extratags": extratags}
+
+
+def export_embed_plan(
+    config: Optional[MetadataConfig],
+    source_exif: Optional[dict],
+    source_path: str,
+    gear: Optional[GearLibrary] = None,
+) -> Optional[tuple[bytes, Optional[bytes], bool]]:
+    """(exif_bytes, xmp_bytes, fold_user_comment) for embedding at first encode.
+    None when there is nothing to embed or the payload cannot be built; the
+    caller then keeps the post-hoc rewrite path."""
+    if config is None:
+        return None
+    try:
+        if config.protect_original_metadata:
+            exif_dict = _load_source_exif(source_path, source_exif)
+            if not exif_dict:
+                return None
+            return piexif.dump(_sanitize_exif(exif_dict)), _read_xmp_from_source(source_path), False
+        merged, payload = _merged_exif_and_payload(config, source_exif, gear)
+        xmp_bytes = build_xmp_bytes(payload) if payload.has_any_data() else None
+        return piexif.dump(_sanitize_exif(merged)), xmp_bytes, True
+    except Exception:
+        _log.warning("metadata embed plan failed", exc_info=True)
+        return None
+
+
 def _rewrite_tiff_preserve(
     image_bytes: bytes,
     exif_bytes: bytes,
@@ -666,28 +715,13 @@ def _rewrite_tiff_preserve(
         compression = page.compression.name.lower() if int(page.compression) != 1 else None
         icc = page.iccprofile
 
-    description, extratags = _exif_bytes_to_extratags(exif_bytes)
-    if fold_user_comment:
-        description = _fold_user_comment_into_description(description, extratags)
-
-    if xmp_bytes:
-        extratags.append((_TIFF_XMP_TAG, 7, len(xmp_bytes), xmp_bytes, True))
-
-    metadata, software = _tiff_metadata_from_exif_bytes(exif_bytes)
-    if fold_user_comment:
-        # Artist and Copyright reach the file through extratags on the embed path.
-        metadata = None
-
     tifffile.imwrite(
         output,
         arr,
         photometric=photometric,
         compression=compression,
         iccprofile=icc,
-        description=description or "",
-        metadata=metadata,
-        software=software,
-        extratags=extratags,
+        **tiff_metadata_kwargs(exif_bytes, xmp_bytes, fold_user_comment=fold_user_comment),
     )
 
 

--- a/negpy/features/retouch/logic.py
+++ b/negpy/features/retouch/logic.py
@@ -1029,6 +1029,16 @@ def apply_ir_attenuation(img: ImageBuffer, gain_det: np.ndarray) -> ImageBuffer:
     return ensure_image(cv2.multiply(np.ascontiguousarray(img, dtype=np.float32), gain))
 
 
+def luma_bake_token(retouch) -> str:
+    """Config identity of the auto speck repair, folded into source_hash so the
+    Dust Removal toggle invalidates the uploaded source (mirrors ir_bake_token).
+    hair_bake_token cannot cover this: it joins the hash only when a hair was
+    actually detected, and the speck fill runs regardless."""
+    if not retouch.dust_remove:
+        return ""
+    return f"|dust{round(float(retouch.dust_threshold), 3)}_{int(retouch.dust_size)}"
+
+
 def ir_bake_token(retouch, has_ir: bool) -> str:
     """Config-identity token for the IR bake (mirrors ``flatfield_token``); folded into
     source_hash so a toggle or threshold drag invalidates the engine cache."""

--- a/negpy/infrastructure/display/icc_lut.py
+++ b/negpy/infrastructure/display/icc_lut.py
@@ -8,7 +8,7 @@ interpolation. The interpolation keeps the 16-bit dynamic range smooth;
 per-sample fidelity is 8-bit (bounded by LUT size and profile non-linearity).
 """
 
-from typing import Any
+from typing import Any, Optional
 import numpy as np
 from numba import prange  # type: ignore
 from PIL import Image, ImageCms
@@ -197,3 +197,75 @@ def apply_icc_u16_greyscale(
     full_lut = np.interp(np.arange(65536, dtype=np.float64), xs, diag.astype(np.float64))
     full_lut = np.clip(full_lut * 65535.0 + 0.5, 0, 65535).astype(np.uint16)
     return full_lut[img_u16]
+
+
+@parallel_njit(cache=True, fastmath=True)
+def _matrix_trc_u8_jit(img: np.ndarray, dec_lut: np.ndarray, m: np.ndarray, enc_lut: np.ndarray) -> np.ndarray:
+    h = img.shape[0]
+    w = img.shape[1]
+    kmax = enc_lut.shape[1] - 1
+    out = np.empty_like(img)
+    for y in prange(h):
+        for x in range(w):
+            r = dec_lut[0, img[y, x, 0]]
+            g = dec_lut[1, img[y, x, 1]]
+            b = dec_lut[2, img[y, x, 2]]
+            for c in range(3):
+                v = m[c, 0] * r + m[c, 1] * g + m[c, 2] * b
+                if v < 0.0:
+                    v = 0.0
+                elif v > 1.0:
+                    v = 1.0
+                f = v * kmax
+                i0 = int(f)
+                if i0 >= kmax:
+                    i0 = kmax - 1
+                d = f - i0
+                e = enc_lut[c, i0] * (1.0 - d) + enc_lut[c, i0 + 1] * d
+                vi = int(e * 255.0 + 0.5)
+                if vi < 0:
+                    vi = 0
+                elif vi > 255:
+                    vi = 255
+                out[y, x, c] = vi
+    return out
+
+
+_ENC_LUT_SIZE = 65536
+
+
+def apply_matrix_trc_u8(img_u8: np.ndarray, src_icc: bytes, dst_icc: bytes) -> Optional[np.ndarray]:
+    """Relative-colorimetric transform between two matrix/TRC profiles on a (H,W,3)
+    uint8 image: TRC decode, inv(dst_pcs) @ src_pcs with gamut clip, TRC encode.
+    None when either profile is not matrix/TRC; the caller falls back to lcms."""
+    from negpy.infrastructure.display.icc_profile import (
+        extract_pcs_matrix,
+        extract_trc_decode_samples,
+        is_matrix_trc_profile,
+    )
+
+    if not (is_matrix_trc_profile(src_icc) and is_matrix_trc_profile(dst_icc)):
+        return None
+    m_src = extract_pcs_matrix(src_icc)
+    m_dst = extract_pcs_matrix(dst_icc)
+    if m_src is None or m_dst is None:
+        return None
+    dec = extract_trc_decode_samples(src_icc, np.linspace(0.0, 1.0, 256))
+    dst_dec_dense = extract_trc_decode_samples(dst_icc, np.linspace(0.0, 1.0, _ENC_LUT_SIZE))
+    if dec is None or dst_dec_dense is None:
+        return None
+    try:
+        m = np.linalg.inv(m_dst) @ m_src
+    except np.linalg.LinAlgError:
+        return None
+    # The accumulate guards interp against a flat toe in a table-based curve.
+    x_enc = np.linspace(0.0, 1.0, _ENC_LUT_SIZE)
+    lin_grid = x_enc
+    enc_rows = []
+    for ch in range(3):
+        d = np.maximum.accumulate(np.clip(dst_dec_dense[ch], 0.0, 1.0))
+        enc_rows.append(np.interp(lin_grid, d, x_enc))
+    enc_lut = np.ascontiguousarray(np.stack(enc_rows).astype(np.float32))
+    dec_lut = np.ascontiguousarray(np.clip(dec, 0.0, 1.0).astype(np.float32))
+    m32 = np.ascontiguousarray(m.astype(np.float32))
+    return _matrix_trc_u8_jit(np.ascontiguousarray(img_u8), dec_lut, m32, enc_lut)

--- a/negpy/infrastructure/display/icc_profile.py
+++ b/negpy/infrastructure/display/icc_profile.py
@@ -89,6 +89,83 @@ def is_matrix_trc_profile(data: bytes) -> bool:
     return has_colorants and has_trc and not has_lut
 
 
+def extract_pcs_matrix(data: bytes) -> Optional[np.ndarray]:
+    """The raw PCS(D50)-relative RGB→XYZ matrix from the colorant tags, unadapted.
+
+    Relative-colorimetric lcms is exactly inv(dst_pcs) @ src_pcs; the D65-referenced
+    matrices from extract_primaries_matrix would fold in Bradford adaptations lcms
+    never applies.
+    """
+    tags = _read_tag_table(data)
+    cols = []
+    for sig in (b"rXYZ", b"gXYZ", b"bXYZ"):
+        entry = tags.get(sig)
+        if entry is None:
+            return None
+        xyz = _read_xyz_tag(data, *entry)
+        if xyz is None:
+            return None
+        cols.append(xyz)
+    return np.column_stack(cols)
+
+
+def _decode_trc_at(data: bytes, offset: int, size: int, x: np.ndarray) -> Optional[np.ndarray]:
+    """One TRC tag's decode (encoded → linear) at points ``x`` in [0, 1].
+    Handles 'curv' and 'para' types 0-4 (ICC spec §10.18); None on anything else."""
+    sig = data[offset : offset + 4]
+    if sig == b"curv":
+        if size < 12:
+            return None
+        count = struct.unpack_from(">I", data, offset + 8)[0]
+        if count == 0:
+            return x.astype(np.float64)
+        if count == 1:
+            g = struct.unpack_from(">H", data, offset + 12)[0] / 256.0
+            return np.power(x, g)
+        if offset + 12 + count * 2 > len(data):
+            return None
+        vals = np.frombuffer(data, dtype=">u2", count=count, offset=offset + 12).astype(np.float64) / 65535.0
+        return np.interp(x, np.linspace(0.0, 1.0, count), vals)
+    if sig == b"para":
+        if size < 12:
+            return None
+        ftype = struct.unpack_from(">H", data, offset + 8)[0]
+        nparams = {0: 1, 1: 3, 2: 4, 3: 5, 4: 7}.get(ftype)
+        if nparams is None or offset + 12 + nparams * 4 > len(data):
+            return None
+        p = [struct.unpack_from(">i", data, offset + 12 + 4 * i)[0] / 65536.0 for i in range(nparams)]
+        if ftype == 0:
+            return np.power(x, p[0])
+        if ftype == 1:
+            g, a, b = p
+            return np.where(x >= -b / a, np.power(np.clip(a * x + b, 0.0, None), g), 0.0)
+        if ftype == 2:
+            g, a, b, c = p
+            return np.where(x >= -b / a, np.power(np.clip(a * x + b, 0.0, None), g) + c, c)
+        if ftype == 3:
+            g, a, b, c, d = p
+            return np.where(x >= d, np.power(np.clip(a * x + b, 0.0, None), g), c * x)
+        g, a, b, c, d, e, f = p
+        return np.where(x >= d, np.power(np.clip(a * x + b, 0.0, None), g) + e, c * x + f)
+    return None
+
+
+def extract_trc_decode_samples(data: bytes, x: np.ndarray) -> Optional[np.ndarray]:
+    """(3, len(x)) float64: the r/g/bTRC decodes at encoded points ``x``, or None
+    when a tag is missing or of an unsupported curve type."""
+    tags = _read_tag_table(data)
+    rows = []
+    for sig in (b"rTRC", b"gTRC", b"bTRC"):
+        entry = tags.get(sig)
+        if entry is None:
+            return None
+        row = _decode_trc_at(data, *entry, x)
+        if row is None:
+            return None
+        rows.append(row)
+    return np.stack(rows)
+
+
 def extract_primaries_matrix(data: bytes) -> Optional[np.ndarray]:
     """Extract the 3x3 D65-referenced RGB→XYZ matrix from rXYZ/gXYZ/bXYZ colorant tags.
 

--- a/negpy/services/assets/gear.py
+++ b/negpy/services/assets/gear.py
@@ -77,14 +77,30 @@ class GearProfiles:
         user = GearProfiles._read_list(os.path.join(GearProfiles._gear_dir(), fname), factory)
         return GearProfiles._merge(bundled, user)
 
+    # (user-file mtime stamp, library); bundled files are static per install.
+    _library_cache: tuple[tuple, GearLibrary] | None = None
+
     @staticmethod
     def load_library() -> GearLibrary:
-        return GearLibrary(
+        gear_dir = GearProfiles._gear_dir()
+        stamp = []
+        for fname in (_CAMERAS_FILE, _LENSES_FILE, _FILM_STOCKS_FILE, _GEAR_PRESETS_FILE):
+            try:
+                stamp.append(os.stat(os.path.join(gear_dir, fname)).st_mtime_ns)
+            except OSError:
+                stamp.append(None)
+        key = tuple(stamp)
+        cached = GearProfiles._library_cache
+        if cached is not None and cached[0] == key:
+            return cached[1]
+        library = GearLibrary(
             cameras=GearProfiles._load_merged(_CAMERAS_FILE, Camera),
             lenses=GearProfiles._load_merged(_LENSES_FILE, Lens),
             film_stocks=GearProfiles._load_merged(_FILM_STOCKS_FILE, FilmStock),
             gear_presets=GearProfiles._load_merged(_GEAR_PRESETS_FILE, GearPreset),
         )
+        GearProfiles._library_cache = (key, library)
+        return library
 
     @staticmethod
     def save_cameras(cameras: list[Camera]) -> None:

--- a/negpy/services/export/contact_sheet_templates.py
+++ b/negpy/services/export/contact_sheet_templates.py
@@ -57,6 +57,9 @@ class ContactSheetTemplates:
 
     DEFAULT_NAME = DEFAULT_NAME
 
+    # (mtime stamp, parsed layouts): the TOML parse re-runs only on a file change.
+    _scan_cache: Optional[tuple[tuple, Dict[str, ContactSheetLayout]]] = None
+
     @staticmethod
     def _templates_dir() -> str:
         return APP_CONFIG.contact_sheet_templates_dir
@@ -68,9 +71,15 @@ class ContactSheetTemplates:
         templates_dir = ContactSheetTemplates._templates_dir()
         if not os.path.isdir(templates_dir):
             return result
-        for fname in os.listdir(templates_dir):
-            if not fname.endswith(".toml"):
-                continue
+        try:
+            with os.scandir(templates_dir) as entries:
+                stamp = tuple(sorted((e.name, e.stat().st_mtime_ns) for e in entries if e.name.endswith(".toml")))
+        except OSError:
+            stamp = None
+        cached = ContactSheetTemplates._scan_cache
+        if stamp is not None and cached is not None and cached[0] == stamp:
+            return cached[1]
+        for fname, _mtime in stamp or ():
             path = os.path.join(templates_dir, fname)
             parsed = ContactSheetTemplates._parse_file(path)
             if parsed is None:
@@ -78,6 +87,8 @@ class ContactSheetTemplates:
             name, layout = parsed
             if name != DEFAULT_NAME:
                 result[name] = layout
+        if stamp is not None:
+            ContactSheetTemplates._scan_cache = (stamp, result)
         return result
 
     @staticmethod

--- a/negpy/services/rendering/gpu_engine.py
+++ b/negpy/services/rendering/gpu_engine.py
@@ -118,13 +118,28 @@ def _keystone_inverse_bytes(converge_v: float, converge_h: float) -> bytes:
 
 
 def _analysis_cache_key(settings: WorkspaceConfig, analysis_source_hash: str) -> tuple:
-    """Identity of the auto-exposure analysis for a frame. Mirrors the CPU base-stage
-    cache key (engine.py) plus the fields that gate refs/anchor/textural, so it survives
-    creative-slider drags but invalidates on anything the meter actually reads."""
+    """Identity of the auto-exposure analysis: only the fields the meter reads.
+    White/black point offsets and trims apply downstream as uniforms and must
+    not invalidate it."""
     e = settings.exposure
+    p = settings.process
     return (
         analysis_source_hash,
-        settings.process,
+        p.process_mode,
+        p.analysis_buffer,
+        p.analysis_rect,
+        p.luma_range_clip,
+        p.color_range_clip,
+        p.e6_normalize,
+        p.use_luma_average,
+        p.use_color_average,
+        p.locked_floors,
+        p.locked_ceils,
+        p.local_floors,
+        p.local_ceils,
+        p.crosstalk_strength,
+        p.crosstalk_matrix,
+        p.crosstalk_process,
         settings.geometry,
         e.cast_removal_strength > 0.0,
         e.auto_exposure,
@@ -200,6 +215,8 @@ class GPUEngine:
         self._buffers: Dict[str, GPUBuffer] = {}
         self._sampler: Optional[Any] = None
         self._tex_cache: Dict[Tuple[int, int, int, str], GPUTexture] = {}
+        self._tex_gen: Dict[Tuple[int, int, int, str], int] = {}
+        self._render_gen: int = 0
 
         self._uniform_names = [
             "geometry",
@@ -240,6 +257,8 @@ class GPUEngine:
         self._analysis_cache: Optional[tuple] = None
         # (analysis_key, per-channel clipped fractions) for the scan-exposure warning.
         self._clip_cache: Optional[tuple] = None
+        # (key, prefiltered grid, clip fractions), keyed without the clip sliders.
+        self._prefilter_cache: Optional[tuple] = None
         self._last_settings: Optional[WorkspaceConfig] = None
         self._last_targets_rev: int = -1
         self._last_scale_factor: float = 1.0
@@ -256,13 +275,15 @@ class GPUEngine:
 
         # Persistent staging buffers, so no create_buffer() per readback
         self._metrics_staging: Optional[Any] = None
-        # (prb, height, buffer): reused when image size and rotation are unchanged
-        self._downsample_staging: Optional[Tuple[int, int, Any]] = None
+        # slot -> (prb, height, buffer): the tiled path alternates two slots.
+        self._downsample_staging: Dict[int, Tuple[int, int, Any]] = {}
 
         # (key, grid): a pure function of geometry, reused across settled frames
         self._uv_grid_cache: Optional[Tuple[Tuple, np.ndarray]] = None
         # Identity of the dodge/burn EV map currently sitting in the local_ev texture.
         self._local_ev_key: Optional[Tuple] = None
+        # (key, maps): mask raster, keyed without grade; grade only rescales plane 1 at upload.
+        self._local_maps_cache: Optional[Tuple[Tuple, Optional[np.ndarray]]] = None
         self._mask_plane: Optional[Tuple[Tuple, np.ndarray, float]] = None
         # Identity of the plane currently sitting in the contrast_mask texture.
         self._mask_tex_key: Optional[Tuple] = None
@@ -334,7 +355,24 @@ class GPUEngine:
         key = (w, h, usage, label)
         if key not in self._tex_cache:
             self._tex_cache[key] = GPUTexture(w, h, usage=usage)
+        self._tex_gen[key] = self._render_gen
         return self._tex_cache[key]
+
+    def evict_stale_textures(self) -> None:
+        """Drop pool textures untouched by the previous render. Bounds batch-export
+        VRAM: a same-dimensions roll keeps its chain, a dimension change frees the
+        old one a render later."""
+        self._render_gen += 1
+        stale = [k for k, gen in self._tex_gen.items() if gen < self._render_gen - 1]
+        if not stale:
+            return
+        for key in stale:
+            tex = self._tex_cache.pop(key, None)
+            self._tex_gen.pop(key, None)
+            if tex is not None:
+                tex.destroy()
+        # Bind groups keyed by id() never match a destroyed view again; drop, don't leak.
+        self._bind_group_cache.clear()
 
     def _init_resources(self) -> None:
         """Initializes hardware pipelines and persistent buffers."""
@@ -536,45 +574,66 @@ class GPUEngine:
         needs_anchor = metered_anchor_override is None and not tiling_mode and (settings.exposure.auto_exposure or readback_metrics)
         needs_textural = textural_range_override is None and not tiling_mode and settings.exposure.auto_normalize_contrast
 
-        analysis_source = None
         prefiltered = None
+        scan_clip_fractions = None
+        analysis_source = None
         unmix_m = effective_crosstalk_matrix(settings.process, settings.process.process_mode)
         if needs_bounds_analysis or needs_refs or needs_anchor or needs_textural:
-            # Use views to avoid copying the full-res image; crop to ROI first.
-            analysis_source = img
-            if settings.geometry.rotation != 0:
-                analysis_source = np.rot90(analysis_source, k=settings.geometry.rotation)
-            if settings.geometry.flip_horizontal:
-                analysis_source = np.fliplr(analysis_source)
-            if settings.geometry.flip_vertical:
-                analysis_source = np.flipud(analysis_source)
-            # A freehand analysis_rect overrides the crop ROI and centered buffer, like the
-            # CPU path. Tiled export uses explicit overrides, so it stays on the ROI.
-            base_roi = roi if not tiling_mode else None
-            analysis_roi, an_buffer = resolve_analysis_region(
-                analysis_source.shape,
-                base_roi,
-                settings.process.analysis_buffer,
-                settings.process.analysis_rect if not tiling_mode else None,
+            # Keyed without the clip sliders: a clip drag reuses the grid and
+            # re-runs only the percentile analysis.
+            p = settings.process
+            prefilter_key = (
+                (
+                    analysis_source_hash,
+                    settings.geometry,
+                    roi,
+                    p.analysis_buffer,
+                    p.analysis_rect,
+                    p.crosstalk_strength,
+                    p.crosstalk_matrix,
+                    p.crosstalk_process,
+                    p.process_mode,
+                )
+                if analysis_source_hash is not None and not tiling_mode
+                else None
             )
-            if analysis_roi is not None:
-                ay1, ay2, ax1, ax2 = analysis_roi
-                analysis_source = np.ascontiguousarray(analysis_source[ay1:ay2, ax1:ax2])
-            if settings.geometry.fine_rotation != 0.0:
-                analysis_source = apply_fine_rotation(analysis_source, settings.geometry.fine_rotation)
-            # The meters must read the frame the print stage gets. The CPU engine
-            # normalizes the keystoned buffer, so this replay has to carry it too or the
-            # two engines measure different bounds.
-            analysis_source = apply_keystone(analysis_source, settings.geometry.converge_v, settings.geometry.converge_h)
+            if prefilter_key is not None and self._prefilter_cache is not None and self._prefilter_cache[0] == prefilter_key:
+                prefiltered, scan_clip_fractions = self._prefilter_cache[1], self._prefilter_cache[2]
+            else:
+                # Use views to avoid copying the full-res image; crop to ROI first.
+                analysis_source = img
+                if settings.geometry.rotation != 0:
+                    analysis_source = np.rot90(analysis_source, k=settings.geometry.rotation)
+                if settings.geometry.flip_horizontal:
+                    analysis_source = np.fliplr(analysis_source)
+                if settings.geometry.flip_vertical:
+                    analysis_source = np.flipud(analysis_source)
+                # A freehand analysis_rect overrides the crop ROI and centered buffer, like the
+                # CPU path. Tiled export uses explicit overrides, so it stays on the ROI.
+                base_roi = roi if not tiling_mode else None
+                analysis_roi, an_buffer = resolve_analysis_region(
+                    analysis_source.shape,
+                    base_roi,
+                    settings.process.analysis_buffer,
+                    settings.process.analysis_rect if not tiling_mode else None,
+                )
+                if analysis_roi is not None:
+                    ay1, ay2, ax1, ax2 = analysis_roi
+                    analysis_source = np.ascontiguousarray(analysis_source[ay1:ay2, ax1:ax2])
+                if settings.geometry.fine_rotation != 0.0:
+                    analysis_source = apply_fine_rotation(analysis_source, settings.geometry.fine_rotation)
+                # The meters must read the frame the print stage gets. The CPU engine
+                # normalizes the keystoned buffer, so this replay has to carry it too or the
+                # two engines measure different bounds.
+                analysis_source = apply_keystone(analysis_source, settings.geometry.converge_v, settings.geometry.converge_h)
 
-            analysis_source = _downsample_for_analysis(analysis_source, APP_CONFIG.preview_render_size)
-            # Shared prefilter, once for all five meters (ROI already applied).
-            # Unmixed like the CPU path so every meter reads the unmixed film.
-            prefiltered = unmix_log_image(prefilter_log_grid(analysis_source, None, an_buffer), unmix_m)
-
-        scan_clip_fractions = None
-        if analysis_source is not None:
-            scan_clip_fractions = measure_clip_fractions(analysis_source, None, an_buffer)
+                analysis_source = _downsample_for_analysis(analysis_source, APP_CONFIG.preview_render_size)
+                # Shared prefilter, once for all five meters (ROI already applied).
+                # Unmixed like the CPU path so every meter reads the unmixed film.
+                prefiltered = unmix_log_image(prefilter_log_grid(analysis_source, None, an_buffer), unmix_m)
+                scan_clip_fractions = measure_clip_fractions(analysis_source, None, an_buffer)
+                if prefilter_key is not None:
+                    self._prefilter_cache = (prefilter_key, prefiltered, scan_clip_fractions)
             if analysis_key is not None:
                 self._clip_cache = (analysis_key, scan_clip_fractions)
         elif analysis_key is not None and self._clip_cache is not None and self._clip_cache[0] == analysis_key:
@@ -822,7 +881,7 @@ class GPUEngine:
                 # This stage re-runs for any exposure change, but the map only moves
                 # with the masks, the geometry and the grade.
                 tiled_maps = local_maps is not None
-                ev_key = (
+                raster_key = (
                     settings.local,
                     settings.geometry.rotation,
                     settings.geometry.fine_rotation,
@@ -831,26 +890,30 @@ class GPUEngine:
                     k1_eff,
                     settings.geometry.converge_v,
                     settings.geometry.converge_h,
-                    settings.exposure.grade,
                     orig_shape,
                     w_rot,
                     h_rot,
                 )
+                ev_key = (raster_key, settings.exposure.grade)
                 if tiled_maps or self._local_ev_key != ev_key:
                     if local_maps is None:
-                        local_maps = compute_local_maps(
-                            settings.local,
-                            h_rot,
-                            w_rot,
-                            orig_shape,
-                            rotation=settings.geometry.rotation,
-                            fine_rotation=settings.geometry.fine_rotation,
-                            flip_horizontal=settings.geometry.flip_horizontal,
-                            flip_vertical=settings.geometry.flip_vertical,
-                            distortion_k1=k1_eff,
-                            converge_v=settings.geometry.converge_v,
-                            converge_h=settings.geometry.converge_h,
-                        )
+                        if self._local_maps_cache is not None and self._local_maps_cache[0] == raster_key:
+                            local_maps = self._local_maps_cache[1]
+                        else:
+                            local_maps = compute_local_maps(
+                                settings.local,
+                                h_rot,
+                                w_rot,
+                                orig_shape,
+                                rotation=settings.geometry.rotation,
+                                fine_rotation=settings.geometry.fine_rotation,
+                                flip_horizontal=settings.geometry.flip_horizontal,
+                                flip_vertical=settings.geometry.flip_vertical,
+                                distortion_k1=k1_eff,
+                                converge_v=settings.geometry.converge_v,
+                                converge_h=settings.geometry.converge_h,
+                            )
+                            self._local_maps_cache = (raster_key, local_maps)
                     from negpy.features.exposure.logic import local_grade_factor_map
 
                     if local_maps is None:
@@ -1820,22 +1883,23 @@ class GPUEngine:
         read_buf.unmap()
         return data
 
-    def _readback_downsampled(self, tex: GPUTexture) -> np.ndarray:
-        """Reads back texture as float32 RGB array, handling hardware alignment."""
+    def _submit_readback(self, tex: GPUTexture, slot: int = 0) -> Optional[tuple]:
+        """Queues a texture→staging copy; _resolve_readback maps it later."""
         device = self.gpu.device
         if not device:
-            return np.zeros((1, 1, 3), dtype=np.float32)
+            return None
         prb = (tex.width * 16 + 255) & ~255
-        if self._downsample_staging is None or self._downsample_staging[:2] != (prb, tex.height):
-            if self._downsample_staging is not None:
-                self._downsample_staging[2].destroy()
+        cur = self._downsample_staging.get(slot)
+        if cur is None or cur[:2] != (prb, tex.height):
+            if cur is not None:
+                cur[2].destroy()
             read_buf = device.create_buffer(
                 size=prb * tex.height,
                 usage=wgpu.BufferUsage.COPY_DST | wgpu.BufferUsage.MAP_READ,
             )
-            self._downsample_staging = (prb, tex.height, read_buf)
+            self._downsample_staging[slot] = (prb, tex.height, read_buf)
         else:
-            read_buf = self._downsample_staging[2]
+            read_buf = cur[2]
         encoder = device.create_command_encoder()
         encoder.copy_texture_to_buffer(
             {"texture": tex.texture},
@@ -1843,15 +1907,27 @@ class GPUEngine:
             (tex.width, tex.height, 1),
         )
         device.queue.submit([encoder.finish()])
+        return (read_buf, prb, tex.width, tex.height)
+
+    @staticmethod
+    def _resolve_readback(handle: tuple) -> np.ndarray:
+        read_buf, prb, w, h = handle
         read_buf.map_sync(wgpu.MapMode.READ)
         try:
-            raw = np.frombuffer(read_buf.read_mapped(), dtype=np.uint8).reshape((tex.height, prb))
-            valid = raw[:, : tex.width * 16]
-            result = valid.view(np.float32).reshape((tex.height, tex.width, 4))
+            raw = np.frombuffer(read_buf.read_mapped(), dtype=np.uint8).reshape((h, prb))
+            valid = raw[:, : w * 16]
+            result = valid.view(np.float32).reshape((h, w, 4))
             # The texture is already display-encoded (output_encode pass).
             return result[:, :, :3]
         finally:
             read_buf.unmap()
+
+    def _readback_downsampled(self, tex: GPUTexture) -> np.ndarray:
+        """Reads back texture as float32 RGB array, handling hardware alignment."""
+        handle = self._submit_readback(tex)
+        if handle is None:
+            return np.zeros((1, 1, 3), dtype=np.float32)
+        return self._resolve_readback(handle)
 
     def _dispatch_pass(self, encoder: Any, pipeline_name: str, bindings: list, w: int, h: int) -> None:
         """Configures and dispatches a compute pass."""
@@ -1924,9 +2000,12 @@ class GPUEngine:
         readback_metrics: bool = True,
         cam_xyz: Optional[list] = None,
         camera_wb: Optional[list] = None,
+        source_hash: Optional[str] = None,
+        analysis_source_hash: Optional[str] = None,
     ) -> Tuple[np.ndarray, Dict[str, Any]]:
         """High-level processing entry point with automatic tiling."""
         self._init_resources()
+        self.evict_stale_textures()
         h, w = img.shape[:2]
         max_tex = self.gpu.limits.get("max_texture_dimension_2d", 8192)
         rot = settings.geometry.rotation % 4
@@ -1941,6 +2020,8 @@ class GPUEngine:
             readback_metrics=readback_metrics,
             cam_xyz=cam_xyz,
             camera_wb=camera_wb,
+            source_hash=source_hash,
+            analysis_source_hash=analysis_source_hash,
         )
         return self._readback_downsampled(tex_final), metrics
 
@@ -2126,6 +2207,10 @@ class GPUEngine:
             halo = max(halo, int(np.ceil(max(5.0, 25.0 * scale_factor))))
         halo = min(halo, 512)
 
+        # The queue serializes tile N's staging copy ahead of tile N+1's passes, so
+        # deferring the map_sync by one tile is safe and overlaps the wait.
+        pending: Optional[tuple] = None
+        tile_index = 0
         for ty in range(0, crop_h, TILE_SIZE):
             for tx in range(0, crop_w, TILE_SIZE):
                 tw, th = min(TILE_SIZE, crop_w - tx), min(TILE_SIZE, crop_h - ty)
@@ -2156,7 +2241,19 @@ class GPUEngine:
                     camera_wb=camera_wb,
                     contrast_mask_override=global_mask,
                 )
-                full_source_res[ty : ty + th, tx : tx + tw] = self._readback_downsampled(tile_res)[oy : oy + th, ox : ox + tw]
+                handle = self._submit_readback(tile_res, slot=tile_index % 2)
+                if pending is not None:
+                    p_handle, p_ty, p_tx, p_th, p_tw, p_oy, p_ox = pending
+                    full_source_res[p_ty : p_ty + p_th, p_tx : p_tx + p_tw] = self._resolve_readback(p_handle)[
+                        p_oy : p_oy + p_th, p_ox : p_ox + p_tw
+                    ]
+                pending = (handle, ty, tx, th, tw, oy, ox)
+                tile_index += 1
+        if pending is not None:
+            p_handle, p_ty, p_tx, p_th, p_tw, p_oy, p_ox = pending
+            full_source_res[p_ty : p_ty + p_th, p_tx : p_tx + p_tw] = self._resolve_readback(p_handle)[
+                p_oy : p_oy + p_th, p_ox : p_ox + p_tw
+            ]
 
         # Mirrors PrintService.apply_layout: only INTER_AREA is area-correct on a shrink.
         shrinking = content_w < crop_w or content_h < crop_h
@@ -2185,6 +2282,7 @@ class GPUEngine:
             if tex is not retain:
                 tex.destroy()
         self._tex_cache.clear()
+        self._tex_gen.clear()
         # Bind groups reference the destroyed views, so drop them.
         self._bind_group_cache.clear()
         self._bind_layout_cache.clear()
@@ -2194,6 +2292,7 @@ class GPUEngine:
         self._current_source_hash = None
         self._last_settings = None
         self._local_ev_key = None
+        self._local_maps_cache = None
         self._mask_tex_key = None
         if collect:
             gc.collect()
@@ -2205,9 +2304,9 @@ class GPUEngine:
         if self._metrics_staging is not None:
             self._metrics_staging.destroy()
             self._metrics_staging = None
-        if self._downsample_staging is not None:
-            self._downsample_staging[2].destroy()
-            self._downsample_staging = None
+        for staging in self._downsample_staging.values():
+            staging[2].destroy()
+        self._downsample_staging.clear()
         for buf in self._buffers.values():
             buf.destroy()
         self._buffers.clear()

--- a/negpy/services/rendering/image_processor.py
+++ b/negpy/services/rendering/image_processor.py
@@ -38,6 +38,7 @@ from negpy.features.retouch.logic import (
     downsample_ir,
     hair_bake_token,
     ir_bake_token,
+    luma_bake_token,
     ir_defect_score,
     ir_detect_cutoff,
     ir_detect_target,
@@ -500,6 +501,7 @@ class ImageProcessor:
             + sensor_token(settings.process)
             + ir_bake_token(settings.retouch, ir_buffer is not None)
             + manual_bake_token(settings.retouch)
+            + luma_bake_token(settings.retouch)
         )
 
         # Bake the IR correction before detection so meters/stats see the corrected buffer.
@@ -869,6 +871,7 @@ class ImageProcessor:
             + sensor_token(params.process)
             + ir_bake_token(params.retouch, ir_full is not None)
             + manual_bake_token(params.retouch)
+            + luma_bake_token(params.retouch)
         )
         f32_buffer, _, _, ir_routed = self._ir_bake(f32_buffer, ir_full, params, detect_key)
         orig_ret = params.retouch
@@ -1224,6 +1227,7 @@ class ImageProcessor:
                 + sensor_token(params.process)
                 + ir_bake_token(params.retouch, ir_full is not None)
                 + manual_bake_token(params.retouch)
+                + luma_bake_token(params.retouch)
             )
             f32_buffer, _, _, ir_routed = self._ir_bake(f32_buffer, ir_full, params, detect_key)
             orig_ret = params.retouch

--- a/negpy/services/rendering/image_processor.py
+++ b/negpy/services/rendering/image_processor.py
@@ -6,9 +6,10 @@ import rawpy
 import tifffile
 import imagecodecs
 import numpy as np
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import replace as dc_replace
 from functools import lru_cache
-from PIL import Image, ImageCms
+from PIL import Image, ImageCms, PngImagePlugin
 from typing import Callable, Tuple, Optional, Any, Dict, List, Sequence
 from negpy.kernel.system.logging import get_logger
 from negpy.kernel.system.config import APP_CONFIG
@@ -78,13 +79,20 @@ from negpy.infrastructure.loaders.helpers import (
 )
 from negpy.services.export.print import PrintService
 from negpy.infrastructure.display.color_spaces import ColorSpaceRegistry, WORKING_COLOR_SPACE
-from negpy.infrastructure.display.icc_lut import DEFAULT_LUT_SIZE, apply_icc_u16_rgb
+from negpy.infrastructure.display.icc_lut import DEFAULT_LUT_SIZE, apply_icc_u16_rgb, apply_matrix_trc_u8
 
 # Preview soft-proof LUT grid. Finer than the display LUT because the proof clips at the
 # output gamut boundary, and interpolating across that kink is where the error is.
 PROOF_LUT_SIZE = 65
 
 logger = get_logger(__name__)
+
+
+@lru_cache(maxsize=16)
+def _read_icc_bytes(path: str) -> bytes:
+    with open(path, "rb") as f:
+        return f.read()
+
 
 # (photometric, primaries, transfer) for JXL's enumerated color encoding (D65 white only,
 # no ICC). Other spaces must hard-fail. Transfers verified against the bundled icc/*.icc:
@@ -356,14 +364,15 @@ class ImageProcessor:
         if key == self._retouch_detect_key and self._retouch_detect_value is not None:
             return self._retouch_detect_value
 
+        small = _detection_downsample(img)
         stats_key = (source_key, int(ret.dust_size))
         if stats_key == self._dust_stats_key and self._dust_stats_value is not None:
             stats = self._dust_stats_value
         else:
-            stats = compute_dust_stats(_detection_downsample(img), ret.dust_size)
+            stats = compute_dust_stats(small, ret.dust_size)
             self._dust_stats_key = stats_key
             self._dust_stats_value = stats
-        score, hair_luma = detect_luma_score(_detection_downsample(img), ret.dust_threshold, ret.dust_size, stats=stats)
+        score, hair_luma = detect_luma_score(small, ret.dust_threshold, ret.dust_size, stats=stats)
         value = (score, [hair_luma] if hair_luma is not None else [])
         self._retouch_detect_key = key
         self._retouch_detect_value = value
@@ -679,14 +688,15 @@ class ImageProcessor:
             return self._source_cache_value
 
         if params.stitch.stitch_enabled and params.stitch.stitch_paths:
-            parts, irs = [], []
-            source_cs = WORKING_COLOR_SPACE
-            for i, path in enumerate((file_path, *params.stitch.stitch_paths)):
-                f32, ir, cs = self._decode_oriented_f32(path, _part_params(params, i), fast_decode)
-                if i == 0:
-                    source_cs = cs
-                parts.append(f32)
-                irs.append(ir)
+            # libraw/tifffile release the GIL, so the parts decode concurrently.
+            all_paths = (file_path, *params.stitch.stitch_paths)
+            with ThreadPoolExecutor(max_workers=min(3, len(all_paths))) as pool:
+                decoded = list(
+                    pool.map(lambda ip: self._decode_oriented_f32(ip[1], _part_params(params, ip[0]), fast_decode), enumerate(all_paths))
+                )
+            parts = [f32 for f32, _ir, _cs in decoded]
+            irs = [ir for _f32, ir, _cs in decoded]
+            source_cs = decoded[0][2]
             f32_buffer, ir_full = stitch_composite(parts, irs, params.stitch)
             result = (f32_buffer, ir_full, source_cs)
         else:
@@ -715,7 +725,19 @@ class ImageProcessor:
         # differently on the two paths.
         is_triplet = is_rgb_triplet(rgbcfg) and not hdr_active(params.hdr)
 
-        rgb, metadata = self._decode_sensor_rgb(file_path, linear_raw, fast=fast_decode, wb_override=wb_override)
+        decoded: Dict[str, np.ndarray] = {}
+        if is_triplet:
+            # libraw releases the GIL, so all three exposures decode concurrently.
+            for label, path in (("green", rgbcfg.green_path), ("blue", rgbcfg.blue_path)):
+                if not os.path.exists(path):
+                    raise FileNotFoundError(f"RGB-scan {label} exposure not found: {path}")
+            siblings = [p for p in dict.fromkeys((rgbcfg.green_path, rgbcfg.blue_path)) if p != file_path]
+            with ThreadPoolExecutor(max_workers=1 + len(siblings)) as pool:
+                primary_future = pool.submit(self._decode_sensor_rgb, file_path, linear_raw, fast=fast_decode, wb_override=wb_override)
+                decoded = dict(zip(siblings, pool.map(lambda p: self._decode_sensor_rgb(p, linear_raw)[0], siblings)))
+                rgb, metadata = primary_future.result()
+        else:
+            rgb, metadata = self._decode_sensor_rgb(file_path, linear_raw, fast=fast_decode, wb_override=wb_override)
         # No embedded profile (scanner-raw linear, sensor-native RAW) means the buffer is
         # already in the working space, so "Same as Source" exports without converting.
         source_cs = str(metadata.get("color_space") or WORKING_COLOR_SPACE)
@@ -725,16 +747,11 @@ class ImageProcessor:
         ir_full = metadata.get("ir")
 
         if is_triplet:
-            # Assemble one frame from the R/G/B exposures. The primary (red) file is already
-            # decoded above, so reuse it and decode only green and blue.
-            for label, path in (("green", rgbcfg.green_path), ("blue", rgbcfg.blue_path)):
-                if not os.path.exists(path):
-                    raise FileNotFoundError(f"RGB-scan {label} exposure not found: {path}")
 
             def _decode(path: str) -> np.ndarray:
                 if path == file_path:
                     return rgb
-                return self._decode_sensor_rgb(path, linear_raw)[0]
+                return decoded[path]
 
             rgb = merge_rgb_triplet(_decode, file_path, rgbcfg.green_path, rgbcfg.blue_path, align=rgbcfg.align)
 
@@ -751,10 +768,20 @@ class ImageProcessor:
             # a bracket whose frames sit on different white balances solves wrong ratios
             # and reports nothing.
             bracket_wb = None if linear_raw else metadata.get("camera_wb")
+            # fast_decode must ride along: a half-size primary against full-size
+            # siblings is a shape mismatch, not just a slow merge.
+            hdr_siblings = [p for p in dict.fromkeys(params.hdr.hdr_paths) if p != file_path]
+            with ThreadPoolExecutor(max_workers=min(3, max(1, len(hdr_siblings)))) as pool:
+                hdr_decoded = dict(
+                    zip(
+                        hdr_siblings,
+                        pool.map(
+                            lambda p: self._decode_sensor_rgb(p, linear_raw, fast=fast_decode, wb_override=bracket_wb)[0], hdr_siblings
+                        ),
+                    )
+                )
             f32_buffer = merge_bracket(
-                # fast_decode must ride along: a half-size primary against full-size
-                # siblings is a shape mismatch, not just a slow merge.
-                lambda p: rgb if p == file_path else self._decode_sensor_rgb(p, linear_raw, fast=fast_decode, wb_override=bracket_wb)[0],
+                lambda p: rgb if p == file_path else hdr_decoded[p],
                 file_path,
                 params.hdr,
             )
@@ -865,6 +892,13 @@ class ImageProcessor:
             prefer_gpu = False
 
         if prefer_gpu and self.engine_gpu:
+            # Mirrors run_pipeline's base_hash, so a multi-preset batch of one frame
+            # reuses the source upload and the meter cache.
+            export_hash = (
+                detect_key
+                + (hair_bake_token(orig_ret) if hair_masks else "")
+                + f"|res{w_raw}x{h_raw}|half{half}:{split_x}:{crop_rect}:{gutter_thickness}"
+            )
             buffer, _gpu_metrics = self.engine_gpu.process(
                 f32_buffer,
                 params,
@@ -873,6 +907,8 @@ class ImageProcessor:
                 readback_metrics=False,
                 cam_xyz=self._cam_xyz_by_path.get(file_path, (None, None))[0],
                 camera_wb=self._cam_xyz_by_path.get(file_path, (None, None))[1],
+                source_hash=export_hash,
+                analysis_source_hash=export_hash,
             )
         else:
             buffer, _ = self.run_pipeline(
@@ -908,6 +944,7 @@ class ImageProcessor:
         crop_rect: Optional[tuple[float, float, float, float]] = None,
         gutter_thickness: float = 0.0,
         diptych: Optional[Tuple[WorkspaceConfig, WorkspaceConfig]] = None,
+        embed_plan: Optional[tuple] = None,
     ) -> Tuple[Optional[bytes], str]:
         """Performs high-resolution export with color management.
 
@@ -915,6 +952,9 @@ class ImageProcessor:
         back into the original geometry. Each half is sliced before the pipeline, so its
         normalization sees the same pixels the user edited it on. ``params`` is unused
         then — the halves own the edit. One encode, so no double compression.
+
+        ``embed_plan`` (from writer.export_embed_plan): TIFF/PNG embed it at the
+        first encode instead of the post-hoc rewrite.
         """
         try:
             if diptych is not None:
@@ -950,7 +990,7 @@ class ImageProcessor:
                     crop_rect=crop_rect,
                     gutter_thickness=gutter_thickness,
                 )
-            return self._encode_export(buffer, export_settings, color_space, working_color_space)
+            return self._encode_export(buffer, export_settings, color_space, working_color_space, embed_plan=embed_plan)
 
         except Exception as e:
             logger.error(f"Export pipeline failed: {e}")
@@ -962,6 +1002,7 @@ class ImageProcessor:
         export_settings,
         color_space: str,
         working_color_space: str = WORKING_COLOR_SPACE,
+        embed_plan: Optional[tuple] = None,
     ) -> Tuple[bytes, str]:
         """Encodes a processed float buffer to the target format's file bytes.
 
@@ -996,6 +1037,12 @@ class ImageProcessor:
                 img_int = float_to_uint16(buffer)
                 img_out, icc_bytes = self._apply_color_management_u16(img_int, working_color_space, color_space, icc_output, icc_input)
 
+            meta_kwargs = {}
+            if embed_plan is not None:
+                from negpy.features.metadata.writer import tiff_metadata_kwargs
+
+                exif_bytes, xmp_bytes, fold = embed_plan
+                meta_kwargs = tiff_metadata_kwargs(exif_bytes, xmp_bytes, fold_user_comment=fold)
             output_buf = io.BytesIO()
             tifffile.imwrite(
                 output_buf,
@@ -1004,6 +1051,7 @@ class ImageProcessor:
                 iccprofile=icc_bytes,
                 compression="zlib",
                 predictor=True,
+                **meta_kwargs,
             )
             return output_buf.getvalue(), "tiff"
         elif fmt == ExportFormat.PNG:
@@ -1025,6 +1073,13 @@ class ImageProcessor:
             save_kwargs: Dict[str, Any] = {"format": "PNG", "compress_level": 6}
             if icc_bytes:
                 save_kwargs["icc_profile"] = icc_bytes
+            if embed_plan is not None:
+                exif_bytes, xmp_bytes, _fold = embed_plan
+                save_kwargs["exif"] = exif_bytes
+                if xmp_bytes:
+                    pnginfo = PngImagePlugin.PngInfo()
+                    pnginfo.add_itxt("XML:com.adobe.xmp", xmp_bytes.decode("utf-8"), zip=False)
+                    save_kwargs["pnginfo"] = pnginfo
             pil_img.save(output_buf, **save_kwargs)
             return output_buf.getvalue(), "png"
         elif fmt == ExportFormat.JXL:
@@ -1235,12 +1290,10 @@ class ImageProcessor:
     def _get_target_icc_bytes(self, color_space: str, icc_path: Optional[str]) -> Optional[bytes]:
         """Loads ICC profile data for embedding (custom output profile or target space)."""
         if icc_path and os.path.exists(icc_path):
-            with open(icc_path, "rb") as f:
-                return f.read()
+            return _read_icc_bytes(icc_path)
         path = ColorSpaceRegistry.get_icc_path(color_space)
         if path and os.path.exists(path):
-            with open(path, "rb") as f:
-                return f.read()
+            return _read_icc_bytes(path)
         return None
 
     @staticmethod
@@ -1487,6 +1540,16 @@ class ImageProcessor:
             if pil_img.mode not in ("RGB", "L"):
                 pil_img = pil_img.convert("RGB" if pil_img.mode != "I;16" else "L")
 
+            if pil_img.mode == "RGB":
+                # Matrix/TRC pairs take the parallel kernel; LUT profiles (printer
+                # ICCs) return None and fall through to exact lcms.
+                src_bytes = self._get_target_icc_bytes(working_color_space, input_icc_path)
+                dst_bytes = self._get_target_icc_bytes(color_space, output_icc_path)
+                if src_bytes and dst_bytes:
+                    fast = apply_matrix_trc_u8(np.asarray(pil_img), src_bytes, dst_bytes)
+                    if fast is not None:
+                        return Image.fromarray(fast), dst_bytes
+
             result_pil = ImageCms.profileToProfile(
                 pil_img,
                 p_src,
@@ -1645,13 +1708,17 @@ class ImageProcessor:
             compression="tiff_lzw" if fmt == "TIFF" else None,
         )
 
+    def release_source_cache(self) -> None:
+        """Drops the decoded-source and pre-correction caches (full-res arrays)."""
+        self._source_cache_key = None
+        self._source_cache_value = None
+        self._precorrect_key = None
+        self._precorrect_value = None
+
     def cleanup(self, release_source_cache: bool = True, collect: bool = True, retain: Any = None) -> None:
         """Evacuates transient GPU resources; ``retain`` survives the teardown."""
         if release_source_cache:
-            self._source_cache_key = None
-            self._source_cache_value = None
-            self._precorrect_key = None
-            self._precorrect_value = None
+            self.release_source_cache()
         if self.engine_gpu:
             self.engine_gpu.cleanup(collect=collect, retain=retain)
 

--- a/tests/metadata/test_writer.py
+++ b/tests/metadata/test_writer.py
@@ -623,3 +623,56 @@ class TestJxlSourceMetadata:
         xmp = _read_xmp_from_source(str(path))
 
         assert xmp is not None and b"Portra 400" in xmp
+
+
+class TestExportEmbedPlan:
+    """First-encode embedding must carry the same metadata as the post-hoc rewrite."""
+
+    SOURCE_EXIF = {
+        "0th": {piexif.ImageIFD.Make: b"Plustek", piexif.ImageIFD.Model: b"OpticFilm"},
+        "Exif": {piexif.ExifIFD.LensModel: b"Nikkor 50mm"},
+        "GPS": {},
+        "Interop": {},
+        "1st": {},
+    }
+
+    def _tags(self, tiff_bytes: bytes) -> dict:
+        with tifffile.TiffFile(io.BytesIO(tiff_bytes)) as tf:
+            return {t.name: t.value for t in tf.pages[0].tags}
+
+    def test_tiff_first_encode_matches_rewrite(self) -> None:
+        from negpy.features.metadata.writer import export_embed_plan, tiff_metadata_kwargs
+
+        config = MetadataConfig(film="Portra 400", developer="C-41")
+        plan = export_embed_plan(config, dict(self.SOURCE_EXIF), "/nonexistent.tif")
+        assert plan is not None
+        exif_bytes, xmp_bytes, fold = plan
+
+        arr = np.random.randint(0, 65535, (16, 16, 3), dtype=np.uint16)
+        buf = io.BytesIO()
+        tifffile.imwrite(
+            buf,
+            arr,
+            photometric="rgb",
+            compression="zlib",
+            predictor=True,
+            **tiff_metadata_kwargs(exif_bytes, xmp_bytes, fold_user_comment=fold),
+        )
+        first_encode = self._tags(buf.getvalue())
+
+        rewrite = self._tags(embed_metadata(_make_tiff_bytes(), config, dict(self.SOURCE_EXIF)))
+
+        for name in ("ImageDescription", "Make", "Model", "LensModel"):
+            assert first_encode.get(name) == rewrite.get(name), name
+        assert ("XMP" in first_encode) == ("XMP" in rewrite)
+
+    def test_preserve_mode_without_source_exif_is_none(self) -> None:
+        from negpy.features.metadata.writer import export_embed_plan
+
+        config = MetadataConfig(protect_original_metadata=True)
+        assert export_embed_plan(config, None, "/nonexistent.tif") is None
+
+    def test_no_config_is_none(self) -> None:
+        from negpy.features.metadata.writer import export_embed_plan
+
+        assert export_embed_plan(None, dict(self.SOURCE_EXIF), "/nonexistent.tif") is None

--- a/tests/metrics/test_export.py
+++ b/tests/metrics/test_export.py
@@ -1,0 +1,66 @@
+"""
+Wall-clock metrics for the export path: full-res render and encode, measured
+separately (real GPU when available, synthetic source on disk).
+
+Recorded under ``export.*``; the regression check in ``test_preview_load``
+compares every metric in the session snapshot against ``NEGPY_METRICS_BASELINE``.
+"""
+
+from __future__ import annotations
+
+import time
+
+import numpy as np
+import pytest
+import tifffile
+
+from negpy.domain.models import WorkspaceConfig
+from negpy.infrastructure.gpu.device import GPUDevice
+
+from . import recorder
+
+pytestmark = [pytest.mark.slow, pytest.mark.metrics]
+
+# Above TILING_THRESHOLD_PX, so the measured path is the tiled one real scans take.
+_W, _H = 4600, 3200
+
+
+@pytest.fixture(scope="module")
+def rig(tmp_path_factory):
+    if not GPUDevice.get().is_available:
+        pytest.skip("GPU not available")
+    from negpy.services.rendering.image_processor import ImageProcessor
+
+    rng = np.random.default_rng(1)
+    arr = (rng.random((_H, _W, 3)) * 40000 + 8000).astype(np.uint16)
+    path = tmp_path_factory.mktemp("export") / "metric_source.tif"
+    tifffile.imwrite(path, arr, photometric="rgb")
+
+    proc = ImageProcessor()
+    try:
+        yield proc, str(path)
+    finally:
+        proc.destroy_all()
+
+
+def test_export_render_and_encode(rig) -> None:
+    proc, path = rig
+    cfg = WorkspaceConfig()
+
+    # Warm run; measure steady state.
+    fbuf, cs = proc._render_export_buffer(path, cfg, cfg.export, "metrics-export")
+    proc._encode_export(fbuf, cfg.export, cs)
+
+    t0 = time.perf_counter()
+    fbuf, cs = proc._render_export_buffer(path, cfg, cfg.export, "metrics-export-2")
+    render_s = time.perf_counter() - t0
+
+    t0 = time.perf_counter()
+    bits, _ = proc._encode_export(fbuf, cfg.export, cs)
+    encode_s = time.perf_counter() - t0
+
+    assert bits
+    recorder.record("export.render_s", render_s)
+    recorder.record("export.encode_s", encode_s)
+    assert render_s < 30.0, f"export render took {render_s:.1f}s"
+    assert encode_s < 10.0, f"export encode took {encode_s:.1f}s"

--- a/tests/metrics/test_render_frame.py
+++ b/tests/metrics/test_render_frame.py
@@ -90,6 +90,14 @@ def _sepia(base, i):
     return dataclasses.replace(base, toning=dataclasses.replace(base.toning, sepia_strength=0.02 * (i + 1)))
 
 
+def _white_point(base, i):
+    return dataclasses.replace(base, process=dataclasses.replace(base.process, white_point_offset=0.001 * (i + 1)))
+
+
+def _luma_clip(base, i):
+    return dataclasses.replace(base, process=dataclasses.replace(base.process, luma_range_clip=0.001 * (i + 1)))
+
+
 def test_drag_frame(rig) -> None:
     """An exposure slider step: resumes from the exposure stage, no metrics readback."""
     elapsed = _frame_seconds(rig, _density, settle=False)
@@ -102,6 +110,22 @@ def test_late_stage_drag_frame(rig) -> None:
     elapsed = _frame_seconds(rig, _sepia, settle=False)
     recorder.record("render.frame.drag_late_stage_s", elapsed)
     assert elapsed < 0.5, f"a toning-only frame took {elapsed * 1000:.0f}ms"
+
+
+def test_white_point_drag_frame(rig) -> None:
+    """A white-point step applies as a uniform offset: it must reuse the analysis
+    cache and cost no more than a creative-slider frame."""
+    elapsed = _frame_seconds(rig, _white_point, settle=False)
+    recorder.record("render.frame.drag_offset_s", elapsed)
+    assert elapsed < 0.5, f"a white-point drag frame took {elapsed * 1000:.0f}ms"
+
+
+def test_clip_drag_frame(rig) -> None:
+    """A clip step re-meters by design, but reuses the prefiltered log grid; only
+    the percentile analysis re-runs."""
+    elapsed = _frame_seconds(rig, _luma_clip, settle=False)
+    recorder.record("render.frame.drag_remeter_s", elapsed)
+    assert elapsed < 0.5, f"a clip drag frame took {elapsed * 1000:.0f}ms"
 
 
 def test_settle_frame(rig) -> None:

--- a/tests/test_asset_scan_caches.py
+++ b/tests/test_asset_scan_caches.py
@@ -1,0 +1,43 @@
+"""Mtime-stamped caches on the gear library and contact-sheet template scans.
+
+Both run on the debounced sidebar resync; the caches must serve unchanged files
+without disk reads and must pick up an on-disk change immediately.
+"""
+
+import json
+import os
+
+from negpy.services.assets.gear import GearProfiles
+from negpy.services.export.contact_sheet_templates import ContactSheetTemplates
+
+
+def test_gear_library_cache_hits_and_invalidates(tmp_path, monkeypatch):
+    monkeypatch.setattr(GearProfiles, "_gear_dir", staticmethod(lambda: str(tmp_path)))
+    monkeypatch.setattr(GearProfiles, "_library_cache", None)
+
+    first = GearProfiles.load_library()
+    assert GearProfiles.load_library() is first
+
+    cam_file = tmp_path / "cameras.json"
+    cam_file.write_text(json.dumps([{"id": "c1", "make": "Nikon", "model": "F3"}]))
+    os.utime(cam_file, ns=(2, 2))
+
+    reloaded = GearProfiles.load_library()
+    assert reloaded is not first
+    assert any(c.model == "F3" for c in reloaded.cameras)
+    assert GearProfiles.load_library() is reloaded
+
+
+def test_template_scan_cache_hits_and_invalidates(tmp_path, monkeypatch):
+    monkeypatch.setattr(ContactSheetTemplates, "_templates_dir", staticmethod(lambda: str(tmp_path)))
+    monkeypatch.setattr(ContactSheetTemplates, "_scan_cache", None)
+
+    assert ContactSheetTemplates.list_templates() == [ContactSheetTemplates.DEFAULT_NAME]
+
+    (tmp_path / "grid.toml").write_text('name = "Grid"\n[layout]\ncell_px = 400\n')
+    names = ContactSheetTemplates.list_templates()
+    assert "Grid" in names
+
+    cached = ContactSheetTemplates._scan_cache
+    ContactSheetTemplates.list_templates()
+    assert ContactSheetTemplates._scan_cache is cached

--- a/tests/test_batch_progress.py
+++ b/tests/test_batch_progress.py
@@ -96,11 +96,9 @@ def test_export_batch_keeps_source_cache_for_consecutive_same_file(tmp_path) -> 
     # a.cr2 exported twice (multi-format preset), then b.cr2.
     worker.run_batch([_task("a.cr2"), _task("a.cr2"), _task("b.cr2")])
 
-    assert proc.cleanup.call_args_list == [
-        call(release_source_cache=False, collect=False),  # next task = same source
-        call(release_source_cache=True, collect=False),
-        call(release_source_cache=True, collect=False),  # last task
-    ]
+    # Decoded source dropped only at source boundaries; VRAM evacuated once per batch.
+    assert proc.release_source_cache.call_args_list == [call(), call()]
+    assert proc.cleanup.call_args_list == [call(release_source_cache=True, collect=False)]
     assert proc.process_export.call_count == 3
 
     # _same_decode_source mirrors the _load_source_f32 cache key fields.

--- a/tests/test_drag_readback_flags.py
+++ b/tests/test_drag_readback_flags.py
@@ -1,0 +1,48 @@
+"""Drag ticks from the Process/Sensor sliders must not request metrics readback.
+
+A tick with readback_metrics=True is treated as a settled frame: metrics passes,
+a blocking map_sync, a thumbnail readback and a full right-panel refresh.
+"""
+
+from unittest.mock import MagicMock
+
+from negpy.desktop.view.sidebar.process import ProcessSidebar
+from negpy.desktop.view.sidebar.sensor import SensorSidebar
+
+
+def _readback_kwarg(panel) -> bool:
+    return panel.update_config_section.call_args.kwargs["readback_metrics"]
+
+
+def _process_stub() -> MagicMock:
+    panel = MagicMock()
+    panel._wp_field.return_value = "white_point_offset"
+    panel._bp_field.return_value = "black_point_offset"
+    panel.state.config.process = MagicMock(lock_bounds=False)
+    return panel
+
+
+def test_process_sliders_follow_persist() -> None:
+    for handler in (
+        ProcessSidebar._on_white_point_changed,
+        ProcessSidebar._on_black_point_changed,
+        ProcessSidebar._on_buffer_changed,
+        ProcessSidebar._on_luma_range_clip_changed,
+        ProcessSidebar._on_color_range_clip_changed,
+    ):
+        for persist in (False, True):
+            panel = _process_stub()
+            handler(panel, 0.1, persist=persist)
+            assert _readback_kwarg(panel) is persist, handler.__name__
+
+
+def test_sensor_sliders_follow_persist() -> None:
+    for handler in (
+        SensorSidebar._on_crosstalk_strength_changed,
+        SensorSidebar._on_hue_trim_changed,
+    ):
+        for persist in (False, True):
+            panel = MagicMock()
+            panel.state.config.process = MagicMock(lock_bounds=False)
+            handler(panel, 0.1, persist=persist)
+            assert _readback_kwarg(panel) is persist, handler.__name__

--- a/tests/test_export_color_management.py
+++ b/tests/test_export_color_management.py
@@ -1,369 +1,61 @@
+"""Export ICC fast path: the matrix/TRC kernel must match lcms within 1 LSB."""
+
 import unittest
 
 import numpy as np
-from PIL import ImageCms
+from PIL import Image, ImageCms
 
-from negpy.domain.models import ColorSpace
-from negpy.infrastructure.display.color_mgmt import (
-    ColorService,
-    apply_display_transform,
-    get_display_lut,
-    icc_bytes_for_space,
-    open_profile_from_bytes,
-    profile_description,
-)
-from negpy.infrastructure.display.color_spaces import WORKING_COLOR_SPACE, ColorSpaceRegistry
-from negpy.infrastructure.display.icc_lut import apply_icc_u16_rgb
+from negpy.infrastructure.display.color_spaces import ColorSpaceRegistry
+from negpy.infrastructure.display.icc_lut import apply_matrix_trc_u8
 from negpy.services.rendering.image_processor import ImageProcessor
 
 
-def _open(cs_name: str):
-    path = ColorSpaceRegistry.get_icc_path(cs_name)
-    return ImageCms.getOpenProfile(path)
-
-
-def _decode_to_srgb_u16(img_u16: np.ndarray, src_cs: str) -> np.ndarray:
-    """Render a buffer (tagged `src_cs`) into sRGB, as a color-managed viewer would."""
-    return apply_icc_u16_rgb(
-        img_u16,
-        _open(src_cs),
-        ImageCms.createProfile("sRGB"),
-        ImageCms.Intent.RELATIVE_COLORIMETRIC,
-        ImageCms.Flags.BLACKPOINTCOMPENSATION,
-    )
-
-
-class TestExportColorManagement(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.proc = ImageProcessor()
-
-    def test_greyscale_export_matches_gamma22_tag(self):
-        """B&W luma must be re-encoded from the working TRC (Adobe RGB 563/256) to the
-        gamma 2.2 expected by the GrayGamma2.2 tag, so a viewer recovers the linear luma.
-
-        The two gammas are now near-identical, so this is a round-trip check rather than
-        a check that the re-encode moves the values."""
-        from negpy.kernel.image.logic import working_oetf_encode
-
-        lin = np.linspace(0.05, 0.9, 6, dtype=np.float32)
-        enc = np.asarray(working_oetf_encode(lin))  # engine-output luma in the working TRC
-        u16 = np.clip(enc * 65535.0 + 0.5, 0, 65535).astype(np.uint16).reshape(1, -1)
-
-        out, _icc = self.proc._apply_color_management_u16_greyscale(u16, WORKING_COLOR_SPACE, ColorSpace.GREYSCALE.value, None)
-
-        decoded = (out.astype(np.float32) / 65535.0) ** 2.2  # as a Gamma2.2 viewer would decode
-        np.testing.assert_allclose(decoded.reshape(-1), lin, atol=0.01)
-
-    def test_export_is_appearance_preserving_across_spaces(self):
-        """Exporting to sRGB / Adobe / ProPhoto must look the same in a CM viewer.
-
-        Working space is Adobe RGB. A real working→target conversion preserves the
-        in-gamut appearance, so decoding each export back through its embedded
-        profile yields ~identical sRGB pixels. (The old tag-only behaviour diverged.)
-        """
-        # Mid patch well inside every gamut so no clipping masks differences.
-        patch = np.array([[[0.50, 0.40, 0.30]]], dtype=np.float32)
-        img_u16 = (patch * 65535.0 + 0.5).astype(np.uint16)
-
-        decoded = {}
-        for target in (ColorSpace.SRGB.value, ColorSpace.ADOBE_RGB.value, ColorSpace.PROPHOTO.value):
-            out, _ = self.proc._apply_color_management_u16_rgb(img_u16, WORKING_COLOR_SPACE, target, None, None)
-            decoded[target] = _decode_to_srgb_u16(out, target).astype(np.float32) / 65535.0
-
-        ref = decoded[ColorSpace.SRGB.value]
-        for target, arr in decoded.items():
-            self.assertTrue(
-                np.allclose(arr, ref, atol=0.02),
-                msg=f"{target} export diverges from sRGB export in CM view: {arr.ravel()} vs {ref.ravel()}",
-            )
-
-    def test_same_space_export_is_noop(self):
-        """working == target with no custom profile leaves pixels untouched."""
-        img_u16 = np.random.randint(0, 65535, size=(4, 4, 3), dtype=np.uint16)
-        out, icc = self.proc._apply_color_management_u16_rgb(img_u16, WORKING_COLOR_SPACE, WORKING_COLOR_SPACE, None, None)
-        np.testing.assert_array_equal(out, img_u16)
-        self.assertIsNotNone(icc)  # target profile still embedded
-
-    def test_cms_codec_unavailable_falls_back_to_lut_transform(self):
-        """Some imagecodecs builds ship without the cms codec compiled in (observed on
-        an unnotarized macOS arm64 build), surfacing as ImportError only once the
-        codec is actually invoked. The 16-bit RGB export path must still colour-manage
-        via the LUT transform rather than silently ship unmanaged pixels."""
-        from unittest.mock import patch
-
-        import imagecodecs
-
-        img_u16 = (np.array([[[0.50, 0.40, 0.30]]], dtype=np.float32) * 65535.0 + 0.5).astype(np.uint16)
-
-        # Force imagecodecs' lazy module __getattr__ to materialize cms_transform as a
-        # real attribute first — patching it while still lazy makes mock's teardown
-        # (hasattr/getattr on the module) re-enter that same __getattr__ and recurse.
-        imagecodecs.cms_transform  # noqa: B018
-
-        with patch(
-            "negpy.services.rendering.image_processor.imagecodecs.cms_transform",
-            side_effect=ImportError("could not import name 'cms_transform' from 'imagecodecs'"),
-        ):
-            out_fallback, icc = self.proc._apply_color_management_u16(img_u16, WORKING_COLOR_SPACE, ColorSpace.SRGB.value, None, None)
-
-        # Same LUT resolution the fallback uses (PROOF_LUT_SIZE), so this checks the
-        # fallback wiring itself rather than the LUT's own approximation error.
-        from negpy.services.rendering.image_processor import PROOF_LUT_SIZE
-
-        out_direct, _ = self.proc._apply_color_management_u16_rgb(
-            img_u16, WORKING_COLOR_SPACE, ColorSpace.SRGB.value, None, None, lut_size=PROOF_LUT_SIZE
-        )
-
-        self.assertIsNotNone(icc)
-        self.assertFalse(np.array_equal(out_fallback, img_u16), "fallback must still colour-manage, not pass the source through untouched")
-        np.testing.assert_allclose(out_fallback.astype(np.float32), out_direct.astype(np.float32), atol=2.0)
-
-    def test_a_failed_transform_still_tags_the_pixels_it_ships(self):
-        """When the transform fails for a reason the LUT fallback does not cover, the
-        buffer goes out untouched — still in the working space. Shipping it untagged
-        makes every viewer read it as sRGB, so the export is wrong with nothing to
-        show why."""
-        from unittest.mock import patch
-
-        import imagecodecs
-
-        img_u16 = (np.array([[[0.50, 0.40, 0.30]]], dtype=np.float32) * 65535.0 + 0.5).astype(np.uint16)
-        working_icc = icc_bytes_for_space(WORKING_COLOR_SPACE)
-
-        imagecodecs.cms_transform  # noqa: B018  (materialize before patching; see the test above)
-        with patch(
-            "negpy.services.rendering.image_processor.imagecodecs.cms_transform",
-            side_effect=RuntimeError("lcms2 refused the profile"),
-        ):
-            out, icc = self.proc._apply_color_management_u16(img_u16, WORKING_COLOR_SPACE, ColorSpace.SRGB.value, None, None)
-        np.testing.assert_array_equal(out, img_u16)
-        self.assertEqual(icc, working_icc)
-
-        with patch(
-            "negpy.services.rendering.image_processor.apply_icc_u16_rgb",
-            side_effect=RuntimeError("LUT build failed"),
-        ):
-            out, icc = self.proc._apply_color_management_u16_rgb(img_u16, WORKING_COLOR_SPACE, ColorSpace.SRGB.value, None, None)
-        np.testing.assert_array_equal(out, img_u16)
-        self.assertEqual(icc, working_icc)
-
-
-class TestDisplayTransform(unittest.TestCase):
-    def test_srgb_working_is_identity(self):
-        img = np.random.rand(4, 4, 3).astype(np.float32)
-        out = apply_display_transform(img, ColorSpace.SRGB.value)
-        np.testing.assert_array_equal(out, img)
-        self.assertIsNone(get_display_lut(ColorSpace.SRGB.value))
-
-    def test_display_matches_simulate_on_srgb(self):
-        """The float display LUT must agree with PIL's simulate_on_srgb (Adobe→sRGB)."""
-        from PIL import Image
-
-        patch = np.array([[[0.80, 0.30, 0.20]]], dtype=np.float32)
-        lut_out = apply_display_transform(patch, WORKING_COLOR_SPACE)[0, 0]
-
-        u8 = (patch * 255.0 + 0.5).astype(np.uint8)
-        sim = ColorService.simulate_on_srgb(Image.fromarray(u8, mode="RGB"), WORKING_COLOR_SPACE)
-        sim_arr = np.asarray(sim, dtype=np.float32)[0, 0] / 255.0
-
-        self.assertTrue(
-            np.allclose(lut_out, sim_arr, atol=0.02),
-            msg=f"display LUT {lut_out} != simulate_on_srgb {sim_arr}",
-        )
-
-    def test_non_rgb_buffer_passthrough(self):
-        grey = np.random.rand(4, 4).astype(np.float32)
-        out = apply_display_transform(grey, WORKING_COLOR_SPACE)
-        np.testing.assert_array_equal(out, grey)
-
-    def test_color_managed_defaults_use_working_space(self):
-        """Color-space params must default to the working space, not a hardcoded
-        'sRGB' that silently skips color management on the float32 path (cf. #518)."""
-        import inspect
-
-        from negpy.desktop.converters import ImageConverter
-        from negpy.desktop.workers.render import ThumbnailUpdateTask
-        from negpy.services.assets.thumbnails import get_rendered_thumbnail
-
-        # Premise: the working space is not sRGB, so the default choice is load-bearing.
-        self.assertNotEqual(WORKING_COLOR_SPACE, ColorSpace.SRGB.value)
-        self.assertEqual(inspect.signature(ImageConverter.to_qimage).parameters["color_space"].default, WORKING_COLOR_SPACE)
-        self.assertEqual(inspect.signature(get_rendered_thumbnail).parameters["color_space"].default, WORKING_COLOR_SPACE)
-        self.assertEqual(ThumbnailUpdateTask.__dataclass_fields__["color_space"].default, WORKING_COLOR_SPACE)
-
-
-def _icc_bytes(cs_name: str) -> bytes:
-    with open(ColorSpaceRegistry.get_icc_path(cs_name), "rb") as f:
+def _icc_bytes(space: str) -> bytes:
+    path = ColorSpaceRegistry.get_icc_path(space)
+    assert path is not None
+    with open(path, "rb") as f:
         return f.read()
 
 
-class TestMonitorDisplayProfile(unittest.TestCase):
-    """The display transform must target the monitor profile, not always sRGB."""
-
-    def test_no_monitor_is_legacy_srgb(self):
-        # Default (no monitor profile) keeps the sRGB-display behaviour: sRGB working
-        # stays identity, so existing callers are unaffected.
-        self.assertIsNone(get_display_lut(ColorSpace.SRGB.value))
-        self.assertIsNone(get_display_lut(ColorSpace.SRGB.value, None))
-
-    def test_monitor_profile_makes_srgb_working_nonidentity(self):
-        # On a P3 display even an sRGB working space needs a transform.
-        lut = get_display_lut(ColorSpace.SRGB.value, _icc_bytes(ColorSpace.P3_D65.value))
-        self.assertIsNotNone(lut)
-
-    def test_monitor_display_differs_from_srgb_display(self):
-        p3 = _icc_bytes(ColorSpace.P3_D65.value)
-        patch = np.array([[[0.80, 0.30, 0.20]]], dtype=np.float32)
-        srgb_disp = apply_display_transform(patch, WORKING_COLOR_SPACE)[0, 0]
-        p3_disp = apply_display_transform(patch, WORKING_COLOR_SPACE, p3)[0, 0]
-        self.assertFalse(
-            np.allclose(srgb_disp, p3_disp, atol=0.02),
-            msg=f"P3 display {p3_disp} should differ from sRGB display {srgb_disp}",
-        )
-
-
-class TestDisplayProfileOverrideHelpers(unittest.TestCase):
-    """Helpers backing the manual Display-profile override dropdown."""
-
-    def test_icc_bytes_for_space_opens_as_profile(self):
-        data = icc_bytes_for_space(ColorSpace.P3_D65.value)
-        self.assertTrue(data)
-        # Must open as a usable profile (drives apply_display_transform).
-        self.assertIsNotNone(open_profile_from_bytes(data))
-
-    def test_icc_bytes_for_space_unknown_is_none(self):
-        self.assertIsNone(icc_bytes_for_space("NotARealSpace"))
-
-    def test_profile_description_none_is_srgb_fallback(self):
-        self.assertEqual(profile_description(None), "sRGB fallback")
-
-    def test_profile_description_reads_name(self):
-        desc = profile_description(icc_bytes_for_space(ColorSpace.P3_D65.value))
-        self.assertTrue(desc and desc != "sRGB fallback")
-
-    def test_override_bytes_match_apply_transform(self):
-        # An override to Display P3 must produce the same display LUT as feeding those
-        # bytes directly — i.e. the dropdown selection drives the real transform.
-        p3 = icc_bytes_for_space(ColorSpace.P3_D65.value)
-        patch = np.array([[[0.80, 0.30, 0.20]]], dtype=np.float32)
-        via_override = apply_display_transform(patch, WORKING_COLOR_SPACE, p3)
-        via_direct = apply_display_transform(patch, WORKING_COLOR_SPACE, _icc_bytes(ColorSpace.P3_D65.value))
-        np.testing.assert_array_equal(via_override, via_direct)
-
-
-class TestPrintProfileDetection(unittest.TestCase):
-    """`_is_print_profile` routes paper/printer profiles to the paper-white proof."""
-
-    class _Stub:
-        def __init__(self, device_class="", xcolor_space="RGB "):
-            self.profile = type("P", (), {"device_class": device_class, "xcolor_space": xcolor_space})()
-
-    def test_printer_class_is_print(self):
-        self.assertTrue(ImageProcessor._is_print_profile(self._Stub(device_class="prtr ")))
-
-    def test_cmyk_space_is_print(self):
-        self.assertTrue(ImageProcessor._is_print_profile(self._Stub(xcolor_space="CMYK")))
-
-    def test_bundled_display_spaces_not_print(self):
-        for cs in (ColorSpace.SRGB.value, ColorSpace.ADOBE_RGB.value, ColorSpace.P3_D65.value):
-            prof = ImageCms.getOpenProfile(ColorSpaceRegistry.get_icc_path(cs))
-            self.assertFalse(ImageProcessor._is_print_profile(prof), msg=f"{cs} should not be a print profile")
-
-
-class TestSoftProofToMonitor(unittest.TestCase):
-    """Soft proof must chain working→output→monitor when a display profile is set."""
-
+class TestMatrixTrcFastPath(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.proc = ImageProcessor()
+        rng = np.random.default_rng(11)
+        cls.arr = (rng.random((256, 384, 3)) * 255).astype(np.uint8)
+        cls.working = "Adobe RGB"
 
-    def test_proof_unchanged_without_monitor(self):
-        from PIL import Image
-
-        u8 = (np.array([[[0.70, 0.40, 0.25]]], dtype=np.float32) * 255.0 + 0.5).astype(np.uint8)
-        img = Image.fromarray(u8, mode="RGB")
-        out_path = ColorSpaceRegistry.get_icc_path(ColorSpace.SRGB.value)
-        a = np.asarray(self.proc.soft_proof_preview(img, WORKING_COLOR_SPACE, None, out_path), dtype=np.float32)
-        b = np.asarray(self.proc.soft_proof_preview(img, WORKING_COLOR_SPACE, None, out_path, None), dtype=np.float32)
-        np.testing.assert_array_equal(a, b)
-
-    def test_proof_in_gamut_stable_across_output_spaces(self):
-        """An in-gamut proof must look the same regardless of export space (#243).
-
-        The output→display step always runs (sRGB display here), so source→output→
-        display cancels to source→display for in-gamut colors — the intermediate
-        export space drops out. Only out-of-gamut colors should differ.
-        """
-        from PIL import Image
-
-        u8 = (np.array([[[0.55, 0.42, 0.30]]], dtype=np.float32) * 255.0 + 0.5).astype(np.uint8)
-        img = Image.fromarray(u8, mode="RGB")
-        spaces = (
-            ColorSpace.SRGB.value,
-            ColorSpace.ADOBE_RGB.value,
-            ColorSpace.REC2020.value,
-            ColorSpace.PROPHOTO.value,
-        )
-        outs = [
-            np.asarray(
-                self.proc.soft_proof_preview(img, WORKING_COLOR_SPACE, None, ColorSpaceRegistry.get_icc_path(s)),
-                dtype=np.float32,
-            )
-            for s in spaces
-        ]
-        ref = outs[0]
-        for s, arr in zip(spaces, outs):
-            # ±2/255: only 8-bit LUT rounding, not a per-space appearance shift.
-            self.assertTrue(np.allclose(arr, ref, atol=2.0), msg=f"{s} proof diverges: {arr.ravel()} vs {ref.ravel()}")
-
-    def test_proof_to_monitor_matches_explicit_chain(self):
-        from PIL import Image
-
-        p3 = _icc_bytes(ColorSpace.P3_D65.value)
-        out_path = ColorSpaceRegistry.get_icc_path(ColorSpace.SRGB.value)
-        u8 = (np.array([[[0.70, 0.40, 0.25]]], dtype=np.float32) * 255.0 + 0.5).astype(np.uint8)
-        img = Image.fromarray(u8, mode="RGB")
-
-        no_mon = np.asarray(self.proc.soft_proof_preview(img, WORKING_COLOR_SPACE, None, out_path), dtype=np.float32)
-        with_mon = np.asarray(self.proc.soft_proof_preview(img, WORKING_COLOR_SPACE, None, out_path, p3), dtype=np.float32)
-        # The output→monitor step changes the displayed pixels.
-        self.assertFalse(np.allclose(no_mon, with_mon, atol=1.0))
-
-        # ...and equals an explicit working→output→monitor chain (relative + BPC).
-        p_work = _open(WORKING_COLOR_SPACE)
-        p_out = _open(ColorSpace.SRGB.value)
-        p_mon = open_profile_from_bytes(p3)
-        step1 = ImageCms.profileToProfile(
-            img,
-            p_work,
-            p_out,
+    def _lcms_reference(self, target: str) -> np.ndarray:
+        p_src = ImageProcessor._resolve_src_profile(self.working, None)
+        p_dst = ImageProcessor._resolve_dst_profile(target, None)
+        ref = ImageCms.profileToProfile(
+            Image.fromarray(self.arr),
+            p_src,
+            p_dst,
             renderingIntent=ImageCms.Intent.RELATIVE_COLORIMETRIC,
             outputMode="RGB",
             flags=ImageCms.Flags.BLACKPOINTCOMPENSATION,
         )
-        step2 = ImageCms.profileToProfile(
-            step1,
-            p_out,
-            p_mon,
-            renderingIntent=ImageCms.Intent.RELATIVE_COLORIMETRIC,
-            outputMode="RGB",
-            flags=ImageCms.Flags.BLACKPOINTCOMPENSATION,
-        )
-        chain = np.asarray(step2, dtype=np.float32)
-        np.testing.assert_allclose(with_mon, chain, atol=1.0)
+        return np.asarray(ref).astype(np.int16)
 
+    def test_matches_lcms_within_one_lsb(self):
+        src = _icc_bytes(self.working)
+        for target in ("sRGB", "Rec 2020", "ProPhoto RGB"):
+            with self.subTest(target=target):
+                out = apply_matrix_trc_u8(self.arr, src, _icc_bytes(target))
+                self.assertIsNotNone(out)
+                delta = np.abs(out.astype(np.int16) - self._lcms_reference(target))
+                self.assertLessEqual(delta.max(), 1)
 
-class TestSessionBoundaryProfile(unittest.TestCase):
-    def test_session_workspace_matches_working_space(self):
-        """AppState's boundary profile must be the working space.
+    def test_same_space_is_identity(self):
+        src = _icc_bytes(self.working)
+        out = apply_matrix_trc_u8(self.arr, src, src)
+        np.testing.assert_array_equal(out, self.arr)
 
-        It is handed to export/proof/thumbnail/CPU-display as the *source* profile for
-        the engine's working-space-encoded buffer; drift silently mis-tags every export.
-        """
-        from negpy.desktop.session import AppState
-
-        self.assertEqual(AppState().workspace_color_space, WORKING_COLOR_SPACE)
+    def test_non_matrix_profile_falls_through(self):
+        """A profile without RGB colorant tags (greyscale) must return None so the
+        caller takes the exact lcms path."""
+        grey = _icc_bytes("Greyscale")
+        self.assertIsNone(apply_matrix_trc_u8(self.arr, _icc_bytes(self.working), grey))
 
 
 if __name__ == "__main__":

--- a/tests/test_export_color_management.py
+++ b/tests/test_export_color_management.py
@@ -1,30 +1,394 @@
-"""Export ICC fast path: the matrix/TRC kernel must match lcms within 1 LSB."""
-
 import unittest
 
 import numpy as np
-from PIL import Image, ImageCms
+from PIL import ImageCms
 
-from negpy.infrastructure.display.color_spaces import ColorSpaceRegistry
-from negpy.infrastructure.display.icc_lut import apply_matrix_trc_u8
+from negpy.domain.models import ColorSpace
+from negpy.infrastructure.display.color_mgmt import (
+    ColorService,
+    apply_display_transform,
+    get_display_lut,
+    icc_bytes_for_space,
+    open_profile_from_bytes,
+    profile_description,
+)
+from negpy.infrastructure.display.color_spaces import WORKING_COLOR_SPACE, ColorSpaceRegistry
+from negpy.infrastructure.display.icc_lut import apply_icc_u16_rgb
 from negpy.services.rendering.image_processor import ImageProcessor
 
 
-def _icc_bytes(space: str) -> bytes:
-    path = ColorSpaceRegistry.get_icc_path(space)
-    assert path is not None
-    with open(path, "rb") as f:
+def _open(cs_name: str):
+    path = ColorSpaceRegistry.get_icc_path(cs_name)
+    return ImageCms.getOpenProfile(path)
+
+
+def _decode_to_srgb_u16(img_u16: np.ndarray, src_cs: str) -> np.ndarray:
+    """Render a buffer (tagged `src_cs`) into sRGB, as a color-managed viewer would."""
+    return apply_icc_u16_rgb(
+        img_u16,
+        _open(src_cs),
+        ImageCms.createProfile("sRGB"),
+        ImageCms.Intent.RELATIVE_COLORIMETRIC,
+        ImageCms.Flags.BLACKPOINTCOMPENSATION,
+    )
+
+
+class TestExportColorManagement(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.proc = ImageProcessor()
+
+    def test_greyscale_export_matches_gamma22_tag(self):
+        """B&W luma must be re-encoded from the working TRC (Adobe RGB 563/256) to the
+        gamma 2.2 expected by the GrayGamma2.2 tag, so a viewer recovers the linear luma.
+
+        The two gammas are now near-identical, so this is a round-trip check rather than
+        a check that the re-encode moves the values."""
+        from negpy.kernel.image.logic import working_oetf_encode
+
+        lin = np.linspace(0.05, 0.9, 6, dtype=np.float32)
+        enc = np.asarray(working_oetf_encode(lin))  # engine-output luma in the working TRC
+        u16 = np.clip(enc * 65535.0 + 0.5, 0, 65535).astype(np.uint16).reshape(1, -1)
+
+        out, _icc = self.proc._apply_color_management_u16_greyscale(u16, WORKING_COLOR_SPACE, ColorSpace.GREYSCALE.value, None)
+
+        decoded = (out.astype(np.float32) / 65535.0) ** 2.2  # as a Gamma2.2 viewer would decode
+        np.testing.assert_allclose(decoded.reshape(-1), lin, atol=0.01)
+
+    def test_export_is_appearance_preserving_across_spaces(self):
+        """Exporting to sRGB / Adobe / ProPhoto must look the same in a CM viewer.
+
+        Working space is Adobe RGB. A real working→target conversion preserves the
+        in-gamut appearance, so decoding each export back through its embedded
+        profile yields ~identical sRGB pixels. (The old tag-only behaviour diverged.)
+        """
+        # Mid patch well inside every gamut so no clipping masks differences.
+        patch = np.array([[[0.50, 0.40, 0.30]]], dtype=np.float32)
+        img_u16 = (patch * 65535.0 + 0.5).astype(np.uint16)
+
+        decoded = {}
+        for target in (ColorSpace.SRGB.value, ColorSpace.ADOBE_RGB.value, ColorSpace.PROPHOTO.value):
+            out, _ = self.proc._apply_color_management_u16_rgb(img_u16, WORKING_COLOR_SPACE, target, None, None)
+            decoded[target] = _decode_to_srgb_u16(out, target).astype(np.float32) / 65535.0
+
+        ref = decoded[ColorSpace.SRGB.value]
+        for target, arr in decoded.items():
+            self.assertTrue(
+                np.allclose(arr, ref, atol=0.02),
+                msg=f"{target} export diverges from sRGB export in CM view: {arr.ravel()} vs {ref.ravel()}",
+            )
+
+    def test_same_space_export_is_noop(self):
+        """working == target with no custom profile leaves pixels untouched."""
+        img_u16 = np.random.randint(0, 65535, size=(4, 4, 3), dtype=np.uint16)
+        out, icc = self.proc._apply_color_management_u16_rgb(img_u16, WORKING_COLOR_SPACE, WORKING_COLOR_SPACE, None, None)
+        np.testing.assert_array_equal(out, img_u16)
+        self.assertIsNotNone(icc)  # target profile still embedded
+
+    def test_cms_codec_unavailable_falls_back_to_lut_transform(self):
+        """Some imagecodecs builds ship without the cms codec compiled in (observed on
+        an unnotarized macOS arm64 build), surfacing as ImportError only once the
+        codec is actually invoked. The 16-bit RGB export path must still colour-manage
+        via the LUT transform rather than silently ship unmanaged pixels."""
+        from unittest.mock import patch
+
+        import imagecodecs
+
+        img_u16 = (np.array([[[0.50, 0.40, 0.30]]], dtype=np.float32) * 65535.0 + 0.5).astype(np.uint16)
+
+        # Force imagecodecs' lazy module __getattr__ to materialize cms_transform as a
+        # real attribute first — patching it while still lazy makes mock's teardown
+        # (hasattr/getattr on the module) re-enter that same __getattr__ and recurse.
+        imagecodecs.cms_transform  # noqa: B018
+
+        with patch(
+            "negpy.services.rendering.image_processor.imagecodecs.cms_transform",
+            side_effect=ImportError("could not import name 'cms_transform' from 'imagecodecs'"),
+        ):
+            out_fallback, icc = self.proc._apply_color_management_u16(img_u16, WORKING_COLOR_SPACE, ColorSpace.SRGB.value, None, None)
+
+        # Same LUT resolution the fallback uses (PROOF_LUT_SIZE), so this checks the
+        # fallback wiring itself rather than the LUT's own approximation error.
+        from negpy.services.rendering.image_processor import PROOF_LUT_SIZE
+
+        out_direct, _ = self.proc._apply_color_management_u16_rgb(
+            img_u16, WORKING_COLOR_SPACE, ColorSpace.SRGB.value, None, None, lut_size=PROOF_LUT_SIZE
+        )
+
+        self.assertIsNotNone(icc)
+        self.assertFalse(np.array_equal(out_fallback, img_u16), "fallback must still colour-manage, not pass the source through untouched")
+        np.testing.assert_allclose(out_fallback.astype(np.float32), out_direct.astype(np.float32), atol=2.0)
+
+    def test_a_failed_transform_still_tags_the_pixels_it_ships(self):
+        """When the transform fails for a reason the LUT fallback does not cover, the
+        buffer goes out untouched — still in the working space. Shipping it untagged
+        makes every viewer read it as sRGB, so the export is wrong with nothing to
+        show why."""
+        from unittest.mock import patch
+
+        import imagecodecs
+
+        img_u16 = (np.array([[[0.50, 0.40, 0.30]]], dtype=np.float32) * 65535.0 + 0.5).astype(np.uint16)
+        working_icc = icc_bytes_for_space(WORKING_COLOR_SPACE)
+
+        imagecodecs.cms_transform  # noqa: B018  (materialize before patching; see the test above)
+        with patch(
+            "negpy.services.rendering.image_processor.imagecodecs.cms_transform",
+            side_effect=RuntimeError("lcms2 refused the profile"),
+        ):
+            out, icc = self.proc._apply_color_management_u16(img_u16, WORKING_COLOR_SPACE, ColorSpace.SRGB.value, None, None)
+        np.testing.assert_array_equal(out, img_u16)
+        self.assertEqual(icc, working_icc)
+
+        with patch(
+            "negpy.services.rendering.image_processor.apply_icc_u16_rgb",
+            side_effect=RuntimeError("LUT build failed"),
+        ):
+            out, icc = self.proc._apply_color_management_u16_rgb(img_u16, WORKING_COLOR_SPACE, ColorSpace.SRGB.value, None, None)
+        np.testing.assert_array_equal(out, img_u16)
+        self.assertEqual(icc, working_icc)
+
+
+class TestDisplayTransform(unittest.TestCase):
+    def test_srgb_working_is_identity(self):
+        img = np.random.rand(4, 4, 3).astype(np.float32)
+        out = apply_display_transform(img, ColorSpace.SRGB.value)
+        np.testing.assert_array_equal(out, img)
+        self.assertIsNone(get_display_lut(ColorSpace.SRGB.value))
+
+    def test_display_matches_simulate_on_srgb(self):
+        """The float display LUT must agree with PIL's simulate_on_srgb (Adobe→sRGB)."""
+        from PIL import Image
+
+        patch = np.array([[[0.80, 0.30, 0.20]]], dtype=np.float32)
+        lut_out = apply_display_transform(patch, WORKING_COLOR_SPACE)[0, 0]
+
+        u8 = (patch * 255.0 + 0.5).astype(np.uint8)
+        sim = ColorService.simulate_on_srgb(Image.fromarray(u8, mode="RGB"), WORKING_COLOR_SPACE)
+        sim_arr = np.asarray(sim, dtype=np.float32)[0, 0] / 255.0
+
+        self.assertTrue(
+            np.allclose(lut_out, sim_arr, atol=0.02),
+            msg=f"display LUT {lut_out} != simulate_on_srgb {sim_arr}",
+        )
+
+    def test_non_rgb_buffer_passthrough(self):
+        grey = np.random.rand(4, 4).astype(np.float32)
+        out = apply_display_transform(grey, WORKING_COLOR_SPACE)
+        np.testing.assert_array_equal(out, grey)
+
+    def test_color_managed_defaults_use_working_space(self):
+        """Color-space params must default to the working space, not a hardcoded
+        'sRGB' that silently skips color management on the float32 path (cf. #518)."""
+        import inspect
+
+        from negpy.desktop.converters import ImageConverter
+        from negpy.desktop.workers.render import ThumbnailUpdateTask
+        from negpy.services.assets.thumbnails import get_rendered_thumbnail
+
+        # Premise: the working space is not sRGB, so the default choice is load-bearing.
+        self.assertNotEqual(WORKING_COLOR_SPACE, ColorSpace.SRGB.value)
+        self.assertEqual(inspect.signature(ImageConverter.to_qimage).parameters["color_space"].default, WORKING_COLOR_SPACE)
+        self.assertEqual(inspect.signature(get_rendered_thumbnail).parameters["color_space"].default, WORKING_COLOR_SPACE)
+        self.assertEqual(ThumbnailUpdateTask.__dataclass_fields__["color_space"].default, WORKING_COLOR_SPACE)
+
+
+def _icc_bytes(cs_name: str) -> bytes:
+    with open(ColorSpaceRegistry.get_icc_path(cs_name), "rb") as f:
         return f.read()
 
 
+class TestMonitorDisplayProfile(unittest.TestCase):
+    """The display transform must target the monitor profile, not always sRGB."""
+
+    def test_no_monitor_is_legacy_srgb(self):
+        # Default (no monitor profile) keeps the sRGB-display behaviour: sRGB working
+        # stays identity, so existing callers are unaffected.
+        self.assertIsNone(get_display_lut(ColorSpace.SRGB.value))
+        self.assertIsNone(get_display_lut(ColorSpace.SRGB.value, None))
+
+    def test_monitor_profile_makes_srgb_working_nonidentity(self):
+        # On a P3 display even an sRGB working space needs a transform.
+        lut = get_display_lut(ColorSpace.SRGB.value, _icc_bytes(ColorSpace.P3_D65.value))
+        self.assertIsNotNone(lut)
+
+    def test_monitor_display_differs_from_srgb_display(self):
+        p3 = _icc_bytes(ColorSpace.P3_D65.value)
+        patch = np.array([[[0.80, 0.30, 0.20]]], dtype=np.float32)
+        srgb_disp = apply_display_transform(patch, WORKING_COLOR_SPACE)[0, 0]
+        p3_disp = apply_display_transform(patch, WORKING_COLOR_SPACE, p3)[0, 0]
+        self.assertFalse(
+            np.allclose(srgb_disp, p3_disp, atol=0.02),
+            msg=f"P3 display {p3_disp} should differ from sRGB display {srgb_disp}",
+        )
+
+
+class TestDisplayProfileOverrideHelpers(unittest.TestCase):
+    """Helpers backing the manual Display-profile override dropdown."""
+
+    def test_icc_bytes_for_space_opens_as_profile(self):
+        data = icc_bytes_for_space(ColorSpace.P3_D65.value)
+        self.assertTrue(data)
+        # Must open as a usable profile (drives apply_display_transform).
+        self.assertIsNotNone(open_profile_from_bytes(data))
+
+    def test_icc_bytes_for_space_unknown_is_none(self):
+        self.assertIsNone(icc_bytes_for_space("NotARealSpace"))
+
+    def test_profile_description_none_is_srgb_fallback(self):
+        self.assertEqual(profile_description(None), "sRGB fallback")
+
+    def test_profile_description_reads_name(self):
+        desc = profile_description(icc_bytes_for_space(ColorSpace.P3_D65.value))
+        self.assertTrue(desc and desc != "sRGB fallback")
+
+    def test_override_bytes_match_apply_transform(self):
+        # An override to Display P3 must produce the same display LUT as feeding those
+        # bytes directly — i.e. the dropdown selection drives the real transform.
+        p3 = icc_bytes_for_space(ColorSpace.P3_D65.value)
+        patch = np.array([[[0.80, 0.30, 0.20]]], dtype=np.float32)
+        via_override = apply_display_transform(patch, WORKING_COLOR_SPACE, p3)
+        via_direct = apply_display_transform(patch, WORKING_COLOR_SPACE, _icc_bytes(ColorSpace.P3_D65.value))
+        np.testing.assert_array_equal(via_override, via_direct)
+
+
+class TestPrintProfileDetection(unittest.TestCase):
+    """`_is_print_profile` routes paper/printer profiles to the paper-white proof."""
+
+    class _Stub:
+        def __init__(self, device_class="", xcolor_space="RGB "):
+            self.profile = type("P", (), {"device_class": device_class, "xcolor_space": xcolor_space})()
+
+    def test_printer_class_is_print(self):
+        self.assertTrue(ImageProcessor._is_print_profile(self._Stub(device_class="prtr ")))
+
+    def test_cmyk_space_is_print(self):
+        self.assertTrue(ImageProcessor._is_print_profile(self._Stub(xcolor_space="CMYK")))
+
+    def test_bundled_display_spaces_not_print(self):
+        for cs in (ColorSpace.SRGB.value, ColorSpace.ADOBE_RGB.value, ColorSpace.P3_D65.value):
+            prof = ImageCms.getOpenProfile(ColorSpaceRegistry.get_icc_path(cs))
+            self.assertFalse(ImageProcessor._is_print_profile(prof), msg=f"{cs} should not be a print profile")
+
+
+class TestSoftProofToMonitor(unittest.TestCase):
+    """Soft proof must chain working→output→monitor when a display profile is set."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.proc = ImageProcessor()
+
+    def test_proof_unchanged_without_monitor(self):
+        from PIL import Image
+
+        u8 = (np.array([[[0.70, 0.40, 0.25]]], dtype=np.float32) * 255.0 + 0.5).astype(np.uint8)
+        img = Image.fromarray(u8, mode="RGB")
+        out_path = ColorSpaceRegistry.get_icc_path(ColorSpace.SRGB.value)
+        a = np.asarray(self.proc.soft_proof_preview(img, WORKING_COLOR_SPACE, None, out_path), dtype=np.float32)
+        b = np.asarray(self.proc.soft_proof_preview(img, WORKING_COLOR_SPACE, None, out_path, None), dtype=np.float32)
+        np.testing.assert_array_equal(a, b)
+
+    def test_proof_in_gamut_stable_across_output_spaces(self):
+        """An in-gamut proof must look the same regardless of export space (#243).
+
+        The output→display step always runs (sRGB display here), so source→output→
+        display cancels to source→display for in-gamut colors — the intermediate
+        export space drops out. Only out-of-gamut colors should differ.
+        """
+        from PIL import Image
+
+        u8 = (np.array([[[0.55, 0.42, 0.30]]], dtype=np.float32) * 255.0 + 0.5).astype(np.uint8)
+        img = Image.fromarray(u8, mode="RGB")
+        spaces = (
+            ColorSpace.SRGB.value,
+            ColorSpace.ADOBE_RGB.value,
+            ColorSpace.REC2020.value,
+            ColorSpace.PROPHOTO.value,
+        )
+        outs = [
+            np.asarray(
+                self.proc.soft_proof_preview(img, WORKING_COLOR_SPACE, None, ColorSpaceRegistry.get_icc_path(s)),
+                dtype=np.float32,
+            )
+            for s in spaces
+        ]
+        ref = outs[0]
+        for s, arr in zip(spaces, outs):
+            # ±2/255: only 8-bit LUT rounding, not a per-space appearance shift.
+            self.assertTrue(np.allclose(arr, ref, atol=2.0), msg=f"{s} proof diverges: {arr.ravel()} vs {ref.ravel()}")
+
+    def test_proof_to_monitor_matches_explicit_chain(self):
+        from PIL import Image
+
+        p3 = _icc_bytes(ColorSpace.P3_D65.value)
+        out_path = ColorSpaceRegistry.get_icc_path(ColorSpace.SRGB.value)
+        u8 = (np.array([[[0.70, 0.40, 0.25]]], dtype=np.float32) * 255.0 + 0.5).astype(np.uint8)
+        img = Image.fromarray(u8, mode="RGB")
+
+        no_mon = np.asarray(self.proc.soft_proof_preview(img, WORKING_COLOR_SPACE, None, out_path), dtype=np.float32)
+        with_mon = np.asarray(self.proc.soft_proof_preview(img, WORKING_COLOR_SPACE, None, out_path, p3), dtype=np.float32)
+        # The output→monitor step changes the displayed pixels.
+        self.assertFalse(np.allclose(no_mon, with_mon, atol=1.0))
+
+        # ...and equals an explicit working→output→monitor chain (relative + BPC).
+        p_work = _open(WORKING_COLOR_SPACE)
+        p_out = _open(ColorSpace.SRGB.value)
+        p_mon = open_profile_from_bytes(p3)
+        step1 = ImageCms.profileToProfile(
+            img,
+            p_work,
+            p_out,
+            renderingIntent=ImageCms.Intent.RELATIVE_COLORIMETRIC,
+            outputMode="RGB",
+            flags=ImageCms.Flags.BLACKPOINTCOMPENSATION,
+        )
+        step2 = ImageCms.profileToProfile(
+            step1,
+            p_out,
+            p_mon,
+            renderingIntent=ImageCms.Intent.RELATIVE_COLORIMETRIC,
+            outputMode="RGB",
+            flags=ImageCms.Flags.BLACKPOINTCOMPENSATION,
+        )
+        chain = np.asarray(step2, dtype=np.float32)
+        np.testing.assert_allclose(with_mon, chain, atol=1.0)
+
+
+class TestSessionBoundaryProfile(unittest.TestCase):
+    def test_session_workspace_matches_working_space(self):
+        """AppState's boundary profile must be the working space.
+
+        It is handed to export/proof/thumbnail/CPU-display as the *source* profile for
+        the engine's working-space-encoded buffer; drift silently mis-tags every export.
+        """
+        from negpy.desktop.session import AppState
+
+        self.assertEqual(AppState().workspace_color_space, WORKING_COLOR_SPACE)
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
 class TestMatrixTrcFastPath(unittest.TestCase):
+    """The 8-bit export fast path must match lcms within 1 LSB."""
+
     @classmethod
     def setUpClass(cls):
         rng = np.random.default_rng(11)
         cls.arr = (rng.random((256, 384, 3)) * 255).astype(np.uint8)
-        cls.working = "Adobe RGB"
+        cls.working = WORKING_COLOR_SPACE
+
+    @staticmethod
+    def _icc_bytes(space: str) -> bytes:
+        path = ColorSpaceRegistry.get_icc_path(space)
+        assert path is not None
+        with open(path, "rb") as f:
+            return f.read()
 
     def _lcms_reference(self, target: str) -> np.ndarray:
+        from PIL import Image
+
         p_src = ImageProcessor._resolve_src_profile(self.working, None)
         p_dst = ImageProcessor._resolve_dst_profile(target, None)
         ref = ImageCms.profileToProfile(
@@ -38,25 +402,27 @@ class TestMatrixTrcFastPath(unittest.TestCase):
         return np.asarray(ref).astype(np.int16)
 
     def test_matches_lcms_within_one_lsb(self):
-        src = _icc_bytes(self.working)
+        from negpy.infrastructure.display.icc_lut import apply_matrix_trc_u8
+
+        src = self._icc_bytes(self.working)
         for target in ("sRGB", "Rec 2020", "ProPhoto RGB"):
             with self.subTest(target=target):
-                out = apply_matrix_trc_u8(self.arr, src, _icc_bytes(target))
+                out = apply_matrix_trc_u8(self.arr, src, self._icc_bytes(target))
                 self.assertIsNotNone(out)
                 delta = np.abs(out.astype(np.int16) - self._lcms_reference(target))
                 self.assertLessEqual(delta.max(), 1)
 
     def test_same_space_is_identity(self):
-        src = _icc_bytes(self.working)
+        from negpy.infrastructure.display.icc_lut import apply_matrix_trc_u8
+
+        src = self._icc_bytes(self.working)
         out = apply_matrix_trc_u8(self.arr, src, src)
         np.testing.assert_array_equal(out, self.arr)
 
     def test_non_matrix_profile_falls_through(self):
         """A profile without RGB colorant tags (greyscale) must return None so the
         caller takes the exact lcms path."""
-        grey = _icc_bytes("Greyscale")
-        self.assertIsNone(apply_matrix_trc_u8(self.arr, _icc_bytes(self.working), grey))
+        from negpy.infrastructure.display.icc_lut import apply_matrix_trc_u8
 
-
-if __name__ == "__main__":
-    unittest.main()
+        grey = self._icc_bytes("Greyscale")
+        self.assertIsNone(apply_matrix_trc_u8(self.arr, self._icc_bytes(self.working), grey))

--- a/tests/test_exposure_logic.py
+++ b/tests/test_exposure_logic.py
@@ -289,3 +289,23 @@ class TestExposureDomainDodgeBurn(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+def test_block_median_b2_fast_path_matches_np_median():
+    """The b==2 min/max fast path must agree with np.median over 2x2 blocks."""
+    import numpy as np
+
+    from negpy.features.exposure.models import EXPOSURE_CONSTANTS
+    from negpy.features.exposure.normalization import _block_median_grid
+
+    grid = int(EXPOSURE_CONSTANTS["analysis_grid"])
+    rng = np.random.default_rng(9)
+    # Long edge just over the grid, so b == 2.
+    img = rng.random((grid + 40, (grid * 2) // 3, 3)).astype(np.float32)
+
+    out = _block_median_grid(img)
+
+    h, w = img.shape[:2]
+    hb, wb = (h // 2) * 2, (w // 2) * 2
+    ref = np.median(img[:hb, :wb].reshape(hb // 2, 2, wb // 2, 2, 3), axis=(1, 3))
+    np.testing.assert_allclose(out, ref, atol=1e-6)

--- a/tests/test_gpu_analysis_cache.py
+++ b/tests/test_gpu_analysis_cache.py
@@ -31,6 +31,21 @@ class TestAnalysisCacheKey(unittest.TestCase):
         ):
             self.assertEqual(k0, _analysis_cache_key(cfg, "src"))
 
+    def test_downstream_process_fields_keep_key(self):
+        """White/black point offsets, per-channel trims and hue trim are applied as
+        uniform offsets after the meter, so their drags must reuse the analysis."""
+        k0 = _analysis_cache_key(self.cfg, "src")
+        for cfg in (
+            replace(self.cfg, process=replace(self.cfg.process, white_point_offset=0.1)),
+            replace(self.cfg, process=replace(self.cfg.process, black_point_offset=-0.05)),
+            replace(self.cfg, process=replace(self.cfg.process, white_point_trim_red=0.02)),
+            replace(self.cfg, process=replace(self.cfg.process, black_point_trim_blue=0.02)),
+            replace(self.cfg, process=replace(self.cfg.process, hue_trim=5.0)),
+            replace(self.cfg, process=replace(self.cfg.process, lock_bounds=True)),
+            replace(self.cfg, process=replace(self.cfg.process, narrowband_scan=True)),
+        ):
+            self.assertEqual(k0, _analysis_cache_key(cfg, "src"))
+
     def test_analysis_settings_change_key(self):
         """Anything feeding the meter must invalidate the key."""
         k0 = _analysis_cache_key(self.cfg, "src")
@@ -38,6 +53,10 @@ class TestAnalysisCacheKey(unittest.TestCase):
             replace(self.cfg, process=replace(self.cfg.process, analysis_buffer=self.cfg.process.analysis_buffer + 0.05)),
             replace(self.cfg, process=replace(self.cfg.process, luma_range_clip=0.05)),
             replace(self.cfg, process=replace(self.cfg.process, color_range_clip=0.05)),
+            replace(self.cfg, process=replace(self.cfg.process, crosstalk_strength=0.5)),
+            replace(self.cfg, process=replace(self.cfg.process, use_luma_average=True)),
+            replace(self.cfg, process=replace(self.cfg.process, locked_floors=(0.1, 0.1, 0.1))),
+            replace(self.cfg, process=replace(self.cfg.process, local_floors=(0.1, 0.1, 0.1))),
             replace(self.cfg, geometry=replace(self.cfg.geometry, rotation=1)),
             replace(self.cfg, exposure=replace(self.cfg.exposure, cast_removal_strength=0.0)),
             replace(self.cfg, exposure=replace(self.cfg.exposure, auto_exposure=not self.cfg.exposure.auto_exposure)),

--- a/tests/test_gpu_stage_skip.py
+++ b/tests/test_gpu_stage_skip.py
@@ -183,14 +183,29 @@ class TestLocalMapCache(unittest.TestCase):
 
         self.assertEqual(self._count_rasterisations(drag), 1)
 
-    def test_grade_change_rebuilds_the_map(self):
-        """The green lane carries a grade-derived slope factor."""
+    def test_grade_change_reapplies_factor_without_rerasterising(self):
+        """The green lane carries a grade-derived slope factor, but the raster itself
+        does not depend on grade: a grade move re-uploads with a new factor only."""
+        from negpy.features.exposure import logic as exposure_logic
 
-        def move_grade():
-            self._render(self.cfg)
-            self._render(_sub(self.cfg, "exposure", grade=4.0))
+        factor_calls = {"n": 0}
+        real_factor = exposure_logic.local_grade_factor_map
 
-        self.assertEqual(self._count_rasterisations(move_grade), 2)
+        def factor_spy(*a, **k):
+            factor_calls["n"] += 1
+            return real_factor(*a, **k)
+
+        exposure_logic.local_grade_factor_map = factor_spy
+        try:
+
+            def move_grade():
+                self._render(self.cfg)
+                self._render(_sub(self.cfg, "exposure", grade=4.0))
+
+            self.assertEqual(self._count_rasterisations(move_grade), 1)
+        finally:
+            exposure_logic.local_grade_factor_map = real_factor
+        self.assertEqual(factor_calls["n"], 2)
 
     def test_mask_edit_rebuilds_the_map(self):
         def move_mask():

--- a/tests/test_gpu_texture_pool_eviction.py
+++ b/tests/test_gpu_texture_pool_eviction.py
@@ -1,0 +1,52 @@
+"""Generation-based texture-pool eviction across export renders.
+
+The pool survives a batch so a same-dimensions roll reuses its chain, but a
+dimension change must free the old chain, or VRAM grows with every size seen.
+"""
+
+import unittest
+
+import numpy as np
+
+from negpy.domain.models import WorkspaceConfig
+from negpy.infrastructure.gpu.device import GPUDevice
+
+
+class TestTexturePoolEviction(unittest.TestCase):
+    def setUp(self):
+        if not GPUDevice.get().is_available:
+            self.skipTest("GPU not available")
+        from negpy.services.rendering.gpu_engine import GPUEngine
+
+        self.eng = GPUEngine()
+        self.addCleanup(self.eng.destroy_all)
+        rng = np.random.default_rng(5)
+        self.img_a = rng.random((256, 320, 3), dtype=np.float32) * 0.5 + 0.2
+        self.img_b = rng.random((320, 200, 3), dtype=np.float32) * 0.5 + 0.2
+        self.cfg = WorkspaceConfig()
+
+    def test_same_dimensions_reuse_the_chain(self):
+        self.eng.process(self.img_a, self.cfg)
+        keys = set(self.eng._tex_cache)
+        self.eng.process(self.img_a, self.cfg)
+        self.assertEqual(set(self.eng._tex_cache), keys)
+
+    def test_dimension_change_frees_the_old_chain(self):
+        self.eng.process(self.img_a, self.cfg)
+        keys_a = set(self.eng._tex_cache)
+
+        # Grace render: the A chain is still pooled alongside B's.
+        self.eng.process(self.img_b, self.cfg)
+        after_first_b = set(self.eng._tex_cache)
+        self.assertTrue(keys_a <= after_first_b)
+
+        # Second B render evicts everything the first B render did not touch.
+        self.eng.process(self.img_b, self.cfg)
+        after_second_b = set(self.eng._tex_cache)
+        self.assertLess(len(after_second_b), len(after_first_b))
+        for gen in self.eng._tex_gen.values():
+            self.assertGreaterEqual(gen, self.eng._render_gen - 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_retouch_logic.py
+++ b/tests/test_retouch_logic.py
@@ -450,3 +450,40 @@ def test_line_sensitivity_trades_reach_for_restraint():
 def test_scratch_detect_bar_is_monotonic():
     bars = [scratch_detect_bar(v) for v in (0.05, 0.5, 0.95)]
     assert bars == sorted(bars), "higher must be more conservative"
+
+
+def test_luma_bake_token_tracks_the_toggle_and_params():
+    from negpy.features.retouch.logic import luma_bake_token
+
+    off = luma_bake_token(RetouchConfig(dust_remove=False))
+    on = luma_bake_token(RetouchConfig(dust_remove=True))
+    assert off == ""
+    assert on != off
+    assert luma_bake_token(RetouchConfig(dust_remove=True, dust_threshold=0.5)) != on
+
+
+def test_dust_toggle_changes_engine_source_hash():
+    """The speck bake mutates the source, so the toggle must change the hash both
+    engine caches key on — or the GPU keeps rendering the stale uploaded texture."""
+    import dataclasses
+    from unittest.mock import patch
+
+    from negpy.domain.models import WorkspaceConfig
+    from negpy.services.rendering.image_processor import ImageProcessor
+
+    proc = ImageProcessor()
+    proc.engine_gpu = None  # CPU branch; both engines receive the same hash
+    img = np.random.default_rng(0).random((64, 96, 3)).astype(np.float32)
+    cfg = WorkspaceConfig()
+    seen = []
+
+    def spy(buf, settings, source_hash, context=None):
+        seen.append(source_hash)
+        return buf
+
+    with patch.object(proc.engine_cpu, "process", side_effect=spy):
+        proc.run_pipeline(img, cfg, "src", render_size_ref=1600.0, prefer_gpu=False, readback_metrics=False)
+        cfg_on = dataclasses.replace(cfg, retouch=dataclasses.replace(cfg.retouch, dust_remove=True))
+        proc.run_pipeline(img, cfg_on, "src", render_size_ref=1600.0, prefer_gpu=False, readback_metrics=False)
+
+    assert seen[0] != seen[1], "dust_remove toggle left source_hash unchanged"

--- a/tests/test_right_panel_wiring.py
+++ b/tests/test_right_panel_wiring.py
@@ -1,0 +1,36 @@
+"""Signal wiring of the right panel's analysis refresh.
+
+_paint_negative_peek emits image_updated only, never metrics_available, so the
+image_updated path must refresh the histograms itself or entering Peek Negative
+leaves the chart in print mode.
+"""
+
+from unittest.mock import MagicMock
+
+from negpy.desktop.view.sidebar.right_panel import RightPanel
+
+
+def _panel_stub(last_metrics: dict) -> MagicMock:
+    panel = MagicMock()
+    panel.controller.session.state.last_metrics = last_metrics
+    panel.controller.state.flat_peek = False
+    panel.controller.state.negative_peek = True
+    panel._clip_fracs = (None, None)
+    return panel
+
+
+def test_update_analysis_refreshes_histograms() -> None:
+    metrics = {"interactive": False, "histogram_density": [1.0]}
+    panel = _panel_stub(metrics)
+
+    RightPanel._update_analysis(panel)
+
+    panel._update_histograms.assert_called_once_with(metrics)
+
+
+def test_update_analysis_skips_mid_gesture_frames() -> None:
+    panel = _panel_stub({"interactive": True})
+
+    RightPanel._update_analysis(panel)
+
+    panel._update_histograms.assert_not_called()


### PR DESCRIPTION
## Summary

Second perf pass (after #777). Normal drag/settle frames were already fast; this targets the pathological preview drags and the export path. All numbers from the 890M iGPU, 23.5MPx scan at 1600px preview unless noted.

| Scenario | Before | After |
|---|---|---|
| White/black-point, trim, hue-trim drag | 117 ms | 9 ms |
| Grade drag with a local mask | 48 ms | 24 ms |
| Clip / analysis-buffer drag (re-meters by design) | 133 ms | 54 ms |
| Export render + encode (tiled JPEG) | 1.25 + 0.47 s | 0.96 + 0.17 s |
| Export 57MPx | 2.45 + 1.19 s | 1.91 + 0.46 s |
| Export ARW RGB-triplet render | 5.65 s | 3.71 s |

## Preview

- Analysis cache key narrowed to the fields the meter reads; WP/BP offsets, per-channel trims and hue trim apply as uniforms and no longer bust it.
- Process/Sensor sliders send `readback_metrics=False` mid-drag (tone.py pattern) instead of paying settled-frame cost per tick.
- Local-mask raster cached grade-free; grade re-applies only the factor map at upload.
- Meter prefilter (replay + log10 + block-median) cached without the clip sliders; block median of 4 via strided min/max/sum.
- Export/metadata sidebar sync debounced; gear library and contact-sheet templates mtime-cached (was per-tick disk I/O on the UI thread).
- Duplicate histogram repaint per settled frame dropped.

## Export

- Exact matrix/TRC ICC kernel for named-space 8-bit exports, within 1 LSB of lcms on every bundled space (pinned by a test); lcms kept for custom/LUT profiles. JPEG bytes shift up to 1 LSB.
- TIFF/PNG metadata embedded at the first encode; the post-hoc rewrite decoded and re-compressed the full-res file.
- Batch export keeps the GPU texture pool; generation-based eviction bounds VRAM when dimensions change. Export passes source hashes, so multi-preset export of a non-tiled frame skips re-upload and re-metering.
- Triplet/HDR/stitch parts decode concurrently.
- Tiled loop overlaps each tile's readback wait with the next tile's dispatch.

## Verified

- `make all` green; parity suites (`test_gpu_tiled_parity`, `test_gpu_stage_skip`, `test_pipeline_parity`) pass.
- New tests: ICC kernel vs lcms delta, analysis-key invalidation matrix, first-encode metadata equivalence, batch cleanup contract.
- New CI metrics: `export.render_s`/`export.encode_s` plus worst-case drag metrics; render files added to the metrics workflow path filter.

## Rejected on the way

- Trilinear-LUT ICC transform: max delta 17/255 at gamut-clip creases.
- Demosaic-chooser "hotspot": profile artifact of `raw.raw_type` triggering libraw unpack, which postprocess needs anyway.