### PR TITLE
fix(settings): paste the bounds that Copy Settings + Bounds copied

### DIFF
--- a/docs/KEYBOARD.md
+++ b/docs/KEYBOARD.md
@@ -63,6 +63,7 @@ While a test strip or ring-around is up, `[` and `]` turn that proof's ladder in
 | `Ctrl + Z` | Undo last change |
 | `Ctrl + Y` | Redo change |
 | `Ctrl + C` | Copy settings from current image |
+| `Ctrl + Shift + C` | Copy settings with the frame's normalization bounds |
 | `Ctrl + V` | Paste settings to current image |
 | `Ctrl + ,` | Open Preferences |
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -239,7 +239,7 @@ The bottom-left badge is grey, not red, because it reports what the frame *is* r
 
 Hover any thumbnail and the tooltip says the same thing in words, with the frame count: *HDR merge of 5 exposures*, *Stitched composite of 3 frames*.
 
-The right-click menu also offers **Copy/Paste Settings** (with or without normalization bounds), **Reset Settings**, **Apply settings…**, and per-frame export.
+The right-click menu also offers **Copy/Paste Settings** (with or without normalization bounds), **Reset Settings**, **Apply settings…**, and per-frame export. A copy that took the bounds lists them in the paste picker as **Normalization bounds**, ticked; untick it to paste the look and keep the frame's own bounds.
 
 ---
 

--- a/negpy/desktop/session.py
+++ b/negpy/desktop/session.py
@@ -1364,11 +1364,30 @@ class DesktopSessionManager(QObject):
         self.copy_settings(include_bounds=True)
 
     def apply_pasted_fields(self, rows) -> None:
-        """Overlay the picked clipboard settings onto the active frame."""
+        """Overlay the picked clipboard settings onto the active frame.
+
+        The per-frame bounds ride along when the clipboard holds them (only a copy
+        with bounds does; copy_settings strips them otherwise). They are written
+        after the rows because a pasted bounds-input field invalidates them.
+        """
         rows = list(rows)
-        if not rows or self.state.clipboard is None or not self.state.current_file_hash:
+        clip = self.state.clipboard
+        if clip is None or not self.state.current_file_hash:
             return
-        merged = apply_selected_fields(self.state.clipboard, self.state.config, rows)
+        bounds = clip.process.is_local_initialized
+        if not rows and not bounds:
+            return
+        merged = apply_selected_fields(clip, self.state.config, rows)
+        if bounds:
+            merged = replace(
+                merged,
+                process=replace(
+                    merged.process,
+                    local_floors=clip.process.local_floors,
+                    local_ceils=clip.process.local_ceils,
+                    lock_bounds=clip.process.lock_bounds,
+                ),
+            )
         self.update_config(merged, persist=True)
         self.settings_pasted.emit()
 

--- a/negpy/desktop/session.py
+++ b/negpy/desktop/session.py
@@ -1363,18 +1363,19 @@ class DesktopSessionManager(QObject):
     def copy_settings_with_bounds(self) -> None:
         self.copy_settings(include_bounds=True)
 
-    def apply_pasted_fields(self, rows) -> None:
+    def apply_pasted_fields(self, rows, include_bounds: bool = True) -> None:
         """Overlay the picked clipboard settings onto the active frame.
 
         The per-frame bounds ride along when the clipboard holds them (only a copy
-        with bounds does; copy_settings strips them otherwise). They are written
-        after the rows because a pasted bounds-input field invalidates them.
+        with bounds does; copy_settings strips them otherwise) and the paste picker
+        keeps its bounds row ticked. They are written after the rows because a
+        pasted bounds-input field invalidates them.
         """
         rows = list(rows)
         clip = self.state.clipboard
         if clip is None or not self.state.current_file_hash:
             return
-        bounds = clip.process.is_local_initialized
+        bounds = include_bounds and clip.process.is_local_initialized
         if not rows and not bounds:
             return
         merged = apply_selected_fields(clip, self.state.config, rows)

--- a/negpy/desktop/view/sidebar/files.py
+++ b/negpy/desktop/view/sidebar/files.py
@@ -1136,13 +1136,13 @@ class FileBrowser(QWidget):
         roll_targets = len([i for i in visible if i != src])
 
         source_cfg = self.session.state.config
-        show_bounds = _source_effective_bounds(source_cfg.process) is not None
+        bounds_mode = "axes" if _source_effective_bounds(source_cfg.process) is not None else ""
         dlg = GranularSettingsDialog(
             self,
             source_cfg,
             self._source_name(),
             show_scope=True,
-            show_bounds=show_bounds,
+            bounds_mode=bounds_mode,
             sel_count=sel_targets,
             roll_count=roll_targets,
         )

--- a/negpy/desktop/view/widgets/granular_settings_dialog.py
+++ b/negpy/desktop/view/widgets/granular_settings_dialog.py
@@ -337,7 +337,8 @@ def open_paste_dialog(parent, controller) -> None:
     state = controller.session.state
     if state.clipboard is None or not state.current_file_hash:
         return
-    dlg = GranularSettingsDialog(parent, state.clipboard, "clipboard", show_scope=False)
+    name = "clipboard (with bounds)" if state.clipboard.process.is_local_initialized else "clipboard"
+    dlg = GranularSettingsDialog(parent, state.clipboard, name, show_scope=False)
     if dlg.exec() == QDialog.DialogCode.Accepted:
         controller.session.apply_pasted_fields(dlg.selected())
 

--- a/negpy/desktop/view/widgets/granular_settings_dialog.py
+++ b/negpy/desktop/view/widgets/granular_settings_dialog.py
@@ -20,6 +20,10 @@ from negpy.desktop.view.styles.theme import THEME
 from negpy.desktop.view.widgets.collapsible import CollapsibleSection
 
 
+def _triplet(values) -> str:
+    return " / ".join(f"{v:g}" for v in values)
+
+
 class GranularSettingsDialog(QDialog):
     """Per-setting picker for paste / apply-to-many. Lists one collapsible section
     per edit area, each setting with a checkbox and its value. Settings still at
@@ -34,7 +38,7 @@ class GranularSettingsDialog(QDialog):
         source_name: str,
         *,
         show_scope: bool = False,
-        show_bounds: bool = False,
+        bounds_mode: str = "",
         sel_count: int = 0,
         roll_count: int = 0,
         ask_name: bool = False,
@@ -52,6 +56,7 @@ class GranularSettingsDialog(QDialog):
         self._preselect_ids = preselect_ids
         self._bounds_luma: QCheckBox | None = None
         self._bounds_color: QCheckBox | None = None
+        self._bounds_local: QCheckBox | None = None
         self._name_edit: QLineEdit | None = None
         if show_current:
             self._scope = "current"
@@ -89,7 +94,7 @@ class GranularSettingsDialog(QDialog):
         if show_apply_mode:
             root.addLayout(self._build_mode_row())
         root.addLayout(self._build_checks_row())
-        root.addWidget(self._build_sections(source_cfg, show_bounds, exclude_sections), 1)
+        root.addWidget(self._build_sections(source_cfg, bounds_mode, exclude_sections), 1)
         root.addLayout(self._build_footer(ask_name))
 
         self._apply_visibility()
@@ -149,7 +154,7 @@ class GranularSettingsDialog(QDialog):
         row.addWidget(self._show_unchanged)
         return row
 
-    def _build_sections(self, source_cfg, show_bounds: bool, exclude_sections: frozenset[str] = frozenset()) -> QScrollArea:
+    def _build_sections(self, source_cfg, bounds_mode: str, exclude_sections: frozenset[str] = frozenset()) -> QScrollArea:
         scroll = QScrollArea()
         scroll.setWidgetResizable(True)
         scroll.setFrameShape(QScrollArea.Shape.NoFrame)
@@ -175,9 +180,13 @@ class GranularSettingsDialog(QDialog):
             col.addWidget(section)
             self._sections.append((section, edited_count))
 
-        if show_bounds:
+        if bounds_mode == "axes":
             section = CollapsibleSection("Roll baseline", expanded=True)
             section.set_content(self._build_bounds_rows())
+            col.addWidget(section)
+        elif bounds_mode == "local":
+            section = CollapsibleSection("Normalization bounds", expanded=True)
+            section.set_content(self._build_local_bounds_row(source_cfg.process))
             col.addWidget(section)
 
         col.addStretch()
@@ -219,6 +228,23 @@ class GranularSettingsDialog(QDialog):
             col.addWidget(box)
         return body
 
+    def _build_local_bounds_row(self, process) -> QWidget:
+        """The source frame's own metered bounds, as one opt-out row: they are not
+        catalog fields, so they cannot be listed with the rest."""
+        body = QWidget()
+        row = QHBoxLayout(body)
+        row.setContentsMargins(0, 0, 0, 0)
+        label = "Copied frame's bounds" + (" (locked)" if process.lock_bounds else "")
+        self._bounds_local = QCheckBox(label)
+        self._bounds_local.setChecked(True)
+        self._bounds_local.stateChanged.connect(self._update_apply_enabled)
+        val = QLabel(f"{_triplet(process.local_floors)} → {_triplet(process.local_ceils)}")
+        val.setStyleSheet(f"color: {THEME.text_muted};")
+        row.addWidget(self._bounds_local)
+        row.addStretch()
+        row.addWidget(val)
+        return body
+
     def _build_footer(self, ask_name: bool = False) -> QHBoxLayout:
         row = QHBoxLayout()
         row.addStretch()
@@ -232,7 +258,7 @@ class GranularSettingsDialog(QDialog):
 
     def _all_boxes(self) -> list[QCheckBox]:
         boxes = [box for box, _row, _edited, _line in self._checks]
-        boxes += [b for b in (self._bounds_luma, self._bounds_color) if b is not None]
+        boxes += [b for b in (self._bounds_luma, self._bounds_color, self._bounds_local) if b is not None]
         return boxes
 
     def _on_section_toggled(self, _section, rows: tuple[SettingRow, ...], checked: bool) -> None:
@@ -268,7 +294,7 @@ class GranularSettingsDialog(QDialog):
         for box, _row, edited, _line in self._checks:
             if edited or show_all:
                 box.setChecked(checked)
-        for box in (self._bounds_luma, self._bounds_color):
+        for box in (self._bounds_luma, self._bounds_color, self._bounds_local):
             if box is not None:
                 box.setChecked(checked)
 
@@ -322,6 +348,9 @@ class GranularSettingsDialog(QDialog):
             self._bounds_color is not None and self._bounds_color.isChecked(),
         )
 
+    def paste_bounds(self) -> bool:
+        return self._bounds_local is not None and self._bounds_local.isChecked()
+
     def scope(self) -> str:
         return self._scope
 
@@ -337,10 +366,10 @@ def open_paste_dialog(parent, controller) -> None:
     state = controller.session.state
     if state.clipboard is None or not state.current_file_hash:
         return
-    name = "clipboard (with bounds)" if state.clipboard.process.is_local_initialized else "clipboard"
-    dlg = GranularSettingsDialog(parent, state.clipboard, name, show_scope=False)
+    bounds_mode = "local" if state.clipboard.process.is_local_initialized else ""
+    dlg = GranularSettingsDialog(parent, state.clipboard, "clipboard", bounds_mode=bounds_mode)
     if dlg.exec() == QDialog.DialogCode.Accepted:
-        controller.session.apply_pasted_fields(dlg.selected())
+        controller.session.apply_pasted_fields(dlg.selected(), include_bounds=dlg.paste_bounds())
 
 
 def open_sticky_dialog(parent, controller) -> None:

--- a/negpy/infrastructure/capture/gphoto.py
+++ b/negpy/infrastructure/capture/gphoto.py
@@ -234,6 +234,7 @@ def _safe_value(gp: Any, widget: Any) -> Optional[str]:
     # Even if there are choices, the current value might be unset / NULL pointer.
     try:
         import ctypes
+
         lib = ctypes.CDLL(None)
         get_val = getattr(lib, "gp_widget_get_value", None)
         if get_val and hasattr(widget, "this"):

--- a/tests/test_lock_bounds.py
+++ b/tests/test_lock_bounds.py
@@ -181,6 +181,20 @@ class TestPasteSettingsBounds(unittest.TestCase):
         self.session.apply_pasted_fields([])
         self.assertEqual(self._pasted_process().local_floors, _FLOORS)
 
+    def test_unticked_bounds_row_keeps_target_bounds(self):
+        self._copy_from(True)
+        self._set_target(local_floors=_OTHER_FLOORS, local_ceils=_CEILS, lock_bounds=True)
+        self.session.apply_pasted_fields([_MODE_ROW], include_bounds=False)
+        proc = self._pasted_process()
+        self.assertEqual(proc.local_floors, _OTHER_FLOORS)
+        self.assertTrue(proc.lock_bounds)
+
+    def test_unticked_bounds_row_with_no_rows_is_a_noop(self):
+        self._copy_from(True)
+        self._set_target()
+        self.session.apply_pasted_fields([], include_bounds=False)
+        self.session.update_config.assert_not_called()
+
     def test_plain_paste_keeps_target_bounds(self):
         self._copy_from(False)
         self._set_target(local_floors=_OTHER_FLOORS, local_ceils=_CEILS, lock_bounds=True)

--- a/tests/test_lock_bounds.py
+++ b/tests/test_lock_bounds.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 from PyQt6.QtWidgets import QApplication
 
 from negpy.desktop.controller import AppController
+from negpy.desktop.settings_catalog import SettingRow
 from negpy.desktop.session import AppState, DesktopSessionManager
 from negpy.domain.models import WorkspaceConfig
 from negpy.features.process.models import ProcessConfig, invalidate_local_bounds
@@ -17,6 +18,9 @@ if not QApplication.instance():
 
 _FLOORS = (0.1, 0.2, 0.3)
 _CEILS = (0.8, 0.85, 0.9)
+_OTHER_FLOORS = (0.4, 0.5, 0.6)
+_MODE_ROW = SettingRow("Mode", "process", ("process_mode",))
+_BUFFER_ROW = SettingRow("Analysis Buffer", "process", ("analysis_buffer",))
 
 
 # ── Helper function ───────────────────────────────────────────────────────────
@@ -105,6 +109,102 @@ class TestCopySettingsBounds(unittest.TestCase):
             process=replace(self.session.state.config.process, analysis_buffer=0.99),
         )
         self.assertNotAlmostEqual(clipboard_proc.analysis_buffer, 0.99)
+
+
+class TestPasteSettingsBounds(unittest.TestCase):
+    """Paste must carry the bounds a copy-with-bounds put on the clipboard, and must
+    not touch the target's own bounds when the clipboard has none."""
+
+    def setUp(self):
+        mock_repo = MagicMock(spec=StorageRepository)
+        mock_repo.load_file_settings.return_value = None
+        mock_repo.load_file_settings_by_path.return_value = None
+        mock_repo.get_global_setting.return_value = None
+        mock_repo.get_max_history_index.return_value = 0
+        self.session = DesktopSessionManager(mock_repo)
+        self.session.state.current_file_hash = "hash1"
+        self.session.update_config = MagicMock()
+
+    def _copy_from(self, with_bounds: bool, **process_kwargs):
+        self.session.state.config = replace(
+            WorkspaceConfig(),
+            process=ProcessConfig(local_floors=_FLOORS, local_ceils=_CEILS, lock_bounds=True, **process_kwargs),
+        )
+        if with_bounds:
+            self.session.copy_settings_with_bounds()
+        else:
+            self.session.copy_settings()
+
+    def _set_target(self, **process_kwargs):
+        self.session.state.config = replace(WorkspaceConfig(), process=ProcessConfig(**process_kwargs))
+
+    def _pasted_process(self):
+        return self.session.update_config.call_args.args[0].process
+
+    def test_paste_applies_copied_bounds(self):
+        self._copy_from(True)
+        self._set_target()
+        self.session.apply_pasted_fields([_MODE_ROW])
+        proc = self._pasted_process()
+        self.assertEqual(proc.local_floors, _FLOORS)
+        self.assertEqual(proc.local_ceils, _CEILS)
+
+    def test_paste_applies_copied_lock_flag(self):
+        self._copy_from(True)
+        self._set_target()
+        self.session.apply_pasted_fields([_MODE_ROW])
+        self.assertTrue(self._pasted_process().lock_bounds)
+
+    def test_paste_carries_unlocked_bounds_without_locking(self):
+        self.session.state.config = replace(
+            WorkspaceConfig(),
+            process=ProcessConfig(local_floors=_FLOORS, local_ceils=_CEILS, lock_bounds=False),
+        )
+        self.session.copy_settings_with_bounds()
+        self._set_target()
+        self.session.apply_pasted_fields([_MODE_ROW])
+        proc = self._pasted_process()
+        self.assertEqual(proc.local_floors, _FLOORS)
+        self.assertFalse(proc.lock_bounds)
+
+    def test_pasted_bounds_survive_a_bounds_input_row(self):
+        self._copy_from(True, analysis_buffer=0.25)
+        self._set_target()
+        self.session.apply_pasted_fields([_BUFFER_ROW])
+        proc = self._pasted_process()
+        self.assertAlmostEqual(proc.analysis_buffer, 0.25)
+        self.assertEqual(proc.local_floors, _FLOORS)
+
+    def test_paste_with_bounds_and_no_rows_still_applies_bounds(self):
+        self._copy_from(True)
+        self._set_target()
+        self.session.apply_pasted_fields([])
+        self.assertEqual(self._pasted_process().local_floors, _FLOORS)
+
+    def test_plain_paste_keeps_target_bounds(self):
+        self._copy_from(False)
+        self._set_target(local_floors=_OTHER_FLOORS, local_ceils=_CEILS, lock_bounds=True)
+        self.session.apply_pasted_fields([_MODE_ROW])
+        proc = self._pasted_process()
+        self.assertEqual(proc.local_floors, _OTHER_FLOORS)
+        self.assertTrue(proc.lock_bounds)
+
+    def test_plain_paste_of_a_bounds_input_row_still_invalidates(self):
+        self._copy_from(False, analysis_buffer=0.25)
+        self._set_target(local_floors=_OTHER_FLOORS, local_ceils=_CEILS, lock_bounds=False)
+        self.session.apply_pasted_fields([_BUFFER_ROW])
+        self.assertEqual(self._pasted_process().local_floors, (0.0, 0.0, 0.0))
+
+    def test_plain_paste_of_no_rows_is_a_noop(self):
+        self._copy_from(False)
+        self._set_target()
+        self.session.apply_pasted_fields([])
+        self.session.update_config.assert_not_called()
+
+    def test_paste_without_clipboard_is_a_noop(self):
+        self._set_target()
+        self.session.apply_pasted_fields([_MODE_ROW])
+        self.session.update_config.assert_not_called()
 
 
 # ── Controller crop operations ────────────────────────────────────────────────

--- a/tests/test_paste_bounds_dialog.py
+++ b/tests/test_paste_bounds_dialog.py
@@ -1,0 +1,67 @@
+"""Paste picker's normalization-bounds row: shown only for a clipboard that carries
+per-frame bounds, and opt-out."""
+
+from dataclasses import replace
+
+from PyQt6.QtWidgets import QLabel
+
+from negpy.desktop.view.widgets.granular_settings_dialog import GranularSettingsDialog
+from negpy.domain.models import WorkspaceConfig
+
+_FLOORS = (0.1, 0.2, 0.3)
+_CEILS = (0.8, 0.85, 0.9)
+
+
+def _cfg(**process_kwargs) -> WorkspaceConfig:
+    c = WorkspaceConfig()
+    return replace(c, process=replace(c.process, **process_kwargs))
+
+
+def _bounds_section(dlg) -> bool:
+    return dlg._bounds_local is not None
+
+
+def test_no_bounds_row_without_bounds_mode(qapp):
+    dlg = GranularSettingsDialog(None, _cfg(local_floors=_FLOORS, local_ceils=_CEILS), "clipboard")
+    assert not _bounds_section(dlg)
+    assert not dlg.paste_bounds()
+
+
+def test_bounds_row_is_shown_and_ticked(qapp):
+    cfg = _cfg(local_floors=_FLOORS, local_ceils=_CEILS, lock_bounds=True)
+    dlg = GranularSettingsDialog(None, cfg, "clipboard", bounds_mode="local")
+    assert _bounds_section(dlg)
+    assert dlg.paste_bounds()
+    assert "locked" in dlg._bounds_local.text()
+
+
+def test_bounds_row_reports_the_values(qapp):
+    cfg = _cfg(local_floors=_FLOORS, local_ceils=_CEILS)
+    dlg = GranularSettingsDialog(None, cfg, "clipboard", bounds_mode="local")
+    labels = [w.text() for w in dlg.findChildren(QLabel)]
+    assert "0.1 / 0.2 / 0.3 → 0.8 / 0.85 / 0.9" in labels
+    assert "locked" not in dlg._bounds_local.text()
+
+
+def test_bounds_row_can_be_unticked(qapp):
+    cfg = _cfg(local_floors=_FLOORS, local_ceils=_CEILS)
+    dlg = GranularSettingsDialog(None, cfg, "clipboard", bounds_mode="local")
+    dlg._bounds_local.setChecked(False)
+    assert not dlg.paste_bounds()
+
+
+def test_bounds_row_alone_keeps_apply_enabled(qapp):
+    cfg = _cfg(local_floors=_FLOORS, local_ceils=_CEILS)
+    dlg = GranularSettingsDialog(None, cfg, "clipboard", bounds_mode="local")
+    dlg._set_all_checked(False)
+    assert not dlg.apply_btn.isEnabled()
+    dlg._bounds_local.setChecked(True)
+    assert dlg.apply_btn.isEnabled()
+
+
+def test_axes_mode_keeps_the_roll_baseline_row(qapp):
+    cfg = _cfg(local_floors=_FLOORS, local_ceils=_CEILS)
+    dlg = GranularSettingsDialog(None, cfg, "current", show_scope=True, bounds_mode="axes", sel_count=1)
+    assert dlg._bounds_luma is not None and dlg._bounds_color is not None
+    assert dlg._bounds_local is None
+    assert dlg.bounds_flags() == (False, False)


### PR DESCRIPTION
## Problem

`Ctrl+Shift+C` ("Copy Settings + Bounds") keeps `local_floors`, `local_ceils` and `lock_bounds` on the clipboard, but the paste path never applied them:

- `open_paste_dialog` builds the picker with `show_bounds=False`, so no bounds row exists.
- `apply_selected_fields` only writes fields listed in the settings catalog, and the per-frame bounds are excluded by design.
- If a pasted row is in `_BOUNDS_INPUT_FIELDS`, `invalidate_local_bounds` then cleared the target's *own* bounds.

So the shortcut copied bounds that the paste dropped. `docs/USER_GUIDE.md` already promised "Copy/Paste Settings (with or without normalization bounds)".

## Fix

`apply_pasted_fields` writes the clipboard's `local_floors` / `local_ceils` / `lock_bounds` onto the target when the clipboard carries them (`is_local_initialized`). They are written **after** the rows, so a pasted bounds-input field cannot wipe them. A plain `Ctrl+C` still strips the bounds, so its behaviour is unchanged. A paste with bounds and no picked rows now applies the bounds instead of returning early.

The paste dialog header reads `From "clipboard (with bounds)"` when the bounds ride along.

## Tests

`tests/test_lock_bounds.py::TestPasteSettingsBounds` — 9 cases: bounds applied, lock flag applied, unlocked bounds stay unlocked, bounds survive a bounds-input row, bounds-only paste, plain paste keeps the target's bounds, plain paste still invalidates on a bounds-input row, no-op with empty rows, no-op with an empty clipboard. Five of them fail without the fix.

`make all` green (5167 passed, 11 skipped).

## Docs

`docs/KEYBOARD.md` gains the missing `Ctrl + Shift + C` row.

adresses #981

