### PR TITLE
feat(preview): configurable preview render size

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,10 @@ max_texture_size = "auto"
 # Force HQ preview on/off. Uncomment to override saved preference.
 # force_hq_preview = false
 
+# Long edge of the interactive preview in pixels (512-8192). Higher is a sharper
+# canvas and more VRAM per frame.
+# preview_render_size = 1600
+
 # Preview cache size — keeps recently-viewed photos in memory for instant navigation.
 # Lower these on low-RAM machines. Uncomment to override defaults (~1.2 GB / 8 photos).
 # preview_cache_max_bytes = 1200000000

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@
 - New: **NegPy gets a macOS menu bar** — Window (minimize, zoom, close, window list) and Help (tour, shortcuts, guide, update check, report an issue). @seanharding
 - New: **Choose what sits on the toolbar** — drag to reorder the toolbar and the Favourites pickers, plus an Edit Toolbar… entry.
 - New: **Mask tint steps aside while you adjust it** — Burn, Feather and Grade sliders are no longer judged through the tint overlay; overlapping masks fade too. @Icodextrin
+- New: **Preview resolution is configurable** — `preview_render_size` under `[performance]` in `override.toml` sets the interactive preview's long edge, between the 1600 px default and a full HQ decode.
 - New: **Single-shot scan preview** for scanners with no motorized frame feed (Plustek and similar) — a lightweight preview-and-crop dialog before the full scan. @cymbal221
 - Change: **Export and preview performance** — batch export overlaps decode, render and encode across files instead of running them strictly in sequence; slider drags on Process and Sensor, and other worst-case interactions, no longer pay settled-frame cost.
 - Change: **Canvas zoom reads real scan pixels** — 100% now means one scan pixel per screen pixel in every mode, and a HUD pill flags when 100% is showing an upscaled preview. @seanharding

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -889,6 +889,7 @@ If NegPy crashes on launch or has rendering glitches, you can force backend sett
 | `display.qt_rhi_backend` | `"auto"`, `"vulkan"`, `"d3d12"`, `"metal"`, `"opengl"`, `"software"` | Qt UI rendering backend. |
 | `display.qt_platform` | `"auto"`, `"xcb"`, `"wayland"` | Window system plugin (Linux only). |
 | `performance.max_texture_size` | `"auto"` or a number, e.g. `4096` | Caps GPU texture size; reduce on low-VRAM cards. |
+| `performance.preview_render_size` | a number, 512 to 8192, e.g. `3000` | Long edge of the interactive preview (default `1600`). Higher is a sharper canvas at 100% zoom; every rendered frame costs proportionally more VRAM, so lower `preview_cache_max_bytes` and `render_memo_max_entries` to match. RAW files decode at half sensor size for the preview, so there is nothing to gain past half the long edge of your scan. |
 | `performance.force_hq_preview` | `true` / `false` (or absent) | Overrides the saved HQ preview toggle. |
 | `performance.preview_cache_max_bytes` | a number, e.g. `1200000000` | Preview cache memory budget (default about 1.2 GB). |
 | `performance.preview_cache_max_entries` | a number, e.g. `8` | Max recently-viewed photos kept in memory. |

--- a/negpy/kernel/system/override.py
+++ b/negpy/kernel/system/override.py
@@ -1,9 +1,18 @@
+import logging
 import os
 import sys
 import tomllib
 from dataclasses import dataclass
 
 from negpy.domain.types import AppConfig
+
+
+logger = logging.getLogger(__name__)
+
+# A hand-edited preview size below this is not a usable canvas (`= true` coerces to 1,
+# since bool is an int), and above it no GPU can hold the frame.
+_PREVIEW_SIZE_MIN = 512
+_PREVIEW_SIZE_MAX = 8192
 
 
 _DEFAULT_TOML_LINUX_WIN = """\
@@ -39,6 +48,10 @@ qt_platform = "auto"
 # "auto" lets wgpu/hardware decide the maximum. Set a number (e.g. 4096) to cap it.
 max_texture_size = "auto"
 
+# Long edge of the interactive preview, in pixels. Higher is a sharper canvas at 100%
+# zoom and more VRAM and CPU per frame. Clamped to 512-8192.
+# preview_render_size = 1600
+
 # Preview cache size. Larger keeps more recently-viewed photos in memory for instant
 # navigation; lower it on machines with little RAM. Uncomment to override defaults.
 # preview_cache_max_bytes = 1200000000
@@ -73,6 +86,7 @@ class OverrideConfig:
     force_hq_preview: bool | None = None
     cpu_parallel: bool | None = None
     max_texture_size: int | None = None
+    preview_render_size: int | None = None
     preview_cache_max_bytes: int | None = None
     preview_cache_max_entries: int | None = None
     preview_cache_max_full_res_entries: int | None = None
@@ -141,6 +155,9 @@ def _parse(data: dict) -> OverrideConfig:
     raw_tex = performance.get("max_texture_size")
     max_tex: int | None = int(raw_tex) if isinstance(raw_tex, int) and raw_tex > 0 else None
 
+    raw_prev = performance.get("preview_render_size")
+    prev_size: int | None = int(raw_prev) if isinstance(raw_prev, int) and raw_prev > 0 else None
+
     raw_cache_b = performance.get("preview_cache_max_bytes")
     cache_b: int | None = int(raw_cache_b) if isinstance(raw_cache_b, int) and raw_cache_b > 0 else None
 
@@ -164,6 +181,7 @@ def _parse(data: dict) -> OverrideConfig:
         force_hq_preview=force_hq,
         cpu_parallel=cpu_parallel,
         max_texture_size=max_tex,
+        preview_render_size=prev_size,
         preview_cache_max_bytes=cache_b,
         preview_cache_max_entries=cache_n,
         preview_cache_max_full_res_entries=cache_fr,
@@ -227,6 +245,12 @@ def apply(cfg: OverrideConfig, app_config: AppConfig) -> None:
 
     if cfg.cpu_parallel is not None:
         app_config.cpu_parallel = cfg.cpu_parallel
+
+    if cfg.preview_render_size is not None:
+        size = min(_PREVIEW_SIZE_MAX, max(_PREVIEW_SIZE_MIN, cfg.preview_render_size))
+        if size != cfg.preview_render_size:
+            logger.warning("preview_render_size %d is out of range, using %d", cfg.preview_render_size, size)
+        app_config.preview_render_size = size
 
     if cfg.preview_cache_max_bytes is not None:
         app_config.preview_cache_max_bytes = cfg.preview_cache_max_bytes

--- a/tests/test_override_config.py
+++ b/tests/test_override_config.py
@@ -92,6 +92,17 @@ class TestOverrideConfigParsing(unittest.TestCase):
         for value in (0, -1, "eight", None):
             self.assertIsNone(_parse({"performance": {"render_memo_max_entries": value}}).render_memo_max_entries)
 
+    def test_parse_preview_render_size(self):
+        cfg = _parse({"performance": {"preview_render_size": 3000}})
+        self.assertEqual(cfg.preview_render_size, 3000)
+        app = _make_app_config()
+        apply(cfg, app)
+        self.assertEqual(app.preview_render_size, 3000)
+
+    def test_parse_preview_render_size_rejects_nonsense(self):
+        for value in (0, -1, "big", None):
+            self.assertIsNone(_parse({"performance": {"preview_render_size": value}}).preview_render_size)
+
     def test_parse_invalid_backend_falls_back_to_auto(self):
         cfg = _parse({"rendering": {"backend": "directx9"}})
         self.assertEqual(cfg.backend, "auto")
@@ -323,6 +334,21 @@ class TestApplyOverride(unittest.TestCase):
         app_config = _make_app_config()
         apply(cfg, app_config)
         self.assertIsNone(app_config.max_texture_size)
+
+    def test_preview_render_size_below_range_is_clamped(self):
+        app_config = _make_app_config()
+        apply(OverrideConfig(preview_render_size=1), app_config)
+        self.assertEqual(app_config.preview_render_size, 512)
+
+    def test_preview_render_size_above_range_is_clamped(self):
+        app_config = _make_app_config()
+        apply(OverrideConfig(preview_render_size=40000), app_config)
+        self.assertEqual(app_config.preview_render_size, 8192)
+
+    def test_preview_render_size_none_leaves_app_config_unchanged(self):
+        app_config = _make_app_config(preview_render_size=1600)
+        apply(OverrideConfig(preview_render_size=None), app_config)
+        self.assertEqual(app_config.preview_render_size, 1600)
 
     def test_force_hq_preview_true_propagated(self):
         cfg = OverrideConfig(force_hq_preview=True)


### PR DESCRIPTION
Closes #936.

The interactive preview long edge was pinned at 1600 px, so a 4K screen had only two states: a canvas upscaled to 181%, or HQ, which decodes the whole 80 MP scan and exhausts a 12 GB GPU. Nothing in between.

`preview_render_size` under `[performance]` in `override.toml` sets that middle ground, in pixels. Read once at startup, so every existing read site picks it up with no other change.

Pixels only, no percent form: every read site expects one global int, and a fraction of the source would change the value per frame.

## Notes

- Clamped to 512-8192 in `apply()` rather than `_parse()`. The file is hand-edited: `= true` coerces to 1 because `bool` is an `int`, and a huge value cannot be allocated. `_parse` runs before `setup_logging`, so a warning there would be lost.
- `HEAL_SIZE_REF` and `_IR_DETECT_REF` stay pinned at 1600. They exist so a stored heal keeps its footprint when the preview size changes.
- The RAW fast path decodes half-size, so there is nothing to gain past half the sensor long edge. Documented rather than enforced.

## Verification

`make all` green (4735 passed). New cases in `tests/test_override_config.py` cover parse, apply and both clamp ends.

End to end on a 6016 px NEF, through the real loader and `PreviewManager`:

| `override.toml` | `APP_CONFIG` | preview long edge | warning |
|---|---|---|---|
| key absent | 1600 | 1600 | - |
| `preview_render_size = 3000` | 3000 | 3000 | - |
| `preview_render_size = 40000` | 8192 | 3008 (half-size decode ceiling) | clamped |
| `preview_render_size = true` | 512 | 512 | clamped |