### PR TITLE
feat(ui): float the modeless windows over the main window on macOS

### DIFF
--- a/negpy/desktop/view/sidebar/calibration_window.py
+++ b/negpy/desktop/view/sidebar/calibration_window.py
@@ -21,6 +21,7 @@ from PyQt6.QtWidgets import (
 from negpy.desktop.view.sidebar.live_view_window import SettingStepper
 from negpy.desktop.view.sidebar.roi_image import RoiImageLabel
 from negpy.desktop.view.styles.theme import THEME
+from negpy.desktop.view.widgets.floating_panel import float_over_app
 
 
 class CalibrationWindow(QDialog):
@@ -33,6 +34,7 @@ class CalibrationWindow(QDialog):
         super().__init__(parent)
         self.setWindowTitle("New preset — calibrate on the film base")
         self.setModal(False)
+        float_over_app(self)
         self.resize(820, 680)
         layout = QVBoxLayout(self)
 

--- a/negpy/desktop/view/sidebar/live_view_window.py
+++ b/negpy/desktop/view/sidebar/live_view_window.py
@@ -16,6 +16,7 @@ from PyQt6.QtWidgets import QDialog, QHBoxLayout, QLabel, QProgressBar, QPushBut
 
 from negpy.desktop.view.sidebar.roi_image import RoiImageLabel
 from negpy.desktop.view.styles.theme import THEME
+from negpy.desktop.view.widgets.floating_panel import float_over_app
 
 #: Progress-bar chunk color per triplet channel. The live view freezes during a triplet,
 #: because the capture now holds the camera without gaps, so the bar carries the R to G
@@ -132,6 +133,7 @@ class LiveViewWindow(QDialog):
         super().__init__(parent)
         self.setWindowTitle("Scanlight — Live View")
         self.setModal(False)
+        float_over_app(self)
         self.resize(900, 720)
         layout = QVBoxLayout(self)
 

--- a/negpy/desktop/view/widgets/crosstalk_editor_dialog.py
+++ b/negpy/desktop/view/widgets/crosstalk_editor_dialog.py
@@ -25,6 +25,7 @@ from negpy.desktop.view.styles.theme import THEME
 from negpy.desktop.view.widgets.sliders import CompactSlider
 from negpy.features.process.models import DEFAULT_CROSSTALK_MATRIX, ProcessMode
 from negpy.services.assets.crosstalk import CrosstalkProfiles, CrosstalkType
+from negpy.desktop.view.widgets.floating_panel import float_over_app
 
 #: Selectable provenances, in dropdown group order. "Other" is not offered: it exists to
 #: keep a hand-written type loadable, not as something to choose.
@@ -118,6 +119,7 @@ class CrosstalkEditorDialog(QDialog):
         self._default_process = str(process_mode or ProcessMode.C41)
 
         self.setWindowTitle("Crosstalk Matrices")
+        float_over_app(self)
         self.resize(680, 620)
         self.setMinimumSize(520, 560)
         self._init_ui()

--- a/negpy/desktop/view/widgets/exposure_targets_dialog.py
+++ b/negpy/desktop/view/widgets/exposure_targets_dialog.py
@@ -6,6 +6,7 @@ from PyQt6.QtWidgets import QDialog, QDialogButtonBox, QVBoxLayout
 from negpy.desktop.view.styles.templates import hint_label, section_subheader
 from negpy.desktop.view.widgets.sliders import CompactSlider
 from negpy.features.exposure.models import DEFAULT_TARGETS, TUNABLE_TARGETS
+from negpy.desktop.view.widgets.floating_panel import float_over_app
 
 # (key, slider label, tooltip) grouped under a heading + explanatory blurb.
 _GROUPS = (
@@ -66,6 +67,7 @@ class ExposureTargetsDialog(QDialog):
     def __init__(self, current: Dict[str, float], parent=None):
         super().__init__(parent)
         self.setWindowTitle("Auto Density & Grade Targets")
+        float_over_app(self)
         self.setMinimumWidth(340)
 
         self._sliders: Dict[str, CompactSlider] = {}

--- a/negpy/desktop/view/widgets/floating_panel.py
+++ b/negpy/desktop/view/widgets/floating_panel.py
@@ -1,0 +1,23 @@
+"""Keep a modeless window above the main window."""
+
+import sys
+
+from PyQt6.QtCore import Qt
+from PyQt6.QtWidgets import QWidget
+
+
+def float_over_app(widget: QWidget, platform: str | None = None) -> None:
+    """Make a modeless window a macOS utility panel, so the main window cannot bury it.
+
+    macOS gives a non-modal dialog no ordering over its parent, so this raises it to an
+    NSPanel. Windows and Linux already keep an owned window above its owner, and the panel
+    chrome there costs a taskbar button, so they are left alone.
+
+    Call before the first show(): setting flags on a visible window hides it.
+    """
+    if (sys.platform if platform is None else platform) != "darwin":
+        return
+    widget.setWindowFlags(widget.windowFlags() | Qt.WindowType.Tool)
+    # A panel hides while another app is frontmost. An export outlives the app being
+    # frontmost, so the window has to stay put.
+    widget.setAttribute(Qt.WidgetAttribute.WA_MacAlwaysShowToolWindow, True)

--- a/negpy/desktop/view/widgets/progress_dialog.py
+++ b/negpy/desktop/view/widgets/progress_dialog.py
@@ -12,6 +12,7 @@ from PyQt6.QtWidgets import (
 )
 
 from negpy.desktop.view.styles.theme import THEME
+from negpy.desktop.view.widgets.floating_panel import float_over_app
 
 
 class ProgressDialog(QDialog):
@@ -26,6 +27,7 @@ class ProgressDialog(QDialog):
         super().__init__(parent)
         self.setWindowTitle("Working…")
         self.setModal(False)
+        float_over_app(self)
         self.setFixedWidth(360)
         self.setStyleSheet(f"""
             QDialog {{ background-color: {THEME.bg_panel}; border: 1px solid {THEME.border_primary}; }}

--- a/tests/test_floating_panel.py
+++ b/tests/test_floating_panel.py
@@ -1,0 +1,30 @@
+import sys
+
+from PyQt6.QtCore import Qt
+from PyQt6.QtWidgets import QDialog
+
+from negpy.desktop.view.widgets.floating_panel import float_over_app
+from negpy.desktop.view.widgets.progress_dialog import ProgressDialog
+
+
+def test_float_over_app_makes_a_panel_on_macos() -> None:
+    dlg = QDialog()
+    float_over_app(dlg, platform="darwin")
+    assert dlg.windowFlags() & Qt.WindowType.Tool == Qt.WindowType.Tool
+    assert dlg.testAttribute(Qt.WidgetAttribute.WA_MacAlwaysShowToolWindow)
+
+
+def test_float_over_app_leaves_other_platforms_alone() -> None:
+    for platform in ("win32", "linux"):
+        dlg = QDialog()
+        before = dlg.windowFlags()
+        float_over_app(dlg, platform=platform)
+        assert dlg.windowFlags() == before
+        assert not dlg.testAttribute(Qt.WidgetAttribute.WA_MacAlwaysShowToolWindow)
+
+
+def test_progress_dialog_floats_and_stays_modeless() -> None:
+    dlg = ProgressDialog()
+    assert not dlg.isModal()
+    is_panel = bool(dlg.windowFlags() & Qt.WindowType.Tool)
+    assert is_panel == (sys.platform == "darwin")

--- a/tests/test_floating_panel.py
+++ b/tests/test_floating_panel.py
@@ -6,11 +6,15 @@ from PyQt6.QtWidgets import QDialog
 from negpy.desktop.view.widgets.floating_panel import float_over_app
 from negpy.desktop.view.widgets.progress_dialog import ProgressDialog
 
+# Qt::Tool shares the Window and Dialog bits, so only the masked windowType() tells
+# a panel from a plain dialog — `flags & Tool` is truthy for both.
+
 
 def test_float_over_app_makes_a_panel_on_macos() -> None:
     dlg = QDialog()
+    assert dlg.windowType() == Qt.WindowType.Dialog
     float_over_app(dlg, platform="darwin")
-    assert dlg.windowFlags() & Qt.WindowType.Tool == Qt.WindowType.Tool
+    assert dlg.windowType() == Qt.WindowType.Tool
     assert dlg.testAttribute(Qt.WidgetAttribute.WA_MacAlwaysShowToolWindow)
 
 
@@ -20,11 +24,20 @@ def test_float_over_app_leaves_other_platforms_alone() -> None:
         before = dlg.windowFlags()
         float_over_app(dlg, platform=platform)
         assert dlg.windowFlags() == before
+        assert dlg.windowType() == Qt.WindowType.Dialog
         assert not dlg.testAttribute(Qt.WidgetAttribute.WA_MacAlwaysShowToolWindow)
+
+
+def test_float_over_app_keeps_the_other_flags() -> None:
+    dlg = QDialog()
+    dlg.setWindowFlags(dlg.windowFlags() | Qt.WindowType.WindowCloseButtonHint)
+    float_over_app(dlg, platform="darwin")
+    assert dlg.windowType() == Qt.WindowType.Tool
+    assert dlg.windowFlags() & Qt.WindowType.WindowCloseButtonHint
 
 
 def test_progress_dialog_floats_and_stays_modeless() -> None:
     dlg = ProgressDialog()
     assert not dlg.isModal()
-    is_panel = bool(dlg.windowFlags() & Qt.WindowType.Tool)
+    is_panel = dlg.windowType() == Qt.WindowType.Tool
     assert is_panel == (sys.platform == "darwin")

--- a/tests/test_tutorial_overlay.py
+++ b/tests/test_tutorial_overlay.py
@@ -68,7 +68,7 @@ def test_tutorial_overlay_uses_top_level_window_on_windows() -> None:
 
     if sys.platform == "win32":
         assert overlay.isWindow()
-        assert overlay.windowFlags() & Qt.WindowType.Tool
+        assert overlay.windowType() == Qt.WindowType.Tool
         assert overlay.windowFlags() & Qt.WindowType.FramelessWindowHint
         assert overlay.windowModality() == Qt.WindowModality.WindowModal
     else:


### PR DESCRIPTION
The export progress window could be buried by the main window: macOS gives a non-modal dialog no ordering over its parent. Raise it, and the other four modeless windows, to an NSPanel so they stay above NegPy's own windows.

macOS only. Windows and Linux already keep an owned window above its owner, and the panel chrome there costs a taskbar button — the way you find a minimized long export. WA_MacAlwaysShowToolWindow keeps the panel visible while another app is frontmost, which a bare NSPanel does not.

Covers the export/analysis/thumbnail progress window, the crosstalk and exposure target editors, and the Scanlight live-view and calibration windows. The 39 exec() dialogs are already on top by modality.