### PR TITLE
perf(render): cut the CPU meter and export copies out of a GPU frame

### DIFF
--- a/negpy/features/exposure/normalization.py
+++ b/negpy/features/exposure/normalization.py
@@ -158,8 +158,7 @@ def prefilter_log_grid(
     fed to the *_from_log meters. Re-prefiltering it (roi=None, buffer=0) is a no-op
     (_block_median_grid early-returns when b<=1), so results stay bit-exact.
     """
-    epsilon = 1e-6
-    img_log = np.log10(np.clip(np.nan_to_num(image, nan=epsilon, posinf=1.0, neginf=epsilon), epsilon, 1.0))
+    img_log = to_log_density(image)
     if roi:
         y1, y2, x1, x2 = roi
         img_log = img_log[y1:y2, x1:x2]
@@ -239,10 +238,51 @@ def unmix_log_image(img_log: ImageBuffer, matrix: Optional[np.ndarray]) -> Image
     return np.einsum("hwc,kc->hwk", img_log.astype(np.float32, copy=False), matrix.astype(np.float32))
 
 
+def sorted_channel_grid(img_log: ImageBuffer) -> np.ndarray:
+    """
+    Per-channel sorted values of a prefiltered grid, shape (n, 3). The clip percentiles
+    index into it, so a clip drag re-reads one sort instead of re-partitioning the grid.
+    """
+    return np.sort(img_log.reshape(-1, 3), axis=0)
+
+
+def percentile_from_sorted(sorted_grid: np.ndarray, q: float) -> np.ndarray:
+    """
+    The three channels' `np.percentile(grid[:, :, ch], q)`, read off `sorted_channel_grid`.
+
+    Bit-exact needs numpy's arithmetic, not its definition: virtual index `(n-1)*(q/100)`
+    in float64, the far half interpolated back from the upper sample, and a weight that
+    keeps `q`'s own type -- numpy interpolates in float32 for a Python `q` and float64 for
+    an `np.float64` one, and both kinds of caller exist here.
+    """
+    n = sorted_grid.shape[0]
+    virtual = (n - 1) * np.true_divide(q, 100)
+    lo = min(max(int(np.floor(virtual)), 0), n - 1)
+    hi = min(lo + 1, n - 1)
+    t = virtual - lo
+    if type(q) in (int, float):
+        t = float(t)
+    a, b = sorted_grid[lo], sorted_grid[hi]
+    diff = b - a
+    return b - diff * (1 - t) if t >= 0.5 else a + diff * t
+
+
+def to_log_density(image: ImageBuffer) -> ImageBuffer:
+    """
+    Linear scan -> log10 density, the domain every meter reads.
+
+    fmin/fmax rather than clip: they drop a NaN in favour of the bound, so one clamp covers
+    the NaN and infinity fixup as well.
+    """
+    epsilon = 1e-6
+    return np.log10(np.fmin(np.fmax(image, epsilon), 1.0))
+
+
 def measure_shadow_refs_from_log(
     img_log: ImageBuffer,
     roi: Optional[tuple[int, int, int, int]] = None,
     analysis_buffer: float = 0.0,
+    sorted_grid: Optional[np.ndarray] = None,
 ) -> Tuple[float, float, float]:
     """
     Per-channel shadow reference density: a high percentile of the prefiltered
@@ -252,15 +292,20 @@ def measure_shadow_refs_from_log(
     """
     from negpy.features.exposure.models import EXPOSURE_CONSTANTS
 
+    if roi or analysis_buffer > 0:
+        sorted_grid = None
     if roi:
         y1, y2, x1, x2 = roi
         img_log = img_log[y1:y2, x1:x2]
     if analysis_buffer > 0:
         img_log = get_analysis_crop(img_log, analysis_buffer)
 
-    img_log = _block_median_grid(img_log)
     p = float(EXPOSURE_CONSTANTS["shadow_neutral_percentile"])
-    refs = [float(np.percentile(img_log[:, :, ch], p)) for ch in range(3)]
+    if sorted_grid is not None:
+        refs = [float(v) for v in percentile_from_sorted(sorted_grid, p)]
+    else:
+        img_log = _block_median_grid(img_log)
+        refs = [float(np.percentile(img_log[:, :, ch], p)) for ch in range(3)]
     return (refs[0], refs[1], refs[2])
 
 
@@ -272,8 +317,7 @@ def measure_shadow_log_refs(
     """
     Linear-image wrapper around measure_shadow_refs_from_log.
     """
-    epsilon = 1e-6
-    img_log = np.log10(np.clip(np.nan_to_num(image, nan=epsilon, posinf=1.0, neginf=epsilon), epsilon, 1.0))
+    img_log = to_log_density(image)
     return measure_shadow_refs_from_log(img_log, roi, analysis_buffer)
 
 
@@ -334,15 +378,14 @@ def measure_neutral_axis_from_log(
             return None
         band_chroma = chroma_vals[band]
         thr = float(np.quantile(band_chroma, q))
-        idx = np.nonzero(band)[0][band_chroma <= thr]
-        near_neutral_chroma = float(np.median(chroma_vals[idx])) if idx.size else cap_val
+        keep = band_chroma <= thr
+        idx = np.nonzero(band)[0][keep]
+        near_neutral_chroma = float(np.median(band_chroma[keep])) if idx.size else cap_val
         if idx.size < min_px or near_neutral_chroma > cap_val:
             return None
-        refs = (
-            float(np.median(flat_log[idx, 0])),
-            float(np.median(flat_log[idx, 1])),
-            float(np.median(flat_log[idx, 2])),
-        )
+        # One gather for all three channels: the per-channel fancy index is the cost here.
+        sel = flat_log[idx]
+        refs = (float(np.median(sel[:, 0])), float(np.median(sel[:, 1])), float(np.median(sel[:, 2])))
         return (refs, near_neutral_chroma, int(idx.size))
 
     def _norm_ref(refs: Tuple[float, float, float]) -> Tuple[float, float, float]:
@@ -401,8 +444,7 @@ def measure_neutral_axis(
     analysis_buffer: float = 0.0,
 ) -> Optional[Tuple[Tuple[float, float, float], Tuple[float, float, float], Optional[Tuple[float, float, float]], float]]:
     """Linear-image wrapper around measure_neutral_axis_from_log."""
-    epsilon = 1e-6
-    img_log = np.log10(np.clip(np.nan_to_num(image, nan=epsilon, posinf=1.0, neginf=epsilon), epsilon, 1.0))
+    img_log = to_log_density(image)
     return measure_neutral_axis_from_log(img_log, bounds, roi, analysis_buffer)
 
 
@@ -477,8 +519,7 @@ def measure_anchor(
     """
     Linear-image wrapper around measure_anchor_from_log.
     """
-    epsilon = 1e-6
-    img_log = np.log10(np.clip(np.nan_to_num(image, nan=epsilon, posinf=1.0, neginf=epsilon), epsilon, 1.0))
+    img_log = to_log_density(image)
     return measure_anchor_from_log(img_log, bounds, roi, analysis_buffer)
 
 
@@ -518,8 +559,7 @@ def measure_textural_range(
     """
     Linear-image wrapper around measure_textural_range_from_log.
     """
-    epsilon = 1e-6
-    img_log = np.log10(np.clip(np.nan_to_num(image, nan=epsilon, posinf=1.0, neginf=epsilon), epsilon, 1.0))
+    img_log = to_log_density(image)
     return measure_textural_range_from_log(img_log, roi, analysis_buffer)
 
 
@@ -618,6 +658,7 @@ def _sample_log_bounds(
     base: float,
     process_mode: str,
     e6_normalize: bool,
+    sorted_grid: Optional[np.ndarray] = None,
 ) -> tuple[list, list]:
     """
     Per-channel (floors, ceils) at one clip level. `base` is the robust baseline
@@ -639,15 +680,17 @@ def _sample_log_bounds(
         p_low, p_high = p_high, p_low
         fixed_range = -3.0
 
-    floors = [float(np.percentile(img_log[:, :, ch], p_low)) for ch in range(3)]
+    def _pct(p) -> list:
+        if sorted_grid is not None:
+            return [float(v) for v in percentile_from_sorted(sorted_grid, p)]
+        return [float(np.percentile(img_log[:, :, ch], p)) for ch in range(3)]
 
-    ceils = []
-    for ch in range(3):
-        data = img_log[:, :, ch]
-        if process_mode != ProcessMode.E6 or e6_normalize:
-            ceils.append(float(np.percentile(data, p_high)))
-        else:
-            ceils.append(float(floors[ch] + fixed_range))
+    floors = _pct(p_low)
+
+    if process_mode != ProcessMode.E6 or e6_normalize:
+        ceils = _pct(p_high)
+    else:
+        ceils = [floors[ch] + fixed_range for ch in range(3)]
 
     if margin > 0.0:
         # Expand outward; per-channel sign handles both f < c and f > c (E6).
@@ -760,8 +803,7 @@ def analyze_log_exposure_bounds(
     offsets from the color sampling, so the cast clip is tunable without compressing
     highlights. Identical channels (mono) give zero deviation at any clip.
     """
-    epsilon = 1e-6
-    img_log = np.log10(np.clip(np.nan_to_num(image, nan=epsilon, posinf=1.0, neginf=epsilon), epsilon, 1.0))
+    img_log = to_log_density(image)
     img_log = unmix_log_image(img_log, unmix)
     return analyze_log_exposure_bounds_from_log(img_log, roi, analysis_buffer, process_mode, e6_normalize, percentile_clip, color_clip)
 
@@ -774,10 +816,18 @@ def analyze_log_exposure_bounds_from_log(
     e6_normalize: bool = True,
     percentile_clip: float = 0.0,
     color_clip: float = 0.0,
+    sorted_grid: Optional[np.ndarray] = None,
 ) -> LogNegativeBounds:
-    """Log-image core of analyze_log_exposure_bounds (skips the log10)."""
+    """Log-image core of analyze_log_exposure_bounds (skips the log10).
+
+    ``sorted_grid`` is `sorted_channel_grid(img_log)` from a caller that already holds it;
+    it stands in for both percentile passes, so it is only valid when no ROI or analysis
+    buffer is left to apply here.
+    """
     from negpy.features.exposure.models import EXPOSURE_CONSTANTS
 
+    if roi or analysis_buffer > 0:
+        sorted_grid = None
     if roi:
         y1, y2, x1, x2 = roi
         img_log = img_log[y1:y2, x1:x2]
@@ -789,14 +839,14 @@ def analyze_log_exposure_bounds_from_log(
 
     base_luma = float(EXPOSURE_CONSTANTS["base_luma_clip"])
 
-    floors, ceils = _sample_log_bounds(img_log, percentile_clip, base_luma, process_mode, e6_normalize)
+    floors, ceils = _sample_log_bounds(img_log, percentile_clip, base_luma, process_mode, e6_normalize, sorted_grid)
 
     # Color pass: per-channel deviations recombined onto the luma mean centre and span. The
     # ceils (thin end, base-anchored) come from per-channel percentiles at color_clip. The
     # floors (dense end, scene content) prefer the same-pixel chroma-gated band refs and fall
     # back to the percentile pass when the band holds no trustworthy neutrals, and always for
     # E-6 and margin-mode clips.
-    c_floors, c_ceils = _sample_log_bounds(img_log, color_clip, 0.0, process_mode, e6_normalize)
+    c_floors, c_ceils = _sample_log_bounds(img_log, color_clip, 0.0, process_mode, e6_normalize, sorted_grid)
     if process_mode != ProcessMode.E6 and color_clip >= 0:
         sp = _same_pixel_color_floor_refs(img_log, floors, ceils, (c_ceils[0], c_ceils[1], c_ceils[2]), color_clip)
         if sp is not None:

--- a/negpy/infrastructure/gpu/resources.py
+++ b/negpy/infrastructure/gpu/resources.py
@@ -1,4 +1,5 @@
 import threading
+from typing import Optional
 
 import numpy as np
 import wgpu  # type: ignore
@@ -35,6 +36,7 @@ class GPUTexture:
         self._readback_staging = None  # full-texture readback
         self._region_staging = None  # sub-region readback
         self._region_staging_size: int = 0  # allocated size of _region_staging
+        self._rgba_scratch: Optional[np.ndarray] = None  # RGB -> RGBA padding buffer, alpha written once
         # Serializes readback against destroy: the UI thread probes textures (densitometer, pixel
         # readout) while the render worker may destroy them on file switch. Destroying a mapped
         # staging buffer panics in wgpu-native, and that panic is uncatchable.
@@ -49,9 +51,7 @@ class GPUTexture:
         if data.dtype != np.float32:
             data = data.astype(np.float32)
         if data.shape[2] == 3:
-            rgba = np.ones((data.shape[0], data.shape[1], 4), dtype=np.float32)
-            rgba[:, :, :3] = data
-            data = rgba
+            data = self._pad_to_rgba(data)
 
         gpu.device.queue.write_texture(
             {"texture": self.texture},
@@ -59,6 +59,16 @@ class GPUTexture:
             {"bytes_per_row": data.shape[1] * 16, "rows_per_image": data.shape[0]},
             (data.shape[1], data.shape[0], 1),
         )
+
+    def _pad_to_rgba(self, data: np.ndarray) -> np.ndarray:
+        """RGB -> RGBA in a buffer kept across uploads. Alpha is written when the buffer is
+        made, so a re-upload of the same shape only copies the three colour channels."""
+        shape = (data.shape[0], data.shape[1], 4)
+        if self._rgba_scratch is None or self._rgba_scratch.shape != shape:
+            self._rgba_scratch = np.empty(shape, dtype=np.float32)
+            self._rgba_scratch[:, :, 3] = 1.0
+        np.copyto(self._rgba_scratch[:, :, :3], data)
+        return self._rgba_scratch
 
     def readback_region(self, x: int, y: int, rw: int, rh: int) -> np.ndarray:
         """Downloads a sub-region from VRAM. Significantly faster than a full readback."""
@@ -169,6 +179,7 @@ class GPUTexture:
                         logger.warning(f"Failed to destroy GPU buffer ({attr})", exc_info=e)
                     setattr(self, attr, None)
             self._region_staging_size = 0
+            self._rgba_scratch = None
 
 
 class GPUBuffer:

--- a/negpy/services/export/print.py
+++ b/negpy/services/export/print.py
@@ -243,6 +243,13 @@ class PrintService:
                 interpolation=cv2.INTER_AREA if shrinking else cv2.INTER_LANCZOS4,
             )
 
+        offset_x = (paper_w - target_w) // 2
+        offset_y = PrintService.weighted_offset_y(paper_h, target_h, border_px, border_bottom_px)
+        # No border means the paper buffer is a full-res allocation, fill and copy that
+        # reproduces the scaled content exactly.
+        if (paper_w, paper_h, offset_x, offset_y) == (target_w, target_h, 0, 0):
+            return img_scaled, (0, 0, target_w, target_h)
+
         color_hex = border_color.lstrip("#")
         r, g, b = tuple(int(color_hex[i : i + 2], 16) / 255.0 for i in (0, 2, 4))
 
@@ -253,9 +260,6 @@ class PrintService:
             (r, g, b) if channels > 1 else (r,),
             dtype=img_scaled.dtype,
         )
-        offset_x = (paper_w - target_w) // 2
-        offset_y = PrintService.weighted_offset_y(paper_h, target_h, border_px, border_bottom_px)
-
         h_copy = min(target_h, paper_h - offset_y)
         w_copy = min(target_w, paper_w - offset_x)
 

--- a/negpy/services/rendering/gpu_engine.py
+++ b/negpy/services/rendering/gpu_engine.py
@@ -31,6 +31,7 @@ from negpy.features.exposure.normalization import (
     prefilter_log_grid,
     resolve_analysis_region,
     resolve_bounds_detailed,
+    sorted_channel_grid,
 )
 from negpy.features.geometry.logic import (
     apply_fine_rotation,
@@ -575,6 +576,7 @@ class GPUEngine:
         needs_textural = textural_range_override is None and not tiling_mode and settings.exposure.auto_normalize_contrast
 
         prefiltered = None
+        sorted_grid = None
         scan_clip_fractions = None
         analysis_source = None
         unmix_m = effective_crosstalk_matrix(settings.process, settings.process.process_mode)
@@ -599,6 +601,7 @@ class GPUEngine:
             )
             if prefilter_key is not None and self._prefilter_cache is not None and self._prefilter_cache[0] == prefilter_key:
                 prefiltered, scan_clip_fractions = self._prefilter_cache[1], self._prefilter_cache[2]
+                sorted_grid = self._prefilter_cache[3]
             else:
                 # Use views to avoid copying the full-res image; crop to ROI first.
                 analysis_source = img
@@ -633,11 +636,23 @@ class GPUEngine:
                 prefiltered = unmix_log_image(prefilter_log_grid(analysis_source, None, an_buffer), unmix_m)
                 scan_clip_fractions = measure_clip_fractions(analysis_source, None, an_buffer)
                 if prefilter_key is not None:
-                    self._prefilter_cache = (prefilter_key, prefiltered, scan_clip_fractions)
+                    self._prefilter_cache = (prefilter_key, prefiltered, scan_clip_fractions, None)
             if analysis_key is not None:
                 self._clip_cache = (analysis_key, scan_clip_fractions)
         elif analysis_key is not None and self._clip_cache is not None and self._clip_cache[0] == analysis_key:
             scan_clip_fractions = self._clip_cache[1]
+
+        def _sorted() -> np.ndarray:
+            """The prefiltered grid sorted per channel. Held beside the grid it came from,
+            so a clip drag re-reads one sort instead of re-partitioning per percentile."""
+            nonlocal sorted_grid
+            assert prefiltered is not None
+            if sorted_grid is None:
+                sorted_grid = sorted_channel_grid(prefiltered)
+                cache = self._prefilter_cache
+                if cache is not None and cache[1] is prefiltered:
+                    self._prefilter_cache = (cache[0], cache[1], cache[2], sorted_grid)
+            return sorted_grid
 
         def _analyze_bounds() -> LogNegativeBounds:
             assert prefiltered is not None
@@ -649,6 +664,7 @@ class GPUEngine:
                 e6_normalize=settings.process.e6_normalize,
                 percentile_clip=settings.process.luma_range_clip,
                 color_clip=settings.process.color_range_clip,
+                sorted_grid=_sorted(),
             )
 
         if bounds_override:
@@ -659,7 +675,7 @@ class GPUEngine:
 
         shadow_refs = shadow_refs_override
         if needs_refs and prefiltered is not None:
-            shadow_refs = measure_shadow_refs_from_log(prefiltered, None, 0.0)
+            shadow_refs = measure_shadow_refs_from_log(prefiltered, None, 0.0, sorted_grid=_sorted())
 
         # Neutral axis for the two-point Cast Removal; normalized at consumption.
         neutral_axis_refs = neutral_axis_override
@@ -1921,15 +1937,25 @@ class GPUEngine:
         return (read_buf, prb, tex.width, tex.height)
 
     @staticmethod
-    def _resolve_readback(handle: tuple) -> np.ndarray:
+    def _resolve_readback(handle: tuple, dest: Optional[np.ndarray] = None, crop: Optional[Tuple[int, int]] = None) -> Optional[np.ndarray]:
+        """Maps a queued staging buffer and hands back its RGB.
+
+        The mapped memory dies at unmap, so the copy out happens inside: `dest` takes the
+        trimmed region straight (one copy), else the caller gets an owned array.
+        """
         read_buf, prb, w, h = handle
         read_buf.map_sync(wgpu.MapMode.READ)
         try:
-            raw = np.frombuffer(read_buf.read_mapped(), dtype=np.uint8).reshape((h, prb))
+            raw = np.frombuffer(read_buf.read_mapped(copy=False), dtype=np.uint8).reshape((h, prb))
             valid = raw[:, : w * 16]
-            result = valid.view(np.float32).reshape((h, w, 4))
             # The texture is already display-encoded (output_encode pass).
-            return result[:, :, :3]
+            result = valid.view(np.float32).reshape((h, w, 4))[:, :, :3]
+            if dest is None:
+                return result.copy()
+            oy, ox = crop if crop is not None else (0, 0)
+            dh, dw = dest.shape[:2]
+            dest[:] = result[oy : oy + dh, ox : ox + dw]
+            return None
         finally:
             read_buf.unmap()
 
@@ -1938,7 +1964,9 @@ class GPUEngine:
         handle = self._submit_readback(tex)
         if handle is None:
             return np.zeros((1, 1, 3), dtype=np.float32)
-        return self._resolve_readback(handle)
+        out = self._resolve_readback(handle)
+        assert out is not None
+        return out
 
     def _dispatch_pass(self, encoder: Any, pipeline_name: str, bindings: list, w: int, h: int) -> None:
         """Configures and dispatches a compute pass."""
@@ -2136,12 +2164,19 @@ class GPUEngine:
         # auto refs, anchor or textural range need it.
         unmix_m = effective_crosstalk_matrix(settings.process, settings.process.process_mode)
         prefiltered_cache: Optional[np.ndarray] = None
+        sorted_cache: Optional[np.ndarray] = None
 
         def _prefiltered() -> np.ndarray:
             nonlocal prefiltered_cache
             if prefiltered_cache is None:
                 prefiltered_cache = unmix_log_image(prefilter_log_grid(_analysis_img(), meter_roi, meter_buffer), unmix_m)
             return prefiltered_cache
+
+        def _sorted() -> np.ndarray:
+            nonlocal sorted_cache
+            if sorted_cache is None:
+                sorted_cache = sorted_channel_grid(_prefiltered())
+            return sorted_cache
 
         def _analyze_global_bounds() -> LogNegativeBounds:
             return analyze_log_exposure_bounds_from_log(
@@ -2152,6 +2187,7 @@ class GPUEngine:
                 e6_normalize=settings.process.e6_normalize,
                 percentile_clip=settings.process.luma_range_clip,
                 color_clip=settings.process.color_range_clip,
+                sorted_grid=_sorted(),
             )
 
         if bounds_override:
@@ -2163,7 +2199,7 @@ class GPUEngine:
         global_shadow_refs = None
         global_neutral_axis = None
         if settings.exposure.cast_removal_strength > 0.0 and settings.process.process_mode == ProcessMode.C41:
-            global_shadow_refs = measure_shadow_refs_from_log(_prefiltered(), None, 0.0)
+            global_shadow_refs = measure_shadow_refs_from_log(_prefiltered(), None, 0.0, sorted_grid=_sorted())
             global_neutral_axis = measure_neutral_axis_from_log(_prefiltered(), global_bounds, None, 0.0)
 
         global_metered_anchor = None
@@ -2255,16 +2291,12 @@ class GPUEngine:
                 handle = self._submit_readback(tile_res, slot=tile_index % 2)
                 if pending is not None:
                     p_handle, p_ty, p_tx, p_th, p_tw, p_oy, p_ox = pending
-                    full_source_res[p_ty : p_ty + p_th, p_tx : p_tx + p_tw] = self._resolve_readback(p_handle)[
-                        p_oy : p_oy + p_th, p_ox : p_ox + p_tw
-                    ]
+                    self._resolve_readback(p_handle, full_source_res[p_ty : p_ty + p_th, p_tx : p_tx + p_tw], (p_oy, p_ox))
                 pending = (handle, ty, tx, th, tw, oy, ox)
                 tile_index += 1
         if pending is not None:
             p_handle, p_ty, p_tx, p_th, p_tw, p_oy, p_ox = pending
-            full_source_res[p_ty : p_ty + p_th, p_tx : p_tx + p_tw] = self._resolve_readback(p_handle)[
-                p_oy : p_oy + p_th, p_ox : p_ox + p_tw
-            ]
+            self._resolve_readback(p_handle, full_source_res[p_ty : p_ty + p_th, p_tx : p_tx + p_tw], (p_oy, p_ox))
 
         # Mirrors PrintService.apply_layout: only INTER_AREA is area-correct on a shrink.
         shrinking = content_w < crop_w or content_h < crop_h
@@ -2277,6 +2309,10 @@ class GPUEngine:
             if (content_w != crop_w or content_h != crop_h)
             else full_source_res
         )
+        # No border means the paper buffer is a full-res allocation, fill and copy that
+        # reproduces the content exactly.
+        if (paper_w, paper_h, off_x, off_y) == (content_w, content_h, 0, 0):
+            return scaled_content, metrics_ref
         result = np.zeros((paper_h, paper_w, 3), dtype=np.float32)
         color_hex = settings.finish.border_color.lstrip("#")
         result[:] = tuple(int(color_hex[i : i + 2], 16) / 255.0 for i in (0, 2, 4))

--- a/tests/test_meter_fast_paths.py
+++ b/tests/test_meter_fast_paths.py
@@ -1,0 +1,128 @@
+"""The meter's percentile and log-density shortcuts must be bit-exact, not close.
+
+Both replace numpy expressions whose exact output is baked into every golden, so these
+assert `==`, never approx.
+"""
+
+import unittest
+
+import numpy as np
+
+from negpy.features.exposure.normalization import (
+    analyze_log_exposure_bounds_from_log,
+    measure_shadow_refs_from_log,
+    percentile_from_sorted,
+    prefilter_log_grid,
+    sorted_channel_grid,
+    to_log_density,
+)
+from negpy.features.process.models import ProcessMode
+
+_QS = [0.0, 1e-5, 0.05, 0.35, 1.0, 2.5, 10.0, 33.3333, 49.999, 50.0, 66.6, 90.0, 99.65, 99.99999, 100.0]
+
+
+def _grid(shape, seed=0, scale=1.0):
+    return ((np.random.default_rng(seed).random(shape).astype(np.float32) - 0.5) * scale).copy()
+
+
+class TestPercentileFromSorted(unittest.TestCase):
+    def test_matches_numpy_for_python_and_numpy_quantiles(self):
+        """numpy interpolates in float32 for a plain float q and float64 for np.float64;
+        both kinds of caller exist in the meters, so both must land on the same bits."""
+        for shape in ((533, 800, 3), (37, 41, 3), (2, 3, 3), (1, 1, 3), (4, 4, 3)):
+            for scale in (1.0, 1e-3, 1e3):
+                g = _grid(shape, scale=scale)
+                srt = sorted_channel_grid(g)
+                for q in _QS:
+                    for qq in (q, np.float64(q)):
+                        got = percentile_from_sorted(srt, qq)
+                        for ch in range(3):
+                            self.assertEqual(
+                                float(np.percentile(g[:, :, ch], qq)),
+                                float(got[ch]),
+                                msg=f"shape={shape} scale={scale} q={q!r} ({type(qq).__name__}) ch={ch}",
+                            )
+
+
+class TestSortedGridMeters(unittest.TestCase):
+    def test_bounds_and_shadow_refs_identical_with_and_without_the_sort(self):
+        g = prefilter_log_grid(np.clip(_grid((600, 900, 3), seed=3, scale=0.4) + 0.5, 1e-4, 1.0), None, 0.0)
+        srt = sorted_channel_grid(g)
+        for mode in (ProcessMode.C41, ProcessMode.E6):
+            for e6n in (True, False):
+                for luma_clip in (-0.5, 0.0, 0.35, 2.5):
+                    for color_clip in (0.0, 0.35, 5.0):
+                        slow = analyze_log_exposure_bounds_from_log(
+                            g, None, 0.0, process_mode=mode, e6_normalize=e6n, percentile_clip=luma_clip, color_clip=color_clip
+                        )
+                        fast = analyze_log_exposure_bounds_from_log(
+                            g,
+                            None,
+                            0.0,
+                            process_mode=mode,
+                            e6_normalize=e6n,
+                            percentile_clip=luma_clip,
+                            color_clip=color_clip,
+                            sorted_grid=srt,
+                        )
+                        self.assertEqual(slow.floors, fast.floors)
+                        self.assertEqual(slow.ceils, fast.ceils)
+        self.assertEqual(measure_shadow_refs_from_log(g, None, 0.0), measure_shadow_refs_from_log(g, None, 0.0, sorted_grid=srt))
+
+    def test_sorted_grid_is_ignored_when_a_roi_still_has_to_be_applied(self):
+        """The sort describes the whole grid, so a caller that still crops must not use it."""
+        g = prefilter_log_grid(np.clip(_grid((600, 900, 3), seed=4, scale=0.4) + 0.5, 1e-4, 1.0), None, 0.0)
+        roi = (10, 300, 20, 400)
+        wrong = sorted_channel_grid(g)
+        self.assertEqual(
+            measure_shadow_refs_from_log(g, roi, 0.0),
+            measure_shadow_refs_from_log(g, roi, 0.0, sorted_grid=wrong),
+        )
+
+
+class TestToLogDensity(unittest.TestCase):
+    def test_matches_the_nan_to_num_clip_it_replaces(self):
+        eps = 1e-6
+        for dtype in (np.float32, np.float64):
+            x = (np.random.default_rng(1).random((97, 89, 3)) * 1.4 - 0.2).astype(dtype)
+            x[0, 0] = np.nan
+            x[1, 1] = np.inf
+            x[2, 2] = -np.inf
+            x[3, 3] = 0.0
+            x[4, 4] = 1.0
+            x[5, 5] = eps
+            x[6, 6] = -5.0
+            x[7, 7] = 1e30
+            expected = np.log10(np.clip(np.nan_to_num(x, nan=eps, posinf=1.0, neginf=eps), eps, 1.0))
+            got = to_log_density(x)
+            self.assertEqual(expected.dtype, got.dtype)
+            self.assertTrue(np.array_equal(expected, got), msg=f"{dtype.__name__} differs")
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class TestBorderlessLayoutEarlyOut(unittest.TestCase):
+    """A borderless layout must return exactly what the padded path built."""
+
+    def test_no_border_returns_the_scaled_content_itself(self):
+        from negpy.domain.models import AspectRatio, ExportConfig, ExportResolutionMode
+        from negpy.services.export.print import PrintService
+
+        img = _grid((120, 180, 3), seed=7, scale=0.5) + 0.5
+        export = ExportConfig(export_resolution_mode=ExportResolutionMode.ORIGINAL, paper_aspect_ratio=AspectRatio.ORIGINAL)
+        out, rect = PrintService.apply_layout(img, export, border_size=0.0)
+        self.assertEqual(rect, (0, 0, 180, 120))
+        self.assertTrue(np.array_equal(out, img))
+
+    def test_a_border_still_pads(self):
+        from negpy.domain.models import AspectRatio, ExportConfig, ExportResolutionMode
+        from negpy.services.export.print import PrintService
+
+        img = _grid((120, 180, 3), seed=7, scale=0.5) + 0.5
+        export = ExportConfig(export_resolution_mode=ExportResolutionMode.ORIGINAL, paper_aspect_ratio=AspectRatio.ORIGINAL)
+        out, (ox, oy, w, h) = PrintService.apply_layout(img, export, border_size=1.0, border_color="#000000")
+        self.assertGreater(out.shape[0], img.shape[0])
+        self.assertGreater(out.shape[1], img.shape[1])
+        self.assertTrue(np.array_equal(out[oy : oy + h, ox : ox + w], img))


### PR DESCRIPTION
## Why

A profiling pass over what runs **on the CPU while the GPU engine renders** found the host time is almost entirely meter math, not dispatch:

- A clip-slider drag cost **67 ms of CPU** per frame against **~1 ms** of GPU dispatch and uniform packing — 49 `ndarray.partition` calls over a grid the prefilter cache already held (`_prefilter_cache` excludes the clip sliders by design, so only the percentiles re-run).
- A tiled export allocated, filled and copied a full-res paper buffer even with no border to draw, packed a fresh RGBA host copy per tile upload, and copied every tile's padded staging buffer twice.

## What changed

| | |
|---|---|
| **Sorted-percentile cache** | `sorted_channel_grid` + `percentile_from_sorted` in `normalization.py`, held beside the prefiltered grid in `_prefilter_cache`. Both `_sample_log_bounds` passes and `measure_shadow_refs_from_log` index into one sort — a clip drag sorts nothing. |
| **`_band_refs` gather** | One `flat_log[idx]` gather for all three medians instead of four separate fancy indexes. |
| **`to_log_density`** | `fmin`/`fmax` replaces `nan_to_num` + `clip` at all six log-density conversions; the clamp already does the NaN and infinity fixup. |
| **Borderless layout early-out** | `_process_tiled` and `PrintService.apply_layout` return the content when the paper dims equal it. |
| **RGBA upload scratch** | `GPUTexture` keeps the padding buffer, alpha written once, so an upload copies three channels rather than four into a fresh `np.ones`. |
| **Tile readback** | `read_mapped(copy=False)` copying the trimmed region straight into the assembled buffer. |

## Numbers

890M iGPU, `tests/metrics -m metrics`, interleaved A/B over five rounds (medians). The runs were alternated in both orders because the machine drifts under load; the untouched metrics landing flat is the control.

| metric | before | after |
|---|---|---|
| `render.frame.drag_remeter_s` (clip drag) | 103.9 ms | **64.0 ms (−38%)** |
| `export.render_s` (14.7 MPx, tiled) | 839 ms | **573 ms (−32%)** |
| `drag_s` / `drag_late_stage_s` / `drag_offset_s` / `settle_s` | | flat (±1%) |

In-process isolation: clip-drag CPU 66.7 → 38.8 ms; `_sample_log_bounds` 9.5 → 0.007 ms per call against a 5.4 ms one-time sort.

## No pixel moves

Bit-exactness is the whole risk here, so it is asserted rather than assumed:

- `percentile_from_sorted` matches `np.percentile` on **4032/4032** probes across shapes, scales and quantiles, for both a plain Python `q` and an `np.float64` one. It needs numpy's arithmetic reproduced, not its definition — virtual index `(n-1)*(q/100)`, the far half interpolated back from the upper sample, and a weight typed by `q` (numpy interpolates in float32 for a weak `q` and float64 for a strong one, and both callers exist here). The obvious `q*(n-1)` form is off by an ulp.
- Export bytes **sha-identical** to `main` across five configs: tiled, non-tiled, rotation + crop + border + CLAHE + sharpen halo, contrast mask, flip + fine rotation + cast removal.
- Headless real-app run: the rendered canvas is **sha-identical to `main`** on load, after a Luma Range Clip drag returned to its start, and after navigating away and back.
- New `tests/test_meter_fast_paths.py` (6 tests) pins the percentile helper, the sorted-grid meters, the ROI guard, `to_log_density` over NaN/±inf/0/negatives, and the borderless layout.

`make all` is green apart from two failures that also fail on `main`: `test_plustek_backend` (missing optional `pyopticfilm`) and `test_rgbscan::test_preview_merge_pulls_green_blue_from_their_files`.

## Deliberately left out

- **One analysis pass per tiled export** (~45 ms). The CLAHE-CDF render and the meter block read two different downsamples — unrotated vs rotated + ROI. Deduping them changes the CDF on rotated or cropped frames, which is a pixel change and needs its own decision.
- **`_block_median_grid` float64 accumulate** (28 ms per file switch). float32 roughly halves it and is not bit-exact.

Refuted with numbers, recorded so nobody re-chases them: `apply_matrix_trc_u8`'s per-file profile and TRC-table rebuild is 0.7 ms of a 30 ms call; resizing before `apply_display_transform` for the thumbnail is 5.6 → 4.7 ms, the resize costing what the transform saves.

## Docs

None. No control, default, stage order or pipeline value changed — the rendered and exported pixels are identical.
