### PR TITLE
fix(storage): close the sqlite connections the flat-field migration opens

### DIFF
--- a/negpy/services/assets/flatfield_migration.py
+++ b/negpy/services/assets/flatfield_migration.py
@@ -10,6 +10,7 @@ never raises into app startup.
 
 import json
 import sqlite3
+from contextlib import closing
 from typing import Dict
 
 from negpy.kernel.system.logging import get_logger
@@ -50,7 +51,7 @@ def migrate_legacy_flatfield_profiles(repo) -> None:
     if repo.get_global_setting(_DONE_FLAG):
         return
     try:
-        with sqlite3.connect(repo.edits_db_path) as conn:
+        with closing(sqlite3.connect(repo.edits_db_path)) as conn, conn:
             if _table_exists(conn, "flatfield_profiles"):
                 legacy = conn.execute("SELECT name, path, k1 FROM flatfield_profiles").fetchall()
 

--- a/tests/test_flatfield_migration.py
+++ b/tests/test_flatfield_migration.py
@@ -1,5 +1,6 @@
 import json
 import sqlite3
+from contextlib import closing
 
 import numpy as np
 import pytest
@@ -19,7 +20,7 @@ def legacy_repo(tmp_path, monkeypatch):
     repo = StorageRepository(str(tmp_path / "edits.db"), str(tmp_path / "settings.db"))
     repo.initialize()
 
-    with sqlite3.connect(repo.edits_db_path) as conn:
+    with closing(sqlite3.connect(repo.edits_db_path)) as conn, conn:
         conn.execute("CREATE TABLE flatfield_profiles (name TEXT PRIMARY KEY, path TEXT, k1 REAL DEFAULT 0.0)")
         conn.executemany(
             "INSERT INTO flatfield_profiles (name, path, k1) VALUES (?, ?, ?)",
@@ -38,7 +39,7 @@ def legacy_repo(tmp_path, monkeypatch):
 
 
 def _config(repo, file_hash):
-    with sqlite3.connect(repo.edits_db_path) as conn:
+    with closing(sqlite3.connect(repo.edits_db_path)) as conn:
         row = conn.execute("SELECT settings_json FROM file_settings WHERE file_hash = ?", (file_hash,)).fetchone()
     return json.loads(row[0])
 
@@ -58,7 +59,7 @@ def test_migration_bakes_and_repoints(legacy_repo):
 
     # Active-profile setting remapped name -> id; legacy table gone; flag set.
     assert legacy_repo.get_global_setting("flatfield_active_profile") == profiles["rig-a"]
-    with sqlite3.connect(legacy_repo.edits_db_path) as conn:
+    with closing(sqlite3.connect(legacy_repo.edits_db_path)) as conn:
         assert conn.execute("SELECT name FROM sqlite_master WHERE name='flatfield_profiles'").fetchone() is None
     assert legacy_repo.get_global_setting("flatfield_migrated_v2") is True
 


### PR DESCRIPTION
## Problem

`pytest` emitted seven `ResourceWarning: unclosed database` warnings. They were attributed to `tests/test_geometry_distortion.py`, but that is only where the garbage collector happened to run — the leak is elsewhere.

## Cause

`sqlite3.connect()` used as a context manager commits the transaction on exit but **does not close the connection**. `StorageRepository._connect` already works around this, and its docstring says so, but four call sites bypassed it:

- `negpy/services/assets/flatfield_migration.py` — one connection leaked per migration run
- `tests/test_flatfield_migration.py` — three sites (fixture, `_config` helper, table-dropped assertion)

Four leaking sites across the three tests in that file give exactly the seven warnings observed.

`tests/test_storage_repo.py` uses `try/finally: conn.close()` and was already correct.

## Fix

Wrap each connection in `contextlib.closing`, keeping the inner `, conn` on the two sites that also need the commit.

## Verification

- `uv run pytest tests/test_flatfield_migration.py tests/test_storage_repo.py -W error::ResourceWarning` → 11 passed
- `make lint` → passed
- `make type` → passed
- `make test` → 4880 passed, 11 skipped, no warnings summary

https://claude.ai/code/session_01Ja5BHvYVJq8wu1N9Y2GsUX
