### PR TITLE
fix(capture): prevent segfault when gphoto2 returns NULL values for unpopulated widgets

### DIFF
--- a/negpy/infrastructure/capture/gphoto.py
+++ b/negpy/infrastructure/capture/gphoto.py
@@ -230,6 +230,23 @@ def _safe_value(gp: Any, widget: Any) -> Optional[str]:
     kind = widget.get_type()
     if kind in (gp.GP_WIDGET_RADIO, gp.GP_WIDGET_MENU) and widget.count_choices() == 0:
         return None
+
+    # Even if there are choices, the current value might be unset / NULL pointer.
+    try:
+        import ctypes
+        lib = ctypes.CDLL(None)
+        get_val = getattr(lib, "gp_widget_get_value", None)
+        if get_val and hasattr(widget, "this"):
+            get_val.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+            get_val.restype = ctypes.c_int
+            ptr = ctypes.c_void_p()
+            res = get_val(int(widget.this), ctypes.byref(ptr))
+            if res == 0 and not ptr:
+                logger.debug("gphoto2: widget %r returned a NULL pointer; safely returning None", widget.get_name())
+                return None
+    except Exception:
+        pass
+
     return widget.get_value()
 
 


### PR DESCRIPTION
Issue: When tethering a Sony ILCE-7C on an Apple Silicon Mac using an older manual lens, starting the live preview causes an immediate crash.

Cause: Because the lens has no electronic contacts, the camera doesn't know the current aperture. However, the camera still populates the f-number widget's choices. When read_settings() calls widget.get_value(), the underlying libgphoto2 C library returns a NULL pointer because the current value is unset. The SWIG-generated python-gphoto2 bindings blindly pass this NULL pointer into PyUnicode_FromString, causing a fatal crash that cannot be caught with a Python try/except.

Fix: This PR updates _safe_value() with a null check:. we use ctypes on the already-loaded libgphoto2 library to peek at the C pointer directly. By calling gp_widget_get_value via ctypes and checking if the resulting pointer is NULL, we can safely log a debug message and return None.

Disclosure: Generated with Antigravity/Gemini.