### PR TITLE
Fix issues with trichrome triplet detection and merging

### DIFF
--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -3680,7 +3680,12 @@ class AppController(QObject):
                 capture_frame=capture_frame,
             )
         self._pending_scanned_file = paths[0]
-        self.request_asset_discovery(list(paths))
+        # The capture shot these three exposures for one frame, in red/green/blue order
+        # (CaptureResult.paths), so hand discovery the triplet instead of asking it to
+        # re-derive one it already knows. Deriving it can only refuse a frame it should
+        # have kept: a blank or untextured frame gives the content test nothing to match.
+        triplet = {paths[0]: [paths[1], paths[2]]} if rgb and not white and len(paths) == 3 else None
+        self.request_asset_discovery(list(paths), restore_triplets=triplet)
 
     def effective_output_icc(self) -> Optional[str]:
         """Output profile the preview proofs through: a custom override, else the

--- a/negpy/desktop/workers/render.py
+++ b/negpy/desktop/workers/render.py
@@ -698,19 +698,25 @@ class AssetDiscoveryWorker(QObject):
         return out
 
     def _attach_restored_triplets(self, assets: list, triplets: dict) -> list:
-        """Re-attach saved green/blue exposures to restored red assets (no reclassification)."""
+        """Re-attach known green/blue exposures to their red asset (no reclassification).
+
+        A session manifest holds the red path alone, but a capture hands over all three,
+        so the two exposures that became part of a frame are dropped from the roll.
+        """
         import os
 
         out = []
+        parts: set = set()
         for a in assets:
             gb = triplets.get(a["path"])
             if gb and gb[0] and gb[1] and os.path.exists(gb[0]) and os.path.exists(gb[1]):
                 base = os.path.splitext(a["name"])[0]
                 align = bool(gb[2]) if len(gb) > 2 else True
                 out.append({**a, "name": f"{base} (RGB)", "green_path": gb[0], "blue_path": gb[1], "align": align})
+                parts.update({gb[0], gb[1]})
             else:
                 out.append(a)
-        return out
+        return _without_parts(out, parts)
 
     def _attach_restored_stitches(self, assets: list, stitches: dict) -> list:
         """Re-attach saved stitch registrations to restored primary assets (no re-registration).

--- a/negpy/desktop/workers/render.py
+++ b/negpy/desktop/workers/render.py
@@ -632,7 +632,7 @@ class AssetDiscoveryWorker(QObject):
 
         if task.restore_triplets:
             valid_assets = self._attach_restored_triplets(valid_assets, task.restore_triplets)
-        elif task.rgb_scan and valid_assets:
+        if task.rgb_scan and valid_assets:
             valid_assets = self._group_rgb_triplets(valid_assets)
 
         if task.restore_stitches and valid_assets:
@@ -786,7 +786,12 @@ class AssetDiscoveryWorker(QObject):
         """Classify each file by dominant channel and merge consecutive R/G/B triplets
         into one asset (red is primary; green/blue ride along). A chunk that does not
         hold one of each channel, or whose three exposures do not show the same frame,
-        is left alone: its files stay individual and can be paired by hand."""
+        is left alone: its files stay individual and can be paired by hand.
+
+        An asset that already carries its green and blue exposures keeps them and is
+        not re-examined. Grouping runs beside a restore, not instead of it, so files
+        the restore knew nothing about still get their chance.
+        """
         import os
 
         from negpy.features.rgbscan.logic import (
@@ -797,6 +802,11 @@ class AssetDiscoveryWorker(QObject):
             looks_narrowband,
             probe_frame,
         )
+
+        assembled = [a for a in assets if a.get("green_path") and a.get("blue_path")]
+        assets = [a for a in assets if not (a.get("green_path") and a.get("blue_path"))]
+        if not assets:
+            return assembled
 
         by_path = {a["path"]: a for a in assets}
         ordered = sorted(by_path, key=lambda p: os.path.basename(p).lower())
@@ -810,7 +820,7 @@ class AssetDiscoveryWorker(QObject):
         items = [(p, classify_channel(pr.means)) for p, pr in zip(ordered, probes) if pr is not None]
         signatures = {p: pr.signature for p, pr in zip(ordered, probes) if pr is not None}
 
-        result = []
+        result = list(assembled)
         grouped = set()
         incomplete = mismatched = 0
         for t in group_triplets(items, signatures):

--- a/negpy/features/rgbscan/logic.py
+++ b/negpy/features/rgbscan/logic.py
@@ -20,12 +20,17 @@ _SIG_WIDTH = 96
 # background outside it are identical in every exposure of every frame, so scoring
 # the whole capture correlates two unrelated scenes on their shared surround.
 _SIG_INTERIOR = 0.6
+# Signal floor before the log, in raw levels. Block averages this low carry no structure,
+# only read noise, and without a floor the log turns it into the loudest edges in the map.
+_SIG_FLOOR = 1.0
 # Floor a triplet's three exposures must clear. A backstop, not the discriminator:
 # how well one scene scores across channels varies with how much texture it has, so
 # no single value separates a real triplet from a confusable one on every roll. The
 # ranking test does that. This only has to reject the unrelated, which is what a
-# folder too small for a ranking to mean anything falls back on.
-MIN_TRIPLET_AFFINITY = 0.35
+# folder too small for a ranking to mean anything falls back on. Set well under the
+# weakest real triplet rather than just under the strongest confusable one: a folder
+# large enough to hold a confuser is also large enough for the ranking to catch it.
+MIN_TRIPLET_AFFINITY = 0.25
 
 # Strongest channel over the next, above which a file was lit by one narrowband color.
 # Well clear of both: white light leaves the three channels within a small factor,
@@ -65,26 +70,27 @@ def _channel_means(mosaic: np.ndarray, colors: np.ndarray, black: float) -> Tupl
     return mean_of(0), mean_of(1, 3), mean_of(2)
 
 
-def _scene_signature(mosaic: np.ndarray) -> np.ndarray:
-    """Edge structure of the frame interior, as a z-scored gradient map.
+def _scene_signature(mosaic: np.ndarray, black: float) -> np.ndarray:
+    """Edge structure of the frame interior, as a z-scored gradient map of density.
 
     Block-averaged straight off the mosaic: at this scale a whole CFA cell per block
-    reads as luminance, so no demosaic is needed. Structure rather than tone, because
-    two exposures of one frame are the same scene through different narrowband light
-    and share their edges, not their levels.
+    reads as luminance, so no demosaic is needed. The gradient is taken in log space
+    on the black-subtracted signal, because a linear gradient weights each edge by the
+    local level: one scene then measures differently in a bright exposure and a dark
+    one, and a triplet's blue exposure sits several stops below its red.
     """
     h, w = mosaic.shape[:2]
     block = max(2, (w // _SIG_WIDTH) & ~1)  # even, so every block covers whole CFA cells
     hh, ww = (h // block) * block, (w // block) * block
     if hh < block or ww < block:
         return np.zeros((1, 1), dtype=np.float32)
-    small = mosaic[:hh, :ww].reshape(hh // block, block, ww // block, block).mean(axis=(1, 3))
+    small = mosaic[:hh, :ww].reshape(hh // block, block, ww // block, block).mean(axis=(1, 3)) - black
 
     sh, sw = small.shape
     dh, dw = int(sh * (1.0 - _SIG_INTERIOR) / 2), int(sw * (1.0 - _SIG_INTERIOR) / 2)
     interior = small[dh : sh - dh, dw : sw - dw]
 
-    gy, gx = np.gradient(interior)
+    gy, gx = np.gradient(np.log(np.clip(interior, _SIG_FLOOR, None)))
     return _zscore(np.hypot(gx, gy)).astype(np.float32)
 
 
@@ -109,7 +115,7 @@ def probe_frame(path: str) -> FrameProbe:
         mosaic = raw.raw_image_visible.astype(np.float32)
         colors = raw.raw_colors_visible
         black = float(np.mean(raw.black_level_per_channel))
-        return FrameProbe(means=_channel_means(mosaic, colors, black), signature=_scene_signature(mosaic))
+        return FrameProbe(means=_channel_means(mosaic, colors, black), signature=_scene_signature(mosaic, black))
 
 
 def probe_channel_means(path: str) -> Tuple[float, float, float]:

--- a/tests/test_capture_controller.py
+++ b/tests/test_capture_controller.py
@@ -54,7 +54,9 @@ def _hydrate_and_load(controller, path, process_mode, *, autodetect=True):
 def test_rgb_triplet_enables_merge_and_discovers():
     c = _run(["r.ARW", "g.ARW", "b.ARW"], rgb_mode=True, white_mode=False)
     c.session.repo.save_global_setting.assert_any_call("rgbscan_mode", True)  # triplet → merge ON
-    c.request_asset_discovery.assert_called_once_with(["r.ARW", "g.ARW", "b.ARW"])
+    # The capture knows its own triplet, so discovery is handed it rather than asked to
+    # re-derive it from the pixels -- which can only ever refuse a frame it should keep.
+    c.request_asset_discovery.assert_called_once_with(["r.ARW", "g.ARW", "b.ARW"], restore_triplets={"r.ARW": ["g.ARW", "b.ARW"]})
     assert c._pending_scanned_file == "r.ARW"  # red is primary → auto-selected after discovery
 
 
@@ -70,13 +72,13 @@ def test_rgb_triplet_import_defaults_to_c41_without_autodetect():
 def test_normal_single_scan_leaves_merge_off():
     c = _run(["frame.ARW"], rgb_mode=False)
     c.session.repo.save_global_setting.assert_any_call("rgbscan_mode", False)  # single RAW → no merge
-    c.request_asset_discovery.assert_called_once_with(["frame.ARW"])
+    c.request_asset_discovery.assert_called_once_with(["frame.ARW"], restore_triplets=None)
 
 
 def test_white_slide_leaves_merge_off():
     c = _run(["slide.ARW"], rgb_mode=True, white_mode=True, white_process_mode="auto")
     c.session.repo.save_global_setting.assert_any_call("rgbscan_mode", False)  # one white exposure → no merge
-    c.request_asset_discovery.assert_called_once_with(["slide.ARW"])
+    c.request_asset_discovery.assert_called_once_with(["slide.ARW"], restore_triplets=None)
 
 
 def test_explicit_e6_applies_to_import_after_hydration_without_detection():

--- a/tests/test_rgbscan.py
+++ b/tests/test_rgbscan.py
@@ -16,6 +16,7 @@ from negpy.features.rgbscan.logic import (
     classify_channel,
     frame_affinity,
     capture_ordered,
+    MIN_TRIPLET_AFFINITY,
     group_triplets,
     merge_rgb_triplet,
     probe_channel_means,
@@ -159,6 +160,64 @@ def _triplet_sigs(scene_seed):
         f"g{scene_seed}": _scene_sig(scene_seed, 0.6),
         f"b{scene_seed}": _scene_sig(scene_seed, 0.3),
     }
+
+
+def _exposure(density, contrast, gain, black=256.0, scale=4000.0):
+    """One narrowband exposure of a scene, as raw levels.
+
+    ``density`` is the scene in density units; a channel sees it through its own
+    ``contrast`` and ``gain``, which is what makes two exposures of one frame differ
+    by more than a scale factor.
+    """
+    return (gain * scale * 10.0 ** (-contrast * density) + black).astype(np.float32)
+
+
+def _density_scene(seed, h=384, w=512):
+    """A scene spanning the full density range, so the channels really do land at
+    different levels. Blurred noise on its own varies too little to tell the two
+    signatures apart."""
+    rng = np.random.default_rng(seed)
+    scene = cv2.GaussianBlur(rng.random((h, w), dtype=np.float32), (0, 0), 8.0)
+    scene -= scene.min()
+    return scene / scene.max()
+
+
+def test_scene_signature_survives_a_channel_density_difference():
+    """One scene through two channel transfers differs by a scale factor in density,
+    which the z-score removes, so two exposures agree however far apart their levels
+    sit. A gradient on the levels themselves weights each edge by the local signal
+    and cannot.
+    """
+    from negpy.features.rgbscan.logic import _scene_signature
+
+    scene = _density_scene(1)
+    red = _scene_signature(_exposure(scene, contrast=0.5, gain=1.0), 256.0)
+    blue = _scene_signature(_exposure(scene, contrast=1.9, gain=0.05), 256.0)
+    assert frame_affinity(red, blue) > 0.95
+
+
+def test_scene_signature_still_separates_two_scenes():
+    """The density signature must not agree with everything it is shown."""
+    from negpy.features.rgbscan.logic import _scene_signature
+
+    one = _scene_signature(_exposure(_density_scene(1), contrast=0.6, gain=1.0), 256.0)
+    two = _scene_signature(_exposure(_density_scene(2), contrast=1.8, gain=0.08), 256.0)
+    assert frame_affinity(one, two) < MIN_TRIPLET_AFFINITY
+
+
+def test_scene_signature_dark_exposure_clears_the_floor():
+    """A whole triplet, weakest pair included, on a scene whose blue exposure lands
+    several stops below its red: the shape of every C-41 trichrome frame."""
+    from negpy.features.rgbscan.logic import _scene_signature
+
+    scene = _density_scene(3)
+    sigs = {
+        "r": _scene_signature(_exposure(scene, contrast=0.5, gain=1.0), 256.0),
+        "g": _scene_signature(_exposure(scene, contrast=1.1, gain=0.3), 256.0),
+        "b": _scene_signature(_exposure(scene, contrast=1.9, gain=0.05), 256.0),
+    }
+    items = [("r", RED), ("g", GREEN), ("b", BLUE)]
+    assert group_triplets(items, sigs)[0].ok
 
 
 def test_frame_affinity_separates_same_scene_from_different():
@@ -412,6 +471,35 @@ def test_real_sample_classification(fname, expected):
     if not os.path.exists(path):
         pytest.skip(f"sample {fname} not present")
     assert classify_channel(probe_channel_means(path)) == expected
+
+
+_TRIPLET_SAMPLES = {  # frame -> its three exposures, one C-41 trichrome capture each
+    "Frame007": (
+        "2026-08-r35s-5161_Frame007_R.ORF",
+        "2026-08-r35s-5161_Frame007_G.ORF",
+        "2026-08-r35s-5161_Frame007_B.ORF",
+    ),
+    "Frame026": (
+        "2026-08-r35s-5161_Frame026_R.ORF",
+        "2026-08-r35s-5161_Frame026_G.ORF",
+        "2026-08-r35s-5161_Frame026_B.ORF",
+    ),
+}
+
+
+@pytest.mark.parametrize("frame,files", _TRIPLET_SAMPLES.items())
+def test_real_trichrome_triplet_groups(frame, files):
+    """Real C-41 trichrome frames whose blue exposure sits several stops below their
+    red: the weakest pair a genuine triplet has to clear."""
+    paths = [os.path.join("samples", f) for f in files]
+    if not all(os.path.exists(p) for p in paths):
+        pytest.skip(f"trichrome samples for {frame} not present")
+    from negpy.features.rgbscan.logic import probe_frame
+
+    probes = {p: probe_frame(p) for p in paths}
+    items = [(p, classify_channel(probes[p].means)) for p in paths]
+    assert {ch for _, ch in items} == {RED, GREEN, BLUE}
+    assert group_triplets(items, {p: probes[p].signature for p in paths})[0].ok
 
 
 def test_preview_merge_pulls_green_blue_from_their_files():

--- a/tests/test_rgbscan.py
+++ b/tests/test_rgbscan.py
@@ -579,6 +579,52 @@ def test_restored_session_still_groups_the_files_it_did_not_know_about(tmp_path,
     assert out[1]["green_path"].endswith("f2_g.raw"), "the loose exposures were grouped"
 
 
+def test_restored_triplet_consumes_its_exposures_from_the_roll(tmp_path):
+    """Where the green and blue files are in the list too -- a capture, or a stitch
+    dissolved back into triplet parts -- they belong to the frame, not to the roll."""
+    from negpy.desktop.workers.render import AssetDiscoveryWorker
+
+    names = ["f1_r.raw", "f1_g.raw", "f1_b.raw"]
+    for n in names:
+        (tmp_path / n).write_bytes(n.encode())
+    assets = [{"name": n, "path": str(tmp_path / n), "hash": n} for n in names]
+    triplets = {str(tmp_path / "f1_r.raw"): [str(tmp_path / "f1_g.raw"), str(tmp_path / "f1_b.raw")]}
+
+    out = AssetDiscoveryWorker()._attach_restored_triplets(assets, triplets)
+    assert [a["name"] for a in out] == ["f1_r (RGB)"]
+
+
+def test_a_captured_triplet_assembles_even_with_nothing_to_match_on(tmp_path, monkeypatch):
+    """A frame with no structure -- clear leader, an unexposed frame, a lens cap --
+    gives the content test nothing to correlate, so no floor can admit it. The capture
+    knows the three files are one frame, so it says so instead of asking."""
+    from negpy.desktop.workers.render import AssetDiscoveryTask, AssetDiscoveryWorker
+    from negpy.features.rgbscan import logic
+
+    names = ["f1_r.raw", "f1_g.raw", "f1_b.raw"]
+    for n in names:
+        (tmp_path / n).write_bytes(n.encode() * 64)
+    flat = np.zeros((40, 60), dtype=np.float32)  # a uniform frame z-scores to nothing
+    monkeypatch.setattr(logic, "probe_frame", lambda path: logic.FrameProbe(means=(1.0, 1.0, 1.0), signature=flat))
+    monkeypatch.setattr(logic, "capture_timestamp", lambda path: "")
+    paths = [str(tmp_path / n) for n in names]
+
+    worker = AssetDiscoveryWorker()
+    seen: list = []
+    worker.finished.connect(seen.append)
+
+    def discover(restore_triplets):
+        worker.process(
+            AssetDiscoveryTask(paths=list(paths), supported_extensions=(".raw",), rgb_scan=True, restore_triplets=restore_triplets)
+        )
+        return seen.pop()
+
+    assert len(discover(None)) == 3, "derived from the pixels, a blank frame cannot be grouped"
+
+    out = discover({paths[0]: [paths[1], paths[2]]})
+    assert [a["name"] for a in out] == ["f1_r (RGB)"]
+
+
 def test_grouping_leaves_an_assembled_asset_alone(tmp_path, monkeypatch):
     """An asset that already carries green and blue is not re-examined: its exposures
     are not in the file list, so chunking would mix it into its neighbours."""

--- a/tests/test_rgbscan.py
+++ b/tests/test_rgbscan.py
@@ -536,6 +536,64 @@ def test_attach_restored_triplets_rebuilds_asset(tmp_path):
     assert out[0]["name"].endswith("(RGB)")
 
 
+def _fake_probes(monkeypatch, channels):
+    """Stand in for the raw read: ``channels`` maps basename -> R/G/B, and every file
+    of one frame (same basename prefix before the last "_") shares a signature."""
+    from negpy.features.rgbscan import logic
+
+    def probe(path):
+        name = os.path.basename(path)
+        scene = name.rsplit("_", 1)[0]
+        return logic.FrameProbe(
+            means=tuple(3.0 if i == channels[name] else 1.0 for i in range(3)),
+            signature=_scene_sig(sum(ord(c) for c in scene)),
+        )
+
+    monkeypatch.setattr(logic, "probe_frame", probe)
+    monkeypatch.setattr(logic, "capture_timestamp", lambda path: "")
+
+
+def test_restored_session_still_groups_the_files_it_did_not_know_about(tmp_path, monkeypatch):
+    """A restore re-attaches the triplets it saved; anything else in the manifest is
+    still grouped, or a file left loose in one session could never come back."""
+    from negpy.desktop.workers.render import AssetDiscoveryTask, AssetDiscoveryWorker
+
+    names = ["f1_r.raw", "f1_g.raw", "f1_b.raw", "f2_r.raw", "f2_g.raw", "f2_b.raw"]
+    for n in names:
+        (tmp_path / n).write_bytes(n.encode() * 64)
+    _fake_probes(monkeypatch, {n: {"r": RED, "g": GREEN, "b": BLUE}[n[-5]] for n in names})
+
+    # Frame 1 was assembled last session, so only its red is in the manifest. Frame 2
+    # was left loose, so all three of its exposures are.
+    paths = [str(tmp_path / n) for n in ("f1_r.raw", "f2_r.raw", "f2_g.raw", "f2_b.raw")]
+    triplets = {str(tmp_path / "f1_r.raw"): [str(tmp_path / "f1_g.raw"), str(tmp_path / "f1_b.raw")]}
+
+    worker = AssetDiscoveryWorker()
+    seen: list = []
+    worker.finished.connect(seen.append)
+    worker.process(AssetDiscoveryTask(paths=paths, supported_extensions=(".raw",), rgb_scan=True, restore_triplets=triplets))
+
+    out = sorted(seen.pop(), key=lambda a: a["name"])
+    assert [a["name"] for a in out] == ["f1_r (RGB)", "f2_r (RGB)"]
+    assert out[0]["green_path"].endswith("f1_g.raw"), "the restored triplet keeps its saved exposures"
+    assert out[1]["green_path"].endswith("f2_g.raw"), "the loose exposures were grouped"
+
+
+def test_grouping_leaves_an_assembled_asset_alone(tmp_path, monkeypatch):
+    """An asset that already carries green and blue is not re-examined: its exposures
+    are not in the file list, so chunking would mix it into its neighbours."""
+    from negpy.desktop.workers.render import AssetDiscoveryWorker
+
+    names = ["f2_r.raw", "f2_g.raw", "f2_b.raw"]
+    _fake_probes(monkeypatch, {n: {"r": RED, "g": GREEN, "b": BLUE}[n[-5]] for n in names})
+    assembled = {"name": "f1_r (RGB)", "path": "/f1_r.raw", "hash": "h1", "green_path": "/f1_g.raw", "blue_path": "/f1_b.raw"}
+    loose = [{"name": n, "path": str(tmp_path / n), "hash": n} for n in names]
+
+    out = AssetDiscoveryWorker()._group_rgb_triplets([assembled, *loose])
+    assert [a["name"] for a in out] == ["f1_r (RGB)", "f2_r (RGB)"]
+    assert out[0] is assembled
+
+
 def test_config_roundtrip_preserves_rgbscan():
     cfg = WorkspaceConfig()
     cfg = type(cfg)(**{**cfg.__dict__, "rgbscan": RgbScanConfig(enabled=True, green_path="/g", blue_path="/b")})


### PR DESCRIPTION
This includes three discrete improvements to how we detect and merge trichrome scans. Fixes #998 

1.  To fix the primary reported issue in #998: The test that decides whether three exposures show the same frame measured edges in linear levels, where the same edge reads differently in a bright exposure and a dark one — so a C-41 triplet's blue exposure, several stops under its red, disagreed with its own partners and correct triplets were refused. Measuring in density instead takes the weakest real pair on the reported roll from 0.184 to 0.671, and every trichrome folder on hand still groups exactly as it did or better.
2. Restoring a session re-attached the triplets it had saved and skipped grouping entirely, so any exposure left loose in one session stayed loose across every relaunch. Grouping now runs beside the restore rather than instead of it.
3. The capture knows it just shot red, green and blue for one frame, but threw that away and asked discovery to re-derive it from the pixels — where a wrong grouping isn't reachable and every refusal is therefore a false one, including frames with no detail to match on at all. It now passes the triplet through, which also drops the three raw decodes per captured frame.
