### PR TITLE
Use native per-axis scanner resolution, resampling y to reach beyond it

### DIFF
--- a/negpy/infrastructure/scanners/sane_backend.py
+++ b/negpy/infrastructure/scanners/sane_backend.py
@@ -155,15 +155,81 @@ def _preload_libsane() -> None:
 
 
 def _detect_dpi(opt) -> tuple[int, ...]:
-    if "resolution" not in opt:
+    axis = tuple(sorted(_resolve_resampled_resolutions(opt).keys()))
+    plain: tuple[int, ...] | None = None
+    if "resolution" in opt:
+        constraint = opt["resolution"].constraint
+        # python-sane: list == enumerated values, tuple == (min, max, step) range.
+        if isinstance(constraint, list):
+            plain = tuple(sorted(int(c) for c in constraint))
+        elif isinstance(constraint, tuple) and len(constraint) >= 2:
+            plain = dpi_stops_in_range(constraint[0], constraint[1])
+        else:
+            plain = CANONICAL_DPI_STOPS
+    # Prefer the x/y-derived ladder whenever it reaches higher: some backends (confirmed on
+    # this project's reference Epson V500, over epkowa/interpreter) expose `resolution` as an
+    # artificially narrow convenience subset of the device's real native resolution — which,
+    # since one axis is typically CCD-pitch-limited and the other stepper-motor-step-limited,
+    # can only be reached by setting `x_resolution`/`y_resolution` independently. See
+    # _resolve_resampled_resolutions: a target whose exact value isn't native on both axes is
+    # still reachable by resampling the coarser axis up to match, so `axis` already covers (and
+    # supersedes) the plain square-intersection case, at no extra cost when they coincide.
+    if axis and (plain is None or max(axis) > max(plain)):
+        return axis
+    if plain is not None:
+        return plain
+    return axis  # () when the device has no resolution info of any kind.
+
+
+def _resolve_square_resolutions(opt) -> tuple[int, ...]:
+    """DPI values settable identically on both axes via `x_resolution`/`y_resolution`, with no
+    resampling needed. A strict subset of _resolve_resampled_resolutions's keys — kept as its
+    own function since "zero resampling" is occasionally the more precise thing to ask for.
+
+    Returns the sorted intersection of both axes' discrete value sets when both are present as
+    enumerated lists (not e.g. a plain min/max range). Empty when either option is absent, not
+    a discrete list, or the two axes' value sets don't overlap.
+    """
+    if "x_resolution" not in opt or "y_resolution" not in opt:
         return ()
-    constraint = opt["resolution"].constraint
-    # python-sane: list == enumerated values, tuple == (min, max, step) range.
-    if isinstance(constraint, list):
-        return tuple(sorted(int(c) for c in constraint))
-    if isinstance(constraint, tuple) and len(constraint) >= 2:
-        return dpi_stops_in_range(constraint[0], constraint[1])
-    return CANONICAL_DPI_STOPS
+    x_constraint = opt["x_resolution"].constraint
+    y_constraint = opt["y_resolution"].constraint
+    if not isinstance(x_constraint, list) or not isinstance(y_constraint, list):
+        return ()
+    x_values = {int(v) for v in x_constraint}
+    y_values = {int(v) for v in y_constraint}
+    return tuple(sorted(x_values & y_values))
+
+
+def _resolve_resampled_resolutions(opt) -> dict[int, int]:
+    """Target DPI -> native y_resolution to request, reaching resolutions beyond what either
+    axis alone (or their exact intersection) offers by resampling the slower axis up to match.
+
+    `x_resolution` is always requested at the exact target: on the reference device (Epson
+    V500, epkowa/interpreter) it is the sensor-pitch axis and has a native step at every target
+    worth offering. `y_resolution` — the carriage/stepper axis, whose native ladder can differ
+    from x's and even change shape between sources (confirmed: TPU mode drops 3200/6400 from
+    this device's y ladder entirely) — is requested at the largest native value not exceeding
+    the target, and the gap is resampled up in software afterward.
+
+    Deliberately upsample-only: interpolating in more rows than the stepper actually moved
+    is an honest resample of real data, never inventing detail a downsample would have thrown
+    away. Empty when either axis option is absent or not a discrete list. A target below the
+    y axis's own minimum has no native value to upsample from and is omitted, not clamped.
+    """
+    if "x_resolution" not in opt or "y_resolution" not in opt:
+        return {}
+    x_constraint = opt["x_resolution"].constraint
+    y_constraint = opt["y_resolution"].constraint
+    if not isinstance(x_constraint, list) or not isinstance(y_constraint, list):
+        return {}
+    y_values = sorted(int(v) for v in y_constraint)
+    result: dict[int, int] = {}
+    for x in sorted(int(v) for v in x_constraint):
+        native_y_candidates = [y for y in y_values if y <= x]
+        if native_y_candidates:
+            result[x] = max(native_y_candidates)
+    return result
 
 
 def _detect_depths(opt) -> tuple[int, ...]:
@@ -661,6 +727,23 @@ def _align_ir_to_rgb(rgb: np.ndarray, ir: np.ndarray) -> np.ndarray:
     return ir[y_idx][:, x_idx]
 
 
+def _resample_rows_to_dpi(array: np.ndarray, *, native_dpi: int, target_dpi: int) -> np.ndarray:
+    """Upsample only the row (y/carriage) axis so it represents target_dpi, leaving the column
+    (x/sensor) axis untouched — see _resolve_resampled_resolutions for why only y ever needs
+    this. Always an upsample (target_dpi > native_dpi is a precondition, enforced by the
+    caller): interpolating in more rows than the stepper actually moved is an honest resample
+    of real data, never inventing detail a downsample would have thrown away.
+
+    Bilinear (cv2's default): plenty for reconciling a mechanically-limited stepper axis
+    against a genuinely finer sensor axis. Not used anywhere IR is involved — see the
+    capture_ir guard at the call site — since _align_ir_to_rgb documents that even
+    interpolating IR data risks softening a thin dust defect's minimum.
+    """
+    target_rows = max(1, round(array.shape[0] * target_dpi / native_dpi))
+    width = array.shape[1]
+    return cv2.resize(array, (width, target_rows), interpolation=cv2.INTER_LINEAR)
+
+
 def _validate_inline_rgbi_parameters(
     *,
     frame_format,
@@ -1071,7 +1154,50 @@ class SaneBackend:
             if hasattr(dev, "opt") and "mode" in dev.opt:
                 dev.mode = "RGBI" if (ir_strategy == "rgbi" or ir_strategy == "rgbi-hw3") else "Color"
             dev.depth = params.depth
-            dev.resolution = params.dpi
+
+            # `resolution` alone is sometimes an artificially narrow convenience subset of what
+            # the device can actually do (confirmed on this project's reference Epson V500,
+            # epkowa/interpreter backend: `resolution` tops out at 1600dpi while the native
+            # per-axis ladders reach 6400). When the device exposes settable-per-axis resolution
+            # options, use those instead: `x_resolution` at the exact target (the sensor-pitch
+            # axis has a native step at every target worth offering), `y_resolution` at the
+            # nearest native value at or below it (the carriage/stepper axis, whose ladder can
+            # differ from x's and even lose top-end values depending on source — confirmed: this
+            # device's y ladder drops 3200/6400 entirely under the Transparency Unit). Any gap
+            # between the two is resampled up in software after the read, below. This is what
+            # _detect_dpi() offers in the UI, so an exact match is expected in normal use; fail
+            # loudly rather than silently substitute a nearby value if it's ever missing — a
+            # silent substitution here risks the same class of bug as setting resolution against
+            # stale geometry did earlier, since crop/window math downstream assumes the DPI
+            # actually applied.
+            resampled_dpis = _resolve_resampled_resolutions(option_map)
+            y_native_dpi: int | None = None
+            if resampled_dpis:
+                if params.dpi not in resampled_dpis:
+                    raise RuntimeError(
+                        f"{params.dpi}dpi is not reachable on this device's per-axis "
+                        f"resolution options; choose one of {sorted(resampled_dpis)}"
+                    )
+                y_native_dpi = resampled_dpis[params.dpi]
+                if y_native_dpi != params.dpi and params.capture_ir:
+                    # Resampling the y axis means resampling IR too, to keep the two aligned
+                    # for dust masking — but _align_ir_to_rgb documents that interpolating the
+                    # IR channel at all risks softening a thin dust defect's minimum below what
+                    # the detection pipeline's noise floor expects (a downsample case measured
+                    # there, 0.22 -> 0.31, "shattered"). Untested for the upsample case this is,
+                    # and not worth guessing on a precision-sensitive measurement: fail loudly
+                    # and let the caller pick a DPI native on both axes instead.
+                    raise RuntimeError(
+                        f"{params.dpi}dpi needs resampling the y axis from its native "
+                        f"{y_native_dpi}dpi, which is not supported together with IR capture. "
+                        f"Choose a DPI native on both axes for IR scans: "
+                        f"{_resolve_square_resolutions(option_map)}"
+                    )
+                dev.x_resolution = params.dpi
+                dev.y_resolution = y_native_dpi
+            else:
+                dev.resolution = params.dpi
+
 
             # Validate the complete requested option set before applying any of it, so a missing
             # option never leaves the feeder half-positioned.
@@ -1251,6 +1377,14 @@ class SaneBackend:
                     progress(1.0)
                 except Exception:
                     pass
+
+            # Upsample the carriage/stepper (y/row) axis to match the sensor (x/column) axis
+            # when the requested DPI needed native y < target — see _resolve_resampled_resolutions
+            # above. x is never resampled: on the reference device it always had a native step at
+            # the target already. IR capture together with a resampled DPI is rejected earlier
+            # (see the guard above), so only rgb_array is ever touched here.
+            if y_native_dpi is not None and y_native_dpi != params.dpi:
+                rgb_array = _resample_rows_to_dpi(rgb_array, native_dpi=y_native_dpi, target_dpi=params.dpi)
 
             if ir_array is not None and ir_valid_mask is None:
                 ir_valid_mask = np.ones(ir_array.shape[:2], dtype=np.bool_)

--- a/tests/scanners/test_capabilities.py
+++ b/tests/scanners/test_capabilities.py
@@ -318,6 +318,45 @@ class TestSplitRgbi:
         assert np.array_equal(ir, arr[:, :, 3])
 
 
+class TestResampleRowsToDpi:
+    """`_resample_rows_to_dpi`: upsample only the row (y) axis to represent a higher DPI,
+    leaving columns (x) untouched — the mechanism behind _resolve_resampled_resolutions."""
+
+    def test_upsamples_rows_by_the_dpi_ratio(self) -> None:
+        from negpy.infrastructure.scanners.sane_backend import _resample_rows_to_dpi
+
+        arr = np.zeros((4, 10, 3), dtype=np.uint8)
+        out = _resample_rows_to_dpi(arr, native_dpi=2400, target_dpi=3200)
+
+        assert out.shape[0] == round(4 * 3200 / 2400)  # 5
+        assert out.shape[1] == 10  # columns untouched
+        assert out.shape[2] == 3
+
+    def test_preserves_dtype(self) -> None:
+        from negpy.infrastructure.scanners.sane_backend import _resample_rows_to_dpi
+
+        arr = np.full((4, 4, 3), 1000, dtype=np.uint16)
+        out = _resample_rows_to_dpi(arr, native_dpi=2400, target_dpi=3200)
+
+        assert out.dtype == np.uint16
+
+    def test_works_on_2d_grayscale(self) -> None:
+        from negpy.infrastructure.scanners.sane_backend import _resample_rows_to_dpi
+
+        arr = np.zeros((4, 10), dtype=np.uint8)
+        out = _resample_rows_to_dpi(arr, native_dpi=2400, target_dpi=3200)
+
+        assert out.shape == (5, 10)
+
+    def test_exact_multiple_matches_expected_row_count(self) -> None:
+        from negpy.infrastructure.scanners.sane_backend import _resample_rows_to_dpi
+
+        arr = np.zeros((100, 10, 3), dtype=np.uint8)
+        out = _resample_rows_to_dpi(arr, native_dpi=1600, target_dpi=3200)
+
+        assert out.shape[0] == 200
+
+
 class TestScanExposureTimeCapability:
     """Detection of the SANE `scan-exposure-time` option (e.g. genesys)."""
 
@@ -418,3 +457,192 @@ class TestResolveFilmType:
         from negpy.infrastructure.scanners.sane_backend import _resolve_film_type
 
         assert _resolve_film_type({}, "negative") is None
+
+
+# Real values from `scanimage --help` on the project's reference Epson V500
+# (epkowa/interpreter backend): `--resolution` and `--x-resolution`/`--y-resolution` report
+# genuinely different, asymmetric native ladders.
+_V500_X_RESOLUTIONS = [100, 200, 400, 600, 800, 1200, 1600, 3200, 6400]
+_V500_Y_RESOLUTIONS = [80, 200, 320, 400, 600, 800, 1200, 1600, 2400, 3200, 4800, 6400]
+_V500_PLAIN_RESOLUTIONS = [200, 400, 800, 1600]
+
+
+class TestResolveSquareResolutions:
+    """`_resolve_square_resolutions`: DPI values settable identically on both axes, so pixels
+    stay square, when a device exposes `x_resolution`/`y_resolution` independently."""
+
+    def test_intersects_asymmetric_axis_ladders(self) -> None:
+        from negpy.infrastructure.scanners.sane_backend import _resolve_square_resolutions
+
+        opt = {
+            "x_resolution": FakeOption(constraint=_V500_X_RESOLUTIONS),
+            "y_resolution": FakeOption(constraint=_V500_Y_RESOLUTIONS),
+        }
+        assert _resolve_square_resolutions(opt) == (200, 400, 600, 800, 1200, 1600, 3200, 6400)
+
+    def test_missing_either_axis_returns_empty(self) -> None:
+        from negpy.infrastructure.scanners.sane_backend import _resolve_square_resolutions
+
+        assert _resolve_square_resolutions({"x_resolution": FakeOption(constraint=[100, 200])}) == ()
+        assert _resolve_square_resolutions({"y_resolution": FakeOption(constraint=[100, 200])}) == ()
+        assert _resolve_square_resolutions({}) == ()
+
+    def test_non_list_constraint_returns_empty(self) -> None:
+        """A plain (min, max, step) range would be unusual for this option, but must not raise."""
+        from negpy.infrastructure.scanners.sane_backend import _resolve_square_resolutions
+
+        opt = {
+            "x_resolution": FakeOption(constraint=(50, 6400, 1)),
+            "y_resolution": FakeOption(constraint=[100, 200]),
+        }
+        assert _resolve_square_resolutions(opt) == ()
+
+    def test_no_overlap_returns_empty(self) -> None:
+        from negpy.infrastructure.scanners.sane_backend import _resolve_square_resolutions
+
+        opt = {
+            "x_resolution": FakeOption(constraint=[100, 300]),
+            "y_resolution": FakeOption(constraint=[200, 400]),
+        }
+        assert _resolve_square_resolutions(opt) == ()
+
+
+class TestDetectDpiPrefersRicherAxisLadder:
+    """_detect_dpi: prefer the x/y-derived ladder over `resolution` alone whenever it reaches
+    higher — this is the actual bug found on the V500, where `resolution` alone caps at
+    1600dpi despite the device supporting 6400dpi per axis."""
+
+    def test_v500_reports_up_to_6400_not_1600(self) -> None:
+        from negpy.infrastructure.scanners.sane_backend import _detect_dpi
+
+        opt = {
+            "resolution": FakeOption(constraint=_V500_PLAIN_RESOLUTIONS),
+            "x_resolution": FakeOption(constraint=_V500_X_RESOLUTIONS),
+            "y_resolution": FakeOption(constraint=_V500_Y_RESOLUTIONS),
+        }
+        dpis = _detect_dpi(opt)
+        assert max(dpis) == 6400
+        # 100 is reachable too: x has a native 100 step, and y's minimum (80) is below it, so
+        # it's an upsample away — see _resolve_resampled_resolutions.
+        assert dpis == (100, 200, 400, 600, 800, 1200, 1600, 3200, 6400)
+
+
+    def test_falls_back_to_plain_resolution_when_axis_ladder_is_not_richer(self) -> None:
+        from negpy.infrastructure.scanners.sane_backend import _detect_dpi
+
+        opt = {
+            "resolution": FakeOption(constraint=[100, 200, 300, 400, 600, 1200]),
+            "x_resolution": FakeOption(constraint=[100, 200]),
+            "y_resolution": FakeOption(constraint=[100, 200]),
+        }
+        assert _detect_dpi(opt) == (100, 200, 300, 400, 600, 1200)
+
+    def test_falls_back_to_plain_resolution_when_no_axis_options(self) -> None:
+        from negpy.infrastructure.scanners.sane_backend import _detect_dpi
+
+        opt = {"resolution": FakeOption(constraint=[150, 300, 600, 1200])}
+        assert _detect_dpi(opt) == (150, 300, 600, 1200)
+
+    def test_uses_axis_ladder_when_resolution_option_is_absent(self) -> None:
+        from negpy.infrastructure.scanners.sane_backend import _detect_dpi
+
+        opt = {
+            "x_resolution": FakeOption(constraint=_V500_X_RESOLUTIONS),
+            "y_resolution": FakeOption(constraint=_V500_Y_RESOLUTIONS),
+        }
+        assert max(_detect_dpi(opt)) == 6400
+
+    def test_no_resolution_info_at_all_returns_empty(self) -> None:
+        """Must stay empty, not CANONICAL_DPI_STOPS: pixel-geometry devices with no DPI info
+        fall back to a 35mm default area, which relies on this being falsy."""
+        from negpy.infrastructure.scanners.sane_backend import _detect_dpi
+
+        assert _detect_dpi({}) == ()
+
+
+# Real values from the reference V500 under the Transparency Unit specifically (not the plain
+# `scanimage --help` dump, which reads the Flatbed default): the y ladder actually loses its
+# top two steps (3200, 6400) under TPU, gaining a 9600 instead of them.
+_V500_TPU_X_RESOLUTIONS = [100, 200, 300, 400, 600, 800, 1200, 1600, 3200, 6400]
+_V500_TPU_Y_RESOLUTIONS = [120, 200, 320, 400, 600, 800, 1200, 1600, 2400, 4800, 9600]
+
+
+class TestResolveResampledResolutions:
+    """`_resolve_resampled_resolutions`: target DPI -> native y to request, reaching values
+    neither axis alone (nor their exact intersection) offers by upsampling y in software.
+
+    This is the actual case that motivated the function: under the reference V500's
+    Transparency Unit, y's native ladder drops 3200 and 6400 entirely, so the exact
+    intersection with x tops out at 1600 — but x itself has native 3200/6400 steps, and y's
+    2400 is a legitimate upsample source for a 3200 target.
+    """
+
+    def test_3200_target_upsamples_from_native_y_2400(self) -> None:
+        from negpy.infrastructure.scanners.sane_backend import _resolve_resampled_resolutions
+
+        opt = {
+            "x_resolution": FakeOption(constraint=_V500_TPU_X_RESOLUTIONS),
+            "y_resolution": FakeOption(constraint=_V500_TPU_Y_RESOLUTIONS),
+        }
+        resolved = _resolve_resampled_resolutions(opt)
+        assert resolved[3200] == 2400
+
+    def test_exact_matches_need_no_resample(self) -> None:
+        from negpy.infrastructure.scanners.sane_backend import _resolve_resampled_resolutions
+
+        opt = {
+            "x_resolution": FakeOption(constraint=_V500_TPU_X_RESOLUTIONS),
+            "y_resolution": FakeOption(constraint=_V500_TPU_Y_RESOLUTIONS),
+        }
+        resolved = _resolve_resampled_resolutions(opt)
+        for value in (200, 400, 600, 800, 1200, 1600):
+            assert resolved[value] == value
+
+    def test_6400_target_upsamples_from_native_y_4800(self) -> None:
+        from negpy.infrastructure.scanners.sane_backend import _resolve_resampled_resolutions
+
+        opt = {
+            "x_resolution": FakeOption(constraint=_V500_TPU_X_RESOLUTIONS),
+            "y_resolution": FakeOption(constraint=_V500_TPU_Y_RESOLUTIONS),
+        }
+        assert _resolve_resampled_resolutions(opt)[6400] == 4800
+
+    def test_never_downsamples(self) -> None:
+        """A target below y's own minimum has nothing valid to upsample from and is omitted,
+        not clamped to the nearest-above value (that would be a downsample of y)."""
+        from negpy.infrastructure.scanners.sane_backend import _resolve_resampled_resolutions
+
+        opt = {
+            "x_resolution": FakeOption(constraint=[50, 100, 200]),
+            "y_resolution": FakeOption(constraint=[120, 200]),
+        }
+        resolved = _resolve_resampled_resolutions(opt)
+        assert 50 not in resolved  # below y's minimum (120): nothing to upsample from
+        assert 100 not in resolved  # same: 100 < 120
+        assert resolved[200] == 200
+
+    def test_missing_either_axis_returns_empty(self) -> None:
+        from negpy.infrastructure.scanners.sane_backend import _resolve_resampled_resolutions
+
+        assert _resolve_resampled_resolutions({}) == {}
+        assert _resolve_resampled_resolutions({"x_resolution": FakeOption(constraint=[100])}) == {}
+
+    def test_v500_flatbed_ladder_matches_square_intersection_plus_extras(self) -> None:
+        """Under Flatbed (where y keeps its full ladder, per _V500_Y_RESOLUTIONS), resampling
+        should recover everything the exact intersection did, plus low-end values (100) that
+        square-intersection alone missed because 100 isn't in y's list, just below it (80)."""
+        from negpy.infrastructure.scanners.sane_backend import (
+            _resolve_resampled_resolutions,
+            _resolve_square_resolutions,
+        )
+
+        opt = {
+            "x_resolution": FakeOption(constraint=_V500_X_RESOLUTIONS),
+            "y_resolution": FakeOption(constraint=_V500_Y_RESOLUTIONS),
+        }
+        square = set(_resolve_square_resolutions(opt))
+        resampled = set(_resolve_resampled_resolutions(opt).keys())
+        assert square.issubset(resampled)
+        assert 100 in resampled and 100 not in square
+
+

--- a/tests/scanners/test_transparency_source_switch.py
+++ b/tests/scanners/test_transparency_source_switch.py
@@ -51,7 +51,15 @@ def _flatbed_opts() -> dict[str, FakeOption]:
         "source": FakeOption(constraint=["Flatbed", "Transparency Unit"]),
         "film_type": FakeOption(constraint=["Positive Film", "Negative Film"], active=False),
         "depth": FakeOption(constraint=[8, 16]),
+        # RGBI capability lets tests reach the resample+IR guard without a full coolscan3/
+        # pieusb-style fixture; harmless for every test that leaves capture_ir=False (the
+        # ScanParams default has no fallback — it's always explicit in these tests).
+        "mode": FakeOption(constraint=["Color", "RGBI"]),
+        # `resolution` mirrors the real V500 under Flatbed: an artificially narrow subset of
+        # what the per-axis options below can actually do.
         "resolution": FakeOption(constraint=[75, 150, 300, 600, 1200, 1600]),
+        "x_resolution": FakeOption(constraint=[100, 200, 400, 600, 800, 1200, 1600, 3200, 6400]),
+        "y_resolution": FakeOption(constraint=[80, 200, 320, 400, 600, 800, 1200, 1600, 2400, 3200, 4800, 6400]),
         "tl_x": FakeOption(constraint=(0.0, 215.9, 0.0), unit=3),
         "tl_y": FakeOption(constraint=(0.0, 297.18, 0.0), unit=3),
         "br_x": FakeOption(constraint=(0.0, 215.9, 0.0), unit=3),
@@ -69,6 +77,13 @@ def _transparency_opts() -> dict[str, FakeOption]:
     opts["br_x"] = FakeOption(constraint=(0.0, 68.58, 0.0), unit=3)
     opts["tl_y"] = FakeOption(constraint=(0.0, 236.98, 0.0), unit=3)
     opts["br_y"] = FakeOption(constraint=(0.0, 236.98, 0.0), unit=3)
+    # A second real finding, from the same device: y's native resolution ladder is not just
+    # differently-shaped from x's, it changes shape between sources — under Transparency Unit
+    # it drops 3200 and 6400 entirely (replaced by a 9600 that appears nowhere under Flatbed).
+    # x keeps its full ladder either way. This is what makes _resolve_resampled_resolutions
+    # worth having: the exact x/y intersection alone would cap at 1600 under TPU.
+    opts["x_resolution"] = FakeOption(constraint=[100, 200, 300, 400, 600, 800, 1200, 1600, 3200, 6400])
+    opts["y_resolution"] = FakeOption(constraint=[120, 200, 320, 400, 600, 800, 1200, 1600, 2400, 4800, 9600])
     return opts
 
 
@@ -166,7 +181,14 @@ class TestCapabilityDetectionUsesTransparencyGeometry:
 
 class TestScanOrdersSourceBeforeResolution:
     """The real bug: source switch re-ranges resolution's option, so setting resolution first
-    (the original code order) applied it against an option object the switch then discarded."""
+    (the original code order) applied it against an option object the switch then discarded.
+
+    This fixture has both `resolution` and `x_resolution`/`y_resolution`, matching the real
+    V500 — so a 1600dpi request (present on both the plain and per-axis ladders) takes the
+    axis-pair path (see TestScanUsesAxisResolutionWhenAvailable below for the higher-DPI case
+    that `resolution` alone can't reach). `test_source_is_set_before_resolution` intentionally
+    covers that path.
+    """
 
     def test_source_is_set_before_resolution(self) -> None:
         dev = FakeDev()
@@ -176,7 +198,8 @@ class TestScanOrdersSourceBeforeResolution:
         backend.scan(_DEV_ID, params, None, threading.Event())
 
         names = [name for name, _ in dev.writes]
-        assert names.index("source") < names.index("resolution")
+        assert names.index("source") < names.index("x_resolution")
+        assert names.index("source") < names.index("y_resolution")
 
     def test_requested_resolution_survives_the_source_switch(self) -> None:
         dev = FakeDev()
@@ -185,9 +208,11 @@ class TestScanOrdersSourceBeforeResolution:
 
         backend.scan(_DEV_ID, params, None, threading.Event())
 
-        # The last recorded resolution write is what the scan actually ran with.
-        resolution_writes = [value for name, value in dev.writes if name == "resolution"]
-        assert resolution_writes[-1] == 1600
+        # The last recorded write on each axis is what the scan actually ran with.
+        x_writes = [value for name, value in dev.writes if name == "x_resolution"]
+        y_writes = [value for name, value in dev.writes if name == "y_resolution"]
+        assert x_writes[-1] == 1600
+        assert y_writes[-1] == 1600
 
     def test_film_type_is_set_after_source_when_it_only_activates_post_switch(self) -> None:
         """film_type is `active=False` under Flatbed in this fixture (mirrors the real device,
@@ -201,6 +226,105 @@ class TestScanOrdersSourceBeforeResolution:
         assert ("film_type", "Negative Film") in dev.writes
         names = [name for name, _ in dev.writes]
         assert names.index("source") < names.index("film_type")
+
+
+class TestScanUsesAxisResolutionWhenAvailable:
+    """The actual bug this fixes: `resolution` alone caps at 1600dpi on the reference V500,
+    while the real per-axis native ladders reach 6400 on x and 9600 on y. A DPI reachable only
+    via x_resolution/y_resolution must use that path, and one that isn't must fail loudly
+    rather than silently substitute a nearby value — crop/window math downstream assumes the
+    DPI actually applied, the same class of bug the source/geometry ordering fix guarded
+    against. Every scan here runs under Transparency Unit (see _transparency_opts): its y
+    ladder lacks a native 6400, so a 6400 request needs the axis pair AND a y resample."""
+
+    def test_6400dpi_unreachable_via_plain_resolution_uses_axis_pair(self) -> None:
+        dev = FakeDev()
+        backend = _make_backend(FakeSaneModule(dev))
+        params = ScanParams(dpi=6400, depth=8, capture_ir=False)
+
+        backend.scan(_DEV_ID, params, None, threading.Event())
+
+        assert ("x_resolution", 6400) in dev.writes
+        # TPU's y ladder has no native 6400 (see _transparency_opts) — nearest at-or-below is
+        # 4800, resampled up to 6400 afterward.
+        assert ("y_resolution", 4800) in dev.writes
+        assert ("resolution", 6400) not in dev.writes
+
+    def test_dpi_not_on_either_axis_fails_loudly(self) -> None:
+        dev = FakeDev()
+        backend = _make_backend(FakeSaneModule(dev))
+        # 1000 is on neither this fixture's x nor y ladder, and not reachable by upsampling.
+        params = ScanParams(dpi=1000, depth=8, capture_ir=False)
+
+        try:
+            backend.scan(_DEV_ID, params, None, threading.Event())
+        except RuntimeError as e:
+            assert "1000" in str(e)
+        else:
+            raise AssertionError("expected a RuntimeError for an unreachable DPI")
+
+
+class TestScanResamplesYToMatchTarget:
+    """The specific case that motivated this: 3200dpi is native on x but not on y under TPU
+    (y jumps 2400 -> 4800), so hitting 3200 needs scanning y at its native 2400 and upsampling
+    the resulting rows in software afterward."""
+
+    def test_3200dpi_requests_native_y_2400(self) -> None:
+        dev = FakeDev()
+        backend = _make_backend(FakeSaneModule(dev))
+        params = ScanParams(dpi=3200, depth=8, capture_ir=False)
+
+        backend.scan(_DEV_ID, params, None, threading.Event())
+
+        assert ("x_resolution", 3200) in dev.writes
+        assert ("y_resolution", 2400) in dev.writes
+
+    def test_output_rows_are_upsampled_to_target_not_left_at_native_y(self) -> None:
+        dev = FakeDev()  # frame_data is 4x4x3 regardless of requested resolution (see FakeDev)
+        backend = _make_backend(FakeSaneModule(dev))
+        params = ScanParams(dpi=3200, depth=8, capture_ir=False)
+
+        result = backend.scan(_DEV_ID, params, None, threading.Event())
+
+        # 4 native rows at 2400dpi, upsampled to represent 3200dpi: round(4 * 3200/2400) = 5.
+        assert result.rgb.shape[0] == 5
+        assert result.rgb.shape[1] == 4  # columns (x) are never touched by the y resample.
+
+    def test_exact_native_match_needs_no_resize(self) -> None:
+        """1600 is native on both axes under TPU — output rows must stay exactly at the raw
+        read's row count, not run through any resize (which could itself alter values)."""
+        dev = FakeDev()
+        backend = _make_backend(FakeSaneModule(dev))
+        params = ScanParams(dpi=1600, depth=8, capture_ir=False)
+
+        result = backend.scan(_DEV_ID, params, None, threading.Event())
+
+        assert result.rgb.shape[0] == dev.frame_data.shape[0]
+        assert result.rgb.shape[1] == dev.frame_data.shape[1]
+
+    def test_resample_together_with_ir_capture_fails_loudly(self) -> None:
+        """_align_ir_to_rgb documents that interpolating IR data risks softening a thin dust
+        defect's minimum below what the detection pipeline expects — untested for the upsample
+        case this resample is, so the combination is rejected rather than guessed at."""
+        dev = FakeDev()
+        backend = _make_backend(FakeSaneModule(dev))
+        params = ScanParams(dpi=3200, depth=8, capture_ir=True)
+
+        try:
+            backend.scan(_DEV_ID, params, None, threading.Event())
+        except RuntimeError as e:
+            assert "IR" in str(e)
+        else:
+            raise AssertionError("expected a RuntimeError rejecting resample + IR capture")
+
+    def test_exact_native_dpi_with_ir_capture_is_fine(self) -> None:
+        """The guard is specifically about needing to resample — an exact-native DPI (no
+        resample involved) must work with IR capture same as before."""
+        dev = FakeDev()
+        backend = _make_backend(FakeSaneModule(dev))
+        params = ScanParams(dpi=1600, depth=8, capture_ir=True)
+
+        backend.scan(_DEV_ID, params, None, threading.Event())  # must not raise
 
 
 class TestResolveTransparencySourceIntegration:


### PR DESCRIPTION
`resolution` alone is sometimes an artificially narrow convenience subset of what a scanner can actually do — confirmed on this project's reference Epson V500 (epkowa/interpreter backend): `resolution` tops out at 1600dpi, while the device's real native per-axis capability (`x_resolution`/`y_resolution`) reaches 6400 on x and, depending on source, up to 9600 on y.

The two axes aren't just different, they're asymmetric in a way that changes with `source`: under this device's Transparency Unit, y's native ladder drops 3200 and 6400 entirely (replaced by a 9600 that appears nowhere under Flatbed), while x keeps its full native ladder either way. A plain "use whichever values both axes have in common" approach caps out at 1600 for exactly this reason.

_resolve_resampled_resolutions fixes this by treating x (the sensor-pitch axis, native at every target worth offering on the reference device) as authoritative, and for each of its native values finds the largest native y value at or below it. Any gap between the two is resampled up in software after the read (_resample_rows_to_dpi, bilinear via cv2.resize) — always an upsample, never a downsample, so this only ever recovers real captured detail, never invents it. This is a strict superset of the previous exact-intersection behavior (_resolve_square_resolutions, kept as its own function since "no resampling needed" is occasionally the more precise thing to ask for) and supersedes it in _detect_dpi and at scan time.

IR capture is explicitly rejected together with a DPI that needs resampling: _align_ir_to_rgb documents that even interpolating the IR channel risks softening a thin dust defect's minimum below the detection pipeline's noise floor (a downsample case measured there, 0.22 -> 0.31, "shattered"). Untested for the upsample case this resample is, and not worth guessing at on a precision-sensitive measurement — fails loudly with the native-only alternatives instead of silently degrading dust detection.

Verified end-to-end on an Epson Perfection V500 (epkowa/interpreter, Transparency Unit) on Fedora 44: a 3200dpi scan of a 6x4.5cm medium format negative — unreachable at all under the previous exact-match logic, which capped at 1600 on this device — now scans y natively at 2400 and resamples up, producing visibly more real detail than 1600dpi did, with correct proportions (no stretching on either axis).

Adds regression coverage: pure-function tests for
_resolve_resampled_resolutions and _resample_rows_to_dpi (test_capabilities.py), and scan-level tests in
test_transparency_source_switch.py covering the axis-pair write, the actual row-count upsample on the returned array, the fail-loud path for an unreachable DPI, and the IR-capture rejection. Each new behavior was confirmed to actually fail against the prior (exact-match or no-resample) code before being confirmed against the fix, not just checked for shape.