### PR TITLE
fix(search): keep backslashes so path: queries match on Windows

### DIFF
--- a/negpy/services/assets/search.py
+++ b/negpy/services/assets/search.py
@@ -37,11 +37,21 @@ def parse_query(text: str) -> list[Term]:
     if not text:
         return []
     try:
-        tokens = shlex.split(text)
+        tokens = _tokenize(text)
     except ValueError:
         # Half-typed quote: the box is live, so fall back rather than reject.
         tokens = text.split()
     return [t for t in (_term(tok) for tok in tokens) if t is not None]
+
+
+def _tokenize(text: str) -> list[str]:
+    """Whitespace split that keeps quoted phrases. Escapes are off: a backslash is a path
+    separator on Windows, so `path:roll12\\img` has to reach the matcher intact."""
+    lexer = shlex.shlex(text, posix=True)
+    lexer.whitespace_split = True
+    lexer.commenters = ""
+    lexer.escape = ""
+    return list(lexer)
 
 
 def _term(token: str) -> Optional[Term]:

--- a/tests/test_asset_search.py
+++ b/tests/test_asset_search.py
@@ -232,3 +232,9 @@ def test_facts_for_edited_asset_reads_capture_date_and_place():
     facts = facts_for({"name": "a.nef", "mtime": 0.0}, config)
     assert facts["shot"] == "1998-07-14 16:30"
     assert facts["place"] == "tokyo tokyo japan"
+
+
+def test_backslash_is_a_path_separator_not_an_escape():
+    r"""A Windows path survives tokenizing: a \ separates path parts, it does not escape."""
+    assert parse_query(r"path:roll12\img_0042") == [Term("path", ":", r"roll12\img_0042")]
+    assert _hits(r"path:roll12\img_0042", path=r"c:\photos\roll12\img_0042.nef") is True


### PR DESCRIPTION
`parse_query` tokenizes with `shlex.split`, which applies POSIX rules where a backslash escapes the next character. `iter_library_files` builds path facts with `os.path.join`, so on Windows those facts contain backslashes, but every separator in a `path:` term is stripped before it reaches the matcher. The documented `path:` field returns nothing, with no error.

On the unpatched tree, Python 3.13.5 (MSC v.1943, AMD64):

```
shlex.split(r"path:C:\Users\alkin\Pictures")
-> ['path:C:UsersalkinPictures']
```

`_tokenize` reuses `shlex.split`'s own configuration and clears only the escape character, so quoted phrases still collapse to one term and an unbalanced quote still raises `ValueError` into the existing fallback; `test_quoted_phrase_is_one_term` and `test_unbalanced_quote_falls_back_to_whitespace_split` stay green.

The added test fails on the unpatched source (`'roll12img_0042'` vs `'roll12\img_0042'`) and passes with the fix. `test_asset_search.py` + `test_library_search.py`: 70 passed. Full suite: 5192 passed, 16 skipped, 14 deselected, 57 subtests passed. `ruff check .` clean; `ty check` with the Makefile's flags clean.

CI runs ubuntu-latest only, so this is not observable upstream.
