### PR TITLE
fix(ui): show shortcut labels in the platform's own notation

### DIFF
--- a/docs/KEYBOARD.md
+++ b/docs/KEYBOARD.md
@@ -6,6 +6,8 @@ A slider shortcut reports its new value in the canvas HUD, so you can keep a con
 
 A control that the current mode or a lock has retired does not move by keyboard. Temperature on a B&W frame is an example: the shortcut changes nothing, and the HUD shows the control name instead of a value. A control on another tab, in a collapsed section or behind a closed panel still works.
 
+`Ctrl` in this list is `⌘` on macOS. The app writes each key the way your platform writes it, so a menu, a tooltip and the overlay show `⇧⌘C` there and `Ctrl + Shift + C` elsewhere.
+
 Numpad keys can be bound separately from the number row (for example `Num+9` and `9`). Num Lock must be on for numpad digits.
 
 ## Navigation

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -59,6 +59,8 @@ A frame you have already edited keeps its own look whatever you tick — only ex
 
 ### Menu bar (macOS)
 
+`Ctrl` in this guide is `⌘` on macOS, and every menu, tooltip and shortcut list in the app shows it that way.
+
 On macOS NegPy has a menu bar. Almost nothing in it is new: apart from Report an Issue, every item runs something a button, a window control or a keyboard shortcut already runs.
 
 *   **NegPy**: Preferences… (`⌘,`), which macOS shows in the application menu beside About and Quit.

--- a/negpy/desktop/view/canvas/toolbar.py
+++ b/negpy/desktop/view/canvas/toolbar.py
@@ -16,7 +16,7 @@ from PyQt6.QtWidgets import (
 from negpy.desktop.controller import AppController
 from negpy.desktop.view.keyboard_shortcuts import _context_undo
 from negpy.desktop.view.widgets.granular_settings_dialog import open_paste_dialog
-from negpy.desktop.view.shortcut_registry import key_for, tooltip_with_shortcut
+from negpy.desktop.view.shortcut_registry import label_with_shortcut, tooltip_with_shortcut
 from negpy.desktop.view.styles.theme import THEME
 
 CANVAS_COLORS = [
@@ -330,15 +330,19 @@ class ActionToolbar(QWidget):
         overflow_menu.addSeparator()
 
         self._action_copy = overflow_menu.addAction(
-            qta.icon("fa5s.copy", color=icon_color), "Copy Settings  Ctrl+C", self.session.copy_settings
+            qta.icon("fa5s.copy", color=icon_color), label_with_shortcut("Copy Settings", "copy"), self.session.copy_settings
         )
         self._action_copy.setToolTip("Copy this image's settings to the clipboard")
         self._action_copy_bounds = overflow_menu.addAction(
-            qta.icon("fa5s.copy", color=icon_color), "Copy Settings + Bounds  Ctrl+Shift+C", self.session.copy_settings_with_bounds
+            qta.icon("fa5s.copy", color=icon_color),
+            label_with_shortcut("Copy Settings + Bounds", "copy_with_bounds"),
+            self.session.copy_settings_with_bounds,
         )
         self._action_copy_bounds.setToolTip("Copy settings plus the metering/normalization bounds")
         self._action_paste = overflow_menu.addAction(
-            qta.icon("fa5s.paste", color=icon_color), "Paste Settings  Ctrl+V", lambda: open_paste_dialog(self, self.controller)
+            qta.icon("fa5s.paste", color=icon_color),
+            label_with_shortcut("Paste Settings", "paste"),
+            lambda: open_paste_dialog(self, self.controller),
         )
         self._action_paste.setToolTip("Paste the copied settings onto this image")
         overflow_menu.addSeparator()
@@ -351,10 +355,9 @@ class ActionToolbar(QWidget):
         unload_action.setToolTip("Remove this image from the session (its saved edit is kept)")
         overflow_menu.addSeparator()
 
-        prefs_key = key_for("open_preferences")
         prefs_action = overflow_menu.addAction(
             qta.icon("fa5s.sliders-h", color=icon_color),
-            "Preferences…" + (f"  {prefs_key}" if prefs_key else ""),
+            label_with_shortcut("Preferences…", "open_preferences"),
             self._show_preferences,
         )
         prefs_action.setToolTip("Interface, performance and storage settings for the whole app")

--- a/negpy/desktop/view/canvas/widget.py
+++ b/negpy/desktop/view/canvas/widget.py
@@ -12,6 +12,7 @@ from negpy.desktop.view.canvas.overlay import CanvasOverlay
 from negpy.desktop.view.widgets.granular_settings_dialog import open_paste_dialog
 from negpy.infrastructure.gpu.device import GPUDevice
 from negpy.infrastructure.gpu.resources import GPUTexture
+from negpy.desktop.view.shortcut_registry import label_with_shortcut
 from negpy.desktop.view.styles.theme import THEME
 from negpy.kernel.system.config import APP_CONFIG
 from negpy.kernel.system.logging import get_logger
@@ -645,16 +646,16 @@ class ImageCanvas(QWidget):
             return
 
         menu = QMenu(self)
-        act_wb = menu.addAction("Pick WB  Shift+W")
+        act_wb = menu.addAction(label_with_shortcut("Pick WB", "pick_wb"))
         act_wb.triggered.connect(lambda: self._controller.set_active_tool(ToolMode.WB_PICK))  # type: ignore[union-attr]
-        act_dust = menu.addAction("Pick Dust  Shift+D")
+        act_dust = menu.addAction(label_with_shortcut("Pick Dust", "pick_dust"))
         act_dust.triggered.connect(lambda: self._controller.set_active_tool(ToolMode.DUST_PICK))  # type: ignore[union-attr]
         menu.addSeparator()
-        act_copy = menu.addAction("Copy Settings  Ctrl+C")
+        act_copy = menu.addAction(label_with_shortcut("Copy Settings", "copy"))
         act_copy.triggered.connect(self._controller.session.copy_settings)  # type: ignore[union-attr]
-        act_copy_bounds = menu.addAction("Copy Settings + Bounds  Ctrl+Shift+C")
+        act_copy_bounds = menu.addAction(label_with_shortcut("Copy Settings + Bounds", "copy_with_bounds"))
         act_copy_bounds.triggered.connect(self._controller.session.copy_settings_with_bounds)  # type: ignore[union-attr]
-        act_paste = menu.addAction("Paste Settings  Ctrl+V")
+        act_paste = menu.addAction(label_with_shortcut("Paste Settings", "paste"))
         act_paste.triggered.connect(lambda: open_paste_dialog(self, self._controller))  # type: ignore[arg-type]
         act_paste.setEnabled(self.state.clipboard is not None)
         menu.addSeparator()
@@ -704,7 +705,7 @@ class ImageCanvas(QWidget):
             act_delete.triggered.connect(lambda _=False, k=kind, i=index: controller.delete_heal(k, i))
             menu.addSeparator()
 
-        act_undo = menu.addAction("Undo Last Heal  Ctrl+Z")
+        act_undo = menu.addAction(label_with_shortcut("Undo Last Heal", "undo"))
         act_undo.triggered.connect(controller.undo_last_retouch)
         act_undo.setEnabled(num_heals > 0)
         act_clear = menu.addAction("Clear All Heals…")

--- a/negpy/desktop/view/shortcut_registry.py
+++ b/negpy/desktop/view/shortcut_registry.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass
 from typing import Iterable
 
+from PyQt6.QtGui import QKeySequence
+
 from negpy.desktop.view.slider_shortcut_groups import (
     SLIDER_GROUPS,
     SLIDER_GROUP_BY_ACTION,
@@ -335,6 +337,21 @@ def key_for(action_id: str, bindings: dict[str, str] | None = None) -> str:
     return (bindings or current_bindings()).get(action_id, "")
 
 
+def display_key(key: str) -> str:
+    """A binding written the way the platform writes it: ``⇧⌘C`` on macOS, ``Ctrl+Shift+C``
+    elsewhere. Qt binds portable ``Ctrl`` to ⌘ on macOS, so every label that shows a key
+    goes through here."""
+    if not key:
+        return ""
+    return QKeySequence(key).toString(QKeySequence.SequenceFormat.NativeText) or key
+
+
+def label_with_shortcut(text: str, action_id: str, bindings: dict[str, str] | None = None) -> str:
+    """A menu label with its binding appended, or the plain text when the action has none."""
+    key = display_key(key_for(action_id, bindings))
+    return f"{text}  {key}" if key else text
+
+
 def tooltip_with_shortcut(text: str, action_ids: str | Iterable[str] | None = None, bindings: dict[str, str] | None = None) -> str:
     if action_ids is None:
         return text
@@ -350,7 +367,8 @@ def tooltip_with_shortcut(text: str, action_ids: str | Iterable[str] | None = No
     # on inline <span> elements, where background and padding render but the outline does not,
     # and honours it on table cells, so the chips must be <td>s.
     cells = [
-        f'<td style="border:1px solid #5A5A5A;background:#242424;color:#C8C8C8;padding:1px 6px;font-size:10px;">{key}</td>' for key in keys
+        f'<td style="border:1px solid #5A5A5A;background:#242424;color:#C8C8C8;padding:1px 6px;font-size:10px;">{display_key(key)}</td>'
+        for key in keys
     ]
     # The " & " separator sits in its own borderless cell, so it does not inherit a keycap
     # outline. The whole row is right-aligned on its own line below the text.

--- a/negpy/desktop/view/sidebar/export.py
+++ b/negpy/desktop/view/sidebar/export.py
@@ -31,6 +31,7 @@ from negpy.desktop.view.styles.templates import (
     section_subheader,
     set_hint_kind,
 )
+from negpy.desktop.view.shortcut_registry import tooltip_with_shortcut
 from negpy.desktop.view.styles.theme import THEME
 from negpy.desktop.view.widgets.collapsible import CollapsibleSection
 from negpy.desktop.view.widgets.sliders import CompactSlider
@@ -1039,7 +1040,7 @@ class ExportSidebar(BaseSidebar):
         "current": (
             "Export current frame",
             " Export Current Frame",
-            "Export the current frame with the settings below  Ctrl+E",
+            "Export the current frame with the settings below",
         ),
         "selected": (
             "Export selected frames",
@@ -1052,6 +1053,9 @@ class ExportSidebar(BaseSidebar):
             "Export every visible frame using the settings below",
         ),
     }
+
+    # Only the current-frame scope has a binding; the others fall through to the plain tooltip.
+    _EXPORT_SCOPE_SHORTCUTS = {"current": "export"}
 
     # The two "all visible" scopes, current against saved per-frame settings, collapsed into
     # one when per-frame export settings were retired.
@@ -1108,7 +1112,7 @@ class ExportSidebar(BaseSidebar):
         _label, btn_label, tooltip = self._EXPORT_SCOPES[key]
         self._export_scope_actions[key].setChecked(True)
         self.export_main_btn.setText(btn_label)
-        self.export_main_btn.setToolTip(tooltip)
+        self.export_main_btn.setToolTip(tooltip_with_shortcut(tooltip, self._EXPORT_SCOPE_SHORTCUTS.get(key)))
         if persist:
             self.controller.session.repo.save_global_setting("export_scope", key)
 

--- a/negpy/desktop/view/sidebar/files.py
+++ b/negpy/desktop/view/sidebar/files.py
@@ -45,6 +45,7 @@ from negpy.desktop.view.confirm import confirm_unload
 from negpy.features.hdr.logic import anchor_choices
 from negpy.features.hdr.models import hdr_frame_paths
 from negpy.desktop.view.widgets.overflow_bar import OverflowBar
+from negpy.desktop.view.shortcut_registry import label_with_shortcut
 from negpy.desktop.view.styles.theme import THEME
 from negpy.desktop.view.widgets.granular_settings_dialog import GranularSettingsDialog, open_paste_dialog
 from negpy.infrastructure.filesystem.watcher import FolderWatchService
@@ -1119,9 +1120,11 @@ class FileBrowser(QWidget):
         else:
             menu.addAction("Export current frame").triggered.connect(lambda: self.controller.request_export())
         menu.addSeparator()
-        menu.addAction("Copy Settings  Ctrl+C").triggered.connect(self.session.copy_settings)
-        menu.addAction("Copy Settings + Bounds  Ctrl+Shift+C").triggered.connect(self.session.copy_settings_with_bounds)
-        act_paste = menu.addAction("Paste Settings  Ctrl+V")
+        menu.addAction(label_with_shortcut("Copy Settings", "copy")).triggered.connect(self.session.copy_settings)
+        menu.addAction(label_with_shortcut("Copy Settings + Bounds", "copy_with_bounds")).triggered.connect(
+            self.session.copy_settings_with_bounds
+        )
+        act_paste = menu.addAction(label_with_shortcut("Paste Settings", "paste"))
         act_paste.triggered.connect(lambda: open_paste_dialog(self, self.controller))
         act_paste.setEnabled(state.clipboard is not None)
         menu.addAction("Reset Settings").triggered.connect(self.session.reset_settings)

--- a/negpy/desktop/view/widgets/shortcut_editor.py
+++ b/negpy/desktop/view/widgets/shortcut_editor.py
@@ -38,6 +38,7 @@ from negpy.desktop.view.shortcut_registry import (
     ShortcutEntry,
     categories_in_order,
     category_editor_rows,
+    display_key,
     default_bindings,
     default_slider_steps,
 )
@@ -49,8 +50,8 @@ from negpy.desktop.view.styles.theme import THEME
 
 
 def _format_default_pair(inc_key: str, dec_key: str) -> str:
-    inc = inc_key or "—"
-    dec = dec_key or "—"
+    inc = display_key(inc_key) or "—"
+    dec = display_key(dec_key) or "—"
     return f"{inc} / {dec}"
 
 
@@ -289,7 +290,7 @@ class ShortcutEditorDialog(QDialog):
         inner.setVerticalSpacing(0)
 
         inner.addWidget(QLabel(entry.description), 0, 0)
-        default_lbl = QLabel(entry.default_key or "—")
+        default_lbl = QLabel(display_key(entry.default_key) or "—")
         default_lbl.setStyleSheet(mono)
         inner.addWidget(default_lbl, 0, 1)
         inner.addWidget(edit, 0, 2)
@@ -376,7 +377,7 @@ class ShortcutEditorDialog(QDialog):
                 QMessageBox.warning(
                     self,
                     "Duplicate Shortcut",
-                    f'"{key}" is assigned to both "{REGISTRY[other].description}" and "{REGISTRY[action_id].description}".',
+                    f'"{display_key(key)}" is assigned to both "{REGISTRY[other].description}" and "{REGISTRY[action_id].description}".',
                 )
                 return
             seen[key] = action_id

--- a/negpy/desktop/view/widgets/shortcuts_overlay.py
+++ b/negpy/desktop/view/widgets/shortcuts_overlay.py
@@ -34,6 +34,7 @@ from negpy.desktop.view.shortcut_registry import (
     EditorRowSlider,
     categories_in_order,
     category_editor_rows,
+    display_key,
     slider_step_for,
 )
 from negpy.desktop.view.styles.fonts import mono_font_family
@@ -43,8 +44,8 @@ from negpy.desktop.view.widgets.shortcut_search_line_edit import ShortcutSearchL
 
 
 def _format_key_pair(inc_key: str, dec_key: str) -> str:
-    inc = inc_key or "—"
-    dec = dec_key or "—"
+    inc = display_key(inc_key) or "—"
+    dec = display_key(dec_key) or "—"
     return f"{inc} / {dec}"
 
 
@@ -263,8 +264,8 @@ class ShortcutsOverlay(QDialog):
 
         return body
 
-    def _keycap(self, text: str) -> QLabel:
-        lbl = QLabel(text or "—")
+    def _keycap(self, key: str) -> QLabel:
+        lbl = QLabel(display_key(key) or "—")
         lbl.setStyleSheet(f"""
             color: {THEME.text_primary};
             background-color: {THEME.bg_header};
@@ -297,7 +298,7 @@ class ShortcutsOverlay(QDialog):
         inner.setVerticalSpacing(0)
 
         inner.addWidget(QLabel(entry.description), 0, 0)
-        inner.addWidget(self._mono_label(entry.default_key, mono), 0, 1)
+        inner.addWidget(self._mono_label(display_key(entry.default_key), mono), 0, 1)
         inner.addWidget(self._keycap(self._bindings.get(editor_row.action_id, "")), 0, 2)
         inner.addWidget(QLabel("—"), 0, 3)
         grid.addWidget(row_frame, row, 0, 1, 4)

--- a/negpy/desktop/view/widgets/tutorial_steps.py
+++ b/negpy/desktop/view/widgets/tutorial_steps.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Optional
 
 from PyQt6.QtWidgets import QWidget
 
+from negpy.desktop.view.shortcut_registry import display_key, key_for
 from negpy.desktop.view.widgets.tutorial_overlay import TutorialStep
 
 if TYPE_CHECKING:
@@ -770,7 +771,8 @@ def build(window: "MainWindow") -> list[TutorialStep]:
                 "Scan tab drives the body and Scanlight directly (macOS/Linux). See "
                 "<code>docs/CAMERA_SCANNING.md</code>.<br>"
                 "• See <code>docs/USER_GUIDE.md</code> for the full reference.<br>"
-                "• <b>Preferences</b> (⋯ menu, or <b>Ctrl+,</b>) holds the app-wide settings: "
+                f"• <b>Preferences</b> (⋯ menu, or <b>{display_key(key_for('open_preferences'))}</b>) holds "
+                "the app-wide settings: "
                 "interface, performance budgets and storage. For GPU or rendering trouble that "
                 "stops the app starting, edit <code>Documents/NegPy/override.toml</code>.<br>"
                 "• Edits auto-save to a local database, so there is no manual save needed "

--- a/tests/test_shortcut_registry.py
+++ b/tests/test_shortcut_registry.py
@@ -1,9 +1,13 @@
+import sys
+
 from negpy.desktop.view.shortcut_registry import (
     REGISTRY,
     EditorRowSlider,
     category_editor_rows,
     default_bindings,
     default_slider_steps,
+    display_key,
+    label_with_shortcut,
     load_bindings,
     load_slider_steps,
     merge_bindings,
@@ -149,3 +153,27 @@ def test_every_slider_action_has_a_group():
     for action_id in slider_actions:
         assert action_id in REGISTRY
         assert action_id in SLIDER_GROUP_BY_ACTION
+
+
+def test_display_key_uses_the_platform_notation():
+    # Qt binds portable "Ctrl" to ⌘ on macOS, so the label has to follow the binding.
+    expected = "⇧⌘C" if sys.platform == "darwin" else "Ctrl+Shift+C"
+    assert display_key("Ctrl+Shift+C") == expected
+    assert display_key("") == ""
+
+
+def test_display_key_keeps_an_unparsable_binding():
+    assert display_key("not a key") == "not a key"
+
+
+def test_label_with_shortcut_appends_the_current_binding():
+    bindings = default_bindings()
+    label = label_with_shortcut("Copy Settings", "copy", bindings)
+
+    assert label.startswith("Copy Settings  ")
+    assert label.endswith(display_key(bindings["copy"]))
+
+
+def test_label_with_shortcut_leaves_an_unbound_action_plain():
+    bindings = merge_bindings({"copy": ""})
+    assert label_with_shortcut("Copy Settings", "copy", bindings) == "Copy Settings"


### PR DESCRIPTION
Menu items, tooltips and the shortcut lists wrote every binding as the portable string, so macOS read "Copy Settings  Ctrl+C" for an action Qt had bound to ⌘C. The labels also carried the key as literal text, so a rebound action kept showing its default.

`display_key()` renders a binding with QKeySequence NativeText — the same mapping Qt uses to bind it — and `label_with_shortcut()` builds a menu label from the live binding. Both live in shortcut_registry, so no site needs a platform check. Applied to the ⋯ overflow menu, the canvas, retouch and filmstrip context menus, the Export tooltip, the tooltip keycaps, the ? overlay, the shortcut editor's default column and the tour.