### PR TITLE
fix(watcher): compare hot folder paths by normalized key

### DIFF
--- a/negpy/infrastructure/filesystem/watcher.py
+++ b/negpy/infrastructure/filesystem/watcher.py
@@ -18,6 +18,11 @@ class FolderWatchService:
         if not os.path.exists(folder_path):
             return []
 
+        # existing_paths can carry either separator convention (Qt's file dialogs always
+        # return forward slashes; os.path.abspath below always returns the OS-native form),
+        # and Windows paths are case-insensitive, so compare normcased keys, not raw strings.
+        existing_keys = {os.path.normcase(os.path.abspath(p)) for p in existing_paths}
+
         new_files = []
         try:
             with os.scandir(folder_path) as it:
@@ -26,7 +31,7 @@ class FolderWatchService:
                         ext = os.path.splitext(entry.name)[1].lower()
                         if ext in cls.SUPPORTED_EXTS and not is_ir_sidecar_path(entry.path):
                             full_path = os.path.abspath(entry.path)
-                            if full_path not in existing_paths:
+                            if os.path.normcase(full_path) not in existing_keys:
                                 new_files.append(full_path)
         except Exception:
             pass

--- a/tests/test_folder_watch_path_normalization.py
+++ b/tests/test_folder_watch_path_normalization.py
@@ -1,0 +1,26 @@
+"""FolderWatchService candidate/existing-path comparison.
+
+Candidates come from os.path.abspath (OS-native separators); existing_paths can carry
+Qt's forward-slash convention instead. Windows paths are also case-insensitive. The
+comparison must treat both spellings of the same file as the same path.
+"""
+
+from negpy.infrastructure.filesystem.watcher import FolderWatchService
+
+
+def test_forward_slash_existing_path_is_not_reported_new(tmp_path):
+    (tmp_path / "roll12.nef").write_bytes(b"stub")
+    forward_slash_path = str(tmp_path / "roll12.nef").replace("\\", "/")
+
+    new_files = FolderWatchService.scan_for_new_files(str(tmp_path), {forward_slash_path})
+
+    assert new_files == []
+
+
+def test_genuinely_new_file_is_still_reported(tmp_path):
+    (tmp_path / "roll12.nef").write_bytes(b"stub")
+
+    new_files = FolderWatchService.scan_for_new_files(str(tmp_path), set())
+
+    assert len(new_files) == 1
+    assert new_files[0].endswith("roll12.nef")


### PR DESCRIPTION
Hot Folder re-reports every already-loaded file as new on each poll, if those files came in through Select Images.

`scan_for_new_files` builds candidates with `os.path.abspath`, which returns backslashes on Windows, then tests raw-string membership against `existing_paths`. Paths from `QFileDialog.getOpenFileNames` carry forward slashes, because Qt normalises what it returns. The two spellings of one file never compare equal.

Nothing visibly breaks, which is why it lasted: `add_files` falls back to a content hash and suppresses the duplicate row. The cost is that every poll starts an `AssetDiscoveryTask` and re-hashes each file, every two seconds, while Hot Folder is on.

The fix normalises both sides with `os.path.normcase(os.path.abspath(...))`, built once into a set before the loop. That is the key `controller.py:193` already uses for the same question. `normcase` also folds case, which matters on Windows and is a no-op on POSIX.

Kept inside `scan_for_new_files` rather than at ingestion, so nothing that persists or searches on `path` changes and `#1011` is untouched.

Two tests: the forward-slash case, and one asserting a genuinely new file is still detected. Reverting only the normalisation fails the first and leaves the second green. `test_asset_search.py` stays at 54 passing.
