### PR TITLE
fix(analysis): lock probe row height so the chart stops jittering

### DIFF
--- a/negpy/desktop/view/widgets/stats.py
+++ b/negpy/desktop/view/widgets/stats.py
@@ -26,10 +26,21 @@ _TOOLTIPS = {
 
 
 _PROBE_EMPTY = "—"
+_PROBE_SAMPLE = "ΔD -0.00·0.00·0.00 · D 0.00 · VIII⅔"
 
 # One per zone-placement pin, in pin order. The canvas overlay draws its rings in these
 # same colors, so the sidebar row and the pin on the photo match by eye.
 PIN_COLORS = (THEME.accent_primary, "#FFFFFF", THEME.channel_blue)
+
+
+def _lock_height(label: QLabel, sample: str) -> None:
+    """Freeze a label at the height of *sample*. Zone fractions can come from a taller
+    fallback font, and the Analysis chart above absorbs every pixel a row gains."""
+    text = label.text()
+    label.setText(sample)
+    label.ensurePolished()
+    label.setFixedHeight(label.sizeHint().height())
+    label.setText(text)
 
 
 class DensitometerRow(QWidget):
@@ -55,6 +66,8 @@ class DensitometerRow(QWidget):
         self._value.setAlignment(Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter)
         grid.addWidget(name, 0, 0)
         grid.addWidget(self._value, 0, 1)
+        _lock_height(name, "Probe")
+        _lock_height(self._value, _PROBE_SAMPLE)
         name.setToolTip(self._TOOLTIP)
         self._value.setToolTip(self._TOOLTIP)
 
@@ -131,6 +144,9 @@ class ZonePlacementRows(QWidget):
             grid.addWidget(plus, 0, 4)
             grid.addWidget(remove, 0, 5)
             grid.addWidget(lands, 1, 1, 1, 5)
+            _lock_height(name, "Pin 1 · reads VIII⅔")
+            _lock_height(target, "VIII⅔")
+            _lock_height(lands, "→ lands VIII⅔")
             col.addWidget(row)
             self._rows.append(row)
             self._names.append(name)

--- a/tests/test_probe_row_height.py
+++ b/tests/test_probe_row_height.py
@@ -1,0 +1,40 @@
+import unittest
+
+from negpy.desktop.view.widgets.stats import DensitometerRow, ZonePlacementRows
+from negpy.features.exposure.densitometer import DensitometerReading, zone_roman
+
+
+def _reading(zone: float) -> DensitometerReading:
+    return DensitometerReading((0.12, 0.34, 0.56), 0.4, 1.23, zone)
+
+
+class TestProbeRowHeight(unittest.TestCase):
+    """The Analysis chart is the only stretch-1 child of a fixed-height pane, so a probe
+    row that grows with its glyphs resizes the chart on every hover (#961)."""
+
+    def test_probe_value_height_is_fixed(self):
+        row = DensitometerRow()
+        value = row._value
+        self.assertEqual(value.minimumHeight(), value.maximumHeight())
+
+    def test_probe_row_hint_constant_across_readings(self):
+        row = DensitometerRow()
+        row.set_reading(None)
+        empty = row.sizeHint().height()
+        row.set_reading(_reading(4.0))
+        self.assertEqual(zone_roman(4.0), "IV")
+        whole = row.sizeHint().height()
+        row.set_reading(_reading(4.33))
+        self.assertEqual(zone_roman(4.33), "IV⅓")
+        third = row.sizeHint().height()
+        self.assertEqual((empty, whole), (third, third))
+
+    def test_pin_row_heights_are_fixed(self):
+        rows = ZonePlacementRows()
+        rows.refresh([(0, "IV⅓", 5.0, None, True)])
+        for label in (rows._names[0], rows._target_labels[0], rows._lands[0]):
+            self.assertEqual(label.minimumHeight(), label.maximumHeight())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #961.

## Cause

The Probe row (`DensitometerRow`) pinned no height, so the row was as tall as its label's `sizeHint()`. The reading ends in a zone roman with ⅓/⅔ fractions and also carries `Δ` and `·`; those glyphs can come from a taller fallback face than the UI font, so the label's line height changed between readings — and between a reading and the `—` empty state.

In the Analysis pane, `curve_widget` is the only stretch-1 child of a splitter pane with a fixed height, so every pixel a stretch-0 sibling gained came out of the chart. Hovering the photo therefore resized the chart on each move.

## Fix

Freeze the probe labels — and the zone-placement pin labels, which carry the same zone romans — at the height of a worst-case sample string, measured once after the stylesheet font is applied.

## Tests

`tests/test_probe_row_height.py`: the probe value label has a fixed height, the row's size hint is identical for `—`, `IV` and `IV⅓`, and the pin row labels are fixed too. Two of the three fail without the change.

`make all` green.