### PR TITLE
fix: cap HQ-preview GPU load on integrated GPUs to prevent VRAM crash

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -944,7 +944,7 @@ Settings for the whole application, not for one photo. Open them from the canvas
 *   **Preview cache** and **Preview cache limit**: how many recently-viewed photos stay decoded in memory, and the memory ceiling for them. Lower both on a machine with little RAM.
 *   **HQ buffers**: full-resolution HQ preview buffers kept in memory. Each is large — a 60 MP scan is about 700 MB — and keeping the previous frame makes going back instant.
 *   **Rendered frames**: rendered frames held for navigating back with no re-render.
-*   **GPU texture cap**: largest GPU texture dimension. 0 lets the hardware decide; set it to 4096 if exports run the card out of memory.
+*   **GPU texture cap**: largest GPU texture dimension, including HQ preview loads. 0 lets the hardware decide — except on an integrated GPU, where a conservative default applies automatically to avoid a VRAM crash; set it to 4096 if exports run the card out of memory.
 
 Every row from **Preview size** down is read at startup, so a change needs a restart. A value set in `override.toml` wins over these, and its row is greyed out and says so.
 

--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -684,6 +684,7 @@ class AppController(QObject):
         self.preview_load_requested.connect(self.preview_load_worker.process)
         self.preview_load_worker.splash.connect(self._on_splash_preview)
         self.preview_load_worker.finished.connect(self._on_preview_loaded)
+        self.preview_load_worker.vram_capped.connect(self._on_hq_preview_vram_capped)
         self.preview_load_worker.error.connect(self._on_render_error)
         self.preview_load_worker.load_failed.connect(self._on_preview_load_failed)
 
@@ -1657,6 +1658,17 @@ class AppController(QObject):
                 f["decode_failed"] = message
                 self.session.asset_model.refresh()
                 return
+
+    def _on_hq_preview_vram_capped(self, file_path: str, capped_long_edge: int) -> None:
+        """An HQ load exceeded the GPU's VRAM budget and was downsampled instead of
+        crashing (see preview_manager._load_from_open_raw). Non-blocking — the user can
+        keep working at the reduced resolution or raise max_texture_size in Preferences."""
+        if self._requested_file_path != file_path:
+            return
+        self.set_status(
+            f"Scan too large for available GPU memory — showing a {capped_long_edge}px preview instead of full resolution.",
+            5000,
+        )
 
     def _on_preview_loaded(
         self,

--- a/negpy/desktop/view/widgets/preferences_dialog.py
+++ b/negpy/desktop/view/widgets/preferences_dialog.py
@@ -105,7 +105,8 @@ NUMBER_ROWS: tuple[NumberRow, ...] = (
         16384,
         1024,
         " px",
-        "Largest GPU texture dimension. 0 lets the hardware decide.",
+        "Largest GPU texture dimension, including HQ preview loads. 0 lets the hardware "
+        "decide (a lower default applies automatically on integrated GPUs).",
     ),
 )
 

--- a/negpy/desktop/workers/render.py
+++ b/negpy/desktop/workers/render.py
@@ -854,6 +854,9 @@ class PreviewLoadWorker(QObject):
     finished = pyqtSignal(str, object, object, str, object, str, object)
     splash = pyqtSignal(str, object, object)  # (file_path, buffer, dims) — first paint
     error = pyqtSignal(str)
+    # (file_path, applied long-edge cap px): an HQ load exceeded the GPU's VRAM budget
+    # and was downsampled instead of crashing. Emitted alongside `finished`.
+    vram_capped = pyqtSignal(str, int)
     # (file_path, message): the error carries no path, so badge attribution needs this
     load_failed = pyqtSignal(str, str)
 
@@ -898,6 +901,9 @@ class PreviewLoadWorker(QObject):
                     (time.perf_counter() - t0) * 1000,
                     task.file_path,
                 )
+                capped = metadata.get("vram_capped_long_edge")
+                if capped:
+                    self.vram_capped.emit(task.file_path, int(capped))
                 self.finished.emit(
                     task.file_path, raw, dims, source_cs, ir_preview, detected_mode, (metadata.get("cam_xyz"), metadata.get("camera_wb"))
                 )
@@ -921,6 +927,9 @@ class PreviewLoadWorker(QObject):
                     (time.perf_counter() - t0) * 1000,
                     task.file_path,
                 )
+                capped = metadata.get("vram_capped_long_edge")
+                if capped:
+                    self.vram_capped.emit(task.file_path, int(capped))
                 self.finished.emit(
                     task.file_path, raw, dims, source_cs, ir_preview, detected_mode, (metadata.get("cam_xyz"), metadata.get("camera_wb"))
                 )
@@ -944,6 +953,9 @@ class PreviewLoadWorker(QObject):
                     (time.perf_counter() - t0) * 1000,
                     task.file_path,
                 )
+                capped = metadata.get("vram_capped_long_edge")
+                if capped:
+                    self.vram_capped.emit(task.file_path, int(capped))
                 self.finished.emit(
                     task.file_path, raw, dims, source_cs, ir_preview, detected_mode, (metadata.get("cam_xyz"), metadata.get("camera_wb"))
                 )
@@ -980,6 +992,9 @@ class PreviewLoadWorker(QObject):
                 (time.perf_counter() - t0) * 1000,
                 task.file_path,
             )
+            capped = metadata.get("vram_capped_long_edge")
+            if capped:
+                self.vram_capped.emit(task.file_path, int(capped))
             self.finished.emit(
                 task.file_path, raw, dims, source_cs, ir_preview, detected_mode, (metadata.get("cam_xyz"), metadata.get("camera_wb"))
             )

--- a/negpy/infrastructure/gpu/device.py
+++ b/negpy/infrastructure/gpu/device.py
@@ -50,6 +50,17 @@ class GPUDevice:
         return self.device is not None
 
     @property
+    def is_integrated(self) -> bool:
+        """True for an integrated GPU sharing VRAM with system RAM, where a
+        large scan's actual submittable memory can't be queried up front."""
+        if not self.adapter:
+            return False
+        try:
+            return str(self.adapter.info.get("adapter_type", "")) == "IntegratedGPU"
+        except Exception:
+            return False
+
+    @property
     def backend_name(self) -> Optional[str]:
         if not self.adapter:
             return None

--- a/negpy/kernel/system/override.py
+++ b/negpy/kernel/system/override.py
@@ -17,6 +17,13 @@ PREVIEW_SIZE_MIN = 512
 PREVIEW_SIZE_MAX = 8192
 PREVIEW_SIZE_DEFAULT = 1600
 
+# Default long-edge texture cap applied on integrated GPUs when max_texture_size is
+# left at "auto". Integrated GPUs share VRAM with system RAM and wgpu's public API
+# limits (e.g. max-buffer-size) reflect generic device limits, not real available
+# memory, so an uncapped full-resolution load can exceed what the driver can actually
+# submit and crash the app. Discrete GPUs are unaffected and stay uncapped.
+INTEGRATED_GPU_TEXTURE_CAP_DEFAULT = 6144
+
 
 _DEFAULT_TOML_LINUX_WIN = """\
 # NegPy Override Configuration
@@ -50,8 +57,10 @@ qt_platform = "auto"
 # defaults to false while crash reports are investigated. Uncomment to force.
 # cpu_parallel = true
 
-# Cap GPU texture dimensions in pixels.
-# "auto" lets wgpu/hardware decide the maximum. Set a number (e.g. 4096) to cap it.
+# Cap GPU texture dimensions in pixels, including the HQ/full-resolution preview load.
+# "auto" lets wgpu/hardware decide the maximum -- except on an integrated GPU, where NegPy
+# applies a conservative default (currently 6144px) since shared VRAM can't be queried
+# reliably up front. Set a number (e.g. 4096) to override either default.
 max_texture_size = "auto"
 
 # Long edge of the interactive preview, in pixels. Higher is a sharper canvas at 100%
@@ -269,6 +278,21 @@ def apply(cfg: OverrideConfig, app_config: AppConfig) -> None:
 
     if cfg.render_memo_max_entries is not None:
         app_config.render_memo_max_entries = cfg.render_memo_max_entries
+
+
+def effective_max_texture_size(app_config: AppConfig, gpu: Any) -> int | None:
+    """The texture-size budget to enforce for a full-resolution GPU load.
+
+    An explicit max_texture_size (override.toml or Preferences) always wins. Absent
+    that, an integrated GPU gets a conservative default since its real available
+    VRAM can't be queried reliably. A discrete GPU stays uncapped ("auto"), i.e.
+    returns None.
+    """
+    if app_config.max_texture_size is not None:
+        return app_config.max_texture_size
+    if gpu is not None and getattr(gpu, "is_integrated", False):
+        return INTEGRATED_GPU_TEXTURE_CAP_DEFAULT
+    return None
 
 
 # The [performance] numbers a user can also set in Preferences, saved under these exact key

--- a/negpy/services/rendering/preview_manager.py
+++ b/negpy/services/rendering/preview_manager.py
@@ -18,9 +18,11 @@ from negpy.infrastructure.loaders.helpers import (
     get_best_demosaic_algorithm,
     is_xtrans,
 )
+from negpy.infrastructure.gpu.device import GPUDevice
 from negpy.kernel.image.logic import apply_exif_orientation, ensure_rgb, uint16_to_float32
 from negpy.kernel.image.validation import ensure_image
 from negpy.kernel.system.config import APP_CONFIG
+from negpy.kernel.system.override import effective_max_texture_size
 from negpy.features.flatfield.logic import apply_flatfield, flatfield_token
 from negpy.features.flatfield.models import FlatFieldConfig
 from negpy.features.retouch.logic import downsample_ir
@@ -213,7 +215,27 @@ class PreviewManager:
             h_orig, w_orig = (h_p, w_p)
         t_resize0 = time.perf_counter()
         max_res = APP_CONFIG.preview_render_size
-        if max(h_p, w_p) > max_res and not full_resolution:
+        # A full-resolution (HQ) load skips the preview_render_size cap above, but the decoded
+        # buffer still has to land in a GPU texture. On an integrated GPU sharing VRAM with
+        # system RAM, an uncapped multi-thousand-pixel buffer can exceed what the driver can
+        # actually submit -- radv/amdgpu reports "not enough memory for command submission" and
+        # wgpu-native aborts the process (a Rust panic across the FFI boundary, not a catchable
+        # Python exception). Cap the HQ load too, so this degrades to a smaller preview instead.
+        vram_cap = effective_max_texture_size(APP_CONFIG, GPUDevice.get()) if full_resolution else None
+        if vram_cap is not None and max(h_p, w_p) > vram_cap:
+            scale = vram_cap / max(h_p, w_p)
+            target_w = int(w_p * scale)
+            target_h = int(h_p * scale)
+            preview_raw = ensure_image(
+                cv2.resize(
+                    full_linear,
+                    (target_w, target_h),
+                    interpolation=cv2.INTER_AREA,
+                )
+            )
+            metadata["vram_capped_long_edge"] = vram_cap
+            log("preview vram_cap applied: %dx%d -> %dx%d", w_p, h_p, target_w, target_h)
+        elif max(h_p, w_p) > max_res and not full_resolution:
             scale = max_res / max(h_p, w_p)
             target_w = int(w_p * scale)
             target_h = int(h_p * scale)

--- a/tests/test_override_config.py
+++ b/tests/test_override_config.py
@@ -3,10 +3,12 @@ import os
 import sys
 import tempfile
 import unittest
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from negpy.domain.types import AppConfig
 from negpy.kernel.system.override import (
+    INTEGRATED_GPU_TEXTURE_CAP_DEFAULT,
     PREVIEW_SIZE_MAX,
     PREVIEW_SIZE_MIN,
     OverrideConfig,
@@ -14,6 +16,7 @@ from negpy.kernel.system.override import (
     _platform_defaults,
     apply,
     apply_stored,
+    effective_max_texture_size,
     load_or_create,
     toml_pinned_keys,
 )
@@ -428,3 +431,27 @@ class TestStoredPreferences(unittest.TestCase):
             toml_pinned_keys(OverrideConfig(preview_render_size=1024, max_texture_size=2048)),
             {"preview_render_size", "max_texture_size"},
         )
+
+
+class TestEffectiveMaxTextureSize(unittest.TestCase):
+    """Precedence for the HQ-preview VRAM cap: explicit override > integrated-GPU
+    default > uncapped."""
+
+    def test_explicit_override_wins(self):
+        app = _make_app_config(max_texture_size=4096)
+        gpu = SimpleNamespace(is_integrated=True)
+        self.assertEqual(effective_max_texture_size(app, gpu), 4096)
+
+    def test_integrated_gpu_gets_conservative_default(self):
+        app = _make_app_config(max_texture_size=None)
+        gpu = SimpleNamespace(is_integrated=True)
+        self.assertEqual(effective_max_texture_size(app, gpu), INTEGRATED_GPU_TEXTURE_CAP_DEFAULT)
+
+    def test_discrete_gpu_stays_uncapped(self):
+        app = _make_app_config(max_texture_size=None)
+        gpu = SimpleNamespace(is_integrated=False)
+        self.assertIsNone(effective_max_texture_size(app, gpu))
+
+    def test_no_gpu_stays_uncapped(self):
+        app = _make_app_config(max_texture_size=None)
+        self.assertIsNone(effective_max_texture_size(app, None))

--- a/tests/test_preview_load_worker_detect_mode.py
+++ b/tests/test_preview_load_worker_detect_mode.py
@@ -110,3 +110,52 @@ def test_automatic_import_returns_classifier_result_from_public_process(qapp):
 
     dpm.assert_called_once_with(raw)
     assert finished[0][5] == ProcessMode.E6
+
+
+def test_vram_capped_emits_when_metadata_flags_it(qapp):
+    """A capped HQ load (see preview_manager._load_from_open_raw) fires vram_capped
+    alongside finished, so the controller can surface a status message instead of
+    the load silently coming back smaller than requested."""
+    from negpy.desktop.workers.render import PreviewLoadTask, PreviewLoadWorker
+
+    service = MagicMock()
+    raw = np.ones((4, 4, 3), dtype=np.float32)
+    service.load_linear_preview.return_value = (raw, (4, 4), {"vram_capped_long_edge": 6144})
+    worker = PreviewLoadWorker(service)
+    capped = []
+    worker.vram_capped.connect(lambda *args: capped.append(args))
+    task = PreviewLoadTask(
+        file_path="big.tif",
+        workspace_color_space="Adobe RGB",
+        use_camera_wb=False,
+        use_splash=False,
+        full_resolution=True,
+        detect_mode=False,
+    )
+
+    worker.process(task)
+
+    assert capped == [("big.tif", 6144)]
+
+
+def test_vram_capped_does_not_emit_when_uncapped(qapp):
+    from negpy.desktop.workers.render import PreviewLoadTask, PreviewLoadWorker
+
+    service = MagicMock()
+    raw = np.ones((4, 4, 3), dtype=np.float32)
+    service.load_linear_preview.return_value = (raw, (4, 4), {})
+    worker = PreviewLoadWorker(service)
+    capped = []
+    worker.vram_capped.connect(lambda *args: capped.append(args))
+    task = PreviewLoadTask(
+        file_path="small.tif",
+        workspace_color_space="Adobe RGB",
+        use_camera_wb=False,
+        use_splash=False,
+        full_resolution=True,
+        detect_mode=False,
+    )
+
+    worker.process(task)
+
+    assert capped == []

--- a/tests/test_preview_manager.py
+++ b/tests/test_preview_manager.py
@@ -60,6 +60,95 @@ def test_load_linear_preview_downscales_to_preview_render_size() -> None:
     assert buf.dtype == np.float32
 
 
+def test_load_linear_preview_hq_downscales_to_vram_cap_on_integrated_gpu() -> None:
+    """full_resolution=True on an integrated GPU still gets capped, unlike the uncapped
+    full-res path — this is the fix for the OOM crash on large scans on shared-VRAM GPUs."""
+    h, w = 8000, 6000
+    data = np.full((h, w, 3), 0.5, dtype=np.float32)
+    ctx = NonStandardFileWrapper(data)
+    fake_cfg = SimpleNamespace(
+        preview_render_size=1600,
+        max_texture_size=None,
+        canvas_zoom_min=0.25,
+        canvas_zoom_max=8.0,
+        preview_cache_max_entries=8,
+        preview_cache_max_bytes=10**9,
+    )
+    fake_gpu = SimpleNamespace(is_integrated=True)
+
+    with (
+        patch("negpy.services.rendering.preview_manager.loader_factory") as lf,
+        patch("negpy.services.rendering.preview_manager.APP_CONFIG", fake_cfg),
+        patch("negpy.services.rendering.preview_manager.GPUDevice") as gpu_device_cls,
+    ):
+        gpu_device_cls.get.return_value = fake_gpu
+        lf.get_loader.return_value = (ctx, {"color_space": "Adobe RGB"})
+        buf, dims, out_meta = PreviewManager().load_linear_preview("/fake/path.tif", full_resolution=True)
+
+    assert dims == (8000, 6000)
+    assert max(buf.shape[0], buf.shape[1]) == 6144
+    assert out_meta["vram_capped_long_edge"] == 6144
+
+
+def test_load_linear_preview_hq_explicit_max_texture_size_wins_over_integrated_default() -> None:
+    """An explicit max_texture_size (override.toml/Preferences) takes precedence over the
+    integrated-GPU default."""
+    h, w = 8000, 6000
+    data = np.full((h, w, 3), 0.5, dtype=np.float32)
+    ctx = NonStandardFileWrapper(data)
+    fake_cfg = SimpleNamespace(
+        preview_render_size=1600,
+        max_texture_size=2048,
+        canvas_zoom_min=0.25,
+        canvas_zoom_max=8.0,
+        preview_cache_max_entries=8,
+        preview_cache_max_bytes=10**9,
+    )
+    fake_gpu = SimpleNamespace(is_integrated=True)
+
+    with (
+        patch("negpy.services.rendering.preview_manager.loader_factory") as lf,
+        patch("negpy.services.rendering.preview_manager.APP_CONFIG", fake_cfg),
+        patch("negpy.services.rendering.preview_manager.GPUDevice") as gpu_device_cls,
+    ):
+        gpu_device_cls.get.return_value = fake_gpu
+        lf.get_loader.return_value = (ctx, {"color_space": "Adobe RGB"})
+        buf, _, out_meta = PreviewManager().load_linear_preview("/fake/path.tif", full_resolution=True)
+
+    assert max(buf.shape[0], buf.shape[1]) == 2048
+    assert out_meta["vram_capped_long_edge"] == 2048
+
+
+def test_load_linear_preview_hq_uncapped_on_discrete_gpu() -> None:
+    """A discrete GPU (not integrated) with no explicit max_texture_size stays uncapped,
+    matching the pre-fix full-resolution behavior."""
+    h, w = 8000, 6000
+    data = np.full((h, w, 3), 0.5, dtype=np.float32)
+    ctx = NonStandardFileWrapper(data)
+    fake_cfg = SimpleNamespace(
+        preview_render_size=1600,
+        max_texture_size=None,
+        canvas_zoom_min=0.25,
+        canvas_zoom_max=8.0,
+        preview_cache_max_entries=8,
+        preview_cache_max_bytes=10**9,
+    )
+    fake_gpu = SimpleNamespace(is_integrated=False)
+
+    with (
+        patch("negpy.services.rendering.preview_manager.loader_factory") as lf,
+        patch("negpy.services.rendering.preview_manager.APP_CONFIG", fake_cfg),
+        patch("negpy.services.rendering.preview_manager.GPUDevice") as gpu_device_cls,
+    ):
+        gpu_device_cls.get.return_value = fake_gpu
+        lf.get_loader.return_value = (ctx, {"color_space": "Adobe RGB"})
+        buf, dims, out_meta = PreviewManager().load_linear_preview("/fake/path.tif", full_resolution=True)
+
+    assert dims == (8000, 6000)
+    assert max(buf.shape[0], buf.shape[1]) == 8000
+    assert "vram_capped_long_edge" not in out_meta
+
+
 def test_load_linear_preview_fast_path_line_and_half() -> None:
     """Default (non-HQ) raw: LINEAR + half_size."""
     rgb_u16 = np.zeros((32, 24, 3), dtype=np.uint16)


### PR DESCRIPTION
## Summary

Scanning at 7200dpi (or importing even a modest TIFF) with HQ preview enabled would crash the app outright on an integrated GPU. The full decoded buffer was handed straight to the GPU pipeline with no size budget, and when the driver couldn't actually submit it (radv/amdgpu "not enough memory for command submission"), wgpu-native's Rust panic-on-device-lost aborts the whole process — not a catchable Python exception, since wgpu-native is built with `panic=abort` across the FFI boundary. There was no failsafe: it just took the app down.

This adds one. The full-resolution preview load is now capped against an adapter-aware budget:
- An explicit `max_texture_size` (override.toml or Preferences) always wins.
- Otherwise, an integrated GPU (detected via `adapter.info.adapter_type`) gets a conservative 6144px default.
- Discrete GPUs stay uncapped, as before.

A capped load now downsamples gracefully and surfaces a status message instead of crashing — HQ preview is usable on an iGPU again.

## Test plan
- [x] `make all` (format + lint + type + full test suite) passes
- [x] Added unit tests for the override resolution (`tests/test_override_config.py`), the render worker's mode detection (`tests/test_preview_load_worker_detect_mode.py`), and the preview manager's capped-load path (`tests/test_preview_manager.py`)
- [x] Reproduced the crash on integrated-GPU hardware and confirmed the fix stops it