### PR TITLE
Preferences dialog for app-wide settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Everything lives in your `Documents/NegPy` folder:
 
 ## Troubleshooting
 
-If NegPy crashes on startup or has rendering issues, edit `Documents/NegPy/override.toml`. It is created automatically on first run with sensible defaults for your OS.
+If NegPy crashes on startup or has rendering issues, edit `Documents/NegPy/override.toml`. It is created automatically on first run with sensible defaults for your OS. The `[performance]` numbers are also in **Preferences** (`Ctrl + ,`); a value in this file wins over the dialog, which is what makes it usable when the app will not start.
 
 ```toml
 [rendering]

--- a/docs/KEYBOARD.md
+++ b/docs/KEYBOARD.md
@@ -62,6 +62,7 @@ While a test strip or ring-around is up, `[` and `]` turn that proof's ladder in
 | `Ctrl + Y` | Redo change |
 | `Ctrl + C` | Copy settings from current image |
 | `Ctrl + V` | Paste settings to current image |
+| `Ctrl + ,` | Open Preferences |
 
 ## Viewport
 | Key | Action |
@@ -69,13 +70,13 @@ While a test strip or ring-around is up, `[` and `]` turn that proof's ladder in
 | `Ctrl + [` | Toggle session panel (re-docks when floating) |
 | `Ctrl + ]` | Toggle controls panel (re-docks when floating) |
 | `Ctrl + Shift + L` | Dock session and controls panels |
-| `Mouse Wheel` | Zoom in / out (up to 400%); **Reverse Scroll Zoom** in the toolbar **⋯** menu flips the direction |
+| `Mouse Wheel` | Zoom in / out (up to 400%); **Reverse scroll zoom** in Preferences flips the direction |
 | `Middle Click` + `Drag` | Pan zoomed image |
 | `Left Click` + `Drag` | Pan zoomed image (when no tool is active) |
 
 ## Menu bar (macOS only)
 
-NegPy has a menu bar on macOS, with a **Window** and a **Help** menu. These keys come from it. They are platform window commands, not NegPy actions, so they are fixed and do not appear in the shortcut editor.
+NegPy has a menu bar on macOS: **Preferences…** sits in the application menu, and there is a **Window** and a **Help** menu. These keys come from it. They are platform window commands, not NegPy actions, so they are fixed and do not appear in the shortcut editor.
 
 | Key | Action |
 |-----|--------|

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -11,9 +11,9 @@ This guide is for new users. It explains what each control does and when to reac
 ### Screen layout
 
 *   **Left, the film strip**: your loaded frames as a contact sheet, plus import, sorting and triage tools.
-*   **Centre, the canvas**: the live preview. Most tools (crop, white-balance picker, heal brush, dodge/burn masks) are used by clicking directly on it. Scroll or pinch to zoom, drag to pan. A floating toolbar along the bottom holds Fit/1:1 zoom (**1:1** is one scan pixel per screen pixel, and lights up while you are at it; below **HQ** the preview is scaled up to reach it, which a **preview res · HQ off** pill on the canvas says), undo/redo, rotate/flip and more, moving overflow items into an **⋯** menu as the window narrows. **Edit Toolbar…** in that menu chooses which controls sit on the row and in what order (drag them into place); what does not fit collapses from the right, and the **⋯** menu keeps every action whatever the row shows. That menu also holds **Immersive Canvas** (the image fills the canvas and the toolbar overlaps it; turn it off to reserve space) **Show Slider Values** (every slider's value box stays open instead of appearing under the pointer) and **Reverse Scroll Zoom** (scroll up zooms out instead of in). **Persistent Settings…** chooses which settings carry onto the next file you open. Right-click the image for **Reset View** and **Sticky Zoom** (keeps the current zoom when you switch frames), plus the picker tools and copy/paste settings. With nothing loaded the canvas shows **Load some scans to get started**; click it for **Add files** or **Add folder**.
+*   **Centre, the canvas**: the live preview. Most tools (crop, white-balance picker, heal brush, dodge/burn masks) are used by clicking directly on it. Scroll or pinch to zoom, drag to pan. A floating toolbar along the bottom holds Fit/1:1 zoom (**1:1** is one scan pixel per screen pixel, and lights up while you are at it; below **HQ** the preview is scaled up to reach it, which a **preview res · HQ off** pill on the canvas says), undo/redo, rotate/flip and more, moving overflow items into an **⋯** menu as the window narrows. What does not fit collapses from the right, and the **⋯** menu keeps every action whatever the row shows. **Preferences…** in that menu holds every app-wide setting (§14): the interface options, the performance budgets, **Edit Toolbar…** for which controls sit on the row and in what order, and **Persistent Settings…** for what carries onto the next file you open. Right-click the image for **Reset View** and **Sticky Zoom** (keeps the current zoom when you switch frames), plus the picker tools and copy/paste settings. With nothing loaded the canvas shows **Load some scans to get started**; click it for **Add files** or **Add folder**.
 *   **Left, the film strip**: your loaded frames as a contact sheet, plus import, sorting, and triage tools.
-*   **Centre, the canvas**: the live preview of the current frame. Most tools (crop, white-balance picker, heal brush, dodge/burn masks) are used by clicking directly on it. Scroll/pinch to zoom and drag to pan; a floating toolbar along the bottom holds Fit/1:1 zoom (**1:1** is one scan pixel per screen pixel, and lights up while you are at it; below **HQ** the preview is scaled up to reach it, which a **preview res · HQ off** pill on the canvas says) plus undo/redo, rotate/flip and more, moving overflow items into an **⋯** menu when the window narrows. **Edit Toolbar…** in that menu chooses which controls sit on the row and in what order (drag them into place); what does not fit collapses from the right, and the **⋯** menu keeps every action whatever the row shows. That menu also has **Immersive Canvas** (image fills the canvas and the toolbar overlaps it; turn off to reserve space so it never occludes the image) **Show Slider Values** (keeps every slider's value box open instead of revealing it under the pointer; turn it on if you work by the numbers) and **Reverse Scroll Zoom** (scroll up zooms out instead of in). **Persistent Settings…** chooses which settings carry onto the next file you open. Right-click the image for **Reset View** and **Sticky Zoom** (keeps the current zoom level when you switch to another frame, instead of resetting to fit), alongside the picker tools, copy/paste settings, and **Unload** (removes the frame from the session; its saved edit is kept). With nothing loaded it shows **Load some scans to get started**; click it for **Add files** / **Add folder**.
+*   **Centre, the canvas**: the live preview of the current frame. Most tools (crop, white-balance picker, heal brush, dodge/burn masks) are used by clicking directly on it. Scroll/pinch to zoom and drag to pan; a floating toolbar along the bottom holds Fit/1:1 zoom (**1:1** is one scan pixel per screen pixel, and lights up while you are at it; below **HQ** the preview is scaled up to reach it, which a **preview res · HQ off** pill on the canvas says) plus undo/redo, rotate/flip and more, moving overflow items into an **⋯** menu when the window narrows. What does not fit collapses from the right, and the **⋯** menu keeps every action whatever the row shows. **Preferences…** in that menu holds every app-wide setting (§14): the interface options, the performance budgets, **Edit Toolbar…** for which controls sit on the row and in what order, and **Persistent Settings…** for what carries onto the next file you open. Right-click the image for **Reset View** and **Sticky Zoom** (keeps the current zoom level when you switch to another frame, instead of resetting to fit), alongside the picker tools, copy/paste settings, and **Unload** (removes the frame from the session; its saved edit is kept). With nothing loaded it shows **Load some scans to get started**; click it for **Add files** / **Add folder**.
 *   **Right, the controls**: a pinned **Analysis** readout at the top, and below it an icon tab bar. Each icon opens a *workflow page* holding one or more collapsible panels.
 
 ### Before / After
@@ -53,7 +53,7 @@ Both side panels can be narrowed to give the canvas more room. As the controls p
 
 Open a frame you have not edited and it does not start from bare defaults: the settings that belong to the *rig and the roll* rather than the picture come with it — film process, crop ratio, flips, calibration, paper stock, the Lab polish and your export preferences. The look itself (density, filtration, tone curve, toning, dodge and burn) starts clean on every frame.
 
-**Persistent Settings…** in the canvas **⋯** menu changes that list. Every setting the copy/paste picker knows is there, grouped by panel; tick one to make it carry, untick one to stop it. Tick the whole group from its header checkbox. Values shown are the ones from your last saved edit, so the list reads as what would actually carry.
+**Preferences → Session & Storage → Persistent Settings…** changes that list. Every setting the copy/paste picker knows is there, grouped by panel; tick one to make it carry, untick one to stop it. Tick the whole group from its header checkbox. Values shown are the ones from your last saved edit, so the list reads as what would actually carry.
 
 A frame you have already edited keeps its own look whatever you tick — only export and metadata settings reach it. **Reset Settings** on a frame ignores this list and returns it to bare defaults.
 
@@ -61,6 +61,7 @@ A frame you have already edited keeps its own look whatever you tick — only ex
 
 On macOS NegPy has a menu bar. Almost nothing in it is new: apart from Report an Issue, every item runs something a button, a window control or a keyboard shortcut already runs.
 
+*   **NegPy**: Preferences… (`⌘,`), which macOS shows in the application menu beside About and Quit.
 *   **Window**: Minimize (`⌘M`), Zoom, Close (`⌘W`) and Bring All to Front, then every open NegPy window — the main window plus any live view or calibration window — with a tick against the front one. Select a name to bring that window forward. Minimize and Zoom are unavailable while a window is full screen, as elsewhere on macOS.
 *   **Help**: Take the Tour, Keyboard Shortcuts, Customize Shortcuts, the Analysis panel guide, Report an Issue (which opens the NegPy issue tracker in your browser), and Check for Updates.
 
@@ -373,11 +374,11 @@ The film's dyes each absorb outside their own band, but they are not the only ca
 
 How the negative is measured and normalized into a positive. The film mode that decides *which* conversion runs sits above the panels (§4), and how the scan is decoded lives in **Calibration** (§4.1).
 
-*   **Multi-core CPU Rendering** (canvas toolbar → **»** menu, beside **GPU Acceleration**): spreads the CPU rendering kernels across your cores. It takes effect immediately, with no recompile and no restart.
+*   **Multi-core CPU rendering** (**Preferences → Performance**, beside **GPU acceleration**): spreads the CPU rendering kernels across your cores. It takes effect immediately, with no recompile and no restart.
 
     Be realistic about the gain. The kernels run much faster, but a merge is dominated by decoding the RAW files, which this does not touch, so the whole operation comes down by only about a tenth. Ordinary editing changes less again, because the GPU already carries the pipeline. The gain is largest wherever the CPU does the work: merges, exports, and any machine without a usable GPU.
 
-    On Windows and Linux this is **on**. On macOS it is **off**, pending more evidence: the underlying threading layer terminates the process outright if two threads enter it at once, and while NegPy serialises every such call behind a lock, that has been proven on one Mac rather than on the range of them. If you turn it on and the app ever closes without warning, NegPy notices on the next launch and offers to turn it back off; that is the failure to expect, and it is recoverable. Setting `cpu_parallel` under `[performance]` in `override.toml` still wins over the menu, for a machine that cannot start.
+    On Windows and Linux this is **on**. On macOS it is **off**, pending more evidence: the underlying threading layer terminates the process outright if two threads enter it at once, and while NegPy serialises every such call behind a lock, that has been proven on one Mac rather than on the range of them. If you turn it on and the app ever closes without warning, NegPy notices on the next launch and offers to turn it back off; that is the failure to expect, and it is recoverable. Setting `cpu_parallel` under `[performance]` in `override.toml` still wins over Preferences, for a machine that cannot start.
 
 **Analysis window**, where NegPy measures the black and white points. The slider takes half the row, the three buttons the other half:
 
@@ -879,23 +880,51 @@ Camera scanning needs the optional `python-gphoto2` dependency (`pip install gph
 
 ---
 
-## 14. Startup Override (`override.toml`)
+## 14. Preferences
 
-If NegPy crashes on launch or has rendering glitches, you can force backend settings without touching code. On first run NegPy creates `Documents/NegPy/override.toml` with defaults for your OS. Edit it and restart.
+Settings for the whole application, not for one photo. Open them from the canvas **⋯** menu → **Preferences…**, with `Ctrl + ,`, or on macOS from the application menu. Changes apply as you make them; the rows NegPy reads at startup say so and light a restart notice.
+
+### Interface
+
+*   **UI scale** (80% to 120%): scales the whole interface. Applies after a restart.
+*   **Canvas background**: four swatches — black, dark grey, mid grey, white — for the surround the image sits on. Mid grey is the neutral judgement surround; white reads like a print on a light table.
+*   **Immersive canvas**: the toolbar floats over the image instead of sitting below it, so the frame gets the whole canvas.
+*   **Sticky zoom**: keep the current zoom when you switch frames, instead of resetting to fit. Useful for checking the same magnification across a roll.
+*   **Reverse scroll zoom**: scroll up zooms out.
+*   **Show slider values**: keep every slider's value box open, instead of revealing it on hover.
+*   **Customize Shortcuts…**, **Edit Toolbar…** and **Reset Panel Layout**: the shortcut editor, the picker for which controls sit on the canvas toolbar, and a return to the default panel sizes and positions.
+
+### Performance
+
+*   **GPU acceleration**: render the pipeline on the GPU. The active backend is named below the row. Off falls back to the CPU pipeline, which is slower but produces the same image.
+*   **Multi-core CPU rendering**: see §4.2 — it takes effect at once, with no restart.
+*   **Preview size** (512 to 8192 px): long edge of the interactive canvas. Higher is sharper at 100% zoom, and costs proportionally more VRAM and CPU per frame, so lower the cache limit and the rendered-frame count to match. RAW files decode at half sensor size for the preview, so there is nothing to gain past half the long edge of your scan.
+*   **Preview cache** and **Preview cache limit**: how many recently-viewed photos stay decoded in memory, and the memory ceiling for them. Lower both on a machine with little RAM.
+*   **HQ buffers**: full-resolution HQ preview buffers kept in memory. Each is large — a 60 MP scan is about 700 MB — and keeping the previous frame makes going back instant.
+*   **Rendered frames**: rendered frames held for navigating back with no re-render.
+*   **GPU texture cap**: largest GPU texture dimension. 0 lets the hardware decide; set it to 4096 if exports run the card out of memory.
+
+Every row from **Preview size** down is read at startup, so a change needs a restart. A value set in `override.toml` wins over these, and its row is greyed out and says so.
+
+### Session & Storage
+
+*   **Persistent Settings…**: which edits carry onto the next file you open (§2).
+*   **Manage Database…**: stored row counts and sizes, clearing saved edits, and your library roots.
+
+### Startup override (`override.toml`)
+
+If NegPy crashes on launch or has rendering glitches, force the backend without touching code. On first run NegPy creates `Documents/NegPy/override.toml` with defaults for your OS. Edit it and restart. The `[performance]` numbers above are here too, and a value in this file wins over Preferences — which is what makes the file usable on a machine that will not start.
 
 | Setting | Values | Effect |
 |---------|--------|--------|
 | `rendering.backend` | `"auto"`, `"vulkan"`, `"dx12"`, `"metal"`, `"cpu"` | GPU backend for image processing. `"cpu"` disables GPU entirely. |
 | `display.qt_rhi_backend` | `"auto"`, `"vulkan"`, `"d3d12"`, `"metal"`, `"opengl"`, `"software"` | Qt UI rendering backend. |
 | `display.qt_platform` | `"auto"`, `"xcb"`, `"wayland"` | Window system plugin (Linux only). |
-| `performance.max_texture_size` | `"auto"` or a number, e.g. `4096` | Caps GPU texture size; reduce on low-VRAM cards. |
-| `performance.preview_render_size` | a number, 512 to 8192, e.g. `3000` | Long edge of the interactive preview (default `1600`). Higher is a sharper canvas at 100% zoom; every rendered frame costs proportionally more VRAM, so lower `preview_cache_max_bytes` and `render_memo_max_entries` to match. RAW files decode at half sensor size for the preview, so there is nothing to gain past half the long edge of your scan. |
 | `performance.force_hq_preview` | `true` / `false` (or absent) | Overrides the saved HQ preview toggle. |
-| `performance.preview_cache_max_bytes` | a number, e.g. `1200000000` | Preview cache memory budget (default about 1.2 GB). |
-| `performance.preview_cache_max_entries` | a number, e.g. `8` | Max recently-viewed photos kept in memory. |
-| `performance.preview_cache_max_full_res_entries` | a number, e.g. `2` | Full-resolution HQ preview buffers kept in memory (a 60 MP scan is about 700 MB each). |
 | `performance.cpu_parallel` | `true` / `false` (or absent) | Multi-core CPU rendering kernels. Defaults on, except on macOS. |
 | `logging.level` | `"debug"`, `"info"`, `"warning"`, `"error"` | Log verbosity. Use `"debug"` when reporting issues. |
+
+`max_texture_size`, `preview_render_size`, `preview_cache_max_bytes`, `preview_cache_max_entries`, `preview_cache_max_full_res_entries` and `render_memo_max_entries` take the same values as their Preferences rows.
 
 **Common fixes:**
 
@@ -932,7 +961,7 @@ You can ask for the check again at any time with the **Check for updates** actio
 
 ## Additional Info
 
-*   **GPU acceleration**: NegPy uses your GPU for near-instant previews and responsive sliders. The Normalization panel's analysis (bounds, white/black point, normalize) runs on the CPU. There is no global GPU switch in the UI, so force the CPU pipeline through `override.toml` if you suspect a driver issue.
+*   **GPU acceleration**: NegPy uses your GPU for near-instant previews and responsive sliders. The Normalization panel's analysis (bounds, white/black point, normalize) runs on the CPU. Turn it off in **Preferences → Performance** if you suspect a driver issue, or force the backend in `override.toml`.
 *   **Database**: all edits live in a local SQLite database keyed by file hash, so you can move or rename files without losing your work. Optional `.negpy` sidecars mirror edits next to your sources.
 *   **Saving edits**: edits are written to the database on export, when you switch frames, or when you save explicitly. Closing the app mid-edit without any of those loses unsaved changes.
 *   **Keyboard shortcuts**: [KEYBOARD.md](KEYBOARD.md)

--- a/negpy/desktop/main.py
+++ b/negpy/desktop/main.py
@@ -17,6 +17,7 @@ from negpy.services.assets.gear import GearProfiles
 from negpy.kernel.system.config import APP_CONFIG, BASE_USER_DIR
 from negpy.kernel.system.logging import get_logger, setup_logging
 from negpy.kernel.system.override import apply as apply_override
+from negpy.kernel.system.override import apply_stored as apply_stored_override
 from negpy.kernel.system.override import load_or_create as load_override
 from negpy.kernel.system.parallel import configure_cpu_parallel, parallel_enabled, resolve_cpu_parallel, set_parallel_enabled
 from negpy.kernel.system.paths import get_resource_path
@@ -215,6 +216,10 @@ def main() -> None:
         # can be applied through QT_SCALE_FACTOR, which Qt reads only at startup.
         repo = StorageRepository(APP_CONFIG.edits_db_path, APP_CONFIG.settings_db_path)
         repo.initialize()
+
+        # Preferences fills in the performance numbers override.toml left alone. After the
+        # file's own apply() above, and still before QApplication reads any of them.
+        apply_stored_override(override_cfg, APP_CONFIG, repo.get_global_setting)
 
         # Multi-core Numba kernels: override.toml, then the saved setting, then the platform
         # default (off on macOS). Read before the flags below are overwritten.

--- a/negpy/desktop/view/canvas/toolbar.py
+++ b/negpy/desktop/view/canvas/toolbar.py
@@ -1,15 +1,12 @@
-import os
 from dataclasses import dataclass
 
 import qtawesome as qta
 from PyQt6.QtCore import QSize, Qt
-from PyQt6.QtGui import QActionGroup
 from PyQt6.QtWidgets import (
     QFrame,
     QHBoxLayout,
     QLabel,
     QMenu,
-    QMessageBox,
     QPushButton,
     QToolButton,
     QVBoxLayout,
@@ -19,11 +16,8 @@ from PyQt6.QtWidgets import (
 from negpy.desktop.controller import AppController
 from negpy.desktop.view.keyboard_shortcuts import _context_undo
 from negpy.desktop.view.widgets.granular_settings_dialog import open_paste_dialog
-from negpy.desktop.view.widgets.sliders import apply_slider_value_visibility
-from negpy.kernel.system.parallel import parallel_enabled, set_parallel_enabled
 from negpy.desktop.view.shortcut_registry import key_for, tooltip_with_shortcut
 from negpy.desktop.view.styles.theme import THEME
-from negpy.infrastructure.gpu.device import GPUDevice
 
 CANVAS_COLORS = [
     ("#050505", (0.02, 0.02, 0.02), "Black"),
@@ -256,9 +250,6 @@ class ActionToolbar(QWidget):
             )
         )
 
-        # GPU availability drives the overflow toggle built below (btn moved off the row).
-        self._gpu_available = GPUDevice.get().is_available
-
         # 4. Overflow menu & responsive groups
         self.btn_overflow = QToolButton()
         self.btn_overflow.setIcon(qta.icon("fa5s.ellipsis-h", color=icon_color))
@@ -275,42 +266,8 @@ class ActionToolbar(QWidget):
         self._ov_hq_action = overflow_menu.addAction("Toggle HQ Preview")
         self._ov_hq_action.setCheckable(True)
         self._ov_hq_action.setToolTip("Toggle High Quality Preview")
-
-        # GPU acceleration lives here, not on the editing row. Details are in the tooltip,
-        # refreshed by the dashboard through refresh_gpu_status().
-        self._ov_gpu_action = overflow_menu.addAction(qta.icon("fa5s.bolt", color=icon_color), "GPU Acceleration")
-        self._ov_gpu_action.setCheckable(True)
-        self._ov_gpu_action.setToolTip("GPU Acceleration")
-        if self._gpu_available:
-            self._ov_gpu_action.setChecked(self.session.state.gpu_enabled)
-        else:
-            self._ov_gpu_action.setEnabled(False)
-            self._ov_gpu_action.setChecked(False)
-
-        # Beside GPU Acceleration because it answers the same question, which processor does the
-        # work, and the two trade against each other. With the GPU carrying the pipeline, the CPU
-        # kernels are left with the source assembly, where an HDR solve takes seconds.
-        self._parallel_action = overflow_menu.addAction("Multi-core CPU Rendering")
-        self._parallel_action.setCheckable(True)
-        self._parallel_action.triggered.connect(self._on_cpu_parallel_toggled)
-        self.refresh_cpu_parallel_status()
         overflow_menu.addSeparator()
 
-        # Canvas background, overflow-only with no toolbar swatches. An exclusive checkable group,
-        # so the menu itself shows which color is active.
-        self._ov_color_group = QActionGroup(self)
-        self._ov_color_group.setExclusive(True)
-        self._ov_color_actions: list = []
-        for i, (_, _, label) in enumerate(CANVAS_COLORS):
-            action = overflow_menu.addAction(f"Canvas: {label}")
-            action.setCheckable(True)
-            action.setChecked(i == self.session.state.canvas_bg_index)
-            action.setToolTip(f"Set the canvas background to {label.lower()}")
-            self._ov_color_group.addAction(action)
-            self._ov_color_actions.append(action)
-        overflow_menu.addSeparator()
-
-        overflow_menu.addSeparator()
         self._ov_fit_action = overflow_menu.addAction(qta.icon("fa5s.expand", color=icon_color), "Fit to Window")
         self._ov_fit_action.setToolTip(tooltip_with_shortcut("Fit to Window", "fit_view"))
         self._ov_original_action = overflow_menu.addAction("Original Size (1:1)")
@@ -389,72 +346,18 @@ class ActionToolbar(QWidget):
             qta.icon("fa5s.history", color=icon_color), "Reset Settings", self.session.reset_settings
         )
         reset_settings_action.setToolTip("Discard all edits and return this image to its default look")
-        persistent_action = overflow_menu.addAction(
-            qta.icon("fa5s.thumbtack", color=icon_color),
-            tooltip_with_shortcut("Persistent Settings…", "persistent_settings"),
-            self._show_sticky_dialog,
-        )
-        persistent_action.setToolTip("Choose which settings carry onto the next file you open")
         overflow_menu.addSeparator()
         unload_action = overflow_menu.addAction(qta.icon("fa5s.times-circle", color=icon_color), "Unload", self._on_overflow_unload)
         unload_action.setToolTip("Remove this image from the session (its saved edit is kept)")
         overflow_menu.addSeparator()
-        scale_menu = overflow_menu.addMenu(qta.icon("fa5s.search-plus", color=icon_color), "UI Scale")
-        scale_menu.setToolTipsVisible(True)
-        scale_menu.menuAction().setToolTip("Scale the whole interface (applies after a restart)")
-        self._ui_scale_group = QActionGroup(self)
-        self._ui_scale_group.setExclusive(True)
-        current_scale = float(self.session.repo.get_global_setting("ui_scale", 1.0) or 1.0)
-        for pct in (80, 90, 100, 110, 120):
-            val = pct / 100.0
-            act = scale_menu.addAction(f"{pct}%")
-            act.setCheckable(True)
-            act.setChecked(abs(val - current_scale) < 0.001)
-            self._ui_scale_group.addAction(act)
-            act.triggered.connect(lambda _checked=False, v=val, p=pct: self._on_ui_scale_selected(v, p))
 
-        overflow_menu.addSeparator()
-
-        reset_key = key_for("reset_panel_layout")
-        reset_label = "Reset Panel Layout" + (f"  {reset_key}" if reset_key else "")
-        reset_layout_action = overflow_menu.addAction(
-            qta.icon("fa5s.thumbtack", color=icon_color),
-            reset_label,
-            self._reset_panel_layout,
+        prefs_key = key_for("open_preferences")
+        prefs_action = overflow_menu.addAction(
+            qta.icon("fa5s.sliders-h", color=icon_color),
+            "Preferences…" + (f"  {prefs_key}" if prefs_key else ""),
+            self._show_preferences,
         )
-        reset_layout_action.setToolTip("Restore the default panel sizes and positions")
-        edit_toolbar_action = overflow_menu.addAction(
-            qta.icon("fa5s.wrench", color=icon_color),
-            "Edit Toolbar…",
-            self.open_toolbar_editor,
-        )
-        edit_toolbar_action.setToolTip(tooltip_with_shortcut("Choose which controls sit on the toolbar, and in what order", "edit_toolbar"))
-        self._ov_immersive_action = overflow_menu.addAction("Immersive Canvas")
-        self._ov_immersive_action.setCheckable(True)
-        self._ov_immersive_action.setChecked(self.session.state.immersive_canvas)
-        self._ov_immersive_action.setToolTip(
-            tooltip_with_shortcut("Toolbar overlaps image — turn off to fit the image above the toolbar", "toggle_immersive_canvas")
-        )
-        self._ov_sticky_zoom_action = overflow_menu.addAction("Sticky Zoom")
-        self._ov_sticky_zoom_action.setCheckable(True)
-        self._ov_sticky_zoom_action.setChecked(self.session.state.sticky_zoom)
-        self._ov_sticky_zoom_action.setToolTip(
-            tooltip_with_shortcut("Keep the current zoom level when switching images, instead of resetting to fit", "toggle_sticky_zoom")
-        )
-        self._ov_invert_zoom_action = overflow_menu.addAction("Reverse Scroll Zoom")
-        self._ov_invert_zoom_action.setCheckable(True)
-        self._ov_invert_zoom_action.setChecked(self.session.state.invert_zoom_scroll)
-        self._ov_invert_zoom_action.setToolTip(tooltip_with_shortcut("Scroll up zooms out instead of in", "toggle_invert_zoom_scroll"))
-        self._ov_slider_values_action = overflow_menu.addAction("Show Slider Values")
-        self._ov_slider_values_action.setCheckable(True)
-        self._ov_slider_values_action.setChecked(bool(self.session.repo.get_global_setting("show_slider_values", default=False)))
-        self._ov_slider_values_action.setToolTip(
-            tooltip_with_shortcut("Keep every slider's value box open, instead of revealing it on hover", "toggle_slider_values")
-        )
-        overflow_menu.addSeparator()
-
-        db_action = overflow_menu.addAction(qta.icon("fa5s.database", color=icon_color), "Manage Database…", self._show_database_dialog)
-        db_action.setToolTip("View stored data and clear saved edits")
+        prefs_action.setToolTip("Interface, performance and storage settings for the whole app")
         overflow_menu.addSeparator()
 
         tour_action = overflow_menu.addAction(qta.icon("fa5s.map-signs", color=icon_color), "Take the tour", self._show_tour)
@@ -583,7 +486,6 @@ class ActionToolbar(QWidget):
         self.btn_loupe.toggled.connect(lambda checked: self.controller.toggle_grain_focuser(force=checked))
         self._ov_loupe_action.triggered.connect(lambda checked: self.controller.toggle_grain_focuser(force=checked))
         self.controller.grain_focuser_changed.connect(self._on_grain_focuser_changed)
-        self._ov_gpu_action.toggled.connect(self._on_gpu_toggled)
         self.controller.zoom_changed.connect(self._on_zoom_changed)
 
         self.session.state_changed.connect(self._update_ui_state)
@@ -591,8 +493,6 @@ class ActionToolbar(QWidget):
 
         # Overflow menu action connections
         self._ov_hq_action.triggered.connect(self.controller.toggle_hq_preview)
-        for i, action in enumerate(self._ov_color_actions):
-            action.triggered.connect(lambda checked, idx=i: self._on_canvas_color_changed(idx, True))
         self._ov_rot_l_action.triggered.connect(lambda: self.rotate(1))
         self._ov_rot_r_action.triggered.connect(lambda: self.rotate(-1))
         self._ov_flip_h_action.triggered.connect(lambda: self.flip("horizontal"))
@@ -603,10 +503,6 @@ class ActionToolbar(QWidget):
         self._ov_flat_peek_action.triggered.connect(lambda checked: self.controller.toggle_flat_peek(force=checked))
         self._ov_undo_action.triggered.connect(lambda: _context_undo(self.controller))
         self._ov_redo_action.triggered.connect(self.session.redo)
-        self._ov_immersive_action.triggered.connect(self._on_immersive_toggled)
-        self._ov_sticky_zoom_action.triggered.connect(self._on_sticky_zoom_toggled)
-        self._ov_invert_zoom_action.triggered.connect(self._on_invert_zoom_toggled)
-        self._ov_slider_values_action.triggered.connect(self._on_slider_values_toggled)
 
     def _on_overflow_unload(self) -> None:
         from negpy.desktop.view.confirm import confirm_unload
@@ -615,103 +511,6 @@ class ActionToolbar(QWidget):
             return
         if confirm_unload(self):
             self.session.remove_current_file()
-
-    def _on_immersive_toggled(self, checked: bool) -> None:
-        self.session.set_immersive_canvas(checked)
-
-    def _on_slider_values_toggled(self, checked: bool) -> None:
-        self.session.repo.save_global_setting("show_slider_values", bool(checked))
-        apply_slider_value_visibility(self.window(), bool(checked))
-
-    def _on_sticky_zoom_toggled(self, checked: bool) -> None:
-        self.session.set_sticky_zoom(checked)
-
-    def _on_invert_zoom_toggled(self, checked: bool) -> None:
-        self.session.set_invert_zoom_scroll(checked)
-
-    def _on_gpu_toggled(self, checked: bool) -> None:
-        if checked != self.session.state.gpu_enabled:
-            self.session.set_gpu_enabled(checked)
-
-    def refresh_gpu_status(self) -> None:
-        """Reflect current GPU on/off state and active backend in the overflow toggle."""
-        enabled = self.session.state.gpu_enabled
-        action = self._ov_gpu_action
-
-        action.blockSignals(True)
-        action.setChecked(enabled and self._gpu_available)
-        action.blockSignals(False)
-
-        icon_color = THEME.accent_primary if (enabled and self._gpu_available) else THEME.text_primary
-        action.setIcon(qta.icon("fa5s.bolt", color=icon_color))
-
-        if not self._gpu_available:
-            action.setToolTip("GPU not available on this hardware")
-        elif enabled:
-            try:
-                backend = self.controller.render_worker.processor.backend_name
-            except Exception:
-                backend = "GPU"
-            action.setToolTip(f"GPU Acceleration: ON — {backend}\nClick to force the CPU pipeline.")
-        else:
-            action.setToolTip("GPU Acceleration: OFF — CPU pipeline\nClick to enable WebGPU for near-instant previews.")
-
-    def refresh_cpu_parallel_status(self) -> None:
-        """Reflect on/off in the icon, the way the GPU toggle does.
-
-        A checkable QAction that also carries an icon shows the icon in the indicator slot
-        instead of a tick, so the state has to live in the icon itself or the entry looks
-        identical either way.
-        """
-        enabled = parallel_enabled()
-        action = self._parallel_action
-
-        action.blockSignals(True)
-        action.setChecked(enabled)
-        action.blockSignals(False)
-
-        action.setIcon(qta.icon("fa5s.microchip", color=THEME.accent_primary if enabled else THEME.text_primary))
-        if enabled:
-            action.setToolTip(
-                f"Multi-core CPU Rendering: ON — {os.cpu_count() or '?'} cores\n"
-                "The rendering kernels run 5-8x faster, which is about 10% off a whole HDR\n"
-                "merge — the rest of that time is decoding the RAW files, which this does\n"
-                "not touch. Experimental: if the app closes without warning, turn it off."
-            )
-        else:
-            action.setToolTip(
-                "Multi-core CPU Rendering: OFF — one core\n"
-                "Click to spread the CPU rendering kernels across cores. They run 5-8x\n"
-                "faster, worth roughly 10% off a whole HDR merge — most of that time is\n"
-                "decoding the RAW files. Experimental on macOS."
-            )
-
-    def _on_cpu_parallel_toggled(self, checked: bool) -> None:
-        """Takes effect at once: every kernel is compiled both ways and dispatched per
-        call, so there is nothing to recompile and no restart to wait for."""
-        self.session.repo.save_global_setting("cpu_parallel", bool(checked))
-        set_parallel_enabled(bool(checked))
-        self.session.repo.save_global_setting("cpu_parallel_active", bool(checked))
-        self.refresh_cpu_parallel_status()
-        self.controller.set_status(
-            "Multi-core CPU rendering on — turn it off if the app closes unexpectedly" if checked else "Multi-core CPU rendering off",
-            5000,
-        )
-
-    def _on_ui_scale_selected(self, value: float, pct: int) -> None:
-        self.session.repo.save_global_setting("ui_scale", value)
-        QMessageBox.information(
-            self,
-            "UI Scale",
-            f"UI scale set to {pct}%.\n\nRestart NegPy to apply the change.",
-        )
-
-    def _on_canvas_color_changed(self, idx: int, checked: bool) -> None:
-        if checked:
-            self.session.set_canvas_bg(idx)
-            if self.controller.canvas:
-                _, (r, g, b), _ = CANVAS_COLORS[idx]
-                self.controller.canvas.set_background_color(r, g, b)
 
     def _on_zoom_changed(self, zoom: float) -> None:
         # The label shows the true pixel zoom (zoom_level x fit_scale), which is what the user
@@ -789,13 +588,6 @@ class ActionToolbar(QWidget):
         # Flipping shouldn't drop an active before/after or flat-peek (see rotate()).
         self.controller.rerender_active_view()
 
-    def _reset_panel_layout(self) -> None:
-        from negpy.desktop.view.main_window import MainWindow
-
-        win = self.window()
-        if isinstance(win, MainWindow):
-            win.reset_panel_layout()
-
     def _show_tour(self) -> None:
         from negpy.desktop.view.main_window import MainWindow
 
@@ -809,15 +601,10 @@ class ActionToolbar(QWidget):
         dlg = ShortcutsOverlay(self.window().shortcut_manager, self.window())
         dlg.exec()
 
-    def _show_sticky_dialog(self) -> None:
-        from negpy.desktop.view.widgets.granular_settings_dialog import open_sticky_dialog
+    def _show_preferences(self) -> None:
+        from negpy.desktop.view.widgets.preferences_dialog import open_preferences
 
-        open_sticky_dialog(self.window(), self.controller)
-
-    def _show_database_dialog(self) -> None:
-        from negpy.desktop.view.widgets.database_dialog import DatabaseDialog
-
-        DatabaseDialog(self.session.repo, self.controller, self.window()).exec()
+        open_preferences(self.window(), self.controller)
 
     def _update_ui_state(self) -> None:
         state = self.session.state
@@ -840,9 +627,6 @@ class ActionToolbar(QWidget):
         self.btn_flip_v.setChecked(geo.flip_vertical)
         self._ov_flip_h_action.setChecked(geo.flip_horizontal)
         self._ov_flip_v_action.setChecked(geo.flip_vertical)
-        self._ov_immersive_action.setChecked(state.immersive_canvas)
-        self._ov_sticky_zoom_action.setChecked(state.sticky_zoom)
-        self._ov_invert_zoom_action.setChecked(state.invert_zoom_scroll)
 
         self.btn_undo.setEnabled(state.undo_index > 0)
         self.btn_redo.setEnabled(state.undo_index < state.max_history_index)

--- a/negpy/desktop/view/keyboard_shortcuts.py
+++ b/negpy/desktop/view/keyboard_shortcuts.py
@@ -68,6 +68,13 @@ def _show_shortcuts(window) -> None:
     dlg.exec()
 
 
+def _open_preferences(window, controller) -> None:
+    # Deferred: the dialog reaches the toolbar for the canvas palette, which imports this module.
+    from negpy.desktop.view.widgets.preferences_dialog import open_preferences
+
+    open_preferences(window, controller)
+
+
 class ShortcutManager:
     def __init__(self, window):
         self.window = window
@@ -76,6 +83,14 @@ class ShortcutManager:
         self._shortcuts: list[QShortcut] = []
         self._actions = self._build_actions()
         self.apply_bindings(self.bindings)
+
+    def _toggle_slider_values(self) -> None:
+        from negpy.desktop.view.widgets.sliders import apply_slider_value_visibility
+
+        repo = self.window.controller.session.repo
+        pinned = not bool(repo.get_global_setting("show_slider_values", default=False))
+        repo.save_global_setting("show_slider_values", pinned)
+        apply_slider_value_visibility(self.window, pinned)
 
     def _slider_adjuster(self, getter: Callable[[], object], action_id: str) -> Callable[[], None]:
         group = SLIDER_GROUP_BY_ACTION[action_id]
@@ -158,8 +173,8 @@ class ShortcutManager:
             "toggle_library_tree": self.window.session_panel.toggle_library_tree,
             "toggle_immersive_canvas": lambda: controller.session.set_immersive_canvas(not controller.session.state.immersive_canvas),
             "toggle_sticky_zoom": lambda: controller.session.set_sticky_zoom(not controller.session.state.sticky_zoom),
-            "toggle_slider_values": lambda: toolbar._ov_slider_values_action.trigger(),
-            "toggle_invert_zoom_scroll": lambda: toolbar._ov_invert_zoom_action.trigger(),
+            "toggle_slider_values": self._toggle_slider_values,
+            "toggle_invert_zoom_scroll": lambda: controller.session.set_invert_zoom_scroll(not controller.session.state.invert_zoom_scroll),
             "toggle_left_panel": self.window.toggle_session_dock,
             "toggle_right_panel": self.window.toggle_controls_dock,
             "reset_panel_layout": self.window.reset_panel_layout,
@@ -183,6 +198,7 @@ class ShortcutManager:
             "copy_with_bounds": controller.session.copy_settings_with_bounds,
             "paste": lambda: open_paste_dialog(self.window, controller),
             "persistent_settings": lambda: open_sticky_dialog(self.window, controller),
+            "open_preferences": lambda: _open_preferences(self.window, controller),
             "save_work_print": self.window.right_panel.history_panel.save_work_print,
             "undo": lambda: _context_undo(controller),
             "redo": controller.session.redo,

--- a/negpy/desktop/view/mac_menu_bar.py
+++ b/negpy/desktop/view/mac_menu_bar.py
@@ -57,6 +57,7 @@ class MacMenuBar(QMenuBar):
         self._keyed: list[tuple[QAction, str]] = []
 
         # Apple's order: the app's own menus, then Window, Help.
+        self.app_menu = self._build_app()
         self.window_menu = WindowMenu(window, self)
         self.addMenu(self.window_menu)
         self.help_menu = self._build_help()
@@ -78,6 +79,7 @@ class MacMenuBar(QMenuBar):
         action_id: str = "",
         slot: Optional[Callable[[], None]] = None,
         key: str = "",
+        role: QAction.MenuRole = QAction.MenuRole.NoRole,
     ) -> QAction:
         if slot is None:
             slot = self._window.shortcut_manager.action_for(action_id)
@@ -87,8 +89,9 @@ class MacMenuBar(QMenuBar):
         action = QAction(text, self)
         # Window titles carry the open file's name, and Qt's macOS merge heuristic moves any
         # item whose text looks like "about", "settings" or "quit" into the application menu.
-        # NoRole keeps every item where it was put, whatever a frame is called.
-        action.setMenuRole(QAction.MenuRole.NoRole)
+        # NoRole is the default so an item stays where it was put, whatever a frame is called;
+        # only Preferences asks for a merge, by passing its own role.
+        action.setMenuRole(role)
         action.triggered.connect(lambda _checked=False, run=slot: run())
         if action_id:
             self._keyed.append((action, action_id))
@@ -96,6 +99,16 @@ class MacMenuBar(QMenuBar):
             action.setShortcut(_menu_key(key))
         menu.addAction(action)
         return action
+
+    def _build_app(self) -> QMenu:
+        """Holds only Preferences, which macOS then moves into the application menu.
+
+        PreferencesRole is the one place the NoRole rule above must not apply: the item
+        belongs in the application menu, and only that role puts it there with ⌘,.
+        """
+        menu = self._menu("NegPy")
+        self._add(menu, "Preferences…", action_id="open_preferences", role=QAction.MenuRole.PreferencesRole)
+        return menu
 
     def _build_help(self) -> QMenu:
         menu = self._menu("Help")

--- a/negpy/desktop/view/main_window.py
+++ b/negpy/desktop/view/main_window.py
@@ -478,14 +478,6 @@ class MainWindow(QMainWindow):
         self.controller.batch_finished.connect(self.progress_dialog.finish)
         self.progress_dialog.abort_requested.connect(self.controller.abort_active_batch)
 
-        self.dash_timer = QTimer(self)
-        self.dash_timer.timeout.connect(self._refresh_dashboard)
-        self.dash_timer.start(2000)
-        self._refresh_dashboard()
-
-    def _refresh_dashboard(self) -> None:
-        self.toolbar.refresh_gpu_status()
-
     def _on_batch_started(self, title: str, abortable: bool) -> None:
         """Hot Folder polls every 2 s, so its per-frame import batches (the only
         non-abortable ones) would pop the dialog on every capture. The HUD status

--- a/negpy/desktop/view/shortcut_registry.py
+++ b/negpy/desktop/view/shortcut_registry.py
@@ -202,6 +202,7 @@ REGISTRY: dict[str, ShortcutEntry] = {
     "copy_with_bounds": ShortcutEntry("Ctrl+Shift+C", "Copy settings (with bounds)", "Actions"),
     "paste": ShortcutEntry("Ctrl+V", "Paste settings", "Actions"),
     "persistent_settings": ShortcutEntry("", "Choose which settings carry to the next file", "Actions"),
+    "open_preferences": ShortcutEntry("Ctrl+,", "Open Preferences", "Actions"),
     "save_work_print": ShortcutEntry("Ctrl+Shift+S", "Save the current edit as a named work print", "Actions"),
     "undo": ShortcutEntry("Ctrl+Z", "Undo", "Actions"),
     "redo": ShortcutEntry("Ctrl+Y", "Redo", "Actions"),

--- a/negpy/desktop/view/widgets/preferences_dialog.py
+++ b/negpy/desktop/view/widgets/preferences_dialog.py
@@ -1,0 +1,472 @@
+import os
+from dataclasses import dataclass, fields
+
+import qtawesome as qta
+from PyQt6.QtWidgets import (
+    QButtonGroup,
+    QCheckBox,
+    QComboBox,
+    QDialog,
+    QFrame,
+    QGridLayout,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QScrollArea,
+    QSpinBox,
+    QVBoxLayout,
+    QWidget,
+)
+
+from negpy.desktop.controller import AppController
+from negpy.desktop.view.styles.templates import default_button_height, field_label, hint_label
+from negpy.desktop.view.styles.theme import THEME
+from negpy.desktop.view.widgets.collapsible import CollapsibleSection
+from negpy.desktop.view.widgets.sliders import apply_slider_value_visibility
+from negpy.domain.types import AppConfig
+from negpy.infrastructure.gpu.device import GPUDevice
+from negpy.kernel.system.config import APP_CONFIG
+from negpy.kernel.system.override import (
+    PREVIEW_SIZE_DEFAULT,
+    PREVIEW_SIZE_MAX,
+    PREVIEW_SIZE_MIN,
+    load_or_create,
+    toml_pinned_keys,
+)
+from negpy.kernel.system.parallel import parallel_enabled, set_parallel_enabled
+
+UI_SCALES: tuple[int, ...] = (80, 90, 100, 110, 120)
+
+
+@dataclass(frozen=True)
+class NumberRow:
+    key: str
+    label: str
+    minimum: int
+    maximum: int
+    step: int
+    suffix: str
+    hint: str
+    # Stored in bytes, shown in MB. Nothing else needs a unit conversion.
+    scale: int = 1
+
+
+NUMBER_ROWS: tuple[NumberRow, ...] = (
+    NumberRow(
+        "preview_render_size",
+        "Preview size",
+        PREVIEW_SIZE_MIN,
+        PREVIEW_SIZE_MAX,
+        128,
+        " px",
+        "Long edge of the interactive canvas. Higher is sharper at 100% zoom, and more VRAM and CPU per frame.",
+    ),
+    NumberRow(
+        "preview_cache_max_entries",
+        "Preview cache",
+        1,
+        64,
+        1,
+        " photos",
+        "How many recently-viewed photos stay decoded in memory for instant navigation.",
+    ),
+    NumberRow(
+        "preview_cache_max_bytes",
+        "Preview cache limit",
+        128,
+        32768,
+        128,
+        " MB",
+        "Memory ceiling for that cache. Lower it on a machine with little RAM.",
+        scale=1024 * 1024,
+    ),
+    NumberRow(
+        "preview_cache_max_full_res_entries",
+        "HQ buffers",
+        1,
+        16,
+        1,
+        " photos",
+        "Full-resolution HQ buffers kept in memory. Each is hundreds of MB, and keeping the previous frame makes going back instant.",
+    ),
+    NumberRow(
+        "render_memo_max_entries",
+        "Rendered frames",
+        1,
+        64,
+        1,
+        " frames",
+        "Rendered frames held for navigating back with no re-render.",
+    ),
+    NumberRow(
+        "max_texture_size",
+        "GPU texture cap",
+        0,
+        16384,
+        1024,
+        " px",
+        "Largest GPU texture dimension. 0 lets the hardware decide.",
+    ),
+)
+
+
+def default_for(key: str) -> int:
+    """The build's own value for a performance key, before any override or preference."""
+    if key == "preview_render_size":
+        return PREVIEW_SIZE_DEFAULT
+    for f in fields(AppConfig):
+        if f.name == key:
+            return 0 if f.default is None else int(f.default)
+    return 0
+
+
+class PreferencesDialog(QDialog):
+    """Every application-wide setting in one place.
+
+    Live-apply: each row writes as it changes, the way the overflow menu entries it replaces
+    did. Rows read at startup say so, and light the restart hint instead of applying.
+    """
+
+    def __init__(self, controller: AppController, parent=None, pinned_keys: set[str] | None = None):
+        super().__init__(parent)
+        self.controller = controller
+        self.session = controller.session
+        self.repo = self.session.repo
+        self._window = parent
+        self._gpu_available = GPUDevice.get().is_available
+        self._pinned = _pinned_keys() if pinned_keys is None else pinned_keys
+        self._spins: dict[str, QSpinBox] = {}
+
+        self.setWindowTitle("Preferences")
+        self.setStyleSheet(f"QDialog {{ background: {THEME.bg_dark}; }}")
+        self.resize(700, 720)
+        self._init_ui()
+
+    def _init_ui(self) -> None:
+        root = QVBoxLayout(self)
+        root.setContentsMargins(18, 18, 18, 18)
+        root.setSpacing(12)
+
+        intro = QLabel("Settings for the whole application. Changes apply as you make them, except where a row says otherwise.")
+        intro.setWordWrap(True)
+        root.addWidget(intro)
+
+        self._restart_hint = hint_label("", "warning")
+        self._restart_hint.hide()
+        root.addWidget(self._restart_hint)
+
+        divider = QFrame()
+        divider.setFrameShape(QFrame.Shape.HLine)
+        divider.setStyleSheet(f"color: {THEME.border_color};")
+        root.addWidget(divider)
+
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll.setFrameShape(QScrollArea.Shape.NoFrame)
+        container = QWidget()
+        sections = QVBoxLayout(container)
+        sections.setContentsMargins(0, 0, 0, 0)
+        sections.setSpacing(THEME.space_sm)
+
+        for title, builder in (
+            ("Interface", self._build_interface),
+            ("Performance", self._build_performance),
+            ("Session & Storage", self._build_storage),
+        ):
+            section = CollapsibleSection(title)
+            section.set_content(builder())
+            sections.addWidget(section)
+
+        sections.addStretch()
+        scroll.setWidget(container)
+        root.addWidget(scroll, stretch=1)
+
+        footer = QHBoxLayout()
+        footer.addStretch()
+        close_btn = QPushButton("Close")
+        close_btn.setDefault(True)
+        close_btn.clicked.connect(self.accept)
+        footer.addWidget(close_btn)
+        root.addLayout(footer)
+
+    def _grid(self) -> tuple[QWidget, QGridLayout]:
+        host = QWidget()
+        grid = QGridLayout(host)
+        grid.setContentsMargins(THEME.space_xl, THEME.space_md, THEME.space_xl, THEME.space_md)
+        grid.setHorizontalSpacing(THEME.space_xl)
+        grid.setVerticalSpacing(THEME.space_md)
+        grid.setColumnStretch(1, 1)
+        return host, grid
+
+    def _add_checkbox(self, grid: QGridLayout, row: int, label: str, checked: bool, tooltip: str) -> QCheckBox:
+        box = QCheckBox(label)
+        box.setChecked(checked)
+        box.setToolTip(tooltip)
+        grid.addWidget(box, row, 0, 1, 2)
+        return box
+
+    def _build_interface(self) -> QWidget:
+        host, grid = self._grid()
+        state = self.session.state
+        row = 0
+
+        grid.addWidget(field_label("UI scale"), row, 0)
+        self.scale_combo = QComboBox()
+        for pct in UI_SCALES:
+            self.scale_combo.addItem(f"{pct}%", pct / 100.0)
+        current = float(self.repo.get_global_setting("ui_scale", 1.0) or 1.0)
+        self.scale_combo.setCurrentIndex(min(range(len(UI_SCALES)), key=lambda i: abs(UI_SCALES[i] / 100.0 - current)))
+        self.scale_combo.currentIndexChanged.connect(self._on_ui_scale_changed)
+        self.scale_combo.setToolTip("Scale the whole interface")
+        grid.addWidget(self.scale_combo, row, 1)
+        row += 1
+
+        grid.addWidget(field_label("Canvas background"), row, 0)
+        pills = QHBoxLayout()
+        pills.setSpacing(THEME.space_sm)
+        self.canvas_group = QButtonGroup(self)
+        self.canvas_group.setExclusive(True)
+        self.canvas_pills: list[QPushButton] = []
+        for idx, (hex_color, _, label) in enumerate(_canvas_colors()):
+            pill = QPushButton()
+            pill.setCheckable(True)
+            pill.setChecked(idx == state.canvas_bg_index)
+            pill.setFixedHeight(default_button_height())
+            pill.setToolTip(label)
+            pill.setStyleSheet(_pill_qss(hex_color))
+            pill.clicked.connect(lambda _checked=False, i=idx: self._on_canvas_bg_changed(i))
+            self.canvas_group.addButton(pill, idx)
+            self.canvas_pills.append(pill)
+            pills.addWidget(pill, 1)
+        grid.addLayout(pills, row, 1)
+        row += 1
+
+        self.immersive_box = self._add_checkbox(
+            grid, row, "Immersive canvas", state.immersive_canvas, "Toolbar overlaps the image, instead of sitting below it"
+        )
+        self.immersive_box.toggled.connect(self.session.set_immersive_canvas)
+        row += 1
+
+        self.sticky_zoom_box = self._add_checkbox(
+            grid, row, "Sticky zoom", state.sticky_zoom, "Keep the zoom level when switching images, instead of resetting to fit"
+        )
+        self.sticky_zoom_box.toggled.connect(self.session.set_sticky_zoom)
+        row += 1
+
+        self.invert_zoom_box = self._add_checkbox(
+            grid, row, "Reverse scroll zoom", state.invert_zoom_scroll, "Scroll up zooms out instead of in"
+        )
+        self.invert_zoom_box.toggled.connect(self.session.set_invert_zoom_scroll)
+        row += 1
+
+        self.slider_values_box = self._add_checkbox(
+            grid,
+            row,
+            "Show slider values",
+            bool(self.repo.get_global_setting("show_slider_values", default=False)),
+            "Keep every slider's value box open, instead of revealing it on hover",
+        )
+        self.slider_values_box.toggled.connect(self._on_slider_values_changed)
+        row += 1
+
+        grid.addLayout(
+            _button_row(
+                (
+                    ("Customize Shortcuts…", "fa5s.keyboard", self._open_shortcut_editor),
+                    ("Edit Toolbar…", "fa5s.wrench", self._open_toolbar_editor),
+                    ("Reset Panel Layout", "fa5s.thumbtack", self._reset_panel_layout),
+                )
+            ),
+            row,
+            0,
+            1,
+            2,
+        )
+        return host
+
+    def _build_performance(self) -> QWidget:
+        host, grid = self._grid()
+        row = 0
+
+        self.gpu_box = self._add_checkbox(
+            grid, row, "GPU acceleration", self.session.state.gpu_enabled and self._gpu_available, "Render the pipeline on the GPU"
+        )
+        row += 1
+        if self._gpu_available:
+            self.gpu_box.toggled.connect(self._on_gpu_changed)
+            grid.addWidget(hint_label(f"Active backend: {self._backend_name()}"), row, 0, 1, 2)
+        else:
+            self.gpu_box.setEnabled(False)
+            grid.addWidget(hint_label("No GPU available on this hardware — the CPU pipeline is in use."), row, 0, 1, 2)
+        row += 1
+
+        self.parallel_box = self._add_checkbox(
+            grid,
+            row,
+            "Multi-core CPU rendering",
+            parallel_enabled(),
+            "Spread the CPU rendering kernels across cores. Experimental: turn it off if the app closes without warning.",
+        )
+        self.parallel_box.toggled.connect(self._on_parallel_changed)
+        row += 1
+        grid.addWidget(hint_label(f"{os.cpu_count() or '?'} cores available. Applies at once, no restart."), row, 0, 1, 2)
+        row += 1
+
+        for spec in NUMBER_ROWS:
+            grid.addWidget(field_label(spec.label), row, 0)
+            spin = QSpinBox()
+            spin.setRange(spec.minimum, spec.maximum)
+            spin.setSingleStep(spec.step)
+            spin.setSuffix(spec.suffix)
+            spin.setValue(self._stored_number(spec))
+            if spec.key in self._pinned:
+                spin.setEnabled(False)
+                spin.setToolTip("Set in override.toml, which wins over this dialog")
+            else:
+                spin.valueChanged.connect(lambda value, s=spec: self._on_number_changed(s, value))
+            self._spins[spec.key] = spin
+            grid.addWidget(spin, row, 1)
+            row += 1
+            note = spec.hint + (" Set in override.toml." if spec.key in self._pinned else "")
+            grid.addWidget(hint_label(note), row, 0, 1, 2)
+            row += 1
+
+        return host
+
+    def _build_storage(self) -> QWidget:
+        host, grid = self._grid()
+        grid.addLayout(
+            _button_row(
+                (
+                    ("Persistent Settings…", "fa5s.thumbtack", self._open_sticky_dialog),
+                    ("Manage Database…", "fa5s.database", self._open_database_dialog),
+                )
+            ),
+            0,
+            0,
+            1,
+            2,
+        )
+        grid.addWidget(
+            hint_label("Persistent Settings chooses which edits carry onto the next file you open."),
+            1,
+            0,
+            1,
+            2,
+        )
+        return host
+
+    def _backend_name(self) -> str:
+        try:
+            return str(self.controller.render_worker.processor.backend_name)
+        except Exception:
+            return "GPU"
+
+    def _stored_number(self, spec: NumberRow) -> int:
+        """What the spin box shows: the live value, which is already the resolved one."""
+        live = getattr(APP_CONFIG, spec.key, None)
+        value = default_for(spec.key) if live is None else int(live)
+        return max(spec.minimum, min(spec.maximum, value // spec.scale))
+
+    def _mark_restart(self) -> None:
+        self._restart_hint.setText("Restart NegPy to apply the changed startup settings.")
+        self._restart_hint.show()
+
+    def _on_number_changed(self, spec: NumberRow, value: int) -> None:
+        self.repo.save_global_setting(spec.key, int(value) * spec.scale)
+        self._mark_restart()
+
+    def _on_ui_scale_changed(self, index: int) -> None:
+        self.repo.save_global_setting("ui_scale", float(self.scale_combo.itemData(index)))
+        self._mark_restart()
+
+    def _on_canvas_bg_changed(self, index: int) -> None:
+        self.session.set_canvas_bg(index)
+        canvas = getattr(self.controller, "canvas", None)
+        if canvas is not None:
+            _, (r, g, b), _ = _canvas_colors()[index]
+            canvas.set_background_color(r, g, b)
+
+    def _on_slider_values_changed(self, checked: bool) -> None:
+        self.repo.save_global_setting("show_slider_values", bool(checked))
+        if self._window is not None:
+            apply_slider_value_visibility(self._window, bool(checked))
+
+    def _on_gpu_changed(self, checked: bool) -> None:
+        if checked != self.session.state.gpu_enabled:
+            self.session.set_gpu_enabled(checked)
+
+    def _on_parallel_changed(self, checked: bool) -> None:
+        """Takes effect at once: every kernel is compiled both ways and dispatched per
+        call, so there is nothing to recompile and no restart to wait for."""
+        set_parallel_enabled(bool(checked))
+        self.repo.save_global_settings({"cpu_parallel": bool(checked), "cpu_parallel_active": bool(checked)})
+        self.controller.set_status(
+            "Multi-core CPU rendering on — turn it off if the app closes unexpectedly" if checked else "Multi-core CPU rendering off",
+            5000,
+        )
+
+    def _open_shortcut_editor(self) -> None:
+        manager = getattr(self._window, "shortcut_manager", None)
+        if manager is not None:
+            manager.open_editor(self)
+
+    def _open_toolbar_editor(self) -> None:
+        toolbar = getattr(self._window, "toolbar", None)
+        if toolbar is not None:
+            toolbar.open_toolbar_editor()
+
+    def _reset_panel_layout(self) -> None:
+        window = self._window
+        if window is not None and hasattr(window, "reset_panel_layout"):
+            window.reset_panel_layout()
+
+    def _open_sticky_dialog(self) -> None:
+        from negpy.desktop.view.widgets.granular_settings_dialog import open_sticky_dialog
+
+        open_sticky_dialog(self, self.controller)
+
+    def _open_database_dialog(self) -> None:
+        from negpy.desktop.view.widgets.database_dialog import DatabaseDialog
+
+        DatabaseDialog(self.repo, self.controller, self).exec()
+
+
+def _pill_qss(hex_color: str) -> str:
+    """A swatch that reads as the colour it sets. Checked state is an accent outline: a tick
+    or a text label would have to sit on top of the swatch and fight it for contrast."""
+    return (
+        f"QPushButton {{background: {hex_color}; border: 1px solid {THEME.border_color}; "
+        f"border-radius: {THEME.radius_md}px;}}"
+        f"QPushButton:checked {{border: 2px solid {THEME.accent_secondary};}}"
+    )
+
+
+def _button_row(items) -> QHBoxLayout:
+    """Equal thirds across the row: a settings dialog has no reason to rag its actions left."""
+    layout = QHBoxLayout()
+    layout.setSpacing(THEME.space_md)
+    for label, icon, handler in items:
+        btn = QPushButton(qta.icon(icon, color=THEME.text_primary), f" {label}")
+        btn.clicked.connect(handler)
+        layout.addWidget(btn, 1)
+    return layout
+
+
+def _pinned_keys() -> set[str]:
+    """Which performance keys override.toml has taken over, so their rows stand down."""
+    path = APP_CONFIG.override_toml_path
+    if not path or not os.path.exists(path):
+        return set()
+    return toml_pinned_keys(load_or_create(path))
+
+
+def _canvas_colors():
+    # Deferred: the toolbar reaches this dialog through the shortcut action map.
+    from negpy.desktop.view.canvas.toolbar import CANVAS_COLORS
+
+    return CANVAS_COLORS
+
+
+def open_preferences(parent, controller: AppController) -> None:
+    PreferencesDialog(controller, parent).exec()

--- a/negpy/desktop/view/widgets/tutorial_steps.py
+++ b/negpy/desktop/view/widgets/tutorial_steps.py
@@ -770,9 +770,9 @@ def build(window: "MainWindow") -> list[TutorialStep]:
                 "Scan tab drives the body and Scanlight directly (macOS/Linux). See "
                 "<code>docs/CAMERA_SCANNING.md</code>.<br>"
                 "• See <code>docs/USER_GUIDE.md</code> for the full reference.<br>"
-                "• Having GPU or rendering issues? Edit "
-                "<code>Documents/NegPy/override.toml</code> to switch backends "
-                "without touching code.<br>"
+                "• <b>Preferences</b> (⋯ menu, or <b>Ctrl+,</b>) holds the app-wide settings: "
+                "interface, performance budgets and storage. For GPU or rendering trouble that "
+                "stops the app starting, edit <code>Documents/NegPy/override.toml</code>.<br>"
                 "• Edits auto-save to a local database, so there is no manual save needed "
                 "between files."
             ),

--- a/negpy/kernel/system/config.py
+++ b/negpy/kernel/system/config.py
@@ -15,6 +15,7 @@ from negpy.features.lab.models import LabConfig
 from negpy.features.process.models import ProcessConfig, ProcessMode
 from negpy.features.retouch.models import RetouchConfig
 from negpy.features.toning.models import ToningConfig
+from negpy.kernel.system.override import PREVIEW_SIZE_DEFAULT
 from negpy.kernel.system.paths import get_default_user_dir, get_resource_path
 
 BASE_USER_DIR = get_default_user_dir()
@@ -25,7 +26,7 @@ APP_CONFIG = AppConfig(
     # LocalAssetStore.get_thumbnail drops any that are not this size.
     thumbnail_size=256,
     max_workers=max(1, (os.cpu_count() or 1)),
-    preview_render_size=1600,
+    preview_render_size=PREVIEW_SIZE_DEFAULT,
     max_history_steps=100,
     edits_db_path=os.path.join(BASE_USER_DIR, "edits.db"),
     settings_db_path=os.path.join(BASE_USER_DIR, "settings.db"),

--- a/negpy/kernel/system/override.py
+++ b/negpy/kernel/system/override.py
@@ -2,7 +2,9 @@ import logging
 import os
 import sys
 import tomllib
+from collections.abc import Callable
 from dataclasses import dataclass
+from typing import Any
 
 from negpy.domain.types import AppConfig
 
@@ -11,13 +13,17 @@ logger = logging.getLogger(__name__)
 
 # A hand-edited preview size below this is not a usable canvas (`= true` coerces to 1,
 # since bool is an int), and above it no GPU can hold the frame.
-_PREVIEW_SIZE_MIN = 512
-_PREVIEW_SIZE_MAX = 8192
+PREVIEW_SIZE_MIN = 512
+PREVIEW_SIZE_MAX = 8192
+PREVIEW_SIZE_DEFAULT = 1600
 
 
 _DEFAULT_TOML_LINUX_WIN = """\
 # NegPy Override Configuration
 # Edit this file and restart the app to apply changes.
+#
+# The [performance] numbers are also in Preferences. A value set here wins over the one
+# chosen there, so this file stays the escape hatch for a machine that cannot start.
 #
 # rendering.backend options:
 #   "auto"   - platform default (Vulkan on Linux/Windows, Metal on macOS)
@@ -247,7 +253,7 @@ def apply(cfg: OverrideConfig, app_config: AppConfig) -> None:
         app_config.cpu_parallel = cfg.cpu_parallel
 
     if cfg.preview_render_size is not None:
-        size = min(_PREVIEW_SIZE_MAX, max(_PREVIEW_SIZE_MIN, cfg.preview_render_size))
+        size = min(PREVIEW_SIZE_MAX, max(PREVIEW_SIZE_MIN, cfg.preview_render_size))
         if size != cfg.preview_render_size:
             logger.warning("preview_render_size %d is out of range, using %d", cfg.preview_render_size, size)
         app_config.preview_render_size = size
@@ -263,3 +269,42 @@ def apply(cfg: OverrideConfig, app_config: AppConfig) -> None:
 
     if cfg.render_memo_max_entries is not None:
         app_config.render_memo_max_entries = cfg.render_memo_max_entries
+
+
+# The [performance] numbers a user can also set in Preferences, saved under these exact key
+# names. The bool and string keys are absent on purpose: they are read before the settings
+# database exists, or a wrong choice stops the app from starting.
+STORED_PERF_KEYS: tuple[str, ...] = (
+    "preview_render_size",
+    "preview_cache_max_bytes",
+    "preview_cache_max_entries",
+    "preview_cache_max_full_res_entries",
+    "render_memo_max_entries",
+    "max_texture_size",
+)
+
+
+def toml_pinned_keys(cfg: OverrideConfig) -> set[str]:
+    """Which stored keys override.toml has taken over, so a UI can say so and stand down."""
+    return {key for key in STORED_PERF_KEYS if getattr(cfg, key) is not None}
+
+
+def apply_stored(cfg: OverrideConfig, app_config: AppConfig, get_setting: Callable[[str, Any], Any]) -> None:
+    """Fill in the saved preferences that override.toml left alone.
+
+    Runs after apply(), so the file keeps the last word. max_texture_size stores 0 for
+    "let the hardware decide", which AppConfig spells as None.
+    """
+    pinned = toml_pinned_keys(cfg)
+    for key in STORED_PERF_KEYS:
+        if key in pinned:
+            continue
+        raw = get_setting(key, None)
+        if not isinstance(raw, int) or isinstance(raw, bool):
+            continue
+        if key == "max_texture_size":
+            setattr(app_config, key, raw if raw > 0 else None)
+        elif key == "preview_render_size":
+            setattr(app_config, key, min(PREVIEW_SIZE_MAX, max(PREVIEW_SIZE_MIN, raw)))
+        elif raw > 0:
+            setattr(app_config, key, raw)

--- a/tests/test_canvas_toolbar.py
+++ b/tests/test_canvas_toolbar.py
@@ -138,8 +138,6 @@ class TestCanvasToolbarResponsive(unittest.TestCase):
     def _all_overflow_actions(self, tb: ActionToolbar) -> list:
         return [
             tb._ov_hq_action,
-            tb._ov_gpu_action,
-            *tb._ov_color_actions,
             tb._ov_fit_action,
             tb._ov_original_action,
             tb._ov_compare_action,
@@ -169,6 +167,25 @@ class TestCanvasToolbarResponsive(unittest.TestCase):
         labels = [a.text() for a in tb.btn_overflow.menu().actions()]
         self.assertNotIn("Color Ring-Around", labels)
         self.assertFalse(hasattr(tb, "_ov_ring_action"))
+
+    def test_app_settings_moved_out_of_the_overflow_menu(self):
+        tb = _make_toolbar()
+        labels = [a.text() for a in tb.btn_overflow.menu().actions()]
+        for gone in (
+            "GPU Acceleration",
+            "Multi-core CPU Rendering",
+            "Canvas: Black",
+            "UI Scale",
+            "Immersive Canvas",
+            "Sticky Zoom",
+            "Reverse Scroll Zoom",
+            "Show Slider Values",
+            "Reset Panel Layout",
+            "Edit Toolbar…",
+            "Manage Database…",
+        ):
+            self.assertNotIn(gone, labels)
+        self.assertTrue(any("Preferences" in label for label in labels))
 
     def test_overflow_menu_always_shows_full_action_set(self):
         """Regression: the overflow menu previously mirrored only whatever the row's

--- a/tests/test_mac_menu_bar.py
+++ b/tests/test_mac_menu_bar.py
@@ -70,7 +70,7 @@ def test_menus_are_in_apple_order(window):
     with patch("negpy.desktop.view.mac_menu_bar.sys.platform", "darwin"):
         bar = install_mac_menus(window)
 
-    assert [action.menu().title() for action in bar.actions()] == ["Window", "Help"]
+    assert [action.menu().title() for action in bar.actions()] == ["NegPy", "Window", "Help"]
 
 
 def test_bar_has_no_parent(bar, window):

--- a/tests/test_override_config.py
+++ b/tests/test_override_config.py
@@ -7,11 +7,15 @@ from unittest.mock import patch
 
 from negpy.domain.types import AppConfig
 from negpy.kernel.system.override import (
+    PREVIEW_SIZE_MAX,
+    PREVIEW_SIZE_MIN,
     OverrideConfig,
     _parse,
     _platform_defaults,
     apply,
+    apply_stored,
     load_or_create,
+    toml_pinned_keys,
 )
 
 _ENV_VARS = ("WGPU_BACKEND_TYPE", "QSG_RHI_BACKEND", "QT_QPA_PLATFORM")
@@ -371,3 +375,56 @@ class TestApplyOverride(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestStoredPreferences(unittest.TestCase):
+    """Preferences fills in the performance numbers override.toml left alone."""
+
+    @staticmethod
+    def _stored(**data):
+        return lambda key, default=None: data.get(key, default)
+
+    def test_a_saved_value_fills_a_gap(self):
+        app = _make_app_config()
+        apply_stored(OverrideConfig(), app, self._stored(preview_render_size=2048, render_memo_max_entries=12))
+        self.assertEqual(app.preview_render_size, 2048)
+        self.assertEqual(app.render_memo_max_entries, 12)
+
+    def test_the_toml_wins_over_a_saved_value(self):
+        app = _make_app_config()
+        cfg = OverrideConfig(preview_render_size=1024)
+        apply(cfg, app)
+        apply_stored(cfg, app, self._stored(preview_render_size=4096))
+        self.assertEqual(app.preview_render_size, 1024)
+
+    def test_a_saved_preview_size_is_clamped(self):
+        app = _make_app_config()
+        apply_stored(OverrideConfig(), app, self._stored(preview_render_size=99999))
+        self.assertEqual(app.preview_render_size, PREVIEW_SIZE_MAX)
+
+        apply_stored(OverrideConfig(), app, self._stored(preview_render_size=1))
+        self.assertEqual(app.preview_render_size, PREVIEW_SIZE_MIN)
+
+    def test_a_zero_texture_cap_means_the_hardware_decides(self):
+        app = _make_app_config(max_texture_size=4096)
+        apply_stored(OverrideConfig(), app, self._stored(max_texture_size=0))
+        self.assertIsNone(app.max_texture_size)
+
+    def test_nothing_saved_changes_nothing(self):
+        app = _make_app_config()
+        before = (app.preview_render_size, app.preview_cache_max_entries, app.render_memo_max_entries)
+        apply_stored(OverrideConfig(), app, self._stored())
+        self.assertEqual((app.preview_render_size, app.preview_cache_max_entries, app.render_memo_max_entries), before)
+
+    def test_a_bool_is_not_a_number(self):
+        """JSON storage round-trips True as an int subclass, which would read as 1 entry."""
+        app = _make_app_config()
+        apply_stored(OverrideConfig(), app, self._stored(preview_cache_max_entries=True))
+        self.assertEqual(app.preview_cache_max_entries, 8)
+
+    def test_pinned_keys_name_only_what_the_file_set(self):
+        self.assertEqual(toml_pinned_keys(OverrideConfig()), set())
+        self.assertEqual(
+            toml_pinned_keys(OverrideConfig(preview_render_size=1024, max_texture_size=2048)),
+            {"preview_render_size", "max_texture_size"},
+        )

--- a/tests/test_preferences_dialog.py
+++ b/tests/test_preferences_dialog.py
@@ -1,0 +1,89 @@
+import unittest
+
+from negpy.desktop.view.widgets.preferences_dialog import NUMBER_ROWS, PreferencesDialog, default_for
+from tests.conftest import FakeController, FakeRepo
+
+
+def _dlg(pinned=None, **settings) -> PreferencesDialog:
+    controller = FakeController(FakeRepo(**settings))
+    return PreferencesDialog(controller, None, pinned_keys=pinned or set())
+
+
+class TestPreferencesDialog(unittest.TestCase):
+    def test_every_performance_row_gets_a_spin_box(self):
+        dlg = _dlg()
+        self.assertEqual(set(dlg._spins), {row.key for row in NUMBER_ROWS})
+
+    def test_ui_scale_is_saved_as_a_fraction(self):
+        dlg = _dlg(ui_scale=1.0)
+        dlg.scale_combo.setCurrentIndex(0)  # 80%
+        self.assertAlmostEqual(dlg.repo.data["ui_scale"], 0.8)
+
+    def test_the_scale_combo_opens_on_the_saved_value(self):
+        self.assertEqual(_dlg(ui_scale=1.2).scale_combo.currentText(), "120%")
+
+    def test_slider_values_toggle_is_persisted(self):
+        dlg = _dlg()
+        dlg.slider_values_box.setChecked(True)
+        self.assertIs(dlg.repo.data["show_slider_values"], True)
+
+    def test_canvas_background_pills_cover_every_colour(self):
+        from negpy.desktop.view.canvas.toolbar import CANVAS_COLORS
+
+        dlg = _dlg()
+        self.assertEqual(len(dlg.canvas_pills), len(CANVAS_COLORS))
+        self.assertTrue(dlg.canvas_pills[0].isChecked())
+        self.assertEqual([p.toolTip() for p in dlg.canvas_pills], [label for _, _, label in CANVAS_COLORS])
+
+    def test_clicking_a_pill_sets_that_background(self):
+        dlg = _dlg()
+        dlg.canvas_pills[2].click()
+        dlg.session.set_canvas_bg.assert_called_once_with(2)
+        self.assertTrue(dlg.canvas_pills[2].isChecked())
+        self.assertFalse(dlg.canvas_pills[0].isChecked())
+
+    def test_view_toggles_go_through_the_session(self):
+        dlg = _dlg()
+        dlg.immersive_box.setChecked(not dlg.immersive_box.isChecked())
+        dlg.sticky_zoom_box.setChecked(not dlg.sticky_zoom_box.isChecked())
+        dlg.session.set_immersive_canvas.assert_called_once()
+        dlg.session.set_sticky_zoom.assert_called_once()
+
+    def test_the_cache_limit_is_shown_in_mb_and_stored_in_bytes(self):
+        dlg = _dlg()
+        dlg._spins["preview_cache_max_bytes"].setValue(256)
+        self.assertEqual(dlg.repo.data["preview_cache_max_bytes"], 256 * 1024 * 1024)
+
+    def test_a_plain_number_row_is_stored_as_it_reads(self):
+        dlg = _dlg()
+        dlg._spins["render_memo_max_entries"].setValue(12)
+        self.assertEqual(dlg.repo.data["render_memo_max_entries"], 12)
+
+    def test_the_restart_hint_waits_for_a_startup_change(self):
+        dlg = _dlg()
+        self.assertTrue(dlg._restart_hint.isHidden())
+        dlg.immersive_box.setChecked(not dlg.immersive_box.isChecked())
+        self.assertTrue(dlg._restart_hint.isHidden())
+        dlg._spins["preview_render_size"].setValue(2048)
+        self.assertFalse(dlg._restart_hint.isHidden())
+
+    def test_a_row_override_toml_pins_stands_down(self):
+        dlg = _dlg(pinned={"preview_render_size"})
+        pinned = dlg._spins["preview_render_size"]
+        self.assertFalse(pinned.isEnabled())
+        self.assertTrue(dlg._spins["render_memo_max_entries"].isEnabled())
+        pinned.setValue(4096)
+        self.assertNotIn("preview_render_size", dlg.repo.data)
+
+    def test_texture_cap_defaults_to_hardware_choice(self):
+        self.assertEqual(default_for("max_texture_size"), 0)
+
+    def test_every_number_row_has_a_default_inside_its_range(self):
+        for row in NUMBER_ROWS:
+            with self.subTest(row.key):
+                self.assertGreaterEqual(default_for(row.key) // row.scale, row.minimum)
+                self.assertLessEqual(default_for(row.key) // row.scale, row.maximum)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why

The canvas overflow menu had grown to 36 entries. Fifteen of them were application preferences — UI scale, canvas colour, GPU/CPU rendering, zoom behaviour, slider values, panel layout, database maintenance — sitting in the same flat list as Rotate CW and Undo.

Separately, nine of the twelve `override.toml` keys had no UI at all, including `preview_render_size` and the four cache budgets. A user who wanted a sharper canvas had to hand-edit a TOML file.

## What

One **Preferences** dialog (`negpy/desktop/view/widgets/preferences_dialog.py`), opened from the ⋯ menu, `Ctrl+,`, or the macOS application menu. Live-apply, three collapsible sections:

- **Interface** — UI scale, canvas background as four colour swatches, immersive canvas / sticky zoom / reverse scroll zoom / show slider values, then Customize Shortcuts… · Edit Toolbar… · Reset Panel Layout.
- **Performance** — GPU acceleration (with the active backend named), multi-core CPU rendering, and the six `override.toml` numbers that had no UI: preview size, preview cache count and limit, HQ buffers, rendered frames, GPU texture cap.
- **Session & Storage** — Persistent Settings… · Manage Database…

Rows read at startup light a restart notice instead of applying.

### Precedence

`override.py` gains `apply_stored()` and `toml_pinned_keys()`. A performance number resolves as override.toml → the saved preference → the build default. A key the file pins greys out its row and says so, which keeps the file usable on a machine that will not start.

### Deletions

- 15 entries and 3 separators out of the overflow menu, one `Preferences…` in — `toolbar.py` is −225/+9 lines.
- The 2-second `dash_timer` in `main_window.py` existed only to refresh the GPU entry's tooltip, so it went with it.
- `PREVIEW_SIZE_DEFAULT` now lives beside its min/max in `override.py`; `config.py` uses it rather than repeating `1600`.

### Out of scope

Sidebar panels are untouched. Soft proof, the monitor profile, Tone's Set Targets and auto-detect-on-load stay where they are reached in the flow of editing a frame.

## Verification

- `make all` green: 4756 passed, 8 skipped.
- New `tests/test_preferences_dialog.py`; `tests/test_override_config.py` extended for the precedence, clamping and bool-is-not-a-number cases; `tests/test_canvas_toolbar.py` asserts the settings block left the menu.
- Headless end-to-end through the real GUI: set the preview size and canvas colour, restart, both survived. With `preview_render_size = 1024` in `override.toml` the saved 2048 is correctly ignored.

## Docs

`docs/USER_GUIDE.md` §14 is now Preferences, with the boot-only TOML keys as a subsection. Fixed the stale "There is no global GPU switch in the UI" line. `docs/KEYBOARD.md`, `README.md` and the tutorial's closing step follow the controls to their new home.