### PR TITLE
fix(session): emit history_changed after the new config is live

### DIFF
--- a/negpy/desktop/session.py
+++ b/negpy/desktop/session.py
@@ -1141,6 +1141,7 @@ class DesktopSessionManager(QObject):
         if persist and record_history and config == self.state.config:
             record_history = False
 
+        stepped = False
         if persist and record_history and self.state.current_file_hash:
             # If editing after an undo, drop the now-orphaned future branch
             if self.state.undo_index < self.state.max_history_index:
@@ -1152,9 +1153,14 @@ class DesktopSessionManager(QObject):
             if self.state.undo_index > APP_CONFIG.max_history_steps:
                 self.repo.prune_history(self.state.current_file_hash, max_steps=APP_CONFIG.max_history_steps)
 
-            self.history_changed.emit()
+            stepped = True
 
         self.state.config = config
+
+        # After the assignment: the step above is the *previous* config, and a handler that
+        # reads state.config (the canvas HUD) must see the new one.
+        if stepped:
+            self.history_changed.emit()
 
         if persist:
             self._config_dirty = True

--- a/tests/test_desktop_session.py
+++ b/tests/test_desktop_session.py
@@ -706,6 +706,17 @@ class TestDesktopSessionSync(unittest.TestCase):
         self.assertEqual(self.session.state.config.exposure.density, 1.5)
         self.assertEqual(self.session.state.undo_index, 1)
 
+    def test_history_changed_sees_new_config(self):
+        """The HUD reads state.config from this signal, so the step must already be live."""
+        self.session.select_file(0)
+        seen = []
+        self.session.history_changed.connect(lambda: seen.append(self.session.state.config.exposure.density))
+
+        cfg = replace(self.session.state.config, exposure=replace(self.session.state.config.exposure, density=1.5))
+        self.session.update_config(cfg, persist=True)
+
+        self.assertEqual(seen, [1.5])
+
     def test_history_pruning(self):
         self.session.select_file(0)
         # Perform steps slightly over the limit


### PR DESCRIPTION
The canvas HUD reads state.config when history_changed fires, and the signal was emitted before the assignment, so every pill it draws from the config lagged one edit behind. Changing the export color space from ProPhoto RGB to sRGB left the HUD showing ProPhoto RGB until the next history-recording edit.

The history step still records the previous config, so only the emit moves; the step write stays ahead of the assignment.