### PR TITLE
fix(analysis): measure batch bounds on the assembled composite

### DIFF
--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -33,6 +33,7 @@ from negpy.desktop.workers.render import (
     BatchAutoCropResult,
     BatchAutoCropTask,
     BatchAutoCropWorker,
+    NormalizationInput,
     NormalizationTask,
     NormalizationWorker,
     PreviewLoadTask,
@@ -440,7 +441,7 @@ class AppController(QObject):
         self.thumb_thread.start()
 
         self.norm_thread = QThread()
-        self.norm_worker = NormalizationWorker(self.preview_service, self.session.repo)
+        self.norm_worker = NormalizationWorker(self.preview_service)
         self.norm_worker.moveToThread(self.norm_thread)
         self.batch_autocrop_worker = BatchAutoCropWorker(self.batch_autocrop_preview_service)
         self.batch_autocrop_worker.moveToThread(self.norm_thread)
@@ -2420,7 +2421,7 @@ class AppController(QObject):
         self.loading_started.emit()
         self.request_render()
 
-    def _config_for_autocrop_asset(self, asset: dict) -> WorkspaceConfig:
+    def _config_for_batch_asset(self, asset: dict) -> WorkspaceConfig:
         """Resolve per-asset settings, including unsaved edits on the active frame."""
         if asset.get("hash") == self.state.current_file_hash:
             return resolve_asset_hdr(resolve_asset_stitch(resolve_asset_rgbscan(self.state.config, asset), asset), asset)
@@ -2440,7 +2441,7 @@ class AppController(QObject):
         frames: list[BatchAutoCropInput] = []
         preflight_skipped = 0
         for asset in visible_files:
-            config = self._config_for_autocrop_asset(asset)
+            config = self._config_for_batch_asset(asset)
             if has_manual_crop(config.geometry) or config.geometry.autocrop_mode != AutocropMode.IMAGE:
                 preflight_skipped += 1
                 continue
@@ -2493,7 +2494,7 @@ class AppController(QObject):
             for result in results:
                 asset = result.file_info
                 try:
-                    latest = self._config_for_autocrop_asset(asset)
+                    latest = self._config_for_batch_asset(asset)
                     if has_manual_crop(latest.geometry):
                         conflicted += 1
                         continue
@@ -3007,7 +3008,7 @@ class AppController(QObject):
             return
         self.set_status("Starting Batch Normalization...")
         task = NormalizationTask(
-            files=visible_files,
+            frames=[NormalizationInput(file_info=a, config=self._config_for_batch_asset(a)) for a in visible_files],
             workspace_color_space=self.state.workspace_color_space,
             override_analysis_buffer=self.state.config.process.analysis_buffer,
             override_luma_range_clip=self.state.config.process.luma_range_clip,

--- a/negpy/desktop/workers/render.py
+++ b/negpy/desktop/workers/render.py
@@ -21,7 +21,7 @@ from negpy.features.stitch.models import StitchConfig, stitch_active
 from negpy.features.geometry.processor import GeometryProcessor
 from negpy.infrastructure.display.color_spaces import WORKING_COLOR_SPACE
 from negpy.infrastructure.gpu.resources import GPUTexture
-from negpy.kernel.system.config import APP_CONFIG, DEFAULT_WORKSPACE_CONFIG
+from negpy.kernel.system.config import APP_CONFIG
 from negpy.kernel.system.logging import get_logger
 from negpy.services.rendering.image_processor import ImageProcessor
 
@@ -101,10 +101,18 @@ class ThumbnailUpdateTask:
 
 
 @dataclass(frozen=True)
+class NormalizationInput:
+    """One frame and its dispatch-time settings for roll-wide bounds analysis."""
+
+    file_info: dict
+    config: WorkspaceConfig
+
+
+@dataclass(frozen=True)
 class NormalizationTask:
     """Request to analyze log bounds for a set of files."""
 
-    files: list[dict]
+    frames: list[NormalizationInput]
     workspace_color_space: str
     # Roll-wide overrides taken from the current image, applied to every file's analysis
     # before averaging, so the whole roll shares one buffer and luma bounds.
@@ -1010,6 +1018,37 @@ class PreviewLoadWorker(QObject):
             return ""
 
 
+def decode_asset_preview(
+    preview_service,
+    file_info: dict,
+    config: WorkspaceConfig,
+    workspace_color_space: str,
+) -> np.ndarray:
+    """Decode one asset the way the render path does: a composite through the merge that
+    assembles it, a plain frame direct.
+
+    A batch that decodes only ``file_info["path"]`` sees one member of the composite. For a
+    triplet that member holds real signal in the red channel alone, so anything measured off
+    it is invalid for the assembled three-band source.
+    """
+    from negpy.services.assets.half_frame import base_hash, slice_for_asset
+
+    rgbscan = config.rgbscan
+    common = {
+        "use_camera_wb": not effective_linear_raw(config.process, config.exposure.render_intent),
+        "full_resolution": False,
+        "file_hash": base_hash(file_info.get("hash")),  # halves share one decode
+    }
+    hdr = config.hdr
+    if hdr.hdr_enabled and hdr.hdr_paths:
+        raw, _, _ = preview_service.load_linear_preview_hdr(file_info["path"], hdr, workspace_color_space, **common)
+    elif rgbscan.enabled and rgbscan.green_path and rgbscan.blue_path:
+        raw, _, _ = preview_service.load_linear_preview_rgb(file_info["path"], rgbscan, workspace_color_space, **common)
+    else:
+        raw, _, _ = preview_service.load_linear_preview(file_info["path"], workspace_color_space, **common)
+    return slice_for_asset(raw, file_info)
+
+
 class BatchAutoCropWorker(QObject):
     """Decode, preprocess, and roll-calibrate visible frames off the UI thread."""
 
@@ -1064,28 +1103,7 @@ class BatchAutoCropWorker(QObject):
             self.cancelled.emit()
 
     def _decode(self, frame: BatchAutoCropInput, workspace_color_space: str) -> np.ndarray:
-        from negpy.services.assets.half_frame import base_hash, slice_for_asset
-
-        file_info = frame.file_info
-        config = frame.config
-        rgbscan = config.rgbscan
-        common = {
-            "use_camera_wb": not effective_linear_raw(config.process, config.exposure.render_intent),
-            "full_resolution": False,
-            "file_hash": base_hash(file_info.get("hash")),  # halves share one decode
-        }
-        hdr = config.hdr
-        if hdr.hdr_enabled and hdr.hdr_paths:
-            raw, _, _ = self._preview_service.load_linear_preview_hdr(file_info["path"], hdr, workspace_color_space, **common)
-        elif rgbscan.enabled and rgbscan.green_path and rgbscan.blue_path:
-            raw, _, _ = self._preview_service.load_linear_preview_rgb(file_info["path"], rgbscan, workspace_color_space, **common)
-        else:
-            raw, _, _ = self._preview_service.load_linear_preview(
-                file_info["path"],
-                workspace_color_space,
-                **common,
-            )
-        return slice_for_asset(raw, file_info)
+        return decode_asset_preview(self._preview_service, frame.file_info, frame.config, workspace_color_space)
 
     def _frame_evidence(self, index: int, frame: BatchAutoCropInput, task: BatchAutoCropTask, generation: int) -> Optional[CropEvidence]:
         """Decode and detect one frame. None when it failed or the run was cancelled."""
@@ -1203,10 +1221,9 @@ class NormalizationWorker(QObject):
     cancelled = pyqtSignal()
     error = pyqtSignal(str)
 
-    def __init__(self, preview_service, repo) -> None:
+    def __init__(self, preview_service) -> None:
         super().__init__()
         self._preview_service = preview_service
-        self._repo = repo
         self._cancel = threading.Event()
 
     @pyqtSlot()
@@ -1226,51 +1243,46 @@ class NormalizationWorker(QObject):
         from negpy.domain.interfaces import PipelineContext
         from negpy.features.exposure.normalization import analyze_log_exposure_bounds, resolve_crosstalk_matrix
         from negpy.features.geometry.processor import GeometryProcessor
-        from negpy.services.assets.half_frame import base_hash, slice_for_asset
 
         self._cancel.clear()
-        total = len(task.files)
+        total = len(task.frames)
         limit = max(1, APP_CONFIG.max_workers // 2)
         semaphore = asyncio.Semaphore(limit)
         lock = asyncio.Lock()
         completed = 0
 
-        async def _analyze_file(f_info: dict):
+        async def _analyze_file(frame: NormalizationInput):
             nonlocal completed
+            f_info = frame.file_info
             async with semaphore:
                 if self._cancel.is_set():
                     return None
                 try:
-                    params = self._repo.load_file_settings(f_info["hash"])
+                    params = frame.config
                     # Roll-wide buffer and luma bounds from the current image, applied to every
                     # file, so one slider setting drives the whole batch baseline.
                     analysis_buffer = task.override_analysis_buffer
                     luma_range_clip = task.override_luma_range_clip
                     color_range_clip = task.override_color_range_clip
-                    process_mode = params.process.process_mode if params else DEFAULT_WORKSPACE_CONFIG.process.process_mode
-                    e6_normalize = params.process.e6_normalize if params else DEFAULT_WORKSPACE_CONFIG.process.e6_normalize
-                    geometry = params.geometry if params else DEFAULT_WORKSPACE_CONFIG.geometry
-                    # effective_, not the stored flag: the transfer path decodes neutral whatever
-                    # the flag says, and the comment below is why this must match it.
-                    _an = params if params else DEFAULT_WORKSPACE_CONFIG
-                    linear_raw = effective_linear_raw(_an.process, _an.exposure.render_intent)
+                    process_mode = params.process.process_mode
+                    e6_normalize = params.process.e6_normalize
+                    geometry = params.geometry
 
-                    # to_thread for the blocking load and analysis. Decode with the SAME WB the
-                    # render path uses (use_camera_wb = not linear_raw): the roll-average bounds
-                    # are applied to the render-decoded image, so analysing in a different WB
-                    # space shifts the per-channel floors and ceils and produces a color cast.
-                    raw, _, _ = await asyncio.to_thread(
-                        self._preview_service.load_linear_preview,
-                        f_info["path"],
+                    # to_thread for the blocking load and analysis. decode_asset_preview picks
+                    # the same WB the render path uses (use_camera_wb = not effective linear
+                    # RAW): the roll-average bounds are applied to the render-decoded image, so
+                    # analyzing in a different WB space shifts the per-channel floors and ceils
+                    # and produces a color cast.
+                    raw = await asyncio.to_thread(
+                        decode_asset_preview,
+                        self._preview_service,
+                        f_info,
+                        params,
                         task.workspace_color_space,
-                        not linear_raw,  # use_camera_wb
-                        False,  # full_resolution
-                        base_hash(f_info.get("hash")),  # halves share one decode
                     )
-                    raw = slice_for_asset(raw, f_info)
                     # Bounds must be measured on the same channel mix the render path normalizes.
                     # Triplet composites are never sensor-corrected there.
-                    sensor_matrix = effective_sensor_matrix(params.process) if params is not None else None
+                    sensor_matrix = effective_sensor_matrix(params.process)
                     if sensor_matrix is not None and not is_rgb_triplet(params.rgbscan):
                         raw = await asyncio.to_thread(apply_sensor_correction, raw, sensor_matrix)
 
@@ -1308,7 +1320,7 @@ class NormalizationWorker(QObject):
                     return None
 
         async def _run_batch():
-            tasks = [_analyze_file(f) for f in task.files]
+            tasks = [_analyze_file(f) for f in task.frames]
             return await asyncio.gather(*tasks)
 
         try:

--- a/tests/test_batch_norm_wb.py
+++ b/tests/test_batch_norm_wb.py
@@ -8,7 +8,7 @@ from dataclasses import replace
 
 import numpy as np
 
-from negpy.desktop.workers.render import NormalizationTask, NormalizationWorker
+from negpy.desktop.workers.render import NormalizationInput, NormalizationTask, NormalizationWorker
 from negpy.domain.models import WorkspaceConfig
 
 
@@ -24,12 +24,8 @@ class _FakePreviewService:
         return raw, (8, 8), {}
 
 
-class _FakeRepo:
-    def __init__(self, settings: dict[str, WorkspaceConfig]) -> None:
-        self._settings = settings
-
-    def load_file_settings(self, file_hash):
-        return self._settings.get(file_hash)
+def _frames(settings: dict[str, WorkspaceConfig]) -> list[NormalizationInput]:
+    return [NormalizationInput(file_info={"path": f"/{h}.dng", "hash": h, "name": h}, config=cfg) for h, cfg in settings.items()]
 
 
 def test_batch_analysis_decodes_in_render_wb(qapp):
@@ -39,13 +35,10 @@ def test_batch_analysis_decodes_in_render_wb(qapp):
         "h_flat": replace(base, process=replace(base.process, linear_raw=True)),
     }
     preview = _FakePreviewService()
-    worker = NormalizationWorker(preview, _FakeRepo(settings))
+    worker = NormalizationWorker(preview)
 
     task = NormalizationTask(
-        files=[
-            {"path": "/a.dng", "hash": "h_cam", "name": "a"},
-            {"path": "/b.dng", "hash": "h_flat", "name": "b"},
-        ],
+        frames=_frames(settings),
         workspace_color_space="sRGB",
         override_analysis_buffer=base.process.analysis_buffer,
         override_luma_range_clip=base.process.luma_range_clip,
@@ -90,13 +83,10 @@ def test_batch_analysis_applies_roll_wide_buffer_and_luma_range(qapp, monkeypatc
         "h1": replace(base, process=replace(base.process, analysis_buffer=0.20, luma_range_clip=5.0)),
         "h2": replace(base, process=replace(base.process, analysis_buffer=0.01, luma_range_clip=-2.0)),
     }
-    worker = NormalizationWorker(_FakePreviewService(), _FakeRepo(settings))
+    worker = NormalizationWorker(_FakePreviewService())
 
     task = NormalizationTask(
-        files=[
-            {"path": "/a.dng", "hash": "h1", "name": "a"},
-            {"path": "/b.dng", "hash": "h2", "name": "b"},
-        ],
+        frames=_frames(settings),
         workspace_color_space="sRGB",
         override_analysis_buffer=0.12,
         override_luma_range_clip=3.5,
@@ -109,3 +99,37 @@ def test_batch_analysis_applies_roll_wide_buffer_and_luma_range(qapp, monkeypatc
     for kw in captured_kwargs:
         assert kw["analysis_buffer"] == 0.12
         assert kw["percentile_clip"] == 3.5
+
+
+def test_batch_analysis_decodes_a_triplet_as_a_composite(qapp):
+    """A triplet's bounds must come from the assembled three-band source. Measured on the
+    lone red exposure, green and blue hold sensor leak alone, and the roll baseline then
+    puts every frame's real G/B above their ceils — a solid red roll."""
+    from negpy.features.rgbscan.models import RgbScanConfig
+
+    class _TripletPreviewService(_FakePreviewService):
+        def __init__(self) -> None:
+            super().__init__()
+            self.merged: list[tuple[str, str, str]] = []
+
+        def load_linear_preview_rgb(self, red_path, rgbscan, color_space, **kw):
+            self.merged.append((red_path, rgbscan.green_path, rgbscan.blue_path))
+            return np.full((8, 8, 3), 0.5, dtype=np.float32), (8, 8), {}
+
+    base = WorkspaceConfig()
+    triplet = replace(base, rgbscan=RgbScanConfig(enabled=True, green_path="/g.dng", blue_path="/b.dng"))
+    preview = _TripletPreviewService()
+    worker = NormalizationWorker(preview)
+
+    worker.process(
+        NormalizationTask(
+            frames=[NormalizationInput(file_info={"path": "/r.dng", "hash": "h_r", "name": "r"}, config=triplet)],
+            workspace_color_space="sRGB",
+            override_analysis_buffer=base.process.analysis_buffer,
+            override_luma_range_clip=base.process.luma_range_clip,
+            override_color_range_clip=base.process.color_range_clip,
+        )
+    )
+
+    assert preview.merged == [("/r.dng", "/g.dng", "/b.dng")]
+    assert preview.calls == {}  # never the lone red exposure

--- a/tests/test_batch_progress.py
+++ b/tests/test_batch_progress.py
@@ -7,7 +7,8 @@ from PyQt6.QtWidgets import QApplication
 
 from negpy.desktop.view.widgets.progress_dialog import ProgressDialog
 from negpy.desktop.workers.export import ExportTask, ExportWorker
-from negpy.desktop.workers.render import NormalizationTask, NormalizationWorker
+from negpy.desktop.workers.render import NormalizationInput, NormalizationTask, NormalizationWorker
+from negpy.domain.models import WorkspaceConfig
 from negpy.kernel.system.config import DEFAULT_WORKSPACE_CONFIG
 
 
@@ -105,9 +106,7 @@ def test_export_batch_prefetches_next_source_once_per_task(tmp_path) -> None:
 
 def test_normalization_worker_cancel_emits_cancelled_no_baseline() -> None:
     preview = MagicMock()
-    repo = MagicMock()
-    repo.load_file_settings.return_value = None
-    worker = NormalizationWorker(preview, repo)
+    worker = NormalizationWorker(preview)
 
     def _load(*_a, **_k):
         worker.cancel()
@@ -121,7 +120,12 @@ def test_normalization_worker_cancel_emits_cancelled_no_baseline() -> None:
     worker.cancelled.connect(lambda: cancelled.append(True))
 
     task = NormalizationTask(
-        files=[{"name": "a.cr2", "path": "/tmp/a.cr2", "hash": "a"}],
+        frames=[
+            NormalizationInput(
+                file_info={"name": "a.cr2", "path": "/tmp/a.cr2", "hash": "a"},
+                config=WorkspaceConfig(),
+            )
+        ],
         workspace_color_space="sRGB",
         override_analysis_buffer=0.0,
         override_luma_range_clip=0.0,

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -2135,7 +2135,7 @@ class TestBatchAnalysisFiltering(unittest.TestCase):
             mock_box.question.return_value = 1
             self.controller.request_batch_normalization()
         self.assertEqual(len(self.emitted), 1)
-        self.assertEqual([f["name"] for f in self.emitted[0].files], ["IMG_0001.cr2", "IMG_0002.cr2"])
+        self.assertEqual([f.file_info["name"] for f in self.emitted[0].frames], ["IMG_0001.cr2", "IMG_0002.cr2"])
 
     def test_analysis_zero_matches_does_not_dispatch(self):
         self.visible_indices = []


### PR DESCRIPTION
Batch Analysis decoded each frame from its own file path alone, so an RGB triplet was measured on the red exposure by itself, where green and blue carry nothing but sensor leak. The averaged roll baseline then put every frame's real G and B above their ceils and inverted both to black, leaving a solid red roll. HDR merges had the same fault, measured off the anchor exposure.

The composite-aware decode moves out of BatchAutoCropWorker into a shared decode_asset_preview(), so both batch workers assemble a triplet or a bracket the way the render path does.

NormalizationTask now carries a resolved config per frame instead of raw file dicts the worker re-hydrated by content hash. A triplet keeps the red exposure's hash, so that lookup returned the lone exposure's saved edit; the controller resolves each asset through the same helper batch autocrop uses, which also picks up unsaved edits on the active frame. The worker no longer needs the repository.

Fixes #964 