### PR TITLE
fix: keep Scan as the Enter-key default in the live-view popup

### DIFF
--- a/negpy/desktop/view/sidebar/live_view_window.py
+++ b/negpy/desktop/view/sidebar/live_view_window.py
@@ -213,6 +213,12 @@ class LiveViewWindow(QDialog):
         self.scan_btn.clicked.connect(lambda: self.scanRequested.emit())
         self.retake_btn.clicked.connect(lambda: self.retakeRequested.emit())
 
+        # Pin Scan as the dialog's permanent default button. Without this, Qt hands "default"
+        # status to whichever autoDefault button was clicked most recently, so pressing Retake
+        # once made Enter keep retaking until Scan was clicked again to reclaim it (issue #997).
+        self.scan_btn.setDefault(True)
+        self.retake_btn.setAutoDefault(False)
+
         # Keyboard shortcuts while the pop-up is focused. There are no text fields here, so
         # letter keys are safe. The buttons respect their gated state.
         for key, btn in (("S", self.scan_btn), ("R", self.retake_btn)):

--- a/tests/test_scanlight_sidebar.py
+++ b/tests/test_scanlight_sidebar.py
@@ -104,6 +104,16 @@ def test_live_view_popup_has_capture_toolbar():
     assert not hasattr(w.lv_window, "mag_btn")  # magnifier button removed (click-to-magnify)
 
 
+def test_scan_button_stays_the_enter_key_default():
+    # Regression for issue #997: clicking Retake must not steal Qt's implicit
+    # default-button status from Scan, or Enter keeps retaking afterwards.
+    w = _sidebar()
+    assert w.lv_window.scan_btn.isDefault()
+    assert not w.lv_window.retake_btn.autoDefault()
+    w.lv_window.retake_btn.click()
+    assert w.lv_window.scan_btn.isDefault()
+
+
 def test_magnifier_click_aims_camera_and_maps_to_grid():
     w = _sidebar()
     w.lv_btn.blockSignals(True)


### PR DESCRIPTION
## Problem
Fixes #997.

In the Scanlight live-view popup (`LiveViewWindow`), Scan and Retake are
two separate `QPushButton`s, and neither ever called `setDefault()`.
Qt's implicit rule hands "default button" status to whichever
`autoDefault` push button was clicked most recently, so pressing Retake
once made the Enter key keep retaking every frame after that, until
Scan was clicked manually to reclaim default status. This matched the
reporter's exact description: Enter defaults to "the last pressed
button on the screen" instead of behaving consistently.

## Fix
Pin `scan_btn` as the dialog's permanent default (`setDefault(True)`)
and opt `retake_btn` out of the default-button rotation
(`setAutoDefault(False)`), so Enter always triggers Scan regardless of
which button was clicked last. This mirrors the `setDefault(True)`
pattern already used by every other capture dialog in the app
(`quick_scan_preview_dialog.py`, `prescan_dialog.py`,
`crosstalk_editor_dialog.py`, etc.) — `LiveViewWindow` was the one
outlier that never pinned a default.

The existing `S`/`R` `QShortcut` letter bindings are untouched, since
they call `.click()` directly and don't go through the default-button
mechanism.

## Testing
- Added `test_scan_button_stays_the_enter_key_default`, which clicks
  Retake and asserts Scan is still the dialog default afterward.
- `uv run pytest tests/test_scanlight_sidebar.py` — 95 passed.
- `uv run ruff check` / `ruff format --check` on the changed files —
  clean.