### PR TITLE
fix(export): correct Linear Output WB gains for 3-color CFA sensors

### DIFF
--- a/negpy/services/export/linear_output.py
+++ b/negpy/services/export/linear_output.py
@@ -796,8 +796,14 @@ def _decode_stitch(
 
 
 def _normalize_wb_rgb(wb: tuple[float, float, float, float]) -> tuple[float, float, float]:
-    """Normalize RGGB multipliers to green=1, return (R, G, B)."""
-    g = (wb[1] + wb[3]) / 2.0 if (wb[1] + wb[3]) > 0 else 1.0
+    """Normalize RGGB multipliers to green=1, return (R, G, B).
+
+    A 3-color CFA (X-Trans and others) reports the second green multiplier as 0 rather
+    than a duplicate of the first; averaging it in as-is would halve the green normalizer
+    and double the R/B gains.
+    """
+    g2 = wb[3] if wb[3] > 0 else wb[1]
+    g = (wb[1] + g2) / 2.0 if (wb[1] + g2) > 0 else 1.0
     return (wb[0] / g, 1.0, wb[2] / g)
 
 

--- a/tests/test_linear_output.py
+++ b/tests/test_linear_output.py
@@ -759,6 +759,13 @@ class TestCameraRawSupport:
         assert abs(r - 398.0 / g_avg) < 1e-6
         assert abs(b - 873.0 / g_avg) < 1e-6
 
+    def test_normalize_wb_rgb_xtrans_zero_g2(self) -> None:
+        """A 3-color CFA reports G2 as 0; it must not drag the green normalizer down."""
+        r, g, b = _normalize_wb_rgb((676.0, 302.0, 458.0, 0.0))
+        assert g == 1.0
+        assert abs(r - 676.0 / 302.0) < 1e-6
+        assert abs(b - 458.0 / 302.0) < 1e-6
+
     def test_build_xmp_maketiff_format(self) -> None:
         wb = _CameraWB(
             as_shot=(398.0, 302.0, 873.0, 304.0),


### PR DESCRIPTION
## Summary
- Linear Output's "Apply white balance" produced a strong magenta cast on 3-color CFA sensors (confirmed on a Fuji X-Trans X-E4 RAF). libraw reports the second green multiplier (`G2`) as `0` for these sensors instead of a duplicate of the first, and `_normalize_wb_rgb` averaged that zero into the green normalizer, halving it and doubling the red/blue as-shot gains.
- Falls back to the single green sample when `G2` is `0`, leaving standard Bayer RGGB sensors (two real green samples) unaffected.

Closes #986

## Test plan
- [x] Added `test_normalize_wb_rgb_xtrans_zero_g2` using the reporter's exact as-shot multiplier tuple
- [x] `uv run pytest tests/test_linear_output.py` (185 passed)
- [x] `make lint` / `make type`
- [x] Verified against the actual RAF file from the issue: exported buffer matches natural white balance instead of the magenta cast