### PR TITLE
fix(export): strip stale/vestigial source-camera EXIF on export

### DIFF
--- a/negpy/features/metadata/writer.py
+++ b/negpy/features/metadata/writer.py
@@ -198,7 +198,8 @@ def _demote_scan_datetime(merged: dict) -> None:
 
 
 def _sanitize_exif(exif_dict: dict) -> dict:
-    """Drop entries piexif can't serialize."""
+    """Drop entries piexif can't serialize, plus tags that describe the source
+    rather than the file being written."""
     _RATIONAL_TYPES = {5, 10}
 
     def _short_overflows(value) -> bool:
@@ -213,6 +214,14 @@ def _sanitize_exif(exif_dict: dict) -> dict:
         tags_info = piexif.TAGS.get(ifd_name, {})
         clean = {}
         for tag, value in ifd_data.items():
+            if ifd_name == "Exif" and tag == piexif.ExifIFD.ColorSpace:
+                # The source's ColorSpace tag records the camera's own in-body
+                # rendering (Nikon's non-standard "2" for Adobe RGB is common),
+                # not the space NegPy just rendered into. A stale mismatch against
+                # the file's real color tag (an ICC profile, or JPEG XL's own
+                # enumerated tag) reads as a self-contradicting file to a strict
+                # reader, which drops color management rather than guess.
+                continue
             tag_type = tags_info.get(tag, {}).get("type")
             if isinstance(value, bytes) and tag_type in _RATIONAL_TYPES:
                 continue

--- a/negpy/features/metadata/writer.py
+++ b/negpy/features/metadata/writer.py
@@ -255,6 +255,15 @@ def _sanitize_exif(exif_dict: dict) -> dict:
         if not isinstance(ifd_data, dict):
             result[ifd_name] = ifd_data
             continue
+        if ifd_name == "GPS" and not ({piexif.GPSIFD.GPSLatitude, piexif.GPSIFD.GPSLongitude} & ifd_data.keys()):
+            # A GPS IFD with no actual coordinates is vestigial camera boilerplate (a
+            # version marker with nothing to place on a map). Confirmed empirically:
+            # its bare presence, not any specific field's value, was the one
+            # difference between an export Bridge opened correctly and one it called
+            # untagged and refused to preview -- Bridge reads it as "this still
+            # carries the source's untouched raw GPS block".
+            result[ifd_name] = {}
+            continue
         tags_info = piexif.TAGS.get(ifd_name, {})
         clean = {}
         for tag, value in ifd_data.items():

--- a/negpy/features/metadata/writer.py
+++ b/negpy/features/metadata/writer.py
@@ -197,42 +197,14 @@ def _demote_scan_datetime(merged: dict) -> None:
         exif[piexif.ExifIFD.DateTimeDigitized] = source
 
 
-def _sanitize_exif(exif_dict: dict) -> dict:
-    """Drop entries piexif can't serialize, plus tags that describe the source
-    rather than the file being written."""
-    _RATIONAL_TYPES = {5, 10}
-
-    def _short_overflows(value) -> bool:
-        vals = value if isinstance(value, (tuple, list)) else (value,)
-        return any(isinstance(v, int) and not (0 <= v <= 65535) for v in vals)
-
-    result = {}
-    for ifd_name, ifd_data in exif_dict.items():
-        if not isinstance(ifd_data, dict):
-            result[ifd_name] = ifd_data
-            continue
-        tags_info = piexif.TAGS.get(ifd_name, {})
-        clean = {}
-        for tag, value in ifd_data.items():
-            if ifd_name == "Exif" and tag == piexif.ExifIFD.ColorSpace:
-                # The source's ColorSpace tag records the camera's own in-body
-                # rendering (Nikon's non-standard "2" for Adobe RGB is common),
-                # not the space NegPy just rendered into. A stale mismatch against
-                # the file's real color tag (an ICC profile, or JPEG XL's own
-                # enumerated tag) reads as a self-contradicting file to a strict
-                # reader, which drops color management rather than guess.
-                continue
-            tag_type = tags_info.get(tag, {}).get("type")
-            if isinstance(value, bytes) and tag_type in _RATIONAL_TYPES:
-                continue
-            if tag_type == 3 and _short_overflows(value):
-                continue
-            clean[tag] = value
-        result[ifd_name] = clean
-    return result
-
-
-_JPEG_STRIP_0TH = frozenset(
+# A RAW's 0th IFD describes its embedded preview image, including StripOffsets/
+# JPEGInterchangeFormat/SubIFDs pointers that are absolute to that source file's own
+# byte layout. Copied verbatim into a differently-laid-out export, those offsets land
+# on the wrong bytes -- confirmed for Nikon's SubIFDs tag (330), which parses clean in
+# the source NEF but trips "Bad SubIFD SubDirectory start" once relocated into an
+# export. A reader that walks a stale pointer lands on garbage, including whatever
+# field it uses to judge the file trustworthy enough to color-manage at all.
+_RAW_PREVIEW_0TH_TAGS = frozenset(
     {
         254,
         256,
@@ -252,14 +224,53 @@ _JPEG_STRIP_0TH = frozenset(
 )
 
 
+def _sanitize_exif(exif_dict: dict) -> dict:
+    """Drop entries piexif can't serialize, plus tags that describe the source
+    rather than the file being written."""
+    _RATIONAL_TYPES = {5, 10}
+
+    def _short_overflows(value) -> bool:
+        vals = value if isinstance(value, (tuple, list)) else (value,)
+        return any(isinstance(v, int) and not (0 <= v <= 65535) for v in vals)
+
+    result = {}
+    for ifd_name, ifd_data in exif_dict.items():
+        if not isinstance(ifd_data, dict):
+            result[ifd_name] = ifd_data
+            continue
+        tags_info = piexif.TAGS.get(ifd_name, {})
+        clean = {}
+        for tag, value in ifd_data.items():
+            if ifd_name == "0th" and tag in _RAW_PREVIEW_0TH_TAGS:
+                continue
+            if ifd_name == "Exif" and tag == piexif.ExifIFD.ColorSpace:
+                # The source's ColorSpace tag records the camera's own in-body
+                # rendering (Nikon's non-standard "2" for Adobe RGB is common),
+                # not the space NegPy just rendered into. A stale mismatch against
+                # the file's real color tag (an ICC profile, or JPEG XL's own
+                # enumerated tag) reads as a self-contradicting file to a strict
+                # reader, which drops color management rather than guess.
+                continue
+            if ifd_name == "Exif" and tag == piexif.ExifIFD.MakerNote:
+                # Same stale-absolute-offset problem as the 0th IFD tags above,
+                # one level deeper: a maker note's own internal sub-IFDs (lens
+                # data, AF info, and here the field that decodes as "ColorSpace")
+                # use the same source-relative pointer scheme.
+                continue
+            tag_type = tags_info.get(tag, {}).get("type")
+            if isinstance(value, bytes) and tag_type in _RATIONAL_TYPES:
+                continue
+            if tag_type == 3 and _short_overflows(value):
+                continue
+            clean[tag] = value
+        result[ifd_name] = clean
+    return result
+
+
 def _prepare_jpeg_exif(exif_dict: dict) -> dict:
     prepared = _sanitize_exif(exif_dict)
     prepared.pop("thumbnail", None)
     prepared["1st"] = {}
-    zeroth = prepared.get("0th")
-    if isinstance(zeroth, dict):
-        for tag in _JPEG_STRIP_0TH:
-            zeroth.pop(tag, None)
     return prepared
 
 

--- a/negpy/features/metadata/writer.py
+++ b/negpy/features/metadata/writer.py
@@ -199,11 +199,14 @@ def _demote_scan_datetime(merged: dict) -> None:
 
 # A RAW's 0th IFD describes its embedded preview image, including StripOffsets/
 # JPEGInterchangeFormat/SubIFDs pointers that are absolute to that source file's own
-# byte layout. Copied verbatim into a differently-laid-out export, those offsets land
-# on the wrong bytes -- confirmed for Nikon's SubIFDs tag (330), which parses clean in
-# the source NEF but trips "Bad SubIFD SubDirectory start" once relocated into an
-# export. A reader that walks a stale pointer lands on garbage, including whatever
-# field it uses to judge the file trustworthy enough to color-manage at all.
+# byte layout, plus TIFFEPStandardID declaring TIFF/EP (ISO 12234-2) raw-image
+# compliance. Copied verbatim into a differently-laid-out export, the pointers land
+# on the wrong bytes -- confirmed for Nikon's SubIFDs tag (330), which parses clean
+# in the source NEF but trips "Bad SubIFD SubDirectory start" once relocated into an
+# export -- and the TIFF/EP claim is simply false for a rendered, non-raw output. A
+# raw-aware reader that trusts either one can misjudge the whole file: garbage from a
+# stale pointer, or routing a finished render through raw-specific handling that a
+# TIFF/EP claim invites.
 _RAW_PREVIEW_0TH_TAGS = frozenset(
     {
         254,
@@ -220,6 +223,20 @@ _RAW_PREVIEW_0TH_TAGS = frozenset(
         330,
         513,
         514,
+        piexif.ImageIFD.TIFFEPStandardID,
+    }
+)
+
+# Exif-IFD tags that describe the original sensor capture -- a Bayer CFA pattern, a
+# one-chip sensing method, "directly photographed" -- none of which are still true
+# once NegPy has demosaiced, rendered and re-encoded the image. ColorSpace and
+# MakerNote are dropped for a different reason: see the comments at their use below.
+_RAW_CAPTURE_EXIF_TAGS = frozenset(
+    {
+        piexif.ExifIFD.CFAPattern,
+        piexif.ExifIFD.SensingMethod,
+        piexif.ExifIFD.FileSource,
+        piexif.ExifIFD.SceneType,
     }
 )
 
@@ -242,6 +259,8 @@ def _sanitize_exif(exif_dict: dict) -> dict:
         clean = {}
         for tag, value in ifd_data.items():
             if ifd_name == "0th" and tag in _RAW_PREVIEW_0TH_TAGS:
+                continue
+            if ifd_name == "Exif" and tag in _RAW_CAPTURE_EXIF_TAGS:
                 continue
             if ifd_name == "Exif" and tag == piexif.ExifIFD.ColorSpace:
                 # The source's ColorSpace tag records the camera's own in-body

--- a/tests/test_metadata_writer.py
+++ b/tests/test_metadata_writer.py
@@ -246,5 +246,45 @@ def test_embed_strips_makernote_tag() -> None:
     assert piexif.ExifIFD.MakerNote not in loaded["Exif"]
 
 
+def test_embed_strips_vestigial_gps_block_from_jxl() -> None:
+    """Regression: a camera's GPS IFD with no actual coordinates -- just a
+    version marker, common on bodies with no GPS receiver -- is vestigial
+    boilerplate. Isolated by an 8-file bisection, its bare presence (not
+    exposure, date, Artist/Copyright, or resolution tags, all of which were
+    also tested and are safe) was the one difference between a Print/Flat
+    JPEG XL export Adobe Bridge opened correctly and one it called untagged
+    and refused to preview, routing it through Camera Raw instead."""
+    source_exif = _raw_like_source_exif()
+    source_exif["GPS"] = {piexif.GPSIFD.GPSVersionID: (2, 3, 0, 0)}
+
+    out = embed_metadata(_jxl(), MetadataConfig(), source_exif)
+
+    tiff = read_jxl_exif(out)
+    assert tiff is not None
+    loaded = piexif.load(tiff)
+    assert loaded["GPS"] == {}
+    assert loaded["0th"][piexif.ImageIFD.Make] == b"NIKON CORPORATION"
+
+
+def test_embed_keeps_real_gps_coordinates() -> None:
+    """A GPS block with actual coordinates is real, user-relevant data (unlike
+    a bare version marker) and is not part of the vestigial-block strip."""
+    source_exif = _raw_like_source_exif()
+    source_exif["GPS"] = {
+        piexif.GPSIFD.GPSVersionID: (2, 3, 0, 0),
+        piexif.GPSIFD.GPSLatitudeRef: b"N",
+        piexif.GPSIFD.GPSLatitude: ((59, 1), (54, 1), (0, 1)),
+        piexif.GPSIFD.GPSLongitudeRef: b"E",
+        piexif.GPSIFD.GPSLongitude: ((10, 1), (44, 1), (0, 1)),
+    }
+
+    out = embed_metadata(_jxl(), MetadataConfig(), source_exif)
+
+    tiff = read_jxl_exif(out)
+    assert tiff is not None
+    loaded = piexif.load(tiff)
+    assert loaded["GPS"][piexif.GPSIFD.GPSLatitude] == ((59, 1), (54, 1), (0, 1))
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/test_metadata_writer.py
+++ b/tests/test_metadata_writer.py
@@ -11,8 +11,12 @@ import piexif
 import pytest
 from PIL import Image
 
+import imagecodecs
+import numpy as np
+
 from negpy.features.metadata.models import MetadataConfig
-from negpy.features.metadata.writer import embed_metadata
+from negpy.features.metadata.writer import embed_metadata, preserve_source_metadata
+from negpy.infrastructure.loaders.jxl_boxes import read_jxl_exif
 
 _RAW_PREVIEW_0TH_TAGS = (330, 273, 279, 256, 257, 513, 514)
 
@@ -21,6 +25,13 @@ def _jpeg() -> bytes:
     buf = io.BytesIO()
     Image.new("RGB", (16, 16), (128, 0, 0)).save(buf, "JPEG")
     return buf.getvalue()
+
+
+def _jxl() -> bytes:
+    img = np.zeros((4, 4, 3), dtype=np.uint16)
+    return bytes(
+        imagecodecs.jpegxl_encode(img, bitspersample=16, photometric="RGB", primaries="SRGB", transfer="SRGB", lossless=True, effort=1)
+    )
 
 
 def _raw_like_source_exif() -> dict:
@@ -133,6 +144,44 @@ def test_embed_keeps_small_exif_intact() -> None:
     loaded = piexif.load(out)
     assert loaded["0th"][piexif.ImageIFD.Make] == b"TestCam"
     assert loaded["0th"][piexif.ImageIFD.Orientation] == 1
+
+
+def test_embed_strips_stale_colorspace_tag_jpeg() -> None:
+    """Nikon's non-standard ColorSpace=2 (Adobe RGB) describes the camera's own JPEG
+    rendering, not NegPy's re-render; carried through unchanged it contradicts the
+    file's real color tag and reads as untagged to a strict consumer."""
+    source_exif = _raw_like_source_exif()
+    source_exif["Exif"][piexif.ExifIFD.ColorSpace] = 2
+
+    out = embed_metadata(_jpeg(), MetadataConfig(), source_exif)
+
+    loaded = piexif.load(out)
+    assert piexif.ExifIFD.ColorSpace not in loaded["Exif"]
+
+
+def test_preserve_strips_stale_colorspace_tag_jpeg() -> None:
+    source_exif = _raw_like_source_exif()
+    source_exif["Exif"][piexif.ExifIFD.ColorSpace] = 2
+
+    out = preserve_source_metadata(_jpeg(), source_path="unused.nef", source_exif=source_exif)
+
+    loaded = piexif.load(out)
+    assert piexif.ExifIFD.ColorSpace not in loaded["Exif"]
+
+
+def test_embed_strips_stale_colorspace_tag_jxl() -> None:
+    """Regression: a Nikon ColorSpace=2 carried into a JPEG XL export contradicted
+    the file's own sRGB color tag and made Adobe Bridge report the file untagged."""
+    source_exif = _raw_like_source_exif()
+    source_exif["Exif"][piexif.ExifIFD.ColorSpace] = 2
+
+    out = embed_metadata(_jxl(), MetadataConfig(), source_exif)
+
+    tiff = read_jxl_exif(out)
+    assert tiff is not None
+    loaded = piexif.load(tiff)
+    assert piexif.ExifIFD.ColorSpace not in loaded["Exif"]
+    assert loaded["0th"][piexif.ImageIFD.Make] == b"NIKON CORPORATION"
 
 
 if __name__ == "__main__":

--- a/tests/test_metadata_writer.py
+++ b/tests/test_metadata_writer.py
@@ -204,6 +204,35 @@ def test_embed_strips_raw_preview_ifd_tags_from_jxl() -> None:
     assert zeroth[piexif.ImageIFD.Make] == b"NIKON CORPORATION"
 
 
+def test_embed_strips_raw_capture_tags_from_jxl() -> None:
+    """Regression: CFAPattern/SensingMethod/FileSource/SceneType/TIFFEPStandardID
+    describe the original sensor capture, not NegPy's finished render. Carried
+    through, they told Adobe Bridge the file was TIFF/EP raw-compliant, and it
+    tried to route a rendered JPEG XL through Camera Raw instead of previewing it
+    directly -- landing on a slow, low-res-only preview with no way to open it."""
+    source_exif = _raw_like_source_exif()
+    source_exif["0th"][piexif.ImageIFD.TIFFEPStandardID] = (1, 0, 0, 0)
+    source_exif["Exif"][piexif.ExifIFD.CFAPattern] = b"\x00\x02\x00\x02\x00\x01\x01\x02"
+    source_exif["Exif"][piexif.ExifIFD.SensingMethod] = 2
+    source_exif["Exif"][piexif.ExifIFD.FileSource] = b"\x03"
+    source_exif["Exif"][piexif.ExifIFD.SceneType] = b"\x01"
+
+    out = embed_metadata(_jxl(), MetadataConfig(), source_exif)
+
+    tiff = read_jxl_exif(out)
+    assert tiff is not None
+    loaded = piexif.load(tiff)
+    assert piexif.ImageIFD.TIFFEPStandardID not in loaded["0th"]
+    for tag in (
+        piexif.ExifIFD.CFAPattern,
+        piexif.ExifIFD.SensingMethod,
+        piexif.ExifIFD.FileSource,
+        piexif.ExifIFD.SceneType,
+    ):
+        assert tag not in loaded["Exif"]
+    assert loaded["0th"][piexif.ImageIFD.Make] == b"NIKON CORPORATION"
+
+
 def test_embed_strips_makernote_tag() -> None:
     """A maker note's internal sub-IFDs use the same source-relative pointer
     scheme as the 0th-IFD preview tags; relocated into an export, they resolve

--- a/tests/test_metadata_writer.py
+++ b/tests/test_metadata_writer.py
@@ -1,6 +1,8 @@
 """
-Guards the JPEG EXIF embed against the 64 KB APP1 overflow: source RAWs often carry an
-embedded thumbnail + multi-KB MakerNote that piexif.insert can't pack into one segment.
+Guards the EXIF embed/preserve paths against stale or oversized source metadata: RAW
+preview-IFD and maker-note pointers that are absolute to the source's own byte layout,
+a ColorSpace tag describing the camera's own rendering rather than NegPy's, and a
+64 KB JPEG APP1 overflow from an oversized thumbnail + maker note.
 """
 
 import io
@@ -170,8 +172,8 @@ def test_preserve_strips_stale_colorspace_tag_jpeg() -> None:
 
 
 def test_embed_strips_stale_colorspace_tag_jxl() -> None:
-    """Regression: a Nikon ColorSpace=2 carried into a JPEG XL export contradicted
-    the file's own sRGB color tag and made Adobe Bridge report the file untagged."""
+    """A Nikon ColorSpace=2 carried into a JPEG XL export would contradict the
+    file's own sRGB color tag."""
     source_exif = _raw_like_source_exif()
     source_exif["Exif"][piexif.ExifIFD.ColorSpace] = 2
 
@@ -182,6 +184,37 @@ def test_embed_strips_stale_colorspace_tag_jxl() -> None:
     loaded = piexif.load(tiff)
     assert piexif.ExifIFD.ColorSpace not in loaded["Exif"]
     assert loaded["0th"][piexif.ImageIFD.Make] == b"NIKON CORPORATION"
+
+
+def test_embed_strips_raw_preview_ifd_tags_from_jxl() -> None:
+    """Regression: a RAW's 0th-IFD preview/SubIFD pointers are absolute to the
+    source file's own byte layout. Carried into a JPEG XL export unchanged, they
+    pointed at the wrong bytes ("Bad SubIFD SubDirectory start" from ExifTool) and
+    made Adobe Bridge report the file untagged and refuse to preview it."""
+    source_exif = _raw_like_source_exif()
+
+    out = embed_metadata(_jxl(), MetadataConfig(), source_exif)
+
+    tiff = read_jxl_exif(out)
+    assert tiff is not None
+    loaded = piexif.load(tiff)
+    zeroth = loaded["0th"]
+    for tag in _RAW_PREVIEW_0TH_TAGS:
+        assert tag not in zeroth
+    assert zeroth[piexif.ImageIFD.Make] == b"NIKON CORPORATION"
+
+
+def test_embed_strips_makernote_tag() -> None:
+    """A maker note's internal sub-IFDs use the same source-relative pointer
+    scheme as the 0th-IFD preview tags; relocated into an export, they resolve
+    to the wrong bytes for anything that decodes into them."""
+    source_exif = _raw_like_source_exif()
+    source_exif["Exif"][piexif.ExifIFD.MakerNote] = b"\x00" * 100
+
+    out = embed_metadata(_jpeg(), MetadataConfig(), source_exif)
+
+    loaded = piexif.load(out)
+    assert piexif.ExifIFD.MakerNote not in loaded["Exif"]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Every export format that carries the source camera's EXIF through unchanged
(the default "embed metadata" path and "protect original metadata") was
passing along several categories of source-only data that no longer
describe the file being written:

- **ColorSpace** — the camera's own in-body rendering assumption (Nikon's
  non-standard `2` for Adobe RGB is common), not the space NegPy just
  rendered into.
- **0th-IFD preview pointers** (`StripOffsets`, `SubIFDs`, etc.) and the
  **maker note** — both use offsets absolute to the *source* file's own
  byte layout. Relocated into an export with a different layout, they
  point at the wrong bytes. Confirmed via ExifTool's "Bad SubIFD
  SubDirectory start" on an affected JPEG XL export.
- **Raw-capture markers** (`CFAPattern`, `SensingMethod`, `FileSource`,
  `SceneType`, `TIFFEPStandardID`) — describe the original sensor capture,
  none of which is still true once NegPy has demosaiced and rendered the
  image.
- **A vestigial GPS block** — a bare `GPSVersionID` with no actual
  coordinates, common on bodies with no GPS receiver.

In combination, these made Adobe Bridge misclassify a finished, non-linear
JPEG XL export as raw camera data: it routed the file through Camera Raw
instead of previewing it directly, showing "Untagged" for color profile, a
very slow thumbnail build, and no "Open in Camera Raw" once it gave up.
Isolated with an 8-file bisection against a real Bridge install — exposure
settings, capture dates, Artist/Copyright and resolution tags were all
tested and are unaffected; only the GPS block's bare presence mattered
there, on top of the two structural bugs above.

`_sanitize_exif()` (the one chokepoint every embed/preserve path funnels
through, for every export format) now drops all of the above. A GPS block
that carries real coordinates is untouched — only one with no
`GPSLatitude`/`GPSLongitude` is dropped.

## Test plan

- [x] `tests/test_metadata_writer.py` — 13 tests covering each stripped
      category (JPEG and JPEG XL), plus a regression test confirming real
      GPS coordinates are preserved
- [x] `make lint` / `make type` clean
- [x] Full suite green (no new failures)
- [x] Verified end-to-end against a real affected file: re-embedding the
      exact source NEF's EXIF into a JPEG XL no longer produces any
      ExifTool warnings, and the export now opens correctly (tagged sRGB,
      fast preview) in Adobe Bridge