### PR TITLE
perf(export): pipeline batch decode, render and encode

### DIFF
--- a/negpy/desktop/workers/export.py
+++ b/negpy/desktop/workers/export.py
@@ -1,9 +1,12 @@
+from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass
 from typing import List, Optional, Any, Union
 import gc
 import os
 import tempfile
 import threading
+
+import numpy as np
 from PyQt6.QtCore import QObject, pyqtSignal, pyqtSlot
 from negpy.domain.models import ColorSpace, WorkspaceConfig, ExportConfig, ExportFormat, ExportPreset, ExportPresetOutputMode
 from negpy.features.metadata.writer import embed_metadata, export_embed_plan, preserve_source_metadata
@@ -49,18 +52,6 @@ class LinearOutputTask:
     file_info: dict
     out_path: str
     options: dict
-
-
-def _same_decode_source(a: ExportTask, b: ExportTask) -> bool:
-    """True when the decoded f32 source cache is reusable for the next task
-    (mirrors the _load_source_f32 cache key; the key still verifies on read)."""
-    return (
-        a.file_info["path"] == b.file_info["path"]
-        and a.params.process.linear_raw == b.params.process.linear_raw
-        and a.params.process.sensor_matrix == b.params.process.sensor_matrix
-        and a.params.rgbscan == b.params.rgbscan
-        and a.params.flatfield == b.params.flatfield
-    )
 
 
 _EXT = {
@@ -143,17 +134,34 @@ class ExportWorker(QObject):
 
     @pyqtSlot(list)
     def run_batch(self, tasks: List[ExportTask]) -> None:
-        """Processes an ordered list of export tasks."""
+        """Processes an ordered list of export tasks, pipelined: the prefetcher
+        prepares the next source and the finisher encodes+writes the previous
+        render while the current one renders. One finish in flight, so at most
+        two full-res buffers are held."""
         self._cancel.clear()
         total = len(tasks)
+        finisher = ThreadPoolExecutor(max_workers=1)
+        prefetcher = ThreadPoolExecutor(max_workers=1)
+        pending: Optional[Future] = None
+
+        def _drain(fut: Future) -> None:
+            err = fut.result()
+            if err:
+                self.error.emit(err)
+
         try:
             for i, task in enumerate(tasks):
                 if self._cancel.is_set():
-                    self.cancelled.emit()
-                    return
+                    break
                 full_name = task.file_info["name"]
                 name = os.path.splitext(full_name)[0]
                 self.progress.emit(i + 1, total, name)
+
+                nxt = tasks[i + 1] if i + 1 < len(tasks) else None
+                prefetch_next = nxt is not None and nxt.diptych is None
+                # Not on the first task: its own prepare would queue behind this on the gate.
+                if prefetch_next and i > 0:
+                    self._submit_prefetch(prefetcher, nxt)
 
                 # TIFF/PNG take the metadata at the first encode; the post-hoc
                 # rewrite re-compresses the full-res file.
@@ -165,73 +173,103 @@ class ExportWorker(QObject):
                         task.file_info["path"],
                     )
 
-                bits, status = self._processor.process_export(
+                buffer, status = self._processor.render_export(
                     task.file_info["path"],
                     task.params,
                     task.export_settings,
                     task.file_info["hash"],
                     prefer_gpu=task.gpu_enabled,
                     bounds_override=task.bounds_override,
-                    working_color_space=task.working_color_space,
                     half=int(task.file_info.get("half") or 0),
                     split_x=float(task.file_info.get("split_x") or 0.5),
                     crop_rect=tuple(task.file_info["crop_rect"]) if task.file_info.get("crop_rect") else None,
                     gutter_thickness=float(task.file_info.get("gutter_thickness") or 0.0),
                     diptych=task.diptych,
-                    embed_plan=embed_plan,
                 )
+                if prefetch_next and i == 0:
+                    self._submit_prefetch(prefetcher, nxt)
 
-                if not bits:
-                    # process_export returns (None, error) on failure. Surface it rather than skipping the
-                    # file silently.
+                if buffer is None:
+                    # render_export returns (None, error) on failure. Surface it rather
+                    # than skipping the file silently.
                     self.error.emit(status)
                     continue
 
-                if bits:
-                    if task.metadata_config is not None and embed_plan is None:
-                        if task.metadata_config.protect_original_metadata:
-                            bits = preserve_source_metadata(
-                                bits,
-                                task.file_info["path"],
-                                task.source_exif,
-                            )
-                        else:
-                            bits = embed_metadata(bits, task.metadata_config, task.source_exif)
+                if pending is not None:
+                    _drain(pending)
+                pending = finisher.submit(self._finish_task, task, buffer, status, embed_plan)
 
-                    out_dir, filename, ext = resolve_export_naming(task)
-                    os.makedirs(out_dir, exist_ok=True)
-                    path = os.path.join(out_dir, f"{filename}.{ext}")
-
-                    if not task.export_settings.overwrite:
-                        counter = 2
-                        while os.path.exists(path):
-                            path = os.path.join(out_dir, f"{filename}_{counter}.{ext}")
-                            counter += 1
-
-                    tmp_path = None
-                    try:
-                        with tempfile.NamedTemporaryFile(dir=out_dir, delete=False, suffix=".part") as tmp:
-                            tmp_path = tmp.name
-                            tmp.write(bits)
-                        os.replace(tmp_path, path)
-                    except Exception as write_err:
-                        if tmp_path is not None and os.path.exists(tmp_path):
-                            os.unlink(tmp_path)
-                        self.error.emit(str(write_err))
-                        continue
-
-                # The engine evicts stale pool textures itself per render; the decoded
-                # source is kept until the next task needs a different file.
-                nxt = tasks[i + 1] if i + 1 < len(tasks) else None
-                if nxt is None or not _same_decode_source(task, nxt):
-                    self._processor.release_source_cache()
-
-            self.finished.emit()
+            if pending is not None:
+                _drain(pending)
+                pending = None
+            if self._cancel.is_set():
+                self.cancelled.emit()
+            else:
+                self.finished.emit()
         except Exception as e:
             self.error.emit(str(e))
         finally:
+            prefetcher.shutdown(wait=True)
+            finisher.shutdown(wait=True)
             self._processor.cleanup(release_source_cache=True, collect=False)
             gc.collect()
+
+    def _submit_prefetch(self, prefetcher: ThreadPoolExecutor, nxt: ExportTask) -> None:
+        prefetcher.submit(
+            self._processor.prefetch_export_source,
+            nxt.file_info["path"],
+            nxt.params,
+            nxt.file_info["hash"],
+            half=int(nxt.file_info.get("half") or 0),
+            split_x=float(nxt.file_info.get("split_x") or 0.5),
+            crop_rect=tuple(nxt.file_info["crop_rect"]) if nxt.file_info.get("crop_rect") else None,
+            gutter_thickness=float(nxt.file_info.get("gutter_thickness") or 0.0),
+        )
+
+    def _finish_task(self, task: ExportTask, buffer: np.ndarray, color_space: str, embed_plan: Optional[tuple]) -> Optional[str]:
+        """Encode + metadata + atomic write for one rendered frame, on the finisher
+        thread. Returns an error message, or None on success."""
+        bits, status = self._processor.encode_export(
+            buffer,
+            task.export_settings,
+            color_space,
+            task.working_color_space,
+            embed_plan=embed_plan,
+        )
+        if not bits:
+            return status
+
+        if task.metadata_config is not None and embed_plan is None:
+            if task.metadata_config.protect_original_metadata:
+                bits = preserve_source_metadata(
+                    bits,
+                    task.file_info["path"],
+                    task.source_exif,
+                )
+            else:
+                bits = embed_metadata(bits, task.metadata_config, task.source_exif)
+
+        out_dir, filename, ext = resolve_export_naming(task)
+        os.makedirs(out_dir, exist_ok=True)
+        path = os.path.join(out_dir, f"{filename}.{ext}")
+
+        if not task.export_settings.overwrite:
+            counter = 2
+            while os.path.exists(path):
+                path = os.path.join(out_dir, f"{filename}_{counter}.{ext}")
+                counter += 1
+
+        tmp_path = None
+        try:
+            with tempfile.NamedTemporaryFile(dir=out_dir, delete=False, suffix=".part") as tmp:
+                tmp_path = tmp.name
+                tmp.write(bits)
+            os.replace(tmp_path, path)
+        except Exception as write_err:
+            if tmp_path is not None and os.path.exists(tmp_path):
+                os.unlink(tmp_path)
+            return str(write_err)
+        return None
 
     @pyqtSlot(list)
     def run_linear_output(self, tasks: List[LinearOutputTask]) -> None:

--- a/negpy/services/rendering/image_processor.py
+++ b/negpy/services/rendering/image_processor.py
@@ -1,6 +1,7 @@
 import os
 import io
 import ctypes
+import threading
 import cv2
 import rawpy
 import tifffile
@@ -226,6 +227,11 @@ class ImageProcessor:
         # state, so whichever loses can be deleted without unpicking the other.
         self._ice_key: Optional[tuple] = None
         self._ice_value: Optional[tuple] = None
+
+        # Prefetched export source for the batch worker. The gate serializes the
+        # prepare compute: the decode/bake caches above are single-slot.
+        self._prepare_gate = threading.Lock()
+        self._prepare_slot: Optional[Tuple[tuple, Tuple[np.ndarray, str, str]]] = None
 
         # Called with a label when a slow uncached step starts, for a UI busy cue. Set by
         # RenderWorker. The caller runs on the render thread, so keep it to a signal emit.
@@ -505,21 +511,23 @@ class ImageProcessor:
         )
 
         # Bake the IR correction before detection so meters/stats see the corrected buffer.
+        # Gated: the bake caches are single-slot and the export prefetch bakes on a helper thread.
         want_ir = settings.retouch.ir_dust_remove and ir_buffer is not None and not self._is_flat(settings)
-        img, ir_corrected_mask, ir_degenerate, ir_routed = self._ir_bake(img, ir_buffer, settings, base_hash)
+        with self._prepare_gate:
+            img, ir_corrected_mask, ir_degenerate, ir_routed = self._ir_bake(img, ir_buffer, settings, base_hash)
 
-        orig_ret = settings.retouch
-        detected_dust, hair_masks = self._detect_luma(settings, img, base_hash)
-        img = self._luma_bake(img, detected_dust, base_hash + hair_bake_token(orig_ret))
-        img, manual_routed = self._manual_bake(img, settings, base_hash)
-        extra = [m for m in (ir_routed, manual_routed) if m is not None]
-        if extra:
-            hair_masks = hair_masks + extra  # never mutate the cached list
-        # Inpaint long/twisted hairs into the source, where both engines see it. The token
-        # invalidates the base stage when detection params change.
-        hair_token = hair_bake_token(orig_ret) if hair_masks else ""
-        if hair_masks:
-            img = self._hair_inpaint(img, hair_masks, base_hash + hair_token)
+            orig_ret = settings.retouch
+            detected_dust, hair_masks = self._detect_luma(settings, img, base_hash)
+            img = self._luma_bake(img, detected_dust, base_hash + hair_bake_token(orig_ret))
+            img, manual_routed = self._manual_bake(img, settings, base_hash)
+            extra = [m for m in (ir_routed, manual_routed) if m is not None]
+            if extra:
+                hair_masks = hair_masks + extra  # never mutate the cached list
+            # Inpaint long/twisted hairs into the source, where both engines see it. The token
+            # invalidates the base stage when detection params change.
+            hair_token = hair_bake_token(orig_ret) if hair_masks else ""
+            if hair_masks:
+                img = self._hair_inpaint(img, hair_masks, base_hash + hair_token)
 
         source_hash = base_hash + hair_token + f"|res{w_cols}x{h_orig}"
 
@@ -834,33 +842,43 @@ class ImageProcessor:
             ir_full = np.ascontiguousarray(slice_half(ir_full, half, split_x, crop_rect=crop_rect, gutter_thickness=gutter_thickness))
         return f32_buffer, ir_full
 
-    def _render_export_buffer(
+    def _prepare_export_source(
         self,
         file_path: str,
         params: WorkspaceConfig,
-        export_settings,  # ExportConfig or ExportPreset
         source_hash: str,
-        metrics: Optional[Dict[str, Any]] = None,
-        prefer_gpu: bool = True,
-        bounds_override: Optional[Any] = None,
         half: int = 0,
         split_x: float = 0.5,
         crop_rect: Optional[tuple[float, float, float, float]] = None,
         gutter_thickness: float = 0.0,
-    ) -> Tuple[np.ndarray, str]:
-        """Full-res render of one frame; returns the float buffer and its color space."""
-        # Ensure both GPU and CPU paths use the same export settings.
-        params = dc_replace(params, export=export_settings)
+    ) -> Tuple[np.ndarray, str, str]:
+        """Decode, slice and bake one frame for export: (f32_buffer, source color
+        space, bake token for the engine hash). Served from the handoff slot when
+        prefetched, computed under the gate otherwise."""
+        key = (file_path, source_hash, params, half, split_x, crop_rect, gutter_thickness)
+        slot = self._prepare_slot
+        if slot is not None and slot[0] == key:
+            return slot[1]
+        with self._prepare_gate:
+            slot = self._prepare_slot
+            if slot is not None and slot[0] == key:
+                return slot[1]
+            return self._prepare_export_source_locked(file_path, params, source_hash, half, split_x, crop_rect, gutter_thickness)
 
+    def _prepare_export_source_locked(
+        self,
+        file_path: str,
+        params: WorkspaceConfig,
+        source_hash: str,
+        half: int,
+        split_x: float,
+        crop_rect: Optional[tuple[float, float, float, float]],
+        gutter_thickness: float,
+    ) -> Tuple[np.ndarray, str, str]:
         f32_buffer, ir_full, source_cs = self._load_source_f32(file_path, params)
         f32_buffer, ir_full = self._slice_half_source(
             f32_buffer, ir_full, half, split_x, crop_rect=crop_rect, gutter_thickness=gutter_thickness
         )
-        target_cs = export_settings.export_color_space
-        if target_cs == ColorSpace.SAME_AS_SOURCE.value:
-            target_cs = source_cs
-        color_space = str(target_cs)
-
         detect_key = (
             source_hash
             + flatfield_token(params.flatfield)
@@ -883,6 +901,59 @@ class ImageProcessor:
             hair_masks = hair_masks + extra
         if hair_masks:
             f32_buffer = self._hair_inpaint(f32_buffer, hair_masks, detect_key + hair_bake_token(orig_ret))
+        export_token = detect_key + (hair_bake_token(orig_ret) if hair_masks else "")
+        return f32_buffer, source_cs, export_token
+
+    def prefetch_export_source(
+        self,
+        file_path: str,
+        params: WorkspaceConfig,
+        source_hash: str,
+        half: int = 0,
+        split_x: float = 0.5,
+        crop_rect: Optional[tuple[float, float, float, float]] = None,
+        gutter_thickness: float = 0.0,
+    ) -> None:
+        """Prepare a source into the handoff slot ahead of its render. Failures are
+        dropped; the render's own prepare raises them where they are reported."""
+        key = (file_path, source_hash, params, half, split_x, crop_rect, gutter_thickness)
+        slot = self._prepare_slot
+        if slot is not None and slot[0] == key:
+            return
+        try:
+            with self._prepare_gate:
+                slot = self._prepare_slot
+                if slot is not None and slot[0] == key:
+                    return
+                value = self._prepare_export_source_locked(file_path, params, source_hash, half, split_x, crop_rect, gutter_thickness)
+                self._prepare_slot = (key, value)
+        except Exception:
+            logger.exception(f"Export source prefetch failed for {file_path}")
+
+    def _render_export_buffer(
+        self,
+        file_path: str,
+        params: WorkspaceConfig,
+        export_settings,  # ExportConfig or ExportPreset
+        source_hash: str,
+        metrics: Optional[Dict[str, Any]] = None,
+        prefer_gpu: bool = True,
+        bounds_override: Optional[Any] = None,
+        half: int = 0,
+        split_x: float = 0.5,
+        crop_rect: Optional[tuple[float, float, float, float]] = None,
+        gutter_thickness: float = 0.0,
+    ) -> Tuple[np.ndarray, str]:
+        """Full-res render of one frame; returns the float buffer and its color space."""
+        f32_buffer, source_cs, export_token = self._prepare_export_source(
+            file_path, params, source_hash, half=half, split_x=split_x, crop_rect=crop_rect, gutter_thickness=gutter_thickness
+        )
+        # Ensure both GPU and CPU paths use the same export settings.
+        params = dc_replace(params, export=export_settings)
+        target_cs = export_settings.export_color_space
+        if target_cs == ColorSpace.SAME_AS_SOURCE.value:
+            target_cs = source_cs
+        color_space = str(target_cs)
 
         h_raw, w_raw = f32_buffer.shape[:2]
         export_scale = max(h_raw, w_raw) / float(APP_CONFIG.preview_render_size)
@@ -897,11 +968,7 @@ class ImageProcessor:
         if prefer_gpu and self.engine_gpu:
             # Mirrors run_pipeline's base_hash, so a multi-preset batch of one frame
             # reuses the source upload and the meter cache.
-            export_hash = (
-                detect_key
-                + (hair_bake_token(orig_ret) if hair_masks else "")
-                + f"|res{w_raw}x{h_raw}|half{half}:{split_x}:{crop_rect}:{gutter_thickness}"
-            )
+            export_hash = export_token + f"|res{w_raw}x{h_raw}|half{half}:{split_x}:{crop_rect}:{gutter_thickness}"
             buffer, _gpu_metrics = self.engine_gpu.process(
                 f32_buffer,
                 params,
@@ -932,7 +999,7 @@ class ImageProcessor:
 
         return buffer, color_space
 
-    def process_export(
+    def render_export(
         self,
         file_path: str,
         params: WorkspaceConfig,
@@ -941,23 +1008,18 @@ class ImageProcessor:
         metrics: Optional[Dict[str, Any]] = None,
         prefer_gpu: bool = True,
         bounds_override: Optional[Any] = None,
-        working_color_space: str = WORKING_COLOR_SPACE,
         half: int = 0,
         split_x: float = 0.5,
         crop_rect: Optional[tuple[float, float, float, float]] = None,
         gutter_thickness: float = 0.0,
         diptych: Optional[Tuple[WorkspaceConfig, WorkspaceConfig]] = None,
-        embed_plan: Optional[tuple] = None,
-    ) -> Tuple[Optional[bytes], str]:
-        """Performs high-resolution export with color management.
+    ) -> Tuple[Optional[np.ndarray], str]:
+        """Full-res export render; returns (float buffer, its color space) or (None, error).
 
         ``diptych`` renders the scan's two halves with their own configs and joins them
         back into the original geometry. Each half is sliced before the pipeline, so its
         normalization sees the same pixels the user edited it on. ``params`` is unused
-        then — the halves own the edit. One encode, so no double compression.
-
-        ``embed_plan`` (from writer.export_embed_plan): TIFF/PNG embed it at the
-        first encode instead of the post-hoc rewrite.
+        then — the halves own the edit.
         """
         try:
             if diptych is not None:
@@ -993,11 +1055,66 @@ class ImageProcessor:
                     crop_rect=crop_rect,
                     gutter_thickness=gutter_thickness,
                 )
-            return self._encode_export(buffer, export_settings, color_space, working_color_space, embed_plan=embed_plan)
-
+            return buffer, color_space
         except Exception as e:
-            logger.error(f"Export pipeline failed: {e}")
+            logger.error(f"Export render failed: {e}")
             return None, str(e)
+
+    def encode_export(
+        self,
+        buffer: np.ndarray,
+        export_settings,
+        color_space: str,
+        working_color_space: str = WORKING_COLOR_SPACE,
+        embed_plan: Optional[tuple] = None,
+    ) -> Tuple[Optional[bytes], str]:
+        """Encode a rendered export buffer to file bytes; (bytes, format) or (None, error).
+        Touches no processor state, so it can run on the finisher thread."""
+        try:
+            return self._encode_export(buffer, export_settings, color_space, working_color_space, embed_plan=embed_plan)
+        except Exception as e:
+            logger.error(f"Export encode failed: {e}")
+            return None, str(e)
+
+    def process_export(
+        self,
+        file_path: str,
+        params: WorkspaceConfig,
+        export_settings,  # ExportConfig or ExportPreset
+        source_hash: str,
+        metrics: Optional[Dict[str, Any]] = None,
+        prefer_gpu: bool = True,
+        bounds_override: Optional[Any] = None,
+        working_color_space: str = WORKING_COLOR_SPACE,
+        half: int = 0,
+        split_x: float = 0.5,
+        crop_rect: Optional[tuple[float, float, float, float]] = None,
+        gutter_thickness: float = 0.0,
+        diptych: Optional[Tuple[WorkspaceConfig, WorkspaceConfig]] = None,
+        embed_plan: Optional[tuple] = None,
+    ) -> Tuple[Optional[bytes], str]:
+        """Performs high-resolution export with color management.
+
+        ``embed_plan`` (from writer.export_embed_plan): TIFF/PNG embed it at the
+        first encode instead of the post-hoc rewrite.
+        """
+        buffer, color_space = self.render_export(
+            file_path,
+            params,
+            export_settings,
+            source_hash,
+            metrics=metrics,
+            prefer_gpu=prefer_gpu,
+            bounds_override=bounds_override,
+            half=half,
+            split_x=split_x,
+            crop_rect=crop_rect,
+            gutter_thickness=gutter_thickness,
+            diptych=diptych,
+        )
+        if buffer is None:
+            return None, color_space
+        return self.encode_export(buffer, export_settings, color_space, working_color_space, embed_plan=embed_plan)
 
     def _encode_export(
         self,
@@ -1718,6 +1835,7 @@ class ImageProcessor:
         self._source_cache_value = None
         self._precorrect_key = None
         self._precorrect_value = None
+        self._prepare_slot = None
 
     def cleanup(self, release_source_cache: bool = True, collect: bool = True, retain: Any = None) -> None:
         """Evacuates transient GPU resources; ``retain`` survives the teardown."""

--- a/tests/test_batch_progress.py
+++ b/tests/test_batch_progress.py
@@ -52,11 +52,11 @@ def test_export_worker_cancel_stops_batch_keeps_partial() -> None:
     worker = ExportWorker()
     proc = MagicMock()
 
-    def _process_export(*_a, **_k):
+    def _render_export(*_a, **_k):
         worker.cancel()  # abort requested mid-batch, after first file
-        return (b"", None)  # empty bits => nothing written
+        return (None, "aborted")  # render failed => nothing written
 
-    proc.process_export.side_effect = _process_export
+    proc.render_export.side_effect = _render_export
     worker._processor = proc
 
     finished: list[bool] = []
@@ -68,18 +68,17 @@ def test_export_worker_cancel_stops_batch_keeps_partial() -> None:
 
     assert cancelled == [True]
     assert finished == []
-    assert proc.process_export.call_count == 1  # second task skipped
+    assert proc.render_export.call_count == 1  # second task skipped
 
 
-def test_export_batch_keeps_source_cache_for_consecutive_same_file(tmp_path) -> None:
+def test_export_batch_prefetches_next_source_once_per_task(tmp_path) -> None:
     from unittest.mock import call
 
-    from negpy.desktop.workers.export import _same_decode_source
     from negpy.domain.models import preset_from_export_config
 
     worker = ExportWorker()
     proc = MagicMock()
-    proc.process_export.return_value = (b"bits", None)
+    proc.render_export.return_value = (None, "render failed")  # nothing written
     worker._processor = proc
 
     # Real batches carry ExportPresets (SAME_AS_SOURCE output), like the controller builds.
@@ -96,18 +95,12 @@ def test_export_batch_keeps_source_cache_for_consecutive_same_file(tmp_path) -> 
     # a.cr2 exported twice (multi-format preset), then b.cr2.
     worker.run_batch([_task("a.cr2"), _task("a.cr2"), _task("b.cr2")])
 
-    # Decoded source dropped only at source boundaries; VRAM evacuated once per batch.
-    assert proc.release_source_cache.call_args_list == [call(), call()]
+    # Every task but the first is prefetched ahead of its render; VRAM evacuated
+    # once per batch.
+    prefetched = [c.args[0] for c in proc.prefetch_export_source.call_args_list]
+    assert prefetched == [str(tmp_path / "a.cr2"), str(tmp_path / "b.cr2")]
     assert proc.cleanup.call_args_list == [call(release_source_cache=True, collect=False)]
-    assert proc.process_export.call_count == 3
-
-    # _same_decode_source mirrors the _load_source_f32 cache key fields.
-    a, b = _task("a.cr2"), _task("b.cr2")
-    assert _same_decode_source(a, _task("a.cr2"))
-    assert not _same_decode_source(a, b)
-    flat = replace(DEFAULT_WORKSPACE_CONFIG, flatfield=replace(DEFAULT_WORKSPACE_CONFIG.flatfield, apply=True, profile_id="rig-1"))
-    a_flat = ExportTask(file_info=a.file_info, params=flat, export_settings=preset)
-    assert not _same_decode_source(a, a_flat)
+    assert proc.render_export.call_count == 3
 
 
 def test_normalization_worker_cancel_emits_cancelled_no_baseline() -> None:

--- a/tests/test_export_pipelining.py
+++ b/tests/test_export_pipelining.py
@@ -1,0 +1,142 @@
+"""Batch-export pipelining: the finisher thread encodes and writes the previous
+render while the next file renders, and the prefetcher prepares the next source
+into the ImageProcessor handoff slot."""
+
+import threading
+from dataclasses import replace
+from unittest.mock import MagicMock
+
+import numpy as np
+import tifffile
+
+from negpy.desktop.workers.export import ExportTask, ExportWorker
+from negpy.domain.models import WorkspaceConfig, preset_from_export_config
+from negpy.kernel.system.config import DEFAULT_WORKSPACE_CONFIG
+
+
+def _preset(tmp_path):
+    preset = preset_from_export_config(DEFAULT_WORKSPACE_CONFIG.export)
+    return replace(preset, output_path=str(tmp_path))
+
+
+def _task(tmp_path, name: str, **kwargs) -> ExportTask:
+    return ExportTask(
+        file_info={"name": name, "path": str(tmp_path / name), "hash": name},
+        params=DEFAULT_WORKSPACE_CONFIG,
+        export_settings=_preset(tmp_path),
+        **kwargs,
+    )
+
+
+def _worker(render=(np.zeros((4, 4, 3), np.float32), "sRGB"), encode=(b"JPGDATA", "jpg")):
+    worker = ExportWorker()
+    proc = MagicMock()
+    proc.render_export.return_value = render
+    proc.encode_export.return_value = encode
+    worker._processor = proc
+    return worker, proc
+
+
+def test_finisher_writes_rendered_file_before_finished(tmp_path) -> None:
+    worker, proc = _worker()
+    written_at_finish: list[list] = []
+    worker.finished.connect(lambda: written_at_finish.append(list(tmp_path.glob("*.jpg"))))
+
+    worker.run_batch([_task(tmp_path, "a.cr2")])
+
+    assert len(written_at_finish) == 1
+    assert len(written_at_finish[0]) == 1
+    assert written_at_finish[0][0].read_bytes() == b"JPGDATA"
+
+
+def test_encode_runs_off_the_render_thread(tmp_path) -> None:
+    worker, proc = _worker()
+    idents: list[int] = []
+    proc.encode_export.side_effect = lambda *a, **k: (idents.append(threading.get_ident()), (b"X", "jpg"))[1]
+
+    worker.run_batch([_task(tmp_path, "a.cr2")])
+
+    assert idents and idents[0] != threading.get_ident()
+
+
+def test_encode_error_surfaces_and_batch_continues(tmp_path) -> None:
+    worker, proc = _worker(encode=(None, "encode boom"))
+    errors: list[str] = []
+    finished: list[bool] = []
+    worker.error.connect(errors.append)
+    worker.finished.connect(lambda: finished.append(True))
+
+    worker.run_batch([_task(tmp_path, "a.cr2"), _task(tmp_path, "b.cr2")])
+
+    assert errors == ["encode boom", "encode boom"]
+    assert finished == [True]
+    assert list(tmp_path.glob("*.jpg")) == []
+
+
+def test_cancel_still_writes_the_rendered_file(tmp_path) -> None:
+    worker, proc = _worker()
+
+    def _render(*_a, **_k):
+        worker.cancel()
+        return (np.zeros((4, 4, 3), np.float32), "sRGB")
+
+    proc.render_export.side_effect = _render
+    cancelled: list[bool] = []
+    worker.cancelled.connect(lambda: cancelled.append(True))
+
+    worker.run_batch([_task(tmp_path, "a.cr2"), _task(tmp_path, "b.cr2")])
+
+    assert cancelled == [True]
+    assert proc.render_export.call_count == 1
+    assert len(list(tmp_path.glob("*.jpg"))) == 1
+
+
+def test_prefetch_skips_a_diptych_next_task(tmp_path) -> None:
+    worker, proc = _worker(render=(None, "render failed"))
+    cfg = DEFAULT_WORKSPACE_CONFIG
+    diptych = _task(tmp_path, "b.cr2", diptych=(cfg, cfg))
+
+    worker.run_batch([_task(tmp_path, "a.cr2"), diptych])
+
+    proc.prefetch_export_source.assert_not_called()
+
+
+def _real_processor_and_source(tmp_path):
+    from negpy.services.rendering.image_processor import ImageProcessor
+
+    arr = (np.random.default_rng(0).random((64, 96, 3)) * 40000 + 8000).astype(np.uint16)
+    path = tmp_path / "s.tif"
+    tifffile.imwrite(path, arr, photometric="rgb")
+    return ImageProcessor(), str(path)
+
+
+def test_prefetch_fills_slot_and_prepare_serves_from_it(tmp_path) -> None:
+    proc, path = _real_processor_and_source(tmp_path)
+    cfg = WorkspaceConfig()
+
+    proc.prefetch_export_source(path, cfg, "hash1")
+    assert proc._prepare_slot is not None
+
+    calls: list[int] = []
+    orig = proc._prepare_export_source_locked
+    proc._prepare_export_source_locked = lambda *a, **k: (calls.append(1), orig(*a, **k))[1]
+
+    buf, _cs, _token = proc._prepare_export_source(path, cfg, "hash1")
+    assert calls == []
+    assert buf is proc._prepare_slot[1][0]
+
+    # A different source hash misses the slot and computes the same pixels.
+    buf2, _cs2, _token2 = proc._prepare_export_source(path, cfg, "hash2")
+    assert calls == [1]
+    assert np.array_equal(buf, buf2)
+
+    proc.release_source_cache()
+    assert proc._prepare_slot is None
+
+
+def test_prefetch_failure_is_swallowed(tmp_path) -> None:
+    from negpy.services.rendering.image_processor import ImageProcessor
+
+    proc = ImageProcessor()
+    proc.prefetch_export_source(str(tmp_path / "missing.tif"), WorkspaceConfig(), "h")
+    assert proc._prepare_slot is None

--- a/tests/test_export_pipelining.py
+++ b/tests/test_export_pipelining.py
@@ -10,20 +10,20 @@ import numpy as np
 import tifffile
 
 from negpy.desktop.workers.export import ExportTask, ExportWorker
-from negpy.domain.models import WorkspaceConfig, preset_from_export_config
+from negpy.domain.models import ExportFormat, WorkspaceConfig, preset_from_export_config
 from negpy.kernel.system.config import DEFAULT_WORKSPACE_CONFIG
 
 
-def _preset(tmp_path):
+def _preset(tmp_path, **overrides):
     preset = preset_from_export_config(DEFAULT_WORKSPACE_CONFIG.export)
-    return replace(preset, output_path=str(tmp_path))
+    return replace(preset, output_path=str(tmp_path), **overrides)
 
 
-def _task(tmp_path, name: str, **kwargs) -> ExportTask:
+def _task(tmp_path, name: str, preset=None, **kwargs) -> ExportTask:
     return ExportTask(
         file_info={"name": name, "path": str(tmp_path / name), "hash": name},
         params=DEFAULT_WORKSPACE_CONFIG,
-        export_settings=_preset(tmp_path),
+        export_settings=preset if preset is not None else _preset(tmp_path),
         **kwargs,
     )
 
@@ -140,3 +140,280 @@ def test_prefetch_failure_is_swallowed(tmp_path) -> None:
     proc = ImageProcessor()
     proc.prefetch_export_source(str(tmp_path / "missing.tif"), WorkspaceConfig(), "h")
     assert proc._prepare_slot is None
+
+
+def test_empty_batch_finishes_cleanly() -> None:
+    worker, proc = _worker()
+    finished: list[bool] = []
+    errors: list[str] = []
+    cancelled: list[bool] = []
+    worker.finished.connect(lambda: finished.append(True))
+    worker.error.connect(errors.append)
+    worker.cancelled.connect(lambda: cancelled.append(True))
+
+    worker.run_batch([])
+
+    assert finished == [True]
+    assert errors == []
+    assert cancelled == []
+
+
+def test_progress_emitted_per_task_in_order(tmp_path) -> None:
+    worker, proc = _worker(render=(None, "skip"))
+    seen: list[tuple] = []
+    worker.progress.connect(lambda c, t, n: seen.append((c, t, n)))
+
+    worker.run_batch([_task(tmp_path, "a.cr2"), _task(tmp_path, "b.cr2")])
+
+    assert seen == [(1, 2, "a"), (2, 2, "b")]
+
+
+def test_render_error_skips_file_but_batch_continues(tmp_path) -> None:
+    worker, proc = _worker()
+    proc.render_export.side_effect = [(None, "render boom"), (np.zeros((4, 4, 3), np.float32), "sRGB")]
+    errors: list[str] = []
+    finished: list[bool] = []
+    worker.error.connect(errors.append)
+    worker.finished.connect(lambda: finished.append(True))
+
+    worker.run_batch([_task(tmp_path, "a.cr2"), _task(tmp_path, "b.cr2")])
+
+    assert errors == ["render boom"]
+    assert finished == [True]
+    assert len(list(tmp_path.glob("*.jpg"))) == 1
+
+
+def test_write_error_surfaces_and_batch_continues(tmp_path, monkeypatch) -> None:
+    import negpy.desktop.workers.export as export_mod
+
+    worker, proc = _worker()
+
+    def _boom(src, dst):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(export_mod.os, "replace", _boom)
+    errors: list[str] = []
+    finished: list[bool] = []
+    worker.error.connect(errors.append)
+    worker.finished.connect(lambda: finished.append(True))
+
+    worker.run_batch([_task(tmp_path, "a.cr2"), _task(tmp_path, "b.cr2")])
+
+    assert errors == ["disk full", "disk full"]
+    assert finished == [True]
+    assert list(tmp_path.glob("*.jpg")) == []
+    assert list(tmp_path.glob("*.part")) == []  # tmp file cleaned up on failure
+
+
+def test_unexpected_exception_aborts_batch_with_error(tmp_path) -> None:
+    worker, proc = _worker()
+    proc.render_export.side_effect = RuntimeError("kaboom")
+    errors: list[str] = []
+    finished: list[bool] = []
+    worker.error.connect(errors.append)
+    worker.finished.connect(lambda: finished.append(True))
+
+    worker.run_batch([_task(tmp_path, "a.cr2"), _task(tmp_path, "b.cr2")])
+
+    assert errors == ["kaboom"]
+    assert finished == []
+
+
+def test_no_overwrite_numbers_a_conflicting_target(tmp_path) -> None:
+    worker, _ = _worker()
+    task = _task(tmp_path, "a.cr2")  # overwrite defaults to False
+
+    worker.run_batch([task])
+    worker.run_batch([task])
+
+    files = sorted(p.name for p in tmp_path.glob("*.jpg"))
+    assert len(files) == 2
+    assert any("_2" in n for n in files)
+
+
+def test_overwrite_replaces_the_existing_target(tmp_path) -> None:
+    preset = _preset(tmp_path, overwrite=True)
+    worker, _ = _worker()
+    task = _task(tmp_path, "a.cr2", preset=preset)
+
+    worker.run_batch([task])
+    worker.run_batch([task])
+
+    assert len(list(tmp_path.glob("*.jpg"))) == 1
+
+
+def test_metadata_embeds_on_the_finisher_thread(tmp_path, monkeypatch) -> None:
+    from negpy.features.metadata.models import MetadataConfig
+
+    embed = MagicMock(return_value=b"WITHMETA")
+    monkeypatch.setattr("negpy.desktop.workers.export.embed_metadata", embed)
+    worker, proc = _worker()
+    task = _task(tmp_path, "a.cr2", metadata_config=MetadataConfig(film="Portra 400"))
+
+    worker.run_batch([task])
+
+    embed.assert_called_once()
+    assert embed.call_args.args[0] == b"JPGDATA"
+    assert list(tmp_path.glob("*.jpg"))[0].read_bytes() == b"WITHMETA"
+
+
+def test_protect_original_metadata_uses_preserve(tmp_path, monkeypatch) -> None:
+    from negpy.features.metadata.models import MetadataConfig
+
+    preserve = MagicMock(return_value=b"PRESERVED")
+    embed = MagicMock()
+    monkeypatch.setattr("negpy.desktop.workers.export.preserve_source_metadata", preserve)
+    monkeypatch.setattr("negpy.desktop.workers.export.embed_metadata", embed)
+    worker, proc = _worker()
+    task = _task(tmp_path, "a.cr2", metadata_config=MetadataConfig(protect_original_metadata=True))
+
+    worker.run_batch([task])
+
+    preserve.assert_called_once()
+    embed.assert_not_called()
+    assert list(tmp_path.glob("*.jpg"))[0].read_bytes() == b"PRESERVED"
+
+
+def test_tiff_metadata_goes_through_the_embed_plan(tmp_path, monkeypatch) -> None:
+    from negpy.features.metadata.models import MetadataConfig
+
+    plan = (b"exif", b"xmp", False)
+    monkeypatch.setattr("negpy.desktop.workers.export.export_embed_plan", MagicMock(return_value=plan))
+    embed = MagicMock()
+    monkeypatch.setattr("negpy.desktop.workers.export.embed_metadata", embed)
+    worker, proc = _worker(encode=(b"TIFFDATA", "tiff"))
+    preset = _preset(tmp_path, export_fmt=ExportFormat.TIFF)
+    task = _task(tmp_path, "a.cr2", preset=preset, metadata_config=MetadataConfig())
+
+    worker.run_batch([task])
+
+    assert proc.encode_export.call_args.kwargs["embed_plan"] == plan
+    embed.assert_not_called()
+    assert list(tmp_path.glob("*.tiff"))[0].read_bytes() == b"TIFFDATA"
+
+
+def test_completed_batch_never_emits_cancelled(tmp_path) -> None:
+    worker, _ = _worker()
+    cancelled: list[bool] = []
+    worker.cancelled.connect(lambda: cancelled.append(True))
+
+    worker.run_batch([_task(tmp_path, "a.cr2")])
+
+    assert cancelled == []
+
+
+def test_slot_key_discriminates_every_field(tmp_path) -> None:
+    proc, path = _real_processor_and_source(tmp_path)
+    cfg = WorkspaceConfig()
+
+    calls: list[int] = []
+    orig = proc._prepare_export_source_locked
+    proc._prepare_export_source_locked = lambda *a, **k: (calls.append(1), orig(*a, **k))[1]
+
+    proc.prefetch_export_source(path, cfg, "base")
+    assert len(calls) == 1
+
+    other_cfg = replace(cfg, retouch=replace(cfg.retouch, dust_threshold=cfg.retouch.dust_threshold + 0.1))
+    misses = [
+        (path, cfg, "other-hash", {}),
+        (path, other_cfg, "base", {}),
+        (path, cfg, "base", {"half": 1}),
+        (path, cfg, "base", {"half": 1, "split_x": 0.4}),
+        (path, cfg, "base", {"gutter_thickness": 0.1}),
+    ]
+    for n, (p, c, h, kw) in enumerate(misses, start=2):
+        proc._prepare_export_source(p, c, h, **kw)
+        assert len(calls) == n, f"variation {kw or h} must miss the slot"
+
+    proc._prepare_export_source(path, cfg, "base")
+    assert len(calls) == len(misses) + 1  # exact key still served from the slot
+
+
+def test_prepare_miss_keeps_the_slot(tmp_path) -> None:
+    proc, path = _real_processor_and_source(tmp_path)
+    cfg = WorkspaceConfig()
+
+    proc.prefetch_export_source(path, cfg, "keep")
+    slot = proc._prepare_slot
+    proc._prepare_export_source(path, cfg, "miss")
+    assert proc._prepare_slot is slot
+
+
+def test_prefetch_same_key_twice_computes_once(tmp_path) -> None:
+    proc, path = _real_processor_and_source(tmp_path)
+    cfg = WorkspaceConfig()
+
+    calls: list[int] = []
+    orig = proc._prepare_export_source_locked
+    proc._prepare_export_source_locked = lambda *a, **k: (calls.append(1), orig(*a, **k))[1]
+
+    proc.prefetch_export_source(path, cfg, "twice")
+    proc.prefetch_export_source(path, cfg, "twice")
+    assert calls == [1]
+
+
+def test_render_export_uses_the_prefetched_source(tmp_path) -> None:
+    proc, path = _real_processor_and_source(tmp_path)
+    proc.engine_gpu = None
+    cfg = WorkspaceConfig()
+
+    proc.prefetch_export_source(path, cfg, "hx")
+    calls: list[int] = []
+    orig = proc._prepare_export_source_locked
+    proc._prepare_export_source_locked = lambda *a, **k: (calls.append(1), orig(*a, **k))[1]
+
+    buf, cs = proc.render_export(path, cfg, cfg.export, "hx")
+
+    assert calls == []
+    assert isinstance(buf, np.ndarray)
+    assert cs
+
+
+def test_process_export_equals_render_plus_encode(tmp_path) -> None:
+    proc, path = _real_processor_and_source(tmp_path)
+    proc.engine_gpu = None
+    cfg = WorkspaceConfig()
+
+    bits1, fmt1 = proc.process_export(path, cfg, cfg.export, "pe")
+    buf, cs = proc.render_export(path, cfg, cfg.export, "pe")
+    bits2, fmt2 = proc.encode_export(buf, cfg.export, cs)
+
+    assert bits1 == bits2
+    assert fmt1 == fmt2 == "jpg"
+
+
+def test_render_export_error_returns_none_and_message(tmp_path) -> None:
+    from negpy.services.rendering.image_processor import ImageProcessor
+
+    proc = ImageProcessor()
+    bits, msg = proc.render_export(str(tmp_path / "missing.tif"), WorkspaceConfig(), WorkspaceConfig().export, "h")
+    assert bits is None
+    assert msg
+
+
+def test_encode_export_error_returns_none_and_message() -> None:
+    from negpy.services.rendering.image_processor import ImageProcessor
+
+    proc = ImageProcessor.__new__(ImageProcessor)  # encode path touches no state
+    cfg = WorkspaceConfig()
+    # JXL cannot encode the working space; the raised ValueError must come back as (None, msg).
+    export = replace(cfg.export, export_fmt=ExportFormat.JXL, export_color_space="No Such Space")
+    bits, msg = proc.encode_export(np.zeros((4, 4, 3), np.float32), export, "No Such Space")
+    assert bits is None
+    assert "JPEG XL" in msg
+
+
+def test_concurrent_prefetch_and_prepare_agree(tmp_path) -> None:
+    proc, path = _real_processor_and_source(tmp_path)
+    cfg = WorkspaceConfig()
+
+    ref, _cs, _tok = proc._prepare_export_source(path, cfg, "cA")
+
+    t = threading.Thread(target=proc.prefetch_export_source, args=(path, cfg, "cB"))
+    t.start()
+    got, _cs2, _tok2 = proc._prepare_export_source(path, cfg, "cC")
+    t.join()
+
+    assert np.array_equal(ref, got)
+    assert proc._prepare_slot is not None
+    assert np.array_equal(ref, proc._prepare_slot[1][0])

--- a/tests/test_export_service.py
+++ b/tests/test_export_service.py
@@ -6,10 +6,10 @@ from negpy.desktop.workers import export as export_worker_mod
 from negpy.services.rendering.image_processor import ImageProcessor
 
 
-def test_export_worker_uses_process_export_not_preview_load() -> None:
-    """Export must keep using full-res `process_export(file_path, ...)` — not `PreviewManager` decode."""
+def test_export_worker_uses_full_res_render_not_preview_load() -> None:
+    """Export must keep using full-res `render_export(file_path, ...)` — not `PreviewManager` decode."""
     src = inspect.getsource(export_worker_mod.ExportWorker.run_batch)
-    assert "process_export" in src
+    assert "render_export" in src
     assert "load_linear_preview" not in src
 
 

--- a/tests/test_sensor_calibration.py
+++ b/tests/test_sensor_calibration.py
@@ -178,6 +178,7 @@ def test_run_pipeline_gates_triplets(monkeypatch):
     ip.engine_cpu.process.return_value = np.zeros((8, 8, 3), dtype=np.float32)
     ip._precorrect_key = None
     ip._precorrect_value = None
+    ip._prepare_gate = __import__("threading").Lock()
     ip._augment_retouch = lambda settings, img, key: (settings, None, [])
     ip._ir_bake = lambda img, ir, settings, key: (img, None, None, None)
     ip._is_flat = lambda settings: False


### PR DESCRIPTION
## What

Batch export ran strictly sequential per file: decode+bake → GPU render → encode+write. This pipelines the three stages across files:

- **Prefetcher thread** prepares the next task's source (decode, half-slice, IR/speck/manual bakes) into a handoff slot on `ImageProcessor` while the current file renders.
- **Finisher thread** encodes, embeds metadata and writes the previous render while the next file renders. One finish in flight at a time, so at most two full-res buffers are held.
- `process_export` is split into `render_export` + `encode_export`; `process_export` stays as the composition for single-file callers.

## Why the gate

The decode/bake caches on `ImageProcessor` are single-slot, so two concurrent prepares would tear them. The prepare compute runs under `_prepare_gate`; the export CPU fallback re-enters the bakes through `run_pipeline`, so that block takes the same gate. The slot read is double-checked, and the first task's prefetch is submitted after its render so the batch never starts by queueing behind its own prefetch.

## Measured (890M iGPU)

| Batch | main | this PR |
|---|---|---|
| 6× 23.5 MPx scan → JPEG | 6.32 s | 5.75 s (−9%) |
| 6× 23.5 MPx scan → TIFF | 9.01 s | 6.3 s (−30%) |
| 3× 24 MPx ARW → JPEG | 8.7 s | 7.4 s (−13%) |

Outputs byte-identical to the sequential path in all three runs (cmp on every file). Gains sit below the theoretical stage-max because the iGPU shares memory bandwidth with the CPU stages; a dGPU should see more.

## Semantics kept

- Cancel stops after the current file; its encode still completes and writes.
- Render/encode errors surface per file via `error`, batch continues.
- Diptych tasks are never prefetched (two gated half-prepares of their own).
- Prefetch failures are swallowed; the render's own prepare raises them where they are reported.
- `cleanup(release_source_cache=True)` once per batch in `finally`; `release_source_cache` also drops the handoff slot. The per-boundary `release_source_cache` and `_same_decode_source` are gone: the single-slot decode cache is evicted by the next prefetch itself.
