### PR TITLE
fix(export): stop Linear Output crashing on a camera DNG

### DIFF
--- a/negpy/services/export/linear_output.py
+++ b/negpy/services/export/linear_output.py
@@ -366,14 +366,10 @@ def _decode_linear(
         rgb, ir = _decode_pakon(file_path, geometry, expansion=expansion)
         meta = _SourceMeta(make="Pakon", model=_pakon_spec_desc(file_path))
         return rgb, ir, None, meta
-    if _is_dng(file_path):
+    if _is_dng(file_path) and _is_linearraw_dng(file_path):
         meta = _read_source_meta_tiff(file_path)
-        if _is_linearraw_dng(file_path):
-            rgb, ir = _decode_dng(file_path, geometry, expansion=expansion)
-            return rgb, ir, None, meta
-        if _is_camera_raw(file_path):
-            rgb, ir, wb = _decode_camera_raw(file_path, geometry)
-            return rgb, ir, wb, meta
+        rgb, ir = _decode_dng(file_path, geometry, expansion=expansion)
+        return rgb, ir, None, meta
     if is_coolscan_nef(file_path):
         meta = _read_source_meta_tiff(file_path)
         rgb, ir = _decode_nef(file_path, geometry, gamma_key=gamma_key)

--- a/tests/test_linear_output.py
+++ b/tests/test_linear_output.py
@@ -27,6 +27,7 @@ from negpy.services.export.linear_output import (
     _build_xmp,
     _decode_camera_raw_triplet,
     _decode_dng,
+    _decode_linear,
     _default_pakon_expansion,
     _effective_expansion,
     _is_camera_raw,
@@ -2274,3 +2275,41 @@ class TestSourceMetaExifFallback:
         before = logger.level
         _read_source_meta_exif(path)
         assert logger.level == before
+
+
+class TestCameraDngDecode:
+    """A camera DNG is not LinearRaw, so it takes the general camera-raw path."""
+
+    def _decode(self, **patches):
+        import negpy.services.export.linear_output as lo
+
+        base = {
+            "_is_dng": mock.patch.object(lo, "_is_dng", return_value=True),
+            "_is_linearraw_dng": mock.patch.object(lo, "_is_linearraw_dng", return_value=False),
+            "_read_source_meta_tiff": mock.patch.object(
+                lo, "_read_source_meta_tiff", return_value=_SourceMeta(make="TiffMake", model=None)
+            ),
+            "_decode_camera_raw_buffer": mock.patch.object(
+                lo,
+                "_decode_camera_raw_buffer",
+                return_value=(
+                    np.zeros((4, 4, 3), np.float32),
+                    _CameraWB(as_shot=(1.0, 1.0, 1.0, 1.0), daylight=(1.0, 1.0, 1.0, 1.0)),
+                    _SourceMeta(make="RawMake", model="RawModel"),
+                ),
+            ),
+        }
+        base.update(patches)
+        with base["_is_dng"], base["_is_linearraw_dng"], base["_read_source_meta_tiff"], base["_decode_camera_raw_buffer"]:
+            return _decode_linear("/tmp/frame.dng")
+
+    def test_camera_dng_decodes(self) -> None:
+        rgb, ir, wb, _ = self._decode()
+        assert rgb.shape == (4, 4, 3)
+        assert ir is None
+        assert wb is not None
+
+    def test_camera_dng_merges_tiff_and_raw_metadata(self) -> None:
+        _, _, _, meta = self._decode()
+        assert meta.make == "TiffMake"
+        assert meta.model == "RawModel"


### PR DESCRIPTION
## What

Exporting Linear Output from a camera DNG raises `ValueError: too many values to unpack (expected 3)`.

`_decode_linear`'s DNG branch unpacked `_decode_camera_raw`'s 4-tuple into 3 names:

```python
rgb, ir, wb = _decode_camera_raw(file_path, geometry)   # returns (f32, None, wb, meta)
```

**Who hits it:** anyone exporting Linear Output from an ordinary camera DNG (a DSLR-scanned negative, or Lightroom/DxO output). Not a *LinearRaw* DNG from VueScan/SilverFast — that takes the branch above, which works. `.dng` is in `SUPPORTED_RAW_EXTENSIONS`, so `_is_camera_raw()` matches it.

## Why the fix removes the branch instead of repairing the unpack

That early branch was a stripped-down duplicate of the general camera-RAW handler fifteen lines below it:

| | early DNG branch | general handler |
|---|---|---|
| RGB-triplet scans | ✗ | ✓ |
| Flat-field correction | ✗ | ✓ |
| Sensor matrix | ✗ | ✓ |
| White balance bake | ✗ | ✓ |
| TIFF + rawpy metadata merge | ✗ (TIFF only) | ✓ |

Removing the branch lets camera DNGs fall through to the handler that does all of it, which is what `docs/PIPELINE.md` already describes for camera RAW.

## Notes for the reviewer

- `ty` reports it as `invalid-assignment`, which the CI type-check step currently mutes via `--ignore`. Unmuting that list is separate work and deliberately not in this PR.