### PR TITLE
fix(ui): give Flat Field the shared panel layout

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -486,8 +486,8 @@ Where the frame gets its final shape: what is inside the print, and whether it s
 
 Corrects uneven illumination (vignetting or falloff) from your copy-stand or scanner light, using a reference shot of the bare light source.
 
-*   **Flatfield Correction**: apply the active reference to this image, enabled once a profile exists.
-*   **Reference Profile** dropdown + **Add…** / **Delete**: pick a reference image and save it as a named profile. **Add…** reads the reference once and bakes its correction into the profile, so you can then move, rename or delete the original reference file without affecting your edits. The profile is self-contained, stored in NegPy's own `flatfield` folder like sensor and crosstalk profiles. **Delete** asks first: the baked gain map cannot be recovered, and every frame using the profile loses its correction.
+*   **Profile** dropdown, with **+** and **trash** beside it: pick a reference image and save it as a named profile. **+** reads the reference once and bakes its correction into the profile, so you can then move, rename or delete the original reference file without affecting your edits. The profile is self-contained, stored in NegPy's own `flatfield` folder like sensor and crosstalk profiles. **Trash** asks first: the baked gain map cannot be recovered, and every frame using the profile loses its correction.
+*   **Apply Flat Field**: apply the active reference to this image, enabled once a profile exists.
 
 ---
 

--- a/negpy/desktop/view/sidebar/flatfield.py
+++ b/negpy/desktop/view/sidebar/flatfield.py
@@ -1,6 +1,5 @@
 import os
 
-import qtawesome as qta
 from PyQt6.QtCore import Qt
 from PyQt6.QtWidgets import (
     QApplication,
@@ -8,13 +7,11 @@ from PyQt6.QtWidgets import (
     QFileDialog,
     QHBoxLayout,
     QInputDialog,
-    QPushButton,
 )
 
 from negpy.desktop.view.confirm import confirm_delete_named
 from negpy.desktop.view.sidebar.base import BaseSidebar
-from negpy.desktop.view.styles.templates import section_subheader
-from negpy.desktop.view.styles.theme import THEME
+from negpy.desktop.view.styles.templates import field_label, hint_label
 from negpy.desktop.view.widgets.file_dialogs import last_open_folder, pick_start_dir
 
 _NONE_LABEL = "— None —"
@@ -28,32 +25,28 @@ class FlatFieldSidebar(BaseSidebar):
     """
 
     def _init_ui(self) -> None:
+        row = QHBoxLayout()
+        row.addWidget(field_label("Profile"))
+        self.profile_combo = QComboBox()
+        self.profile_combo.setToolTip("Saved flat-field reference profiles (scan of the bare light source)")
+        row.addWidget(self.profile_combo, 1)
+
+        self.add_btn = self._icon_action("fa5s.plus", "Pick a reference image and save it as a named profile")
+        self.delete_btn = self._icon_action("fa5s.trash", "Remove the selected profile")
+        row.addWidget(self.add_btn)
+        row.addWidget(self.delete_btn)
+        self.layout.addLayout(row)
+
+        self.hint = hint_label("Add a scan of the bare light source to enable.")
+        self.layout.addWidget(self.hint)
+
         self.enable_btn = self._small_toggle(
             "fa5s.lightbulb",
-            "Flatfield Correction",
+            "Apply Flat Field",
             False,
             "Apply the active flat-field reference to this image",
         )
         self.layout.addWidget(self.enable_btn)
-
-        self.layout.addWidget(section_subheader("REFERENCE PROFILE"))
-
-        self.profile_combo = QComboBox()
-        self.profile_combo.setToolTip("Saved flat-field reference profiles (scan of the bare light source)")
-        self.layout.addWidget(self.profile_combo)
-
-        actions = QHBoxLayout()
-        self.add_btn = QPushButton(" Add…")
-        self.add_btn.setIcon(qta.icon("fa5s.plus", color=THEME.text_primary))
-        self.add_btn.setToolTip("Pick a reference image and save it as a named profile")
-
-        self.delete_btn = QPushButton(" Delete")
-        self.delete_btn.setIcon(qta.icon("fa5s.trash", color=THEME.text_primary))
-        self.delete_btn.setToolTip("Remove the selected profile")
-
-        actions.addWidget(self.add_btn)
-        actions.addWidget(self.delete_btn)
-        self.layout.addLayout(actions)
 
         self.layout.addStretch()
         self._refresh_profiles()
@@ -128,6 +121,7 @@ class FlatFieldSidebar(BaseSidebar):
 
             self.enable_btn.setChecked(conf.apply)
             self.enable_btn.setEnabled(bool(conf.profile_id))
+            self.hint.setVisible(not conf.profile_id)
         finally:
             self.block_signals(False)
 


### PR DESCRIPTION
The Flat Field panel used its own look instead of the shared one:

- **Add…** / **Delete** were bare `QPushButton`s with a qta icon, the only unstyled buttons in the tab stack — every other panel builds an icon action from `_icon_action` or `_labeled_action`.
- A `section_subheader("REFERENCE PROFILE")` sat over a single full-width combo. A subheader groups controls; the card header already names the panel. Every other combo in the app sits in a `field_label + combo` row.
- The full-width apply toggle sat above the picker that enables it, greyed with nothing to say why.

Rebuilt on the Sensor panel's idiom: `Profile [combo] [+] [trash]` in one row, a `hint_label` when no profile exists, then the apply toggle. Four widgets become three and the panel is about half as tall.

Delete confirmation, the wait cursor around the reference bake, and the signal-block logic are unchanged.

`docs/USER_GUIDE.md` follows the new control names.

`make all` green.