### PR TITLE
fix(preview): demosaic X-Trans previews with Markesteijn, not LINEAR

### DIFF
--- a/negpy/infrastructure/loaders/helpers.py
+++ b/negpy/infrastructure/loaders/helpers.py
@@ -201,45 +201,26 @@ class NonStandardFileWrapper:
         return (data * 255.0).astype(np.uint8)
 
 
-def get_best_demosaic_algorithm(raw: Any, for_preview: bool = False) -> Any:
-    """
-    Selects optimal demosaicing algorithm based on sensor type and CFA pattern.
-    Exclusively uses algorithms packaged in the standard permissive (LGPL) rawpy build.
+def get_best_demosaic_algorithm(raw: Any) -> Any:
+    """AHD for a mosaiced sensor, LINEAR for anything that arrives de-mosaiced.
 
-    When for_preview=True, selects faster algorithms appropriate for downsampled
-    preview rendering (PPG for Bayer, LINEAR for X-Trans).
+    Only algorithms in the permissive (LGPL) rawpy build are used. On a 6x6 X-Trans CFA
+    this never reaches ahd_interpolate: LibRaw routes filters==9 to Markesteijn ahead of
+    the quality dispatch, 3-pass above PPG and 1-pass at PPG or below. Every value above
+    PPG renders the same image, so the choice only has to stay above PPG.
     """
-    selected_algo = rawpy.DemosaicAlgorithm.LINEAR
-
     if isinstance(raw, NonStandardFileWrapper):
-        return selected_algo
+        return rawpy.DemosaicAlgorithm.LINEAR
 
     try:
-        # Stacked sensors (Linear DNG, Foveon, sRAW)
-        if raw.raw_type == rawpy.RawType.Stack:
-            selected_algo = rawpy.DemosaicAlgorithm.LINEAR
-
-        # Flat sensors (Bayer, X-Trans)
-        elif raw.raw_type == rawpy.RawType.Flat:
-            cfa_block_size = raw.raw_pattern.shape[0]
-
-            if cfa_block_size == 6:
-                # A 6x6 block means a Fujifilm X-Trans sensor. LINEAR is much faster than DHT and its
-                # artifacts are invisible at preview scale. VNG was used before, but it produces dot and
-                # maze artifacts on X-Trans's 6x6 pattern in high-contrast regions (see #272). DHT was
-                # added to dcraw and LibRaw specifically to handle X-Trans, and is also LGPL-clean.
-                selected_algo = rawpy.DemosaicAlgorithm.LINEAR if for_preview else rawpy.DemosaicAlgorithm.DHT
-
-            elif cfa_block_size == 2:
-                # A 2x2 block means a standard Bayer sensor. PPG is faster than AHD with negligible
-                # quality difference at preview scale.
-                selected_algo = rawpy.DemosaicAlgorithm.PPG if for_preview else rawpy.DemosaicAlgorithm.AHD
-
+        # A 2x2 CFA block is Bayer, 6x6 is X-Trans. Anything else (Stack: Linear DNG, Foveon,
+        # sRAW) arrives de-mosaiced and only LINEAR is meaningful.
+        if raw.raw_type == rawpy.RawType.Flat and raw.raw_pattern.shape[0] in (2, 6):
+            return rawpy.DemosaicAlgorithm.AHD
     except (AttributeError, ValueError) as e:
         logger.exception(f"Failed to determine sensor CFA pattern: {e}. Falling back to LINEAR.")
-        selected_algo = rawpy.DemosaicAlgorithm.LINEAR
 
-    return selected_algo
+    return rawpy.DemosaicAlgorithm.LINEAR
 
 
 def is_xtrans(raw: Any) -> bool:

--- a/negpy/services/rendering/preview_manager.py
+++ b/negpy/services/rendering/preview_manager.py
@@ -144,11 +144,15 @@ class PreviewManager:
 
         use_fast = (not full_resolution) and (not isinstance(raw, NonStandardFileWrapper))
         if use_fast:
-            demosaic = rawpy.DemosaicAlgorithm.LINEAR
             # half_size aliases the X-Trans 6x6 CFA into a channel-ratio cast that shows in
             # linear decodes. Bayer 2x2 averages cleanly and camera-WB previews tolerate it, so
             # only linear X-Trans decodes full-res and lets the cv2 downsample below handle it.
-            post_kw: dict = {} if (is_xtrans(raw) and not use_camera_wb) else {"half_size": True}
+            xtrans_full = is_xtrans(raw) and not use_camera_wb
+            post_kw: dict = {} if xtrans_full else {"half_size": True}
+            # That decode is the one preview that interpolates a 6x6 CFA, where LINEAR aliases
+            # far worse than the render it stands in for. PPG is LibRaw's spelling of 1-pass
+            # Markesteijn on X-Trans -- it tracks the 3-pass render at half the cost of matching it.
+            demosaic = rawpy.DemosaicAlgorithm.PPG if xtrans_full else rawpy.DemosaicAlgorithm.LINEAR
         else:
             demosaic = get_best_demosaic_algorithm(raw)
             post_kw = {}
@@ -394,13 +398,9 @@ class PreviewManager:
         try:
             ctx_mgr, _meta = loader_factory.get_loader(file_path, linear_raw=True)
             with ctx_mgr as raw:
-                if isinstance(raw, NonStandardFileWrapper):
-                    demosaic = get_best_demosaic_algorithm(raw)
-                    post_kw: dict = {}
-                else:
-                    demosaic = rawpy.DemosaicAlgorithm.LINEAR
-                    # half_size casts X-Trans channel ratios and skews detection. Bayer is fine.
-                    post_kw = {} if is_xtrans(raw) else {"half_size": True}
+                demosaic = rawpy.DemosaicAlgorithm.LINEAR
+                # half_size casts X-Trans channel ratios and skews detection. Bayer is fine.
+                post_kw: dict = {} if (isinstance(raw, NonStandardFileWrapper) or is_xtrans(raw)) else {"half_size": True}
                 rgb = raw.postprocess(
                     gamma=(1, 1),
                     no_auto_bright=True,

--- a/tests/test_preview_manager.py
+++ b/tests/test_preview_manager.py
@@ -218,7 +218,8 @@ def test_load_linear_preview_hq_uses_best_demosaic_no_half() -> None:
 
 @pytest.mark.parametrize("cfa_block", [2, 6])
 def test_load_linear_preview_hq_demosaic_xtrans_vs_bayer(cfa_block: int) -> None:
-    """HQ: X-Trans (6) uses DHT; Bayer (2) uses AHD."""
+    """HQ: AHD for both. On a 6x6 CFA LibRaw substitutes Markesteijn and reads the value
+    only as a pass count, so what matters there is that it stays above PPG (3-pass)."""
     rgb_u16 = np.ones((32, 32, 3), dtype=np.uint16) * 128
 
     raw = MagicMock()
@@ -239,20 +240,27 @@ def test_load_linear_preview_hq_demosaic_xtrans_vs_bayer(cfa_block: int) -> None
         PreviewManager().load_linear_preview("/fake/path.dng", full_resolution=True)
 
     _, kwargs = raw.postprocess.call_args
-    expected = rawpy.DemosaicAlgorithm.DHT if cfa_block == 6 else rawpy.DemosaicAlgorithm.AHD
-    assert kwargs["demosaic_algorithm"] == expected
+    assert kwargs["demosaic_algorithm"] == rawpy.DemosaicAlgorithm.AHD
+    if cfa_block == 6:
+        assert kwargs["demosaic_algorithm"].value > rawpy.DemosaicAlgorithm.PPG.value
 
 
 @pytest.mark.parametrize(
-    "cfa_block,use_camera_wb,half_expected",
+    "cfa_block,use_camera_wb,half_expected,demosaic_expected",
     [
-        (6, False, False),  # X-Trans + linear: half_size aliases the 6x6 CFA → skip it
-        (6, True, True),  # X-Trans + camera WB: tolerated, keep the fast path
-        (2, False, True),  # Bayer: 2x2 averages cleanly → keep half_size
+        # X-Trans + linear: half_size aliases the 6x6 CFA → skip it, so this decode is the one
+        # preview that interpolates. PPG is LibRaw's cue for 1-pass Markesteijn there; LINEAR
+        # would alias far worse than the render it stands in for.
+        (6, False, False, rawpy.DemosaicAlgorithm.PPG),
+        (6, True, True, rawpy.DemosaicAlgorithm.LINEAR),  # X-Trans + camera WB: tolerated, keep the fast path
+        (2, False, True, rawpy.DemosaicAlgorithm.LINEAR),  # Bayer: 2x2 averages cleanly → keep half_size
     ],
 )
-def test_load_linear_preview_fast_half_size_gated_on_xtrans_linear(cfa_block: int, use_camera_wb: bool, half_expected: bool) -> None:
-    """Fast preview always uses LINEAR; half_size is dropped only for linear X-Trans decodes."""
+def test_load_linear_preview_fast_half_size_gated_on_xtrans_linear(
+    cfa_block: int, use_camera_wb: bool, half_expected: bool, demosaic_expected: object
+) -> None:
+    """half_size is dropped only for linear X-Trans decodes, which then demosaic properly.
+    Under half_size libraw skips interpolation, so the algorithm there is moot."""
     rgb_u16 = np.ones((32, 32, 3), dtype=np.uint16) * 128
 
     raw = MagicMock()
@@ -273,7 +281,7 @@ def test_load_linear_preview_fast_half_size_gated_on_xtrans_linear(cfa_block: in
         PreviewManager().load_linear_preview("/fake/path.dng", color_space="Adobe RGB", use_camera_wb=use_camera_wb, full_resolution=False)
 
     _, kwargs = raw.postprocess.call_args
-    assert kwargs["demosaic_algorithm"] == rawpy.DemosaicAlgorithm.LINEAR
+    assert kwargs["demosaic_algorithm"] == demosaic_expected
     assert (kwargs.get("half_size") is True) == half_expected
 
 

--- a/tests/test_raw_handlers.py
+++ b/tests/test_raw_handlers.py
@@ -30,19 +30,15 @@ class TestRawHandlers(unittest.TestCase):
             self.assertEqual(processed.dtype, np.uint16)
             self.assertAlmostEqual(np.mean(processed), 32767, delta=100)
 
-    def test_xtrans_full_res_uses_dht_not_vng(self):
-        # VNG produces dot/maze artifacts on X-Trans's 6x6 CFA in high-contrast
-        # regions (see issue #272). DHT is the LGPL-clean algorithm built for X-Trans.
+    def test_xtrans_stays_above_ppg_for_3_pass_markesteijn(self):
+        # LibRaw reads this only as a pass count for a 6x6 CFA: PPG or below drops
+        # Markesteijn to 1 pass, which brings back dot/maze artifacts (see issue #272).
         raw = _FakeRaw(rawpy.RawType.Flat, block_size=6)
-        self.assertEqual(get_best_demosaic_algorithm(raw, for_preview=False), rawpy.DemosaicAlgorithm.DHT)
+        self.assertGreater(get_best_demosaic_algorithm(raw).value, rawpy.DemosaicAlgorithm.PPG.value)
 
-    def test_xtrans_preview_uses_linear(self):
-        raw = _FakeRaw(rawpy.RawType.Flat, block_size=6)
-        self.assertEqual(get_best_demosaic_algorithm(raw, for_preview=True), rawpy.DemosaicAlgorithm.LINEAR)
-
-    def test_bayer_full_res_uses_ahd(self):
+    def test_bayer_uses_ahd(self):
         raw = _FakeRaw(rawpy.RawType.Flat, block_size=2)
-        self.assertEqual(get_best_demosaic_algorithm(raw, for_preview=False), rawpy.DemosaicAlgorithm.AHD)
+        self.assertEqual(get_best_demosaic_algorithm(raw), rawpy.DemosaicAlgorithm.AHD)
 
     def test_is_xtrans(self):
         self.assertTrue(is_xtrans(_FakeRaw(rawpy.RawType.Flat, block_size=6)))


### PR DESCRIPTION
Follow-up to investigating #985.

## The finding

libraw routes an X-Trans sensor to Markesteijn **before** it reads the quality number:

```c
else if (quality == 2 && filters > 1000) ppg_interpolate();
else if (filters == 9)                   xtrans_interpolate(quality > 2 ? 3 : 1);  // X-Trans exits here
else if (quality == 3)                   ahd_interpolate();
...
else if (quality == 11)                  dht_interpolate();   // unreachable for a RAF
```

So `DemosaicAlgorithm.DHT` never ran `dht_interpolate` on a Fuji file. Full-res X-Trans has been Markesteijn 3-pass all along — the enum only ever chose the pass count.

Measured on an X-E4 RAF, libraw 0.22.1:

| | AHD vs DHT | AHD vs AHD (noise floor) |
|---|---|---|
| Bayer (2×2) | max 255, mean 1.161 | max 0 — bit-exact |
| X-Trans (6×6) | max 13, mean 0.000 | max 13 |

On Bayer the enum bites and reruns are deterministic. On X-Trans, AHD/DHT/AAHD are indistinguishable from a rerun of the same algorithm (the X-Trans path's OpenMP reduction is what the 13 is).

## The actual defect

The linear X-Trans **preview** decodes full-res with no `half_size` — `half_size` aliases the 6×6 CFA into a channel-ratio cast. That makes it the one preview that genuinely interpolates, and it used `LINEAR`, the worst option for that CFA. The editing view showed worms and moire the export did not have.

Against the final render, downsampled to preview size:

| preview demosaic | decode | RMSE vs downsampled final |
|---|---|---|
| `LINEAR` (before) | 254 ms | 0.992% |
| `PPG` → 1-pass Markesteijn (after) | 572 ms | **0.169%** |
| 3-pass Markesteijn | 1060 ms | 0 (reference) |

`PPG` is libraw's spelling of 1-pass Markesteijn here. Bayer and camera-WB X-Trans keep the `half_size` fast path unchanged — under `half_size` libraw skips interpolation, so the algorithm is moot there.

## Changes

- `preview_manager.py` — linear X-Trans previews demosaic with `PPG` (1-pass Markesteijn) instead of `LINEAR`.
- `helpers.py` — `DHT` → `AHD` for X-Trans (identical output, honest name); comments state the real dispatch and the one constraint that matters, stay above `PPG`. Selector collapsed 30 → 12 lines, behaviour identical.
- Removed the never-passed `for_preview` parameter, whose preview branches described decodes no caller ever made, and a branch in `decode_for_detection` whose two arms both resolved to `LINEAR`.

## Does this close #985?

**No — it may or may not be what the reporter saw.** Markesteijn 3-pass is the ceiling libraw offers, and it was already running on their export. If their moire is in the editing view, this is the fix; if it survives an export, #985 needs a demosaic outside libraw (x-veon, or similar) and stays open. Worth asking them to compare an export before closing anything.

## Testing

`make format` and `make lint` clean. **5291 passed, 13 skipped.**

Two existing tests pinned the old constants (one asserted `DHT` for X-Trans HQ — the misconception itself); both now assert the *constraint* rather than the literal, so a future edit that drops X-Trans to 1-pass or back to `LINEAR` fails. Confirmed the X-Trans assertion fails when the fix is reverted.

`tests/scanners/test_plustek_backend.py` is excluded from that count: 18 failures there on a stashed tree too (`ImportError: cannot import name 'is_gl128_opticfilm' from 'pyopticfilm.scan.bringup'`), a pyopticfilm version skew unrelated to this branch and untouched by it.

