### PR TITLE
Lens distortion without a flat-field profile, at 0.001

### DIFF
--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -8,7 +8,7 @@ Here is what happens to your image. We apply these steps in order, passing the b
 **Code**: `negpy.features.geometry`
 
 *   **Rotation**: we spin the image array in 90° steps and fine-tune with affine transformations, using bilinear interpolation so it stays sharp.
-*   **Lens distortion**: a radial $k_1$ coefficient, a rig property mirrored from the active flat-field profile (`flatfield.k1`), corrected in the same resample.
+*   **Lens distortion**: a radial $k_1$ coefficient (`geometry.distortion_k1`, ±0.10), corrected in the same resample.
 *   **Tilt and Swing** (`geometry.converge_v` / `converge_h`, ±15%): perspective correction, named for the enlarger movements. Tilt about a horizontal axis straightens converging verticals, swing about a vertical axis converging horizontals: the plane-to-plane projectivity a tilted easel realises (Hartley & Zisserman §2.3). Runs last in the forward chain, after $k_1$, since a projectivity cannot be fitted to a barrel-distorted frame. The unit is per-cent of the frame, not tilt degrees, because convergence is $(H/2)\sin\tau / D$ and no magnification or focal length is modelled. Output keeps the canvas size and replicates the wedge, as fine rotation does.
 
     `keystone_matrix_normalized` is the single definition of the quad; the pixel-space matrix and the GPU's inverse both derive from it. Every reader of geometry carries the correction: the uv grid, `map_coords_to_geometry`, autocrop's replay and detection key, and the GPU's analysis replay, whose meters must read the frame the print stage gets. Off-frame card-edge handles need `CoordinateMapping` to fit the grid projectively.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -479,6 +479,8 @@ Where the frame gets its final shape: what is inside the print, and whether it s
 
     Both replicate a wedge along the squeezed edge, as Fine Rotation does; crop it off. Crop before correcting if you can, because the meters read the corrected frame: on an uncropped scan a big correction pulls rebate and surround into the metered area and the print darkens.
 
+*   **Distortion Correction** (-0.100 to 0.100, in steps of 0.001): radial lens distortion. Positive corrects barrel, negative pincushion. Use the film rebate as a straight-edge reference. Corrected before Tilt and Swing.
+
 <!-- panel:flatfield -->
 ### 5.2 Flat Field: even out the light
 
@@ -486,7 +488,6 @@ Corrects uneven illumination (vignetting or falloff) from your copy-stand or sca
 
 *   **Flatfield Correction**: apply the active reference to this image, enabled once a profile exists.
 *   **Reference Profile** dropdown + **Add…** / **Delete**: pick a reference image and save it as a named profile. **Add…** reads the reference once and bakes its correction into the profile, so you can then move, rename or delete the original reference file without affecting your edits. The profile is self-contained, stored in NegPy's own `flatfield` folder like sensor and crosstalk profiles. **Delete** asks first: the baked gain map cannot be recovered, and every frame using the profile loses its correction.
-*   **Distortion** (-0.25 to 0.25): radial lens-distortion correction for the rig, saved with the profile. Use the film rebate as a straight-edge reference.
 
 ---
 

--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -220,9 +220,9 @@ def _autocrop_fingerprint(config: WorkspaceConfig, workspace_color_space: str) -
         str(geometry.autocrop_ratio),
         int(geometry.autocrop_offset),
         round(float(geometry.autocrop_rebate_trim), 4),
+        round(float(geometry.distortion_k1), 9),
         bool(flatfield.apply),
         str(flatfield.profile_id),
-        round(float(flatfield.k1), 9),
         bool(config.process.linear_raw),
         bool(rgbscan.enabled),
         str(rgbscan.green_path),
@@ -3166,15 +3166,14 @@ class AppController(QObject):
     def set_active_flatfield_profile(self, profile_id: str) -> None:
         """
         Selects the globally active flat-field reference profile (or clears it when
-        ``profile_id`` is empty). Stamps its id + rig distortion onto the current
-        image and re-renders.
+        ``profile_id`` is empty). Stamps its id onto the current image and re-renders.
         """
         from negpy.services.assets.flatfield import FlatFieldProfiles
 
         self.session.repo.save_global_setting("flatfield_active_profile", profile_id or "")
         prof = FlatFieldProfiles.get(profile_id) if profile_id else None
         pid = prof.id if prof else ""
-        new_ff = replace(self.state.config.flatfield, profile_id=pid, apply=bool(pid), k1=prof.k1 if prof else 0.0)
+        new_ff = replace(self.state.config.flatfield, profile_id=pid, apply=bool(pid))
         self.session.update_config(replace(self.state.config, flatfield=new_ff), persist=True)
         self.request_render()
 
@@ -3221,20 +3220,6 @@ class AppController(QObject):
         """
         new_ff = replace(self.state.config.flatfield, apply=enabled)
         self.session.update_config(replace(self.state.config, flatfield=new_ff), persist=True)
-        self.request_render()
-
-    def set_flatfield_k1(self, k1: float) -> None:
-        """
-        Sets the rig's radial distortion. Saved into the active flat-field profile (so it
-        applies to every frame on that rig), not the per-image recipe.
-        """
-        new_ff = replace(self.state.config.flatfield, k1=k1)
-        self.session.update_config(replace(self.state.config, flatfield=new_ff), persist=True)
-        active = self.session.repo.get_global_setting("flatfield_active_profile") or ""
-        if active:
-            from negpy.services.assets.flatfield import FlatFieldProfiles
-
-            FlatFieldProfiles.set_k1(active, k1)
         self.request_render()
 
     # ── Scanner integration ───────────────────────────────────────────
@@ -4157,7 +4142,6 @@ class AppController(QObject):
         if source is None:
             return
         geometry = self.state.config.geometry
-        flatfield = self.state.config.flatfield
         original = self.state.original_res if any(self.state.original_res) else source.shape[:2]
         context = PipelineContext(
             original_size=(original[0], original[1]),
@@ -4167,7 +4151,7 @@ class AppController(QObject):
             crop_preview_full=self.state.active_tool in (ToolMode.CROP_MANUAL, ToolMode.ANALYSIS_DRAW),
             wants_uv_grid=False,
         )
-        img = GeometryProcessor(geometry, flatfield.k1 if flatfield.apply else 0.0).process(source, context)
+        img = GeometryProcessor(geometry).process(source, context)
         if not context.crop_preview_full:
             img = CropProcessor(geometry).process(img, context)
         fold_wb = should_fold_camera_wb(self.state.config.process, self.state.config.exposure.render_intent)

--- a/negpy/desktop/session.py
+++ b/negpy/desktop/session.py
@@ -857,14 +857,17 @@ class DesktopSessionManager(QObject):
             if remainder:
                 config = replace(config, export=replace(config.export, **remainder))
 
-        # Flat-field profile and distortion k1 are rig-global, so the active profile's values
-        # always override the per-file ones. New files default to enabled when a profile is
-        # active, and saved files keep their toggle.
+        # The flat-field profile is rig-global, so the active one always overrides the
+        # per-file id. New files default to enabled when a profile is active, and saved
+        # files keep their toggle.
         active_ff = self.repo.get_global_setting("flatfield_active_profile")
         ff_prof = FlatFieldProfiles.get(active_ff) if active_ff else None
         ff_id = ff_prof.id if ff_prof else ""
-        ff_k1 = ff_prof.k1 if ff_prof else 0.0
-        config = replace(config, flatfield=replace(config.flatfield, profile_id=ff_id, k1=ff_k1))
+        config = replace(config, flatfield=replace(config.flatfield, profile_id=ff_id))
+        # Distortion left the profile for the per-image geometry; adopt a legacy rig value
+        # once, on frames that carry none of their own.
+        if config.geometry.distortion_k1 == 0.0 and ff_prof is not None and ff_prof.k1 != 0.0:
+            config = replace(config, geometry=replace(config.geometry, distortion_k1=ff_prof.k1))
 
         rows = load_sticky_rows(self.repo)
         if only_global:

--- a/negpy/desktop/settings_catalog.py
+++ b/negpy/desktop/settings_catalog.py
@@ -129,6 +129,7 @@ CATALOG: list[tuple[str, tuple[SettingRow, ...]]] = [
         _row("Fine Rotation", "geometry", "fine_rotation"),
         _row("Easel Tilt", "geometry", "converge_v"),
         _row("Easel Swing", "geometry", "converge_h"),
+    _row("Distortion Correction", "geometry", "distortion_k1", sticky=True),
         _row("Flip Horizontal", "geometry", "flip_horizontal", sticky=True),
         _row("Flip Vertical", "geometry", "flip_vertical", sticky=True),
     )),

--- a/negpy/desktop/view/sidebar/controls_panel.py
+++ b/negpy/desktop/view/sidebar/controls_panel.py
@@ -866,6 +866,7 @@ class ControlsPanel(QWidget):
                 geo.autocrop_mode != _geo.autocrop_mode,
                 geo.autocrop_offset != _geo.autocrop_offset,
                 geo.autocrop_rebate_trim != _geo.autocrop_rebate_trim,
+                geo.distortion_k1 != _geo.distortion_k1,
             ]
         )
 
@@ -906,7 +907,6 @@ class ControlsPanel(QWidget):
             [
                 ff.apply != _ff.apply,
                 ff.profile_id != _ff.profile_id,
-                ff.k1 != _ff.k1,
             ]
         )
 

--- a/negpy/desktop/view/sidebar/flatfield.py
+++ b/negpy/desktop/view/sidebar/flatfield.py
@@ -16,7 +16,6 @@ from negpy.desktop.view.sidebar.base import BaseSidebar
 from negpy.desktop.view.styles.templates import section_subheader
 from negpy.desktop.view.styles.theme import THEME
 from negpy.desktop.view.widgets.file_dialogs import last_open_folder, pick_start_dir
-from negpy.desktop.view.widgets.sliders import CompactSlider
 
 _NONE_LABEL = "— None —"
 _FILE_FILTER = "Reference images (*.dng *.tif *.tiff *.cr2 *.cr3 *.nef *.arw *.raf *.rw2 *.jpg *.jpeg *.png);;All files (*)"
@@ -56,13 +55,6 @@ class FlatFieldSidebar(BaseSidebar):
         actions.addWidget(self.delete_btn)
         self.layout.addLayout(actions)
 
-        self.layout.addWidget(section_subheader("LENS DISTORTION"))
-        self.k1_slider = CompactSlider("Distortion", -0.25, 0.25, self.state.config.flatfield.k1, step=0.005, has_neutral=True)
-        self.k1_slider.setToolTip(
-            "Radial lens-distortion correction for the copy-stand rig.\nSaved with the profile. Use the film rebate as a straight reference."
-        )
-        self.layout.addWidget(self.k1_slider)
-
         self.layout.addStretch()
         self._refresh_profiles()
 
@@ -71,12 +63,6 @@ class FlatFieldSidebar(BaseSidebar):
         self.profile_combo.currentIndexChanged.connect(self._on_profile_selected)
         self.add_btn.clicked.connect(self._on_add)
         self.delete_btn.clicked.connect(self._on_delete)
-        # Drag = live preview only; commit writes k1 to the profile (its real home).
-        self.k1_slider.valueChanged.connect(
-            lambda v: self.update_config_section("flatfield", render=True, persist=False, readback_metrics=False, k1=v)
-        )
-        self.k1_slider.valueChanged.connect(lambda _v: self.controller.show_rotation_guide())
-        self.k1_slider.valueCommitted.connect(self.controller.set_flatfield_k1)
         self.sync_ui()
 
     def _refresh_profiles(self) -> None:
@@ -142,11 +128,9 @@ class FlatFieldSidebar(BaseSidebar):
 
             self.enable_btn.setChecked(conf.apply)
             self.enable_btn.setEnabled(bool(conf.profile_id))
-            self.k1_slider.setValue(conf.k1)
-            self.k1_slider.setEnabled(bool(conf.profile_id))
         finally:
             self.block_signals(False)
 
     def block_signals(self, blocked: bool) -> None:
-        for w in (self.enable_btn, self.profile_combo, self.add_btn, self.delete_btn, self.k1_slider):
+        for w in (self.enable_btn, self.profile_combo, self.add_btn, self.delete_btn):
             w.blockSignals(blocked)

--- a/negpy/desktop/view/sidebar/geometry.py
+++ b/negpy/desktop/view/sidebar/geometry.py
@@ -167,6 +167,16 @@ class GeometrySidebar(BaseSidebar):
         converge_row.addWidget(self.converge_h_slider)
         self.layout.addLayout(converge_row)
 
+        self.distortion_slider = CompactSlider(
+            "Distortion Correction", -0.10, 0.10, conf.distortion_k1, step=0.001, precision=1000, has_neutral=True
+        )
+        # Nothing derives the readout's decimals from `precision`, so a 0.001 step needs both.
+        self.distortion_slider.spin.setDecimals(3)
+        self.distortion_slider.setToolTip(
+            "Radial lens distortion. Positive corrects barrel, negative pincushion. Use the film rebate as a straight reference."
+        )
+        self.layout.addWidget(self.distortion_slider)
+
     def cycle_guide(self) -> None:
         self.guide_combo.setCurrentIndex((self.guide_combo.currentIndex() + 1) % self.guide_combo.count())
 
@@ -209,7 +219,13 @@ class GeometrySidebar(BaseSidebar):
             lambda v: self.update_config_section("geometry", render=True, persist=True, readback_metrics=True, fine_rotation=-v)
         )
 
-        for slider, field in ((self.converge_v_slider, "converge_v"), (self.converge_h_slider, "converge_h")):
+        self.distortion_slider.valueChanged.connect(lambda _v: self.controller.show_rotation_guide())
+
+        for slider, field in (
+            (self.converge_v_slider, "converge_v"),
+            (self.converge_h_slider, "converge_h"),
+            (self.distortion_slider, "distortion_k1"),
+        ):
             slider.valueChanged.connect(
                 lambda v, f=field: self.update_config_section("geometry", render=True, persist=False, readback_metrics=False, **{f: v})
             )
@@ -276,6 +292,7 @@ class GeometrySidebar(BaseSidebar):
             self.fine_rot_slider.setValue(-conf.fine_rotation)
             self.converge_v_slider.setValue(conf.converge_v)
             self.converge_h_slider.setValue(conf.converge_h)
+            self.distortion_slider.setValue(conf.distortion_k1)
 
             self.manual_crop_btn.setChecked(self.state.active_tool == ToolMode.CROP_MANUAL)
             self.straighten_btn.setChecked(self.state.active_tool == ToolMode.STRAIGHTEN)
@@ -298,6 +315,7 @@ class GeometrySidebar(BaseSidebar):
         self.fine_rot_slider.blockSignals(blocked)
         self.converge_v_slider.blockSignals(blocked)
         self.converge_h_slider.blockSignals(blocked)
+        self.distortion_slider.blockSignals(blocked)
         self.manual_crop_btn.blockSignals(blocked)
         self.straighten_btn.blockSignals(blocked)
         self.reset_crop_btn.blockSignals(blocked)

--- a/negpy/desktop/view/widgets/sliders.py
+++ b/negpy/desktop/view/widgets/sliders.py
@@ -597,7 +597,7 @@ def clone_slider(src: CompactSlider) -> CompactSlider:
     if cls is KelvinSlider:
         return KelvinSlider(label)
     if cls is CompactSlider:
-        return CompactSlider(
+        clone = CompactSlider(
             label,
             src._min,
             src._max,
@@ -609,6 +609,9 @@ def clone_slider(src: CompactSlider) -> CompactSlider:
             unit=src.spin.suffix(),
             inverted=src.slider.invertedAppearance(),
         )
+        # Decimals are not a constructor argument, so a fine slider would drop back to 2.
+        clone.spin.setDecimals(src.spin.decimals())
+        return clone
     raise TypeError(f"clone_slider: unhandled slider class {cls.__name__}")
 
 

--- a/negpy/desktop/workers/render.py
+++ b/negpy/desktop/workers/render.py
@@ -1160,8 +1160,7 @@ class BatchAutoCropWorker(QObject):
                 scale_factor=1.0,
                 process_mode=config.process.process_mode,
             )
-            distortion_k1 = config.flatfield.k1 if config.flatfield.apply else 0.0
-            transformed = GeometryProcessor(detection_geometry, distortion_k1).process(corrected, context)
+            transformed = GeometryProcessor(detection_geometry).process(corrected, context)
             if self._cancel_requested(generation):
                 return None
             return detect_crop_candidate(

--- a/negpy/domain/migrations.py
+++ b/negpy/domain/migrations.py
@@ -44,6 +44,8 @@ KEY_RENAMES: Dict[str, str] = {
     # An old save with True and no rect lands armed, so it resolves on the next render.
     "manual_crop_rect": "crop_rect",
     "auto_crop_enabled": "crop_from_auto",
+    # Lens distortion moved from the rig's flat-field profile to the per-image geometry.
+    "k1": "distortion_k1",
 }
 
 # Fields removed over time. Old saves still carry them, so drop them silently and

--- a/negpy/features/flatfield/models.py
+++ b/negpy/features/flatfield/models.py
@@ -13,7 +13,3 @@ class FlatFieldConfig:
     # machines: the render path resolves the gain by this id, so the original reference image
     # can be moved or deleted without breaking the correction.
     profile_id: str = ""
-    # Radial lens-distortion coefficient. A rig property, so it is mirrored from the active
-    # profile, re-seeded on load, and consumed by the geometry stage. Not owned by the
-    # per-image edit.
-    k1: float = 0.0

--- a/negpy/features/geometry/models.py
+++ b/negpy/features/geometry/models.py
@@ -110,6 +110,8 @@ class GeometryConfig:
     # geometry.logic). Positive converge_v stretches the top edge, converge_h the left.
     converge_v: float = 0.0  # [-15.0, 15.0] %
     converge_h: float = 0.0  # [-15.0, 15.0] %
+    # Radial lens-distortion coefficient, corrected before keystone. [-0.10, 0.10]
+    distortion_k1: float = 0.0
     autocrop_offset: int = 0
     # Free, not 3:2: autocrop reads the film format off the detected frame, so the
     # default fits 6x6, 645 and 6x7 as well as 35mm. A fixed 3:2 center-cropped every

--- a/negpy/features/geometry/processor.py
+++ b/negpy/features/geometry/processor.py
@@ -16,9 +16,8 @@ class GeometryProcessor:
     Rotates and detects crop.
     """
 
-    def __init__(self, config: GeometryConfig, distortion_k1: float = 0.0):
+    def __init__(self, config: GeometryConfig):
         self.config = config
-        self.distortion_k1 = distortion_k1
 
     def process(self, image: ImageBuffer, context: PipelineContext) -> ImageBuffer:
         img = image
@@ -35,8 +34,8 @@ class GeometryProcessor:
         if self.config.fine_rotation != 0.0:
             img = apply_fine_rotation(img, self.config.fine_rotation)
 
-        if self.distortion_k1 != 0.0:
-            img = apply_radial_distortion(img, self.distortion_k1)
+        if self.config.distortion_k1 != 0.0:
+            img = apply_radial_distortion(img, self.config.distortion_k1)
 
         # Last in the forward chain: a plane projectivity cannot be fitted to a frame that
         # still carries barrel distortion.
@@ -51,7 +50,7 @@ class GeometryProcessor:
             "converge_h": self.config.converge_h,
         }
         # Downstream coordinate mappers (retouch/local) need the same correction.
-        context.metrics["distortion_k1"] = self.distortion_k1
+        context.metrics["distortion_k1"] = self.config.distortion_k1
 
         # Drawn or detected, the rect is already in crop_rect: ImageProcessor resolves
         # detection before the engines, never here.

--- a/negpy/services/assets/flatfield.py
+++ b/negpy/services/assets/flatfield.py
@@ -138,20 +138,6 @@ class FlatFieldProfiles:
         return sorted(out, key=lambda t: t[1].lower())
 
     @staticmethod
-    def set_k1(profile_id: str, k1: float) -> None:
-        """Rewrite a profile's rig distortion in place, preserving its baked gain."""
-        data = FlatFieldProfiles._read(profile_id, ("gain", "name", "source"))
-        if data is None or "gain" not in data:
-            return
-        FlatFieldProfiles._write(
-            profile_id,
-            np.ascontiguousarray(data["gain"], dtype=np.float32),
-            name=str(data["name"]) if "name" in data else profile_id,
-            k1=k1,
-            source=str(data["source"]) if "source" in data else "",
-        )
-
-    @staticmethod
     def delete(profile_id: str) -> None:
         try:
             os.remove(FlatFieldProfiles._path_for_id(profile_id))

--- a/negpy/services/rendering/engine.py
+++ b/negpy/services/rendering/engine.py
@@ -102,12 +102,10 @@ class DarkroomEngine:
         if settings.geometry.crop_rect:
             logger.debug(f"Engine process with crop_rect: {settings.geometry.crop_rect}")
 
-        # Folded into the base stage like fine_rotation, not into source_hash, so the slider
-        # re-renders without re-decoding the RAW.
-        distortion_k1 = settings.flatfield.k1 if settings.flatfield.apply else 0.0
+        distortion_k1 = settings.geometry.distortion_k1
 
         def run_base(img_in: ImageBuffer, ctx: PipelineContext) -> ImageBuffer:
-            img_in = GeometryProcessor(settings.geometry, distortion_k1).process(img_in, ctx)
+            img_in = GeometryProcessor(settings.geometry).process(img_in, ctx)
             return NormalizationProcessor(settings.process, settings.exposure.cast_removal_strength).process(img_in, ctx)
 
         # While the crop tool shows the full uncropped frame, the crop-selection fields

--- a/negpy/services/rendering/gpu_engine.py
+++ b/negpy/services/rendering/gpu_engine.py
@@ -316,8 +316,7 @@ class GPUEngine:
         last = self._last_settings
         if last.geometry != settings.geometry:
             return 0
-        # k1 lives in flatfield config but is applied in the geometry pass (stage 0).
-        if last.flatfield.apply != settings.flatfield.apply or last.flatfield.k1 != settings.flatfield.k1:
+        if last.flatfield.apply != settings.flatfield.apply:
             return 0
         if last.process != settings.process or last.exposure != settings.exposure:
             return 1
@@ -491,7 +490,7 @@ class GPUEngine:
         assert device is not None
 
         h, w = img.shape[:2]
-        k1_eff = settings.flatfield.k1 if settings.flatfield.apply else 0.0
+        k1_eff = settings.geometry.distortion_k1
         source_tex = self._get_intermediate_texture(
             w,
             h,
@@ -1358,7 +1357,7 @@ class GPUEngine:
         # scale_s uses the post-rotation dims the geometry pass emits. Zeroed for tiled
         # export below, where geometry runs on the CPU instead.
         w_rot, h_rot = full_dims
-        k1_eff = settings.flatfield.k1 if settings.flatfield.apply else 0.0
+        k1_eff = settings.geometry.distortion_k1
         scale_s = compute_distortion_scale(k1_eff, w_rot, h_rot) if k1_eff != 0.0 else 1.0
         g_data = struct.pack(
             "ifii",
@@ -2148,7 +2147,7 @@ class GPUEngine:
         h, w = img.shape[:2]
 
         # Tiles apply geometry on the CPU (shader uniform zeroed), so distortion too.
-        k1_eff = settings.flatfield.k1 if settings.flatfield.apply else 0.0
+        k1_eff = settings.geometry.distortion_k1
 
         img_rot = img
         if settings.geometry.rotation != 0:

--- a/tests/test_batch_autocrop_worker.py
+++ b/tests/test_batch_autocrop_worker.py
@@ -2,7 +2,6 @@ from dataclasses import replace
 from types import SimpleNamespace
 
 import numpy as np
-import pytest
 
 import negpy.desktop.workers.render as render_workers
 from negpy.desktop.workers.render import (
@@ -127,19 +126,14 @@ def test_batch_autocrop_uses_asset_rgb_triplet_paths(qapp, monkeypatch) -> None:
     ]
 
 
-@pytest.mark.parametrize(("flatfield_enabled", "expected_k1"), [(True, 0.23), (False, 0.0)])
-def test_batch_autocrop_applies_flatfield_and_crop_free_geometry(
-    qapp,
-    monkeypatch,
-    flatfield_enabled: bool,
-    expected_k1: float,
-) -> None:
+def test_batch_autocrop_applies_flatfield_and_crop_free_geometry(qapp, monkeypatch) -> None:
     base = WorkspaceConfig()
     geometry = replace(
         base.geometry,
         rotation=1,
         fine_rotation=2.5,
         flip_horizontal=True,
+        distortion_k1=0.023,
         crop_rect=(0.1, 0.2, 0.8, 0.9),
         crop_from_auto=True,
         autocrop_offset=17,
@@ -148,9 +142,8 @@ def test_batch_autocrop_applies_flatfield_and_crop_free_geometry(
     )
     flatfield = replace(
         base.flatfield,
-        apply=flatfield_enabled,
+        apply=True,
         profile_id="rig-1",
-        k1=0.23,
     )
     config = replace(base, geometry=geometry, flatfield=flatfield)
     preview = _PreviewService()
@@ -162,9 +155,8 @@ def test_batch_autocrop_applies_flatfield_and_crop_free_geometry(
         return image + 1.0
 
     class _GeometryProcessor:
-        def __init__(self, received_geometry, distortion_k1):
+        def __init__(self, received_geometry):
             captured["geometry"] = received_geometry
-            captured["distortion_k1"] = distortion_k1
 
         def process(self, image, context):
             captured["geometry_input"] = image.copy()
@@ -192,7 +184,7 @@ def test_batch_autocrop_applies_flatfield_and_crop_free_geometry(
     assert captured["geometry"].rotation == 1
     assert captured["geometry"].fine_rotation == 2.5
     assert captured["geometry"].flip_horizontal is True
-    assert captured["distortion_k1"] == expected_k1
+    assert captured["geometry"].distortion_k1 == 0.023
     assert np.allclose(captured["geometry_input"], 1.5)
     assert np.allclose(captured["detected_image"], 3.5)
     assert captured["target_ratio"] == "4:3"

--- a/tests/test_config_deserialization.py
+++ b/tests/test_config_deserialization.py
@@ -198,6 +198,14 @@ class TestConfigDeserialization(unittest.TestCase):
         back = WorkspaceConfig.from_flat_dict({"autocrop_offset": 2})
         self.assertEqual(back.geometry.autocrop_rebate_trim, 1.0)
 
+    def test_legacy_flatfield_k1_lands_on_geometry(self):
+        config = WorkspaceConfig.from_flat_dict({"k1": 0.015})
+        self.assertEqual(config.geometry.distortion_k1, 0.015)
+
+    def test_legacy_flatfield_k1_does_not_warn(self):
+        with self.assertNoLogs("negpy.domain.models", level=logging.WARNING):
+            WorkspaceConfig.from_flat_dict({"k1": 0.015})
+
     def test_legacy_use_original_res_does_not_warn(self):
         data = {"use_original_res": False}
         with self.assertNoLogs("negpy.domain.models", level=logging.WARNING):

--- a/tests/test_desktop_session.py
+++ b/tests/test_desktop_session.py
@@ -1,4 +1,5 @@
 import unittest
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 from dataclasses import replace
 
@@ -301,6 +302,21 @@ class TestDesktopSessionSync(unittest.TestCase):
         self.mock_repo.get_global_setting.side_effect = lambda key, default=None: sticky.get(key, default)
         config = self.session._apply_sticky_settings(WorkspaceConfig(), only_global=False)
         self.assertEqual(config.exposure.cast_removal_strength, 0.0)
+
+    def test_legacy_rig_k1_seeds_geometry_once(self):
+        """Distortion left the flat-field profile; a rig that still carries one must not
+        lose it, and must not override a frame's own value."""
+        prof = SimpleNamespace(id="rig-a", k1=-0.05)
+        self.mock_repo.get_global_setting.side_effect = lambda key, default=None: (
+            "rig-a" if key == "flatfield_active_profile" else default
+        )
+        with patch("negpy.desktop.session.FlatFieldProfiles.get", return_value=prof):
+            seeded = self.session._apply_sticky_settings(WorkspaceConfig(), only_global=False)
+            own = WorkspaceConfig(geometry=replace(WorkspaceConfig().geometry, distortion_k1=0.012))
+            kept = self.session._apply_sticky_settings(own, only_global=False)
+
+        self.assertEqual(seeded.geometry.distortion_k1, -0.05)
+        self.assertEqual(kept.geometry.distortion_k1, 0.012)
 
     def test_paper_black_carries_to_new_files(self):
         """Sticky must carry an explicit value over the file's base."""

--- a/tests/test_flatfield_profiles.py
+++ b/tests/test_flatfield_profiles.py
@@ -49,15 +49,11 @@ def test_list_profiles_sorted_by_name(store_dir):
     assert [n for _, n in FlatFieldProfiles.list_profiles()] == ["alpha", "Zeta"]
 
 
-def test_set_k1_preserves_gain_and_token(store_dir):
-    pid = FlatFieldProfiles.import_gain(_gain(), name="rig", k1=0.0)
-    _, tok_before = FlatFieldProfiles.load_gain(pid)
-
-    FlatFieldProfiles.set_k1(pid, 0.12)
-    gain_after, tok_after = FlatFieldProfiles.load_gain(pid)
+def test_legacy_k1_still_readable(store_dir):
+    # A rig profile written before distortion moved to GeometryConfig; session.py seeds
+    # the geometry field from it once.
+    pid = FlatFieldProfiles.import_gain(_gain(), name="rig", k1=0.12)
     assert FlatFieldProfiles.get(pid).k1 == 0.12
-    assert np.array_equal(gain_after, _gain())  # gain untouched by a k1 edit
-    assert tok_after == tok_before  # so the render cache is not invalidated
 
 
 def test_delete_and_missing(store_dir):

--- a/tests/test_geometry_distortion.py
+++ b/tests/test_geometry_distortion.py
@@ -13,7 +13,7 @@ from negpy.features.geometry.logic import (
 from negpy.infrastructure.gpu.device import GPUDevice
 
 # Slider range; the model must be well-behaved (no fold-over) across it.
-_K1_RANGE = [-0.25, -0.1, -0.02, 0.02, 0.1, 0.25]
+_K1_RANGE = [-0.1, -0.02, -0.001, 0.001, 0.02, 0.1]
 
 
 def test_zero_k1_is_identity():
@@ -161,7 +161,7 @@ def test_uv_grid_and_point_mapper_are_consistent(k1):
 
 
 @pytest.mark.skipif(not GPUDevice.get().is_available, reason="GPU not available")
-@pytest.mark.parametrize("k1", [-0.12, 0.12])
+@pytest.mark.parametrize("k1", [-0.08, 0.08])
 def test_cpu_gpu_distortion_parity(k1):
     """The radial model lives in two places (apply_radial_distortion / transform.wgsl);
     they must agree or GPU previews drift from CPU exports."""
@@ -180,8 +180,7 @@ def test_cpu_gpu_distortion_parity(k1):
     img = np.ascontiguousarray(img + rng.uniform(0, 0.01, img.shape).astype(np.float32))
 
     base = WorkspaceConfig()
-    # apply=True gates the distortion; empty reference_path makes the photometric flat a no-op.
-    settings = dataclasses.replace(base, flatfield=dataclasses.replace(base.flatfield, apply=True, k1=k1))
+    settings = dataclasses.replace(base, geometry=dataclasses.replace(base.geometry, distortion_k1=k1))
 
     def render(prefer_gpu):
         result, _ = processor.run_pipeline(

--- a/tests/test_modified_dots.py
+++ b/tests/test_modified_dots.py
@@ -32,7 +32,7 @@ def test_flat_field_edits_light_their_section(qapp):
     assert panel.flatfield_section.modified_count == 0
 
     cfg = controller.state.config
-    controller.state.config = replace(cfg, flatfield=replace(cfg.flatfield, apply=True, k1=-0.02))
+    controller.state.config = replace(cfg, flatfield=replace(cfg.flatfield, apply=True, profile_id="rig-1"))
     panel._sync_modified_dots()
 
     assert panel.flatfield_section.modified_count == 2
@@ -67,7 +67,7 @@ def test_calibration_reset_button_restores_its_fields(qapp):
 def test_flat_field_reset_button_restores_its_section(qapp):
     controller, panel = _panel()
     cfg = controller.state.config
-    controller.state.config = replace(cfg, flatfield=replace(cfg.flatfield, apply=True, k1=-0.02))
+    controller.state.config = replace(cfg, flatfield=replace(cfg.flatfield, apply=True, profile_id="rig-1"))
 
     panel.flatfield_section.reset_requested.emit()
 


### PR DESCRIPTION
Addresses #967.

## Storage, not UI

`k1` lived on the flat-field **profile record**, and `_apply_sticky_settings` overwrote every loaded config's value from the active profile. With no profile there was nowhere to write, so the slider was disabled and the render path zeroed the value alongside the flat-field toggle.

It moves to `GeometryConfig.distortion_k1`: per-image, persisted with the edit, and carried across a roll through a new settings-catalog row. That also deletes the coefficient argument threaded through seven call sites and both `if apply` gates — `GeometryProcessor` reads its own config now.

Migration is one `KEY_RENAMES` entry. The flat key namespace is shared, so the rename recovers the per-image value edits had been persisting all along. An existing rig's coefficient is adopted once, onto frames carrying none of their own, so nobody loses a correction.

## The slider could not reach its own step

It left `precision` at the default 100 — 50 groove positions, 0.01 granularity — and kept Qt's default 2 decimals, so the declared `step=0.005` was unreachable in both directions. The backend already rounded to 9 decimals; only the widget was the limit.

Now `step=0.001`, `precision=1000`, 3 decimals, over a narrower ±0.10. That range is what makes 0.001 reachable by dragging: roughly one step per pixel of groove. Anything past 0.10 is a strong barrel, not a copy-stand rig. `clone_slider` also copies the readout's decimals, which are not a constructor argument, so a Favourites mirror no longer drops back to 2.

## Behaviour change

A saved edit with |k1| > 0.10 clamps to the new range on first sync.

## Verification

`make all` green: 5352 passed, 10 skipped.

Driven headless on a real scan in a sandbox with **no** flat-field profile — the case the discussion reports as impossible:

```
k1=+0.015: mean abs diff vs k1=0 -> 0.04896
k1=-0.015: mean abs diff vs k1=0 -> 0.02741
+0.015 vs -0.015: mean abs diff -> 0.04374
slider enabled=True decimals=3 range=(-0.1, 0.1) step=0.001
```

New tests cover the flat-key migration and the one-shot legacy seed. The CPU↔GPU parity test tracks the new range.

