### PR TITLE
fix(tests): decode the red-only reference neutral in the triplet merge test

### DIFF
--- a/tests/test_rgbscan.py
+++ b/tests/test_rgbscan.py
@@ -511,7 +511,8 @@ def test_preview_merge_pulls_green_blue_from_their_files():
     pm = PreviewManager()
     r, g, b = (os.path.join("samples", f) for f in _SAMPLES)
     merged, _, _ = pm.load_linear_preview_rgb(r, RgbScanConfig(enabled=True, green_path=g, blue_path=b), "Adobe RGB", use_camera_wb=True)
-    red_only, _, _ = pm.load_linear_preview(r, "Adobe RGB", use_camera_wb=True)
+    # The merge decodes every exposure neutral, so the red-only reference must too.
+    red_only, _, _ = pm.load_linear_preview(r, "Adobe RGB", use_camera_wb=False)
     # Red-only has near-zero G/B (narrowband); the merge fills them from the other shots.
     assert merged[..., 1].mean() > red_only[..., 1].mean() * 3
     assert merged[..., 2].mean() > red_only[..., 2].mean() * 3


### PR DESCRIPTION
## What

`test_preview_merge_pulls_green_blue_from_their_files` failed on `main`:

```
assert 0.05445602908730507 < 0.001
 +  where 0.05445602908730507 = abs((0.03344361111521721 - 0.08789964020252228))
```

## Why

`load_linear_preview_rgb` decodes every triplet exposure with camera white
balance off (#952) — a narrowband exposure has no full-spectrum scene for a WB
gain to describe. The test still built its red-only reference with
`use_camera_wb=True`, so the two red channels differed by the raw red WB gain
(2.63x on the sample triplet) and the "red channel is unchanged" assertion
failed.

The merge is correct; the reference was not. It now decodes neutral as well.

## Note

The test skips unless `samples/` is present, so CI never ran it. The failure
only shows locally.

## Verification

`make all` green: lint, ty, 5322 passed / 10 skipped.