### PR TITLE
fix: reduce tiled-export GPU memory pressure on integrated GPUs

### DIFF
--- a/negpy/desktop/main.py
+++ b/negpy/desktop/main.py
@@ -222,6 +222,12 @@ def main() -> None:
         # file's own apply() above, and still before QApplication reads any of them.
         apply_stored_override(override_cfg, APP_CONFIG, repo.get_global_setting)
 
+        # Opt-in smaller-tile/no-pipelining export path: override.toml wins if set, else the
+        # saved Preferences checkbox, else off. Not a STORED_PERF_KEYS entry since apply_stored
+        # skips bool values (see its docstring).
+        if override_cfg.low_vram_export_tiling is None:
+            APP_CONFIG.low_vram_export_tiling = bool(repo.get_global_setting("low_vram_export_tiling", False))
+
         # Multi-core Numba kernels: override.toml, then the saved setting, then the platform
         # default (off on macOS). Read before the flags below are overwritten.
         prev_clean_exit = bool(repo.get_global_setting("clean_shutdown", True))

--- a/negpy/desktop/view/widgets/preferences_dialog.py
+++ b/negpy/desktop/view/widgets/preferences_dialog.py
@@ -313,6 +313,27 @@ class PreferencesDialog(QDialog):
         grid.addWidget(hint_label(f"{os.cpu_count() or '?'} cores available. Applies at once, no restart."), row, 0, 1, 2)
         row += 1
 
+        self.low_vram_tiling_box = self._add_checkbox(
+            grid,
+            row,
+            "Reduce export memory use",
+            APP_CONFIG.low_vram_export_tiling,
+            "Use smaller tiles and less pipelining during export, at some cost to export speed. "
+            "Turn this on if exporting crashes on your GPU (typically an older or "
+            "memory-constrained integrated one).",
+        )
+        if "low_vram_export_tiling" in self._pinned:
+            self.low_vram_tiling_box.setEnabled(False)
+            self.low_vram_tiling_box.setToolTip("Set in override.toml, which wins over this dialog")
+        else:
+            self.low_vram_tiling_box.toggled.connect(self._on_low_vram_tiling_changed)
+        row += 1
+        note = "Applies to the next export started, no restart needed." + (
+            " Set in override.toml." if "low_vram_export_tiling" in self._pinned else ""
+        )
+        grid.addWidget(hint_label(note), row, 0, 1, 2)
+        row += 1
+
         for spec in NUMBER_ROWS:
             grid.addWidget(field_label(spec.label), row, 0)
             spin = QSpinBox()
@@ -407,6 +428,10 @@ class PreferencesDialog(QDialog):
             5000,
         )
 
+    def _on_low_vram_tiling_changed(self, checked: bool) -> None:
+        APP_CONFIG.low_vram_export_tiling = bool(checked)
+        self.repo.save_global_setting("low_vram_export_tiling", bool(checked))
+
     def _open_shortcut_editor(self) -> None:
         manager = getattr(self._window, "shortcut_manager", None)
         if manager is not None:
@@ -459,7 +484,11 @@ def _pinned_keys() -> set[str]:
     path = APP_CONFIG.override_toml_path
     if not path or not os.path.exists(path):
         return set()
-    return toml_pinned_keys(load_or_create(path))
+    cfg = load_or_create(path)
+    pinned = toml_pinned_keys(cfg)
+    if cfg.low_vram_export_tiling is not None:
+        pinned = pinned | {"low_vram_export_tiling"}
+    return pinned
 
 
 def _canvas_colors():

--- a/negpy/domain/types.py
+++ b/negpy/domain/types.py
@@ -47,6 +47,10 @@ class AppConfig:
     # Multi-core Numba kernels on the CPU pipeline. None = the platform default, on
     # everywhere except macOS. True/False = an explicit override.toml choice.
     cpu_parallel: bool | None = None
+    # Smaller tiles and no readback pipelining in the tiled export path, at the cost of
+    # export speed. Off by default -- a user opts in from Preferences or override.toml
+    # when their specific GPU (typically an older/weaker integrated one) needs it.
+    low_vram_export_tiling: bool = False
     # Preview buffer LRU (decoded float preview before render pipeline)
     preview_cache_max_entries: int = 8
     preview_cache_max_bytes: int = 1_200_000_000

--- a/negpy/kernel/system/override.py
+++ b/negpy/kernel/system/override.py
@@ -57,6 +57,11 @@ qt_platform = "auto"
 # defaults to false while crash reports are investigated. Uncomment to force.
 # cpu_parallel = true
 
+# Smaller tiles and no readback pipelining during export, at some cost to export speed.
+# Off by default. Turn on if exporting crashes on your GPU (typically an older or
+# memory-constrained integrated one) -- also available in Preferences.
+# low_vram_export_tiling = true
+
 # Cap GPU texture dimensions in pixels, including the HQ/full-resolution preview load.
 # "auto" lets wgpu/hardware decide the maximum -- except on an integrated GPU, where NegPy
 # applies a conservative default (currently 6144px) since shared VRAM can't be queried
@@ -100,6 +105,7 @@ class OverrideConfig:
     qt_platform: str = "auto"
     force_hq_preview: bool | None = None
     cpu_parallel: bool | None = None
+    low_vram_export_tiling: bool | None = None
     max_texture_size: int | None = None
     preview_render_size: int | None = None
     preview_cache_max_bytes: int | None = None
@@ -167,6 +173,9 @@ def _parse(data: dict) -> OverrideConfig:
     raw_par = performance.get("cpu_parallel")
     cpu_parallel: bool | None = bool(raw_par) if isinstance(raw_par, bool) else None
 
+    raw_low_vram = performance.get("low_vram_export_tiling")
+    low_vram_tiling: bool | None = bool(raw_low_vram) if isinstance(raw_low_vram, bool) else None
+
     raw_tex = performance.get("max_texture_size")
     max_tex: int | None = int(raw_tex) if isinstance(raw_tex, int) and raw_tex > 0 else None
 
@@ -195,6 +204,7 @@ def _parse(data: dict) -> OverrideConfig:
         qt_platform=qt_platform,
         force_hq_preview=force_hq,
         cpu_parallel=cpu_parallel,
+        low_vram_export_tiling=low_vram_tiling,
         max_texture_size=max_tex,
         preview_render_size=prev_size,
         preview_cache_max_bytes=cache_b,
@@ -260,6 +270,9 @@ def apply(cfg: OverrideConfig, app_config: AppConfig) -> None:
 
     if cfg.cpu_parallel is not None:
         app_config.cpu_parallel = cfg.cpu_parallel
+
+    if cfg.low_vram_export_tiling is not None:
+        app_config.low_vram_export_tiling = cfg.low_vram_export_tiling
 
     if cfg.preview_render_size is not None:
         size = min(PREVIEW_SIZE_MAX, max(PREVIEW_SIZE_MIN, cfg.preview_render_size))

--- a/negpy/services/rendering/gpu_engine.py
+++ b/negpy/services/rendering/gpu_engine.py
@@ -78,6 +78,13 @@ _ALT_MODE = {AltProcess.NONE: 0, AltProcess.LITH: 1, AltProcess.CYANOTYPE: 2}
 # Hardware constants
 UNIFORM_ALIGNMENT_DEFAULT = 256
 TILE_SIZE = 2048
+# An integrated GPU shares system RAM as VRAM with no submittable-memory query
+# available up front (see GPUDevice.is_integrated). A full-size 2048px tile's
+# intermediate textures across the pipeline's stages can be enough to blow that
+# tight, unqueryable budget and take the whole process down via wgpu-native's
+# panic-on-device-lost (uncatchable across the FFI boundary). Halving the tile
+# roughly quarters the live per-tile texture footprint.
+TILE_SIZE_INTEGRATED_GPU = 1024
 TILE_HALO = 32
 TILING_THRESHOLD_PX = 12_000_000
 HISTOGRAM_BINS = 256
@@ -2254,13 +2261,21 @@ class GPUEngine:
             halo = max(halo, int(np.ceil(max(5.0, 25.0 * scale_factor))))
         halo = min(halo, 512)
 
+        # An integrated GPU gets a smaller tile (see TILE_SIZE_INTEGRATED_GPU) and
+        # skips the one-tile-ahead pipelining below: on a tight, unqueryable VRAM
+        # budget, keeping two tiles' worth of textures/buffers live at once is the
+        # difference between fitting and a device-lost abort. Discrete GPUs keep
+        # both the full tile size and the overlap for throughput.
+        is_integrated = self.gpu.is_integrated
+        tile_size = TILE_SIZE_INTEGRATED_GPU if is_integrated else TILE_SIZE
+
         # The queue serializes tile N's staging copy ahead of tile N+1's passes, so
         # deferring the map_sync by one tile is safe and overlaps the wait.
         pending: Optional[tuple] = None
         tile_index = 0
-        for ty in range(0, crop_h, TILE_SIZE):
-            for tx in range(0, crop_w, TILE_SIZE):
-                tw, th = min(TILE_SIZE, crop_w - tx), min(TILE_SIZE, crop_h - ty)
+        for ty in range(0, crop_h, tile_size):
+            for tx in range(0, crop_w, tile_size):
+                tw, th = min(tile_size, crop_w - tx), min(tile_size, crop_h - ty)
                 ix1, iy1 = max(0, x1 + tx - halo), max(0, y1 + ty - halo)
                 ix2, iy2 = (
                     min(w_rot, x1 + tx + tw + halo),
@@ -2289,10 +2304,13 @@ class GPUEngine:
                     contrast_mask_override=global_mask,
                 )
                 handle = self._submit_readback(tile_res, slot=tile_index % 2)
-                if pending is not None:
-                    p_handle, p_ty, p_tx, p_th, p_tw, p_oy, p_ox = pending
-                    self._resolve_readback(p_handle, full_source_res[p_ty : p_ty + p_th, p_tx : p_tx + p_tw], (p_oy, p_ox))
-                pending = (handle, ty, tx, th, tw, oy, ox)
+                if is_integrated:
+                    self._resolve_readback(handle, full_source_res[ty : ty + th, tx : tx + tw], (oy, ox))
+                else:
+                    if pending is not None:
+                        p_handle, p_ty, p_tx, p_th, p_tw, p_oy, p_ox = pending
+                        self._resolve_readback(p_handle, full_source_res[p_ty : p_ty + p_th, p_tx : p_tx + p_tw], (p_oy, p_ox))
+                    pending = (handle, ty, tx, th, tw, oy, ox)
                 tile_index += 1
         if pending is not None:
             p_handle, p_ty, p_tx, p_th, p_tw, p_oy, p_ox = pending

--- a/negpy/services/rendering/gpu_engine.py
+++ b/negpy/services/rendering/gpu_engine.py
@@ -78,13 +78,15 @@ _ALT_MODE = {AltProcess.NONE: 0, AltProcess.LITH: 1, AltProcess.CYANOTYPE: 2}
 # Hardware constants
 UNIFORM_ALIGNMENT_DEFAULT = 256
 TILE_SIZE = 2048
-# An integrated GPU shares system RAM as VRAM with no submittable-memory query
-# available up front (see GPUDevice.is_integrated). A full-size 2048px tile's
-# intermediate textures across the pipeline's stages can be enough to blow that
-# tight, unqueryable budget and take the whole process down via wgpu-native's
-# panic-on-device-lost (uncatchable across the FFI boundary). Halving the tile
-# roughly quarters the live per-tile texture footprint.
-TILE_SIZE_INTEGRATED_GPU = 1024
+# Some GPUs -- typically an older or memory-constrained integrated one, sharing system
+# RAM as VRAM with no submittable-memory query available up front -- can have a tight
+# enough budget that a full-size 2048px tile's intermediate textures blow it and take
+# the whole process down via wgpu-native's panic-on-device-lost (uncatchable across the
+# FFI boundary). Halving the tile roughly quarters the live per-tile texture footprint.
+# Gated behind AppConfig.low_vram_export_tiling (Preferences/override.toml) rather than
+# GPUDevice.is_integrated: plenty of integrated GPUs (Apple Silicon, AMD's higher-end
+# APUs) have ample real VRAM and don't need -- or want -- the export slowed down for it.
+TILE_SIZE_LOW_VRAM = 1024
 TILE_HALO = 32
 TILING_THRESHOLD_PX = 12_000_000
 HISTOGRAM_BINS = 256
@@ -2261,13 +2263,14 @@ class GPUEngine:
             halo = max(halo, int(np.ceil(max(5.0, 25.0 * scale_factor))))
         halo = min(halo, 512)
 
-        # An integrated GPU gets a smaller tile (see TILE_SIZE_INTEGRATED_GPU) and
-        # skips the one-tile-ahead pipelining below: on a tight, unqueryable VRAM
-        # budget, keeping two tiles' worth of textures/buffers live at once is the
-        # difference between fitting and a device-lost abort. Discrete GPUs keep
-        # both the full tile size and the overlap for throughput.
-        is_integrated = self.gpu.is_integrated
-        tile_size = TILE_SIZE_INTEGRATED_GPU if is_integrated else TILE_SIZE
+        # Opt-in (AppConfig.low_vram_export_tiling, off by default): a smaller tile
+        # (see TILE_SIZE_LOW_VRAM) and skipping the one-tile-ahead pipelining below --
+        # on a tight, unqueryable VRAM budget, keeping two tiles' worth of
+        # textures/buffers live at once is the difference between fitting and a
+        # device-lost abort. Left off, exports keep both the full tile size and the
+        # overlap for throughput.
+        low_vram = APP_CONFIG.low_vram_export_tiling
+        tile_size = TILE_SIZE_LOW_VRAM if low_vram else TILE_SIZE
 
         # The queue serializes tile N's staging copy ahead of tile N+1's passes, so
         # deferring the map_sync by one tile is safe and overlaps the wait.
@@ -2304,7 +2307,7 @@ class GPUEngine:
                     contrast_mask_override=global_mask,
                 )
                 handle = self._submit_readback(tile_res, slot=tile_index % 2)
-                if is_integrated:
+                if low_vram:
                     self._resolve_readback(handle, full_source_res[ty : ty + th, tx : tx + tw], (oy, ox))
                 else:
                     if pending is not None:

--- a/tests/test_gpu_tiled_igpu.py
+++ b/tests/test_gpu_tiled_igpu.py
@@ -1,0 +1,92 @@
+"""Integrated GPUs get a smaller tile and no readback pipelining in
+`_process_tiled` (see gpu_engine.TILE_SIZE_INTEGRATED_GPU): a full 2048px tile's
+live intermediate textures, doubled up by the one-tile-ahead readback overlap,
+can exceed an iGPU's tight, unqueryable VRAM budget and abort the process via
+wgpu-native's panic-on-device-lost (see issue #738). This must not change the
+tiled export's output, only how much GPU memory is live at once getting there.
+"""
+
+import unittest
+from dataclasses import replace
+from unittest.mock import PropertyMock, patch
+
+import numpy as np
+
+from negpy.domain.models import WorkspaceConfig
+from negpy.features.process.models import ProcessMode
+from negpy.infrastructure.gpu.device import GPUDevice
+from negpy.services.rendering.gpu_engine import GPUEngine, TILE_SIZE, TILE_SIZE_INTEGRATED_GPU
+
+
+def _negative(h: int, w: int) -> np.ndarray:
+    yy, xx = np.mgrid[0:h, 0:w].astype(np.float32)
+    ramp = (xx / w) * 0.5 + (yy / h) * 0.25
+    blobs = 0.08 * np.sin(xx / 90.0) * np.cos(yy / 40.0) + 0.05 * np.sin((xx + yy) / 160.0)
+    img = np.empty((h, w, 3), dtype=np.float32)
+    img[..., 0] = 0.55 + ramp * 0.30 + blobs
+    img[..., 1] = 0.35 + ramp * 0.25 + blobs * 0.7
+    img[..., 2] = 0.15 + ramp * 0.20 + blobs * 0.4
+    return np.clip(img, 1e-4, 1.0)
+
+
+def _base() -> WorkspaceConfig:
+    s = WorkspaceConfig()
+    return replace(
+        s,
+        process=replace(s.process, process_mode=ProcessMode.C41),
+        export=replace(s.export, export_resolution_mode="original"),
+    )
+
+
+@unittest.skipUnless(GPUDevice.get().is_available, "GPU not available")
+class TestGpuTiledIntegratedGpu(unittest.TestCase):
+    def setUp(self):
+        self.engine = GPUEngine()
+        # Wider than either tile size, so both branches actually span multiple tiles.
+        self.img = _negative(300, 2400)
+
+    def tearDown(self):
+        self.engine.destroy_all()
+
+    def _tile_count(self, is_integrated: bool) -> int:
+        calls = 0
+        real = self.engine.process_to_texture
+
+        def counting(*args, **kwargs):
+            nonlocal calls
+            calls += 1
+            return real(*args, **kwargs)
+
+        with patch.object(GPUDevice, "is_integrated", new_callable=PropertyMock) as mock_integrated:
+            mock_integrated.return_value = is_integrated
+            with patch.object(self.engine, "process_to_texture", side_effect=counting):
+                self.engine._process_tiled(self.img, _base(), scale_factor=1.0)
+        return calls
+
+    def test_integrated_gpu_uses_smaller_tile(self):
+        # One extra call is the preview-sized metering pass shared by both branches;
+        # what should differ is how many tiles that leaves for the crop itself.
+        discrete_tiles = self._tile_count(is_integrated=False) - 1
+        integrated_tiles = self._tile_count(is_integrated=True) - 1
+        self.assertGreater(
+            integrated_tiles,
+            discrete_tiles,
+            "Integrated GPU did not split the export into more, smaller tiles",
+        )
+        self.assertEqual(TILE_SIZE, 2048)
+        self.assertLess(TILE_SIZE_INTEGRATED_GPU, TILE_SIZE)
+
+    def test_integrated_gpu_output_matches_discrete_tiling(self):
+        """Smaller tiles and no pipelining must not change what gets exported."""
+        settings = _base()
+        with patch.object(GPUDevice, "is_integrated", new_callable=PropertyMock) as mock_integrated:
+            mock_integrated.return_value = False
+            discrete, _ = self.engine._process_tiled(self.img, settings, scale_factor=1.0)
+            mock_integrated.return_value = True
+            integrated, _ = self.engine._process_tiled(self.img, settings, scale_factor=1.0)
+        self.assertEqual(discrete.shape, integrated.shape)
+        self.assertLess(float(np.abs(discrete - integrated).mean()), 0.0005)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gpu_tiled_low_vram.py
+++ b/tests/test_gpu_tiled_low_vram.py
@@ -1,21 +1,24 @@
-"""Integrated GPUs get a smaller tile and no readback pipelining in
-`_process_tiled` (see gpu_engine.TILE_SIZE_INTEGRATED_GPU): a full 2048px tile's
-live intermediate textures, doubled up by the one-tile-ahead readback overlap,
-can exceed an iGPU's tight, unqueryable VRAM budget and abort the process via
-wgpu-native's panic-on-device-lost (see issue #738). This must not change the
-tiled export's output, only how much GPU memory is live at once getting there.
+"""With AppConfig.low_vram_export_tiling on, `_process_tiled` uses a smaller tile
+and skips readback pipelining (see gpu_engine.TILE_SIZE_LOW_VRAM): a full 2048px
+tile's live intermediate textures, doubled up by the one-tile-ahead readback
+overlap, can exceed a tight, unqueryable VRAM budget (typically an older or
+memory-constrained integrated GPU) and abort the process via wgpu-native's
+panic-on-device-lost (see issue #738). Off by default -- opt in from Preferences
+or override.toml. This must not change the tiled export's output, only how much
+GPU memory is live at once getting there.
 """
 
 import unittest
 from dataclasses import replace
-from unittest.mock import PropertyMock, patch
+from unittest.mock import patch
 
 import numpy as np
 
 from negpy.domain.models import WorkspaceConfig
 from negpy.features.process.models import ProcessMode
 from negpy.infrastructure.gpu.device import GPUDevice
-from negpy.services.rendering.gpu_engine import GPUEngine, TILE_SIZE, TILE_SIZE_INTEGRATED_GPU
+from negpy.kernel.system.config import APP_CONFIG
+from negpy.services.rendering.gpu_engine import GPUEngine, TILE_SIZE, TILE_SIZE_LOW_VRAM
 
 
 def _negative(h: int, w: int) -> np.ndarray:
@@ -39,16 +42,18 @@ def _base() -> WorkspaceConfig:
 
 
 @unittest.skipUnless(GPUDevice.get().is_available, "GPU not available")
-class TestGpuTiledIntegratedGpu(unittest.TestCase):
+class TestGpuTiledLowVram(unittest.TestCase):
     def setUp(self):
         self.engine = GPUEngine()
         # Wider than either tile size, so both branches actually span multiple tiles.
         self.img = _negative(300, 2400)
+        self._prev_low_vram = APP_CONFIG.low_vram_export_tiling
 
     def tearDown(self):
         self.engine.destroy_all()
+        APP_CONFIG.low_vram_export_tiling = self._prev_low_vram
 
-    def _tile_count(self, is_integrated: bool) -> int:
+    def _tile_count(self, low_vram: bool) -> int:
         calls = 0
         real = self.engine.process_to_texture
 
@@ -57,35 +62,33 @@ class TestGpuTiledIntegratedGpu(unittest.TestCase):
             calls += 1
             return real(*args, **kwargs)
 
-        with patch.object(GPUDevice, "is_integrated", new_callable=PropertyMock) as mock_integrated:
-            mock_integrated.return_value = is_integrated
+        with patch.object(APP_CONFIG, "low_vram_export_tiling", low_vram):
             with patch.object(self.engine, "process_to_texture", side_effect=counting):
                 self.engine._process_tiled(self.img, _base(), scale_factor=1.0)
         return calls
 
-    def test_integrated_gpu_uses_smaller_tile(self):
+    def test_low_vram_uses_smaller_tile(self):
         # One extra call is the preview-sized metering pass shared by both branches;
         # what should differ is how many tiles that leaves for the crop itself.
-        discrete_tiles = self._tile_count(is_integrated=False) - 1
-        integrated_tiles = self._tile_count(is_integrated=True) - 1
+        default_tiles = self._tile_count(low_vram=False) - 1
+        low_vram_tiles = self._tile_count(low_vram=True) - 1
         self.assertGreater(
-            integrated_tiles,
-            discrete_tiles,
-            "Integrated GPU did not split the export into more, smaller tiles",
+            low_vram_tiles,
+            default_tiles,
+            "low_vram_export_tiling did not split the export into more, smaller tiles",
         )
         self.assertEqual(TILE_SIZE, 2048)
-        self.assertLess(TILE_SIZE_INTEGRATED_GPU, TILE_SIZE)
+        self.assertLess(TILE_SIZE_LOW_VRAM, TILE_SIZE)
 
-    def test_integrated_gpu_output_matches_discrete_tiling(self):
+    def test_low_vram_output_matches_default_tiling(self):
         """Smaller tiles and no pipelining must not change what gets exported."""
         settings = _base()
-        with patch.object(GPUDevice, "is_integrated", new_callable=PropertyMock) as mock_integrated:
-            mock_integrated.return_value = False
-            discrete, _ = self.engine._process_tiled(self.img, settings, scale_factor=1.0)
-            mock_integrated.return_value = True
-            integrated, _ = self.engine._process_tiled(self.img, settings, scale_factor=1.0)
-        self.assertEqual(discrete.shape, integrated.shape)
-        self.assertLess(float(np.abs(discrete - integrated).mean()), 0.0005)
+        with patch.object(APP_CONFIG, "low_vram_export_tiling", False):
+            default, _ = self.engine._process_tiled(self.img, settings, scale_factor=1.0)
+        with patch.object(APP_CONFIG, "low_vram_export_tiling", True):
+            low_vram, _ = self.engine._process_tiled(self.img, settings, scale_factor=1.0)
+        self.assertEqual(default.shape, low_vram.shape)
+        self.assertLess(float(np.abs(default - low_vram).mean()), 0.0005)
 
 
 if __name__ == "__main__":

--- a/tests/test_override_config.py
+++ b/tests/test_override_config.py
@@ -138,6 +138,18 @@ class TestOverrideConfigParsing(unittest.TestCase):
         cfg = _parse({})
         self.assertIsNone(cfg.force_hq_preview)
 
+    def test_parse_low_vram_export_tiling_true(self):
+        cfg = _parse({"performance": {"low_vram_export_tiling": True}})
+        self.assertTrue(cfg.low_vram_export_tiling)
+
+    def test_parse_low_vram_export_tiling_false(self):
+        cfg = _parse({"performance": {"low_vram_export_tiling": False}})
+        self.assertFalse(cfg.low_vram_export_tiling)
+
+    def test_parse_low_vram_export_tiling_absent_yields_none(self):
+        cfg = _parse({})
+        self.assertIsNone(cfg.low_vram_export_tiling)
+
     def test_parse_empty_dict_returns_all_defaults(self):
         cfg = _parse({})
         self.assertEqual(cfg.backend, "auto")
@@ -374,6 +386,18 @@ class TestApplyOverride(unittest.TestCase):
         app_config = _make_app_config()
         apply(cfg, app_config)
         self.assertIsNone(app_config.force_hq_preview)
+
+    def test_low_vram_export_tiling_true_propagated(self):
+        cfg = OverrideConfig(low_vram_export_tiling=True)
+        app_config = _make_app_config()
+        apply(cfg, app_config)
+        self.assertTrue(app_config.low_vram_export_tiling)
+
+    def test_low_vram_export_tiling_none_leaves_app_config_unchanged(self):
+        cfg = OverrideConfig(low_vram_export_tiling=None)
+        app_config = _make_app_config(low_vram_export_tiling=False)
+        apply(cfg, app_config)
+        self.assertFalse(app_config.low_vram_export_tiling)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Related to #738. #1006 fixed a wgpu-native panic-on-device-lost crash (an uncatchable abort across the FFI boundary) caused by handing an oversized buffer straight to the GPU on integrated GPUs -- but only for the HQ preview load path. #738's crash trace shows the same panic signature during export, through `_process_tiled`, on an Intel HD 615 iGPU.

`_process_tiled` already tiles large exports at a fixed 2048px, so there's no single oversized buffer the way #1006's preview crash had. What it does have: each tile's readback is deferred one tile behind its compute pass (an intentional throughput optimization), so two tiles' worth of intermediate textures/buffers are live on the GPU at once. On a device with a tight, unqueryable VRAM budget, that overlap is a plausible way to tip a submission over the edge.

This shrinks the tile to 1024px and drops the readback pipelining. **Originally this was gated on `GPUDevice.is_integrated`, but that lumps every integrated GPU together** -- a capable one (AMD's 890M, Apple Silicon) would take the smaller-tile/no-pipelining hit meant for older or memory-constrained hardware like the Intel HD 615 above, for no reason. Updated per review: it's now an explicit, **off-by-default** setting, `low_vram_export_tiling`, available in Preferences (Performance section, next to Multi-core CPU rendering) and as an `override.toml` key -- same override-wins-then-saved-setting-then-default resolution as `cpu_parallel`. The tiling/pipelining logic itself is unchanged, only what turns it on.

**This is untested on real hardware.** I have not reproduced #738's crash -- I don't have access to the reporter's setup, and the reasoning here is extended from #1006 (a confirmed fix, on confirmed hardware) rather than from a repro of this specific crash. Output is verified byte-for-byte identical to the default tiled path via new unit tests, so this should be a no-op for everyone until the setting is turned on. Since it's opt-in now, testing matters even more -- I'd appreciate it if @P3RM-Mint (or anyone else hitting export crashes on an integrated GPU) could flip the checkbox once this is available and report back before this is treated as resolving #738.

## Test plan
- [x] `make all` (format, lint, type check, full test suite) passes
- [x] New tests (`tests/test_gpu_tiled_low_vram.py`): `low_vram_export_tiling` uses smaller tiles; output parity with the default tiling (mean abs diff < 0.0005)
- [x] `override.toml` parsing/precedence and the Preferences checkbox covered in `tests/test_override_config.py` / `tests/test_preferences_dialog.py`
- [ ] **Not verified against #738** -- needs confirmation on integrated-GPU hardware, with the setting turned on, from the reporter or another affected user
