### PR TITLE
Camera scanning: keep the PTP claim the identify probe wins

### DIFF
--- a/docs/CAMERA_SCANNING.md
+++ b/docs/CAMERA_SCANNING.md
@@ -57,9 +57,11 @@ app shows the setup hint.
 Then put the camera in **PC Remote** mode and plug it in over USB. NegPy detects it
 automatically. There is no address to type, no login and no pairing.
 
-> On macOS, quit **Preview**, **Photos** and **Image Capture** first. The system's
-> ImageCapture daemons hand a PTP camera to whichever of those apps is open, and
-> libgphoto2 is then locked out.
+> On macOS a PTP camera is claimed by the system's own camera daemon as soon as nothing else
+> holds it, and it does not let go again for minutes. NegPy therefore takes the claim the
+> moment the Camera Scanning panel sees the body and keeps it: while that panel is open the
+> camera belongs to NegPy, and Preview, Photos, Image Capture and other tethering software
+> cannot use it. Unplugging the cable hands it back.
 
 ---
 
@@ -135,9 +137,9 @@ is film-dye crosstalk, which the density-domain **Crosstalk** matrix handles (se
 
 | Symptom | Cause | Fix |
 |---|---|---|
-| The camera dot shows **"in use"** (amber hint) | An ImageCapture app holds the body. Only one program may claim a PTP camera. | **Quit Preview, Photos and Image Capture.** Preview is the usual culprit, because it grabs the camera silently. NegPy reconnects on its own once the camera is free. |
+| The camera dot shows **"in use"** (amber hint) | Another program holds the body, and only one program may claim a PTP camera. On macOS it is usually the system's own camera daemon, which needs no window to be open, so there is often nothing visible to quit. | **Unplug the cable and reconnect it** — that frees the camera at once. The daemon also lets go on its own after a few minutes. Quitting Preview, Photos and Image Capture helps when one of those really is open. NegPy reconnects by itself once the camera is free. |
 | No camera found, and nothing else is running | The body is not in PC Remote mode, or it is a mass-storage/MTP connection. | Set the camera's USB connection mode to **PC Remote**. |
-| `[-10] Timeout reading from or writing to the port`, and no other program holds it | A program crashed while connected. The *camera* still thinks the session is open and refuses a new one. | Power-cycle the camera, or unplug and replug the cable. Nothing on the computer fixes it. |
+| `[-10] Timeout reading from or writing to the port`, and no other program holds it | A program crashed while connected. The *camera* still thinks the session is open and refuses a new one. A timeout that clears on its own is retried silently and never reaches you, so seeing this means it did not clear. | Power-cycle the camera, or unplug and replug the cable. Nothing on the computer fixes it. |
 | Live view is black | The body dropped out of PC Remote, or the lens cap is on. | Power-cycle the camera. |
 | The scan window opens with **"no live view"** instead of a preview | libgphoto2's entry for this body has no preview capability. Either the body genuinely lacks it (Sony a6000), or it is connected in MTP mode, where no body has it. | If the message names MTP, set the camera's USB mode to **PC Remote** and reconnect. If not, this is expected. Scanning works normally, but you must set framing and focus on the camera, and calibration is unavailable because it aims through the live view. |
 | Capture says the camera returned JPEG instead of RAW | The camera's image-quality setting is JPEG, or RAW+JPEG selected the processed file. | Set image quality to **RAW only**, then retry. |

--- a/docs/CAMERA_SCANNING.md
+++ b/docs/CAMERA_SCANNING.md
@@ -57,11 +57,15 @@ app shows the setup hint.
 Then put the camera in **PC Remote** mode and plug it in over USB. NegPy detects it
 automatically. There is no address to type, no login and no pairing.
 
-> On macOS a PTP camera is claimed by the system's own camera daemon as soon as nothing else
-> holds it, and it does not let go again for minutes. NegPy therefore takes the claim the
-> moment the Camera Scanning panel sees the body and keeps it: while that panel is open the
-> camera belongs to NegPy, and Preview, Photos, Image Capture and other tethering software
-> cannot use it. Unplugging the cable hands it back.
+> On macOS a PTP camera is claimed by the system camera daemon as soon as nothing else holds
+> it, and it does not let go again for minutes. NegPy therefore takes the claim the moment the
+> Camera Scanning panel sees the body and keeps it: while that panel is open the camera belongs
+> to NegPy, and Preview, Photos, Image Capture and other tethering software cannot use it.
+> Unplugging the cable hands it back.
+>
+> What wakes that daemon is any application asking for a camera, and it does not have to be one
+> you opened. A background sync client is the common case, silently and repeatedly: check for
+> those first if the camera reads as in use with nothing visible running.
 
 ---
 
@@ -137,7 +141,7 @@ is film-dye crosstalk, which the density-domain **Crosstalk** matrix handles (se
 
 | Symptom | Cause | Fix |
 |---|---|---|
-| The camera dot shows **"in use"** (amber hint) | Another program holds the body, and only one program may claim a PTP camera. On macOS it is usually the system's own camera daemon, which needs no window to be open, so there is often nothing visible to quit. | **Unplug the cable and reconnect it** — that frees the camera at once. The daemon also lets go on its own after a few minutes. Quitting Preview, Photos and Image Capture helps when one of those really is open. NegPy reconnects by itself once the camera is free. |
+| The camera dot shows **"in use"** (amber hint) | Another program holds the body, and only one program may claim a PTP camera. On macOS the holder is the system camera daemon, and it is woken by any application that watches for cameras. Often that application is a **background sync client** with no window and no notification: Google Drive running as a login item has been confirmed to do it, and Dropbox and similar tools behave the same way. | Quit the background app, or remove it from **System Settings → General → Login Items** if it starts itself. Unplugging and reconnecting the cable frees the camera too, but only until that app asks again. Preview, Photos and Image Capture do the same when one of them is genuinely open. NegPy reconnects by itself once the camera is free. |
 | No camera found, and nothing else is running | The body is not in PC Remote mode, or it is a mass-storage/MTP connection. | Set the camera's USB connection mode to **PC Remote**. |
 | `[-10] Timeout reading from or writing to the port`, and no other program holds it | A program crashed while connected. The *camera* still thinks the session is open and refuses a new one. A timeout that clears on its own is retried silently and never reaches you, so seeing this means it did not clear. | Power-cycle the camera, or unplug and replug the cable. Nothing on the computer fixes it. |
 | Live view is black | The body dropped out of PC Remote, or the lens cap is on. | Power-cycle the camera. |

--- a/negpy/desktop/view/sidebar/scan.py
+++ b/negpy/desktop/view/sidebar/scan.py
@@ -135,9 +135,7 @@ class ScanSidebar(QWidget):
         self.ir_check.setToolTip("Scan a separate infrared channel for dust detection")
 
         self.me_check = QCheckBox("Multi-exposure")
-        self.me_check.setToolTip(
-            "Merge short and long colour passes for more highlight and shadow detail. Takes longer."
-        )
+        self.me_check.setToolTip("Merge short and long colour passes for more highlight and shadow detail. Takes longer.")
 
         self.depth_row_widget = QWidget()
         depth_row = QHBoxLayout(self.depth_row_widget)
@@ -502,9 +500,7 @@ class ScanSidebar(QWidget):
         self.me_check.setEnabled(caps.multi_exposure)
         if caps.multi_exposure:
             self.me_check.setChecked(self._settings.multi_exposure)
-            self.me_check.setToolTip(
-                "Merge short and long colour passes for more highlight and shadow detail. Takes longer."
-            )
+            self.me_check.setToolTip("Merge short and long colour passes for more highlight and shadow detail. Takes longer.")
         else:
             self.me_check.setChecked(False)
             self.me_check.setToolTip("Multi-exposure not supported by this device")

--- a/negpy/desktop/view/sidebar/scanlight.py
+++ b/negpy/desktop/view/sidebar/scanlight.py
@@ -977,7 +977,7 @@ class ScanlightSidebar(QWidget):
             if self._lv_polls == 50 and self._lv_frames_seen == 0:  # ~4s without a frame
                 self._set_status(
                     "No live-view image — is the camera in PC Remote? "
-                    "On macOS, quit Preview / Photos / Image Capture — they hold the camera."
+                    "On macOS the system's camera daemon can also be holding it; unplugging the cable frees it."
                 )
                 self._lv_target.set_loading(False)  # stop the spinner; the hint explains why
             return
@@ -1499,7 +1499,7 @@ class ScanlightSidebar(QWidget):
     def _set_cam_status(self, ok: bool, model: str, claimed_elsewhere: bool = False) -> None:
         """Camera dot: '● Camera (USB)' when a body answered, '● Camera' when none did — and
         '● Camera (in use)' when it sits on the bus but another program holds its USB claim
-        (macOS hands it to Preview/Photos/Image Capture the moment one of them opens). The
+        (on macOS usually the system's own camera daemon, which needs no window to be open). The
         enumeration behind the dot cannot see a claim, so without this state the dot showed a
         healthy green while every live-view/scan attempt failed."""
         if claimed_elsewhere:
@@ -1508,7 +1508,8 @@ class ScanlightSidebar(QWidget):
             # hint line turns amber and says what to do, instead of the "plug it in" nudge, which
             # is wrong advice for a present body.
             self._conn_hint.setText(
-                "⚠ Another app is using the camera — close Preview, Photos and Image Capture. NegPy reconnects by itself once it is free."
+                "⚠ Another program is using the camera. On macOS this is usually the system's own camera daemon "
+                "rather than a window you can close; unplugging the cable frees it. NegPy reconnects by itself."
             )
             self._conn_hint.setStyleSheet(f"color: {_WARN_COLOR}; font-size: {THEME.font_size_small}px;")
             self._conn_hint.setVisible(True)

--- a/negpy/desktop/view/sidebar/scanlight.py
+++ b/negpy/desktop/view/sidebar/scanlight.py
@@ -977,7 +977,7 @@ class ScanlightSidebar(QWidget):
             if self._lv_polls == 50 and self._lv_frames_seen == 0:  # ~4s without a frame
                 self._set_status(
                     "No live-view image — is the camera in PC Remote? "
-                    "On macOS the system's camera daemon can also be holding it; unplugging the cable frees it."
+                    "On macOS a background app such as a cloud sync client can be holding it; unplugging frees it."
                 )
                 self._lv_target.set_loading(False)  # stop the spinner; the hint explains why
             return
@@ -1499,7 +1499,7 @@ class ScanlightSidebar(QWidget):
     def _set_cam_status(self, ok: bool, model: str, claimed_elsewhere: bool = False) -> None:
         """Camera dot: '● Camera (USB)' when a body answered, '● Camera' when none did — and
         '● Camera (in use)' when it sits on the bus but another program holds its USB claim
-        (on macOS usually the system's own camera daemon, which needs no window to be open). The
+        (on macOS the system camera daemon, woken by any app that watches for cameras). The
         enumeration behind the dot cannot see a claim, so without this state the dot showed a
         healthy green while every live-view/scan attempt failed."""
         if claimed_elsewhere:
@@ -1508,8 +1508,9 @@ class ScanlightSidebar(QWidget):
             # hint line turns amber and says what to do, instead of the "plug it in" nudge, which
             # is wrong advice for a present body.
             self._conn_hint.setText(
-                "⚠ Another program is using the camera. On macOS this is usually the system's own camera daemon "
-                "rather than a window you can close; unplugging the cable frees it. NegPy reconnects by itself."
+                "⚠ Another program is using the camera. On macOS a background app that watches for cameras, "
+                "a cloud sync client for example, holds it through the system camera daemon. Quit that app or "
+                "unplug the cable. NegPy reconnects by itself."
             )
             self._conn_hint.setStyleSheet(f"color: {_WARN_COLOR}; font-size: {THEME.font_size_small}px;")
             self._conn_hint.setVisible(True)

--- a/negpy/desktop/workers/capture_worker.py
+++ b/negpy/desktop/workers/capture_worker.py
@@ -143,11 +143,12 @@ class CaptureWorker(QObject):
             try:
                 self._camera.open()
             except CameraClaimedError:
-                # Another program holds the USB claim (on macOS: Preview, Photos, Image
-                # Capture). Flip the dot on the False-to-True transition immediately: the next
-                # timer poll is seconds away, and "Scan did nothing" against a green dot is the
-                # confusion this state exists for. Only on the transition, because the poll's own
-                # re-probe lands here too and an unconditional push would recurse.
+                # Another program holds the USB claim (on macOS usually the system's own camera
+                # daemon, which needs no visible window). Flip the dot on the False-to-True
+                # transition immediately: the next timer poll is seconds away, and "Scan did
+                # nothing" against a green dot is the confusion this state exists for. Only on the
+                # transition, because the poll's own re-probe lands here too and an unconditional
+                # push would recurse.
                 first = not self._claimed_elsewhere
                 self._claimed_elsewhere = True
                 if first:
@@ -158,8 +159,8 @@ class CaptureWorker(QObject):
                 raise
             self._claimed_elsewhere = False
             self._model = self._camera.model
-            # Cached so the poll keeps reporting them after this session is closed again: the
-            # identify probe opens and closes immediately, and the UI gates on the result.
+            # Cached so the poll keeps reporting them once the session is released again, which
+            # the last camera window closing does, and the UI gates on the result.
             # Optional, because the `Camera` protocol does not require it: a backend that
             # cannot report abilities must leave the UI ungated instead of breaking the session.
             self._caps = getattr(self._camera, "capabilities", None)
@@ -369,7 +370,11 @@ class CaptureWorker(QObject):
                     self._identify_attempted = True
                     try:
                         self._acquire_camera()
-                        self._close_camera()
+                        # The claim is kept, never handed back. A freed PTP interface is taken by
+                        # the OS camera daemon within seconds and held for minutes, so a probe that
+                        # opened and closed left the user's first live view or scan refused. The
+                        # poll runs only while the camera panel is visible, so holding follows the
+                        # user; the last camera window closing still releases it.
                     except Exception:
                         pass  # verdict already updated by _acquire_camera's except paths
                 # A body on the bus that refused our last open, because another app holds the

--- a/negpy/infrastructure/capture/gphoto.py
+++ b/negpy/infrastructure/capture/gphoto.py
@@ -109,6 +109,13 @@ _DRAIN_SILENCE_MS = 50
 _FUJI_DRAIN_SILENCE_MS = 300
 _FUJI_DRAIN_BUDGET_S = 2.0
 
+#: An open is retried on any error except a claim conflict, and that asymmetry is the point: a
+#: busy transport clears on its own within seconds, while whoever holds a PTP body keeps it for
+#: minutes, so retrying there only delays the one message that explains it. An allow-list of
+#: transport codes was rejected as the alternative — it could only ever name the bodies already
+#: seen, and the next body's hiccup would arrive under a code nobody has reported yet.
+_OPEN_RETRY_DELAYS_S = (0.5, 1.5)
+
 _PREVIEW_INTERVAL_S = 0.05  # the body tops out near 24 fps; this leaves headroom
 _SETTINGS_INTERVAL_S = 2.0
 #: Consecutive preview failures before the session is treated as gone. One dropped frame
@@ -327,19 +334,24 @@ class GphotoCamera:
         if self.is_open():
             return
         self.close()  # drop a handle left behind by a body that went away
-        camera = self._gp.Camera()
-        try:
-            camera.init()
-        except self._gp.GPhoto2Error as exc:
-            # A camera sits on the bus but will not open. On macOS the ImageCapture daemons
-            # hand it to Preview, Photos or Image Capture as soon as one of them is open, and
-            # only one program may claim it. Raise the claim case typed (-53,
-            # GP_ERROR_IO_USB_CLAIM) so the connection poll can pin an "in use by another app"
-            # state on the camera dot, which enumeration alone cannot see.
-            message = f"could not open the camera: {exc}. Close Preview, Photos and Image Capture, then retry."
-            if getattr(exc, "code", None) == -53:
-                raise CameraClaimedError(message) from exc
-            raise GphotoError(message) from exc
+        for delay in (*_OPEN_RETRY_DELAYS_S, None):
+            camera = self._gp.Camera()
+            try:
+                camera.init()
+                break
+            except self._gp.GPhoto2Error as exc:
+                if getattr(exc, "code", None) == -53:
+                    # Only one program may hold a PTP body. Typed (GP_ERROR_IO_USB_CLAIM) so the
+                    # connection poll can pin an "in use by another app" state on the camera dot,
+                    # which enumeration alone cannot see.
+                    raise CameraClaimedError(
+                        f"could not open the camera: {exc}. Another program holds it. On macOS that is usually "
+                        "the system's own camera daemon rather than a window you can see; it releases the camera "
+                        "after a few minutes, and unplugging the cable frees it at once."
+                    ) from exc
+                if delay is None:
+                    raise GphotoError(f"could not open the camera: {exc}") from exc
+                time.sleep(delay)
         self._camera = camera
         self._model = _model_name(camera)
         self._alive = True
@@ -812,7 +824,7 @@ class GphotoCamera:
             # instead of blaming the connection, and make clear that scanning still works.
             return (
                 f"{self._model or 'this camera'} accepted the connection but its live view does not work "
-                "(a known gap in libgphoto2's Fujifilm support). Scanning still works, just without a preview."
+                "(a gap in libgphoto2's support for this body). Scanning still works, just without a preview."
             )
         if self._capabilities.mtp_mode:
             return (

--- a/tests/test_capture_gphoto.py
+++ b/tests/test_capture_gphoto.py
@@ -12,13 +12,22 @@ import os
 import pytest
 
 from negpy.infrastructure.capture.base import Camera
-from negpy.infrastructure.capture.gphoto import GphotoCamera, GphotoError, LiveViewUnsupported, _pin_locale, _safe_value
+from negpy.infrastructure.capture.gphoto import (
+    CameraClaimedError,
+    GphotoCamera,
+    GphotoError,
+    LiveViewUnsupported,
+    _pin_locale,
+    _safe_value,
+)
 
 # ---- fake libgphoto2 --------------------------------------------------------
 
 
 class _Err(Exception):
-    pass
+    def __init__(self, message, code=None):
+        super().__init__(message)
+        self.code = code
 
 
 class _Widget:
@@ -75,8 +84,13 @@ class _Camera:
             raise _Err("[-7] I/O problem")
 
     def init(self):
+        if self._fake.init_codes:
+            code = self._fake.init_codes.pop(0)
+            self._fake.init_attempts += 1
+            raise _Err(f"[{code}] open refused", code)
         if self._fake.init_error:
             raise _Err(self._fake.init_error)
+        self._fake.init_attempts += 1
         self._fake.opened = True
 
     def exit(self):
@@ -209,6 +223,8 @@ class FakeGP:
         self.captures = self.previews = 0
         self.writes: list[tuple[str, str]] = []
         self.init_error = init_error
+        self.init_codes: list[int] = []  # codes init() raises before it succeeds
+        self.init_attempts = 0
         self.raw_name = raw_name
         self._cameras = list(cameras)
         self._settle_writes = settle_writes
@@ -888,3 +904,45 @@ def test_a_value_the_body_never_published_is_refused_not_written(cam, fake, capl
     assert fake.writes == []  # nothing was sent to the body
     message = caplog.text
     assert "does not offer" in message and "1/5" in message  # the body's real choices are named
+
+
+def test_open_retries_a_transport_error_that_clears_itself(fake, monkeypatch):
+    # A body that is enumerated but momentarily busy refuses the open and accepts it moments
+    # later. Surfacing that first refusal sent users hunting for a cause that had already gone,
+    # and on macOS it named apps that were not even running.
+    monkeypatch.setattr("negpy.infrastructure.capture.gphoto.time.sleep", lambda _s: None)
+    # -10 is a timeout the reporter's log shows clearing in a second; -99 is a code no body has
+    # ever handed us, and it must be retried just the same, or the next camera's hiccup gets no
+    # retry only because nobody has met it yet.
+    fake.init_codes = [-10, -99]
+    camera = GphotoCamera(gp_module=fake, jpeg_path="/tmp/negpy_t.jpg", settings_path="/tmp/negpy_t.json")
+
+    camera.open()
+
+    assert camera.is_open()
+    assert fake.init_attempts == 3  # two refusals absorbed, third opened
+    camera.close()
+
+
+def test_open_gives_up_on_a_transport_error_that_does_not_clear(fake, monkeypatch):
+    # The retries are bounded, and what reaches the user names the transport, never a list of
+    # applications that have nothing to do with the failure.
+    monkeypatch.setattr("negpy.infrastructure.capture.gphoto.time.sleep", lambda _s: None)
+    fake.init_codes = [-10, -10, -10, -10]
+    camera = GphotoCamera(gp_module=fake, jpeg_path="/tmp/negpy_t.jpg", settings_path="/tmp/negpy_t.json")
+
+    with pytest.raises(GphotoError, match="could not open the camera") as e:
+        camera.open()
+    assert "Preview" not in str(e.value) and "Image Capture" not in str(e.value)
+
+
+def test_open_never_retries_a_claim_conflict(fake, monkeypatch):
+    # Whoever holds a PTP body keeps it for minutes, so retrying only delays the one message
+    # that explains what happened. It must be typed, too: the camera dot reads that type.
+    monkeypatch.setattr("negpy.infrastructure.capture.gphoto.time.sleep", lambda _s: None)
+    fake.init_codes = [-53, -53, -53, -53]
+    camera = GphotoCamera(gp_module=fake, jpeg_path="/tmp/negpy_t.jpg", settings_path="/tmp/negpy_t.json")
+
+    with pytest.raises(CameraClaimedError):
+        camera.open()
+    assert fake.init_attempts == 1  # refused once, reported at once

--- a/tests/test_capture_worker.py
+++ b/tests/test_capture_worker.py
@@ -254,8 +254,10 @@ def test_poll_self_heals_once_the_other_app_releases_the_camera(monkeypatch):
     worker.poll_connection("")
     assert seen[-1]["usb_claimed_elsewhere"] is False  # healed without any user action
     assert seen[-1]["usb_model"] == "ILCE-7CM2"  # the probe read the real name off the body
-    assert cam.opened and cam.closed  # probe session released again — nothing stays held
-    assert not worker._holds_camera()
+    # The reclaimed session is kept. Handing it back gives the OS camera daemon an opening it
+    # holds for minutes, and the next thing the user does is exactly what needs the camera.
+    assert cam.opened and not cam.closed
+    assert worker._holds_camera()
 
 
 def test_poll_identifies_the_body_on_first_sight(monkeypatch):
@@ -292,7 +294,7 @@ def test_poll_identifies_the_body_on_first_sight(monkeypatch):
     worker.poll_status.connect(seen.append)
     worker.poll_connection("")
     assert seen[-1]["usb_model"] == "ILCE-7CM2"  # real name, not the database placeholder
-    assert not worker._holds_camera()  # the identify session was released again
+    assert worker._holds_camera()  # the probe keeps the claim it won
     worker.poll_connection("")
     assert cam.open_calls == 1  # identified once, not per tick
 

--- a/tests/test_scanlight_sidebar.py
+++ b/tests/test_scanlight_sidebar.py
@@ -516,7 +516,10 @@ def test_poll_camera_claimed_by_another_app_says_so_and_gates(monkeypatch):
     assert "in use" in w.cam_status.text()
     # The advice is readable in the tab (amber hint line), not buried in a tooltip.
     assert w._conn_hint.isVisibleTo(w)
-    assert "close Preview, Photos and Image Capture" in w._conn_hint.text()
+    # The holder is named honestly: on macOS it is usually the system's camera daemon, so telling
+    # the user to close three applications sends them looking for windows that are not open.
+    assert "camera daemon" in w._conn_hint.text()
+    assert "Preview" not in w._conn_hint.text()
     assert "#C8922E" in w._conn_hint.styleSheet()
     # The claim clearing (next successful open / re-plug) restores the normal green dot
     # and puts the hint line back to its plug-in nudge (hidden while a camera is present).

--- a/tests/test_scanlight_sidebar.py
+++ b/tests/test_scanlight_sidebar.py
@@ -516,9 +516,12 @@ def test_poll_camera_claimed_by_another_app_says_so_and_gates(monkeypatch):
     assert "in use" in w.cam_status.text()
     # The advice is readable in the tab (amber hint line), not buried in a tooltip.
     assert w._conn_hint.isVisibleTo(w)
-    # The holder is named honestly: on macOS it is usually the system's camera daemon, so telling
-    # the user to close three applications sends them looking for windows that are not open.
+    # The holder is named honestly: on macOS it is the system camera daemon, woken by whatever
+    # asks for a camera, and that is routinely a background sync client with no window at all.
+    # Telling the user to close three applications sends them hunting for windows that are not
+    # open, which is exactly what happened in issue #949 before the trigger was traced.
     assert "camera daemon" in w._conn_hint.text()
+    assert "background app" in w._conn_hint.text()
     assert "Preview" not in w._conn_hint.text()
     assert "#C8922E" in w._conn_hint.styleSheet()
     # The claim clearing (next successful open / re-plug) restores the normal green dot


### PR DESCRIPTION
Part of #949. It removes the case where NegPy hands the claim back after winning it; it cannot take the interface from a daemon that already holds it, so the issue stays open until the reporter confirms.

## What the log shows

The reporter's `negpy.log` covers the afternoon the problem was reported. Over that period 219 camera sessions opened and 38 opens failed:

| error | count | time until the next successful open |
|---|---|---|
| `[-53] Could not claim the USB device` | 14 | never under 33 s, 305 s on average |
| `[-10] Timeout reading from or writing to the port` | 14 | 1 s at the fastest, 4 s typical |
| `[-105] Unknown model` | 6 | 3 s at the fastest, 5 s typical |
| `[-7] I/O problem` | 3 | 1 s at the fastest |
| `[-1] Unspecified error` | 1 | 7 s |

Two different problems sit in that table, and they want opposite treatment.

## The claim failures are ours

Every one of the 14 claim failures is preceded by a session NegPy opened itself and closed again without using it, between 3 and 111 seconds earlier. None of them follows a session that was actually in use.

That session is the identify probe in the connection poll. It opens the body once per bus appearance to read its real model name, because libgphoto2's database labels newer bodies `USB PTP Class Camera`, and then hands the claim back. On macOS the system's camera daemon takes a freed PTP interface within seconds and does not release it again for minutes, so the next live view or scan is refused. One example from the log, straight after an application start:

```
17:37:09  gphoto2 session open: D800
17:37:12  start_live_view failed: [-53] Could not claim the USB device
```

The probe now keeps what it opened. The poll only runs while the Camera Scanning panel is visible, so holding follows the user's intent, and the existing release when the last camera window closes is untouched, since bodies that hang on to a tethered-capture state depend on it.

This means NegPy owns the camera while that panel is open, and other tethering software cannot use it meanwhile. That is deliberate and now documented.

## The rest clear by themselves

The other 24 failures recover on the very next attempt, once after a single second. They were surfaced as errors anyway. An open now gets three attempts across two seconds, and only a claim conflict is reported at once, because retrying that one would just delay the message that explains it.

The rule is written by exclusion rather than as a list of transport codes: a list could only ever name the bodies already seen, and the next body's hiccup arrives under a code nobody has reported yet. A test covers a code no body has ever sent.

## Two messages were wrong

`Close Preview, Photos and Image Capture` was attached to every open failure, including plain timeouts. The reporter followed it and confirmed none of those applications were running, which is correct: on macOS the holder is usually the system daemon, which has no window to close. That advice now belongs to the claim case alone, says what actually holds the camera, and appears in the panel hint, the live-view hint and the guide.

Separately, a body whose live view fails after advertising one was told this is a gap in libgphoto2's Fujifilm support, whatever the body. The reporter's Nikon received a Fujifilm explanation.

## What wakes the daemon

The reporter traced it with `log stream` while the block was active: `ptpcamerad` was being asked to enumerate cameras by **Google Drive**, running as a login item with no window and no notification. Removing it from the login items freed the camera immediately and scanning worked. That is why his case was a continuous block rather than the occasional one others see: a sync client asks again and again.

"Quit Preview, Photos and Image Capture" cannot find a cause like that, and neither can "unplug the cable", which frees the camera only until the same app asks again. The panel hint, the live-view hint and the guide now point at a background app first, and the guide names the login-items setting.

## Verification

`make all` clean. The four new and changed tests fail on `main` and pass here. One unrelated failure, `test_metadata_presets.py::TestPresetNames::test_load_tooltip_follows_a_rebinding`, is already red on `main`.

I could not reproduce the daemon behaviour on my own rig: my Sony is not claimed by it, so this rests on the log and the code path rather than on a reproduction. @ToddSch1979 offered to test a build and is the right person to confirm it.
