### PR TITLE
fix(session): say when a filter, not a load failure, emptied the Film Strip

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -124,10 +124,10 @@ Toolbar buttons, left to right:
 
     Half Frame does not apply to a frame assembled from more than one file: a Trichrome triplet, a stitch, or an HDR merge. Those are never split, and they never come back as a diptych, even when the file they are built around was worked on as two halves earlier.
 *   **Apply (clone)**: copy the current frame's settings to selected frames or the whole roll. You choose which aspects in a dialog; crop and rotation are always per-image.
-*   **Sheet filter** (funnel): show *All frames*, *Keepers only*, or *Hide rejected*.
+*   **Sheet filter** (funnel): show *All frames*, *Keepers only*, or *Hide rejected*. The choice is remembered between sessions and applies to every roll you open.
 *   **Sort**: by Name or Date, ascending or descending.
 
-Above both sections sit a **filter box**, a **`.*`** regex toggle and a **search-library** button. Inside the Film Strip section is a **tally**, for example "36 frames · 12 keepers · 3 rejected".
+Above both sections sit a **filter box**, a **`.*`** regex toggle and a **search-library** button. Inside the Film Strip section is a **tally**, for example "36 frames · 12 keepers · 3 rejected". While a filter hides frames the tally counts both sets and names the filter, for example "3 of 36 frames · Keepers filter". When a filter hides every frame, the strip carries a message with a **Show all frames** link that clears the filter box and the funnel together.
 
 #### Filtering the sheet
 

--- a/negpy/desktop/session.py
+++ b/negpy/desktop/session.py
@@ -351,6 +351,10 @@ class AssetListModel(QAbstractListModel):
     def sheet_filter(self) -> str:
         return self._sheet_filter
 
+    @property
+    def filter_text(self) -> str:
+        return self._filter_text
+
     def set_sort_order(self, order: str) -> None:
         self._sort_order = order
         self._rebuild_indices()

--- a/negpy/desktop/view/sidebar/files.py
+++ b/negpy/desktop/view/sidebar/files.py
@@ -593,6 +593,17 @@ class FileBrowser(QWidget):
         self.list_view.setAlternatingRowColors(False)
         self.list_view.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
 
+        # Takes the strip's place when a filter hides every frame: a blank panel under a
+        # full tally reads as a load failure.
+        self.empty_label = QLabel("")
+        self.empty_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.empty_label.setWordWrap(True)
+        self.empty_label.setTextFormat(Qt.TextFormat.RichText)
+        self.empty_label.setOpenExternalLinks(False)
+        self.empty_label.setStyleSheet(f"color: {THEME.text_secondary}; font-size: 11px;")
+        self.empty_label.setVisible(False)
+        self.empty_label.linkActivated.connect(lambda _: self._clear_frame_filters())
+
         self.library_tree = LibraryTree(self.controller)
         self.library_section = self._make_section("Library", "fa5s.folder-open", self.library_tree, "library_section_expanded")
 
@@ -602,6 +613,7 @@ class FileBrowser(QWidget):
         frames_layout.setSpacing(4)
         frames_layout.addWidget(self.tally_label)
         frames_layout.addWidget(self.list_view, 1)
+        frames_layout.addWidget(self.empty_label, 1)
         self.frames_section = self._make_section("Film Strip", "fa5s.film", frames, "frames_section_expanded")
 
         layout.addWidget(self.library_section)
@@ -769,6 +781,7 @@ class FileBrowser(QWidget):
         selection_model = self.list_view.selectionModel()
         self._update_unload_button()
         self._update_tally()
+        self._update_empty_state()
 
         current_actual = {
             model.display_to_actual(idx.row()) for idx in selection_model.selectedIndexes() if model.display_to_actual(idx.row()) >= 0
@@ -880,6 +893,18 @@ class FileBrowser(QWidget):
         self._prune_selection_to_visible()
         self.sync_ui()
 
+    def _active_frame_filters(self) -> list:
+        """Names of the filters currently hiding frames, in the order they are applied."""
+        model = self.session.asset_model
+        names = []
+        if model.filter_text:
+            names.append("search")
+        if model.sheet_filter == "keepers":
+            names.append("Keepers")
+        elif model.sheet_filter == "unrejected":
+            names.append("Hide rejected")
+        return names
+
     def _update_tally(self) -> None:
         files = self.session.state.uploaded_files
         if not files:
@@ -888,13 +913,39 @@ class FileBrowser(QWidget):
         keepers = sum(1 for f in files if f.get("keeper"))
         rejected = sum(1 for f in files if f.get("excluded"))
         n = len(files)
-        text = f"{n} frame{'s' if n != 1 else ''}"
+        # The strip shows the model, the tally counts the session, so a filter that hides
+        # every frame reads as an empty panel under a full count unless it is named here.
+        visible = self.session.asset_model.rowCount()
+        text = f"{visible} of {n} frames" if visible != n else f"{n} frame{'s' if n != 1 else ''}"
+        for name in self._active_frame_filters():
+            text += f" · {name} filter"
         if keepers:
             text += f" · {keepers} keeper{'s' if keepers != 1 else ''}"
         if rejected:
             text += f" · {rejected} rejected"
         self.tally_label.setText(text)
         self.tally_label.setVisible(True)
+
+    def _update_empty_state(self) -> None:
+        """Swap the strip for a message when a filter leaves it with nothing to show."""
+        files = self.session.state.uploaded_files
+        filters = self._active_frame_filters()
+        empty = bool(files) and self.session.asset_model.rowCount() == 0 and bool(filters)
+        if empty:
+            named = " and ".join(filters)
+            self.empty_label.setText(
+                f'No frames match the {named} filter.<br><a href="#clear" style="color: {THEME.accent_primary};">Show all frames</a>'
+            )
+        self.empty_label.setVisible(empty)
+        self.list_view.setVisible(not empty)
+
+    def _clear_frame_filters(self) -> None:
+        """Clear both filters from the empty state, so the strip cannot be a dead end."""
+        self.search_input.clear()
+        # Ahead of the debounce the clear would otherwise start, so one click is one rebuild.
+        self.filter_timer.stop()
+        self._apply_filter()
+        self._apply_sheet_filter("all")
 
     def _on_hot_folder_toggled(self, checked: bool) -> None:
         self._update_hot_folder_style(checked)

--- a/tests/test_filmstrip_filter_visibility.py
+++ b/tests/test_filmstrip_filter_visibility.py
@@ -1,0 +1,104 @@
+"""The Film Strip must say when a filter, not a load failure, emptied it.
+
+The tally counts the session and the strip shows the model, so a filter that hides
+every frame reads as a blank panel under a full count unless both are told about it.
+"""
+
+import pytest
+
+from negpy.desktop.session import AssetListModel
+from negpy.desktop.view.sidebar.session_panel import SessionPanel
+
+from conftest import FakeController as _Controller, FakeRepo as _Repo
+
+
+def _files(n, keepers=(), rejected=()):
+    return [
+        {
+            "name": f"_DSC{1000 + i}.NEF",
+            "path": f"/tmp/_DSC{1000 + i}.NEF",
+            "hash": f"hash{i}",
+            "keeper": i in keepers,
+            "excluded": i in rejected,
+        }
+        for i in range(n)
+    ]
+
+
+def _browser(qapp, repo=None, files=None):
+    controller = _Controller(repo if repo is not None else _Repo())
+    controller.state.uploaded_files = files if files is not None else _files(36)
+    controller.session.asset_model = AssetListModel(controller.state)
+    panel = SessionPanel(controller)
+    panel.resize(300, 700)
+    panel.show()
+    qapp.processEvents()
+    return panel.file_browser
+
+
+@pytest.fixture
+def browser(qapp):
+    return _browser(qapp)
+
+
+def test_the_tally_counts_every_frame_when_nothing_is_filtered(browser):
+    assert browser.tally_label.text() == "36 frames"
+    assert browser.list_view.isVisible()
+    assert not browser.empty_label.isVisible()
+
+
+def test_the_tally_names_the_filter_that_emptied_the_strip(qapp):
+    """The reported bug: a persisted Keepers filter over a roll with no keepers
+    left a blank strip under a full count, with the funnel tint the only clue."""
+    browser = _browser(qapp, repo=_Repo(sheet_filter="keepers"))
+    assert browser.session.asset_model.rowCount() == 0
+    assert browser.tally_label.text() == "0 of 36 frames · Keepers filter"
+
+
+def test_the_strip_gives_way_to_a_message_when_a_filter_hides_everything(qapp):
+    browser = _browser(qapp, repo=_Repo(sheet_filter="keepers"))
+    assert browser.empty_label.isVisible()
+    assert not browser.list_view.isVisible()
+    assert "No frames match the Keepers filter" in browser.empty_label.text()
+
+
+def test_clearing_from_the_empty_state_brings_every_frame_back(qapp):
+    browser = _browser(qapp, repo=_Repo(sheet_filter="keepers"))
+    browser._clear_frame_filters()
+    qapp.processEvents()
+    assert browser.session.asset_model.rowCount() == 36
+    assert browser.tally_label.text() == "36 frames"
+    assert browser.list_view.isVisible()
+    assert not browser.empty_label.isVisible()
+
+
+def test_a_filter_that_still_shows_frames_reports_the_shortfall(qapp):
+    browser = _browser(qapp, repo=_Repo(sheet_filter="keepers"), files=_files(36, keepers=(0, 1, 2)))
+    assert browser.session.asset_model.rowCount() == 3
+    assert browser.tally_label.text() == "3 of 36 frames · Keepers filter · 3 keepers"
+    assert browser.list_view.isVisible()
+    assert not browser.empty_label.isVisible()
+
+
+def test_the_search_filter_is_named_too(browser):
+    browser.search_input.setText("nothing-matches-this")
+    browser._apply_filter()
+    assert browser.session.asset_model.rowCount() == 0
+    assert browser.tally_label.text() == "0 of 36 frames · search filter"
+    assert "No frames match the search filter" in browser.empty_label.text()
+
+
+def test_both_filters_are_named_together(qapp):
+    browser = _browser(qapp, repo=_Repo(sheet_filter="keepers"))
+    browser.search_input.setText("nothing-matches-this")
+    browser._apply_filter()
+    assert browser.tally_label.text() == "0 of 36 frames · search filter · Keepers filter"
+    assert "search and Keepers filter" in browser.empty_label.text()
+
+
+def test_an_empty_session_shows_neither_tally_nor_message(qapp):
+    """No frames loaded is not a filtered strip: the panel stays quiet."""
+    browser = _browser(qapp, files=[])
+    assert not browser.tally_label.isVisible()
+    assert not browser.empty_label.isVisible()
+    assert browser.list_view.isVisible()


### PR DESCRIPTION
The tally counts the session and the strip shows the model, so a Sheet filter that matched nothing left a blank panel under a full count: "36 frames" over an empty strip. The tally now counts both sets and names the filter, and the strip carries a message that clears it.

The Sheet filter is a persisted global setting restored at startup, so it outlives the session it was chosen in and applies to every roll opened after. Its only indication was the funnel icon changing tint, which on the dark theme is a few shades on one small glyph. Choosing Keepers once, then opening a roll with nothing flagged, blanked the strip with no visible cause and no reliable repro, since the choice and the symptom are separated by however long it takes to open such a roll.

The tally reads "0 of 36 frames · Keepers filter" whenever the visible count differs from the session count, and names the search box as well when that is what is hiding frames. Below it, the strip gives way to "No frames match the Keepers filter" and a Show all frames link, which clears the filter box and the funnel together so the panel cannot be a dead end.

Worth knowing beyond the empty panel: visible_files is the filtered set, so the Sheet filter also decides which frames Batch Analysis and Roll Baseline average over. The Batch Analysis dialog says so; nothing else did.