### PR TITLE
fix(ui): show batch progress for manual imports during Hot Folder

### DIFF
--- a/negpy/desktop/controller.py
+++ b/negpy/desktop/controller.py
@@ -242,6 +242,7 @@ class _DiscoveryRequest:
     rgb_scan: bool
     half_frame: bool
     half_frame_profile: Optional[dict] = None  # {crop_rect, split_x, gutter_thickness}
+    hot_folder: bool = False
 
 
 def baseline_compare_config(config: WorkspaceConfig) -> WorkspaceConfig:
@@ -416,6 +417,12 @@ class AppController(QObject):
         self._active_batch_abortable = False
         self._batch_serial = 0
         self._active_batch_token: Optional[int] = None
+        # True from the moment a hot-folder-triggered discovery claims the batch lane
+        # until its thumbnail phase ends, including every early exit (discovery error,
+        # no assets found, nothing to thumbnail, thumbnail error) — not merely whether
+        # the Hot Folder toggle is checked, which says nothing about what triggered
+        # the batch currently running.
+        self._hot_folder_sequence_active = False
         self._autocrop_batch_token: Optional[int] = None
         self._autocrop_dispatched = 0
         self._autocrop_preflight_skipped = 0
@@ -807,6 +814,7 @@ class AppController(QObject):
     def _on_thumbnails_finished(self, new_thumbs: Dict[str, Any]) -> None:
         self.status_progress_requested.emit(0, 0)
         self._end_batch("thumbnails")
+        self._hot_folder_sequence_active = False
         broken = self._apply_thumbnails(new_thumbs)
 
         requested = getattr(self, "_thumb_requested", [])
@@ -828,6 +836,12 @@ class AppController(QObject):
         self.session.asset_model.refresh()
 
     # --- Batch progress popup -------------------------------------------------
+
+    @property
+    def hot_folder_sequence_active(self) -> bool:
+        """True while the currently active (or just-finished-discovery, pre-thumbnail)
+        batch belongs to a hot-folder-triggered discovery-through-thumbnails sequence."""
+        return self._hot_folder_sequence_active
 
     def _begin_batch(self, owner: str, title: str, abortable: bool) -> Optional[int]:
         """Claim the shared batch lane and return its generation token."""
@@ -876,9 +890,11 @@ class AppController(QObject):
 
     def _on_discovery_batch_error(self, _message: str) -> None:
         self._discovery_running = False
+        self._hot_folder_sequence_active = False
         self._end_batch("discovery")
 
     def _on_thumbnail_batch_error(self, _message: str) -> None:
+        self._hot_folder_sequence_active = False
         self._on_batch_error("thumbnails")
 
     def _on_normalization_cancelled(self) -> None:
@@ -927,6 +943,7 @@ class AppController(QObject):
         replace_existing: bool = False,
         reselect_path: Optional[str] = None,
         announce_rgb: bool = False,
+        hot_folder: bool = False,
     ) -> None:
         """
         Starts asynchronous discovery of supported assets.
@@ -939,6 +956,10 @@ class AppController(QObject):
         `announce_rgb` allows the modal report when RGB Scan assembles nothing. Set it
         where the user just asked for this folder or just turned the mode on; leaving it
         off is what keeps a restored session from opening a dialog nobody asked for.
+
+        `hot_folder` marks this request as coming from the Hot Folder poll, not from a
+        user action — it drives `hot_folder_sequence_active`, which is what the batch
+        popup checks, rather than whether the toggle happens to be on.
         """
         self._announce_rgb = announce_rgb
         request = _DiscoveryRequest(
@@ -950,6 +971,7 @@ class AppController(QObject):
             rgb_scan=bool(self.session.repo.get_global_setting("rgbscan_mode", False)),
             half_frame=bool(self.session.repo.get_global_setting("half_frame_mode", False)),
             half_frame_profile=self.half_frame_profile(),
+            hot_folder=hot_folder,
         )
         if self._discovery_running:
             self._pending_asset_discoveries.append(request)
@@ -967,7 +989,12 @@ class AppController(QObject):
 
         from negpy.infrastructure.loaders.constants import SUPPORTED_RAW_EXTENSIONS
 
+        # Must be set before _begin_batch: it emits batch_started synchronously, and
+        # the view reads this to decide whether to suppress the popup for it.
+        previous_hot_folder_sequence = self._hot_folder_sequence_active
+        self._hot_folder_sequence_active = request.hot_folder
         if self._begin_batch("discovery", "Hashing files", abortable=False) is None:
+            self._hot_folder_sequence_active = previous_hot_folder_sequence
             self._pending_asset_discoveries.insert(0, request)
             return
         self._discovery_running = True
@@ -1299,6 +1326,10 @@ class AppController(QObject):
             self.session.state.rendered_thumbnails.clear()
             self.session.add_files([], validated_info=valid_assets)
             self.generate_missing_thumbnails()
+            if self._active_batch != "thumbnails":
+                # Nothing to thumbnail — no batch claimed, so no _on_thumbnails_finished
+                # will arrive later to release a hot-folder sequence. End it here.
+                self._hot_folder_sequence_active = False
             idx = None
             if reselect_path:
                 # Guard on a set path: `None in (path, green_path, blue_path)` matches any
@@ -1325,6 +1356,10 @@ class AppController(QObject):
             first_new_idx = len(self.session.state.uploaded_files)
             self.session.add_files([], validated_info=valid_assets)
             self.generate_missing_thumbnails()
+            if self._active_batch != "thumbnails":
+                # Nothing to thumbnail — no batch claimed, so no _on_thumbnails_finished
+                # will arrive later to release a hot-folder sequence. End it here.
+                self._hot_folder_sequence_active = False
             if pending_scan and self._select_file_by_path(pending_scan):
                 selected_pending_scan = True
             elif auto_open and not self.state.current_file_path and len(self.session.state.uploaded_files) > first_new_idx:
@@ -1337,6 +1372,7 @@ class AppController(QObject):
         else:
             self.set_status("NO SUPPORTED ASSETS FOUND", 3000)
             self.status_progress_requested.emit(0, 0)
+            self._hot_folder_sequence_active = False
 
         if pending_scan:
             pending_key = _capture_import_key(pending_scan)

--- a/negpy/desktop/view/main_window.py
+++ b/negpy/desktop/view/main_window.py
@@ -481,8 +481,13 @@ class MainWindow(QMainWindow):
     def _on_batch_started(self, title: str, abortable: bool) -> None:
         """Hot Folder polls every 2 s, so its per-frame import batches (the only
         non-abortable ones) would pop the dialog on every capture. The HUD status
-        line still reports those; abortable batches always show the popup."""
-        if not abortable and self.session_panel.file_browser.hot_folder_btn.isChecked():
+        line still reports those; abortable batches always show the popup.
+
+        Suppression keys off which sequence actually owns this batch
+        (`hot_folder_sequence_active`), not whether the toggle happens to be
+        checked — a manual Add Files/Add Folder/drop while Hot Folder is on must
+        still show progress."""
+        if not abortable and self.controller.hot_folder_sequence_active:
             return
         self.progress_dialog.start(title, abortable)
 

--- a/negpy/desktop/view/sidebar/files.py
+++ b/negpy/desktop/view/sidebar/files.py
@@ -1038,7 +1038,7 @@ class FileBrowser(QWidget):
 
         new_files = FolderWatchService.scan_for_new_files(folder_path, existing)
         if new_files:
-            self.controller.request_asset_discovery(new_files)
+            self.controller.request_asset_discovery(new_files, hot_folder=True)
 
     def prompt_add_files(self) -> None:
         """Public entry point: also driven by the canvas empty state."""

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -22,6 +22,7 @@ from negpy.domain.models import (
     WorkspaceConfig,
 )
 from negpy.infrastructure.scanners.params import ScanParams
+from negpy.services.assets.thumbnails import asset_thumbnail_key
 from negpy.services.rendering.preview_manager import PreviewManager
 
 if not QApplication.instance():
@@ -2103,6 +2104,102 @@ class TestDiscoveryProgressPopup(unittest.TestCase):
         self.mock_session_manager.select_file.assert_called_with(1)
         self.assertIn(os.path.normcase(os.path.abspath(first_paths[0])), self.controller._pending_capture_imports)
         self.assertNotIn(os.path.normcase(os.path.abspath(second_paths[0])), self.controller._pending_capture_imports)
+
+
+class TestHotFolderSequenceState(unittest.TestCase):
+    """`hot_folder_sequence_active` spans a hot-folder-triggered discovery through its
+    thumbnail phase, and only that phase — a manual request never claims it, and every
+    early exit (discovery error, no assets found, nothing to thumbnail, thumbnail error)
+    releases it without waiting for `_on_thumbnails_finished`."""
+
+    def setUp(self):
+        self.mock_session_manager = MagicMock(spec=DesktopSessionManager)
+        self.mock_session_manager.state = AppState()
+        self.mock_session_manager.repo = MagicMock()
+        self.mock_session_manager.repo.get_global_setting.return_value = False
+        self.mock_session_manager.asset_model = MagicMock()
+        self.mock_session_manager.asset_model.visible_actual_indices_ordered.return_value = []
+        self.mock_session_manager.add_files.side_effect = lambda _paths, validated_info=None: (
+            self.mock_session_manager.state.uploaded_files.extend(validated_info or [])
+        )
+
+        with (
+            patch("negpy.desktop.controller.RenderWorker") as mock_rw_class,
+            patch("negpy.desktop.controller.PreviewManager") as mock_pm_class,
+        ):
+            mock_rw_class.return_value = MagicMock()
+            mock_pm_class.return_value = MagicMock(spec=PreviewManager)
+            self.controller = AppController(self.mock_session_manager)
+
+    def tearDown(self):
+        import gc
+
+        for thread in [
+            self.controller.render_thread,
+            self.controller.export_thread,
+            self.controller.thumb_thread,
+            self.controller.norm_thread,
+            self.controller.discovery_thread,
+            self.controller.preview_load_thread,
+            self.controller.scan_thread,
+        ]:
+            if thread is not None and thread.isRunning():
+                thread.quit()
+                thread.wait()
+        del self.controller
+        gc.collect()
+
+    def test_manual_discovery_never_claims_the_sequence(self):
+        self.assertFalse(self.controller.hot_folder_sequence_active)
+        self.controller.request_asset_discovery(["/manual.dng"])
+        self.assertFalse(self.controller.hot_folder_sequence_active, "a manual request must not claim the hot-folder sequence")
+
+    def test_hot_folder_sequence_spans_discovery_and_thumbnails(self):
+        self.assertFalse(self.controller.hot_folder_sequence_active)
+
+        self.controller.request_asset_discovery(["/hot.dng"], hot_folder=True)
+        self.assertTrue(self.controller.hot_folder_sequence_active, "a hot-folder discovery must claim the sequence")
+
+        self.controller.generate_missing_thumbnails = MagicMock(
+            side_effect=lambda: self.controller._begin_batch("thumbnails", "Generating thumbnails", abortable=False)
+        )
+        self.controller._on_discovery_finished([{"name": "hot", "path": "/hot.dng", "hash": "h1"}])
+        self.assertTrue(self.controller.hot_folder_sequence_active, "must stay claimed through the thumbnail phase")
+
+        self.controller._on_thumbnails_finished({})
+        self.assertFalse(self.controller.hot_folder_sequence_active, "must release once thumbnails finish")
+
+    def test_hot_folder_sequence_clears_on_discovery_error(self):
+        self.controller.request_asset_discovery(["/hot.dng"], hot_folder=True)
+        self.assertTrue(self.controller.hot_folder_sequence_active)
+        self.controller._on_discovery_batch_error("boom")
+        self.assertFalse(self.controller.hot_folder_sequence_active)
+
+    def test_hot_folder_sequence_clears_when_no_assets_found(self):
+        self.controller.request_asset_discovery(["/hot.dng"], hot_folder=True)
+        self.assertTrue(self.controller.hot_folder_sequence_active)
+        self.controller._on_discovery_finished([])
+        self.assertFalse(self.controller.hot_folder_sequence_active)
+
+    def test_hot_folder_sequence_clears_when_thumbnails_already_cached(self):
+        asset = {"name": "hot", "path": "/hot.dng", "hash": "h1"}
+        self.mock_session_manager.state.thumbnails[asset_thumbnail_key(asset)] = object()
+
+        self.controller.request_asset_discovery(["/hot.dng"], hot_folder=True)
+        self.assertTrue(self.controller.hot_folder_sequence_active)
+        self.controller._on_discovery_finished([asset])
+        self.assertFalse(self.controller.hot_folder_sequence_active, "nothing to thumbnail is itself the end of the sequence")
+
+    def test_hot_folder_sequence_clears_on_thumbnail_error(self):
+        self.controller.request_asset_discovery(["/hot.dng"], hot_folder=True)
+        self.controller.generate_missing_thumbnails = MagicMock(
+            side_effect=lambda: self.controller._begin_batch("thumbnails", "Generating thumbnails", abortable=False)
+        )
+        self.controller._on_discovery_finished([{"name": "hot", "path": "/hot.dng", "hash": "h1"}])
+        self.assertTrue(self.controller.hot_folder_sequence_active)
+
+        self.controller._on_thumbnail_batch_error("boom")
+        self.assertFalse(self.controller.hot_folder_sequence_active)
 
 
 class TestBatchAnalysisFiltering(unittest.TestCase):

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -99,5 +99,52 @@ class TestDropEvent(unittest.TestCase):
         stub.controller.request_asset_discovery.assert_called_once_with(["/tmp/scan.dng"], auto_open=True)
 
 
+class TestBatchStartedPopupSuppression(unittest.TestCase):
+    """The popup is suppressed by sequence identity (did THIS batch come from the
+    hot-folder poll), never by whether the Hot Folder toggle happens to be checked."""
+
+    def _stub(self, hot_folder_sequence_active: bool, hot_folder_checked: bool = True):
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock
+
+        controller = MagicMock()
+        controller.hot_folder_sequence_active = hot_folder_sequence_active
+        return SimpleNamespace(
+            controller=controller,
+            progress_dialog=MagicMock(),
+            session_panel=SimpleNamespace(
+                file_browser=SimpleNamespace(hot_folder_btn=SimpleNamespace(isChecked=lambda: hot_folder_checked))
+            ),
+        )
+
+    def test_manual_import_shows_popup_even_when_hot_folder_checked(self):
+        from negpy.desktop.view.main_window import MainWindow
+
+        stub = self._stub(hot_folder_sequence_active=False, hot_folder_checked=True)
+
+        MainWindow._on_batch_started(stub, "Hashing files", False)
+
+        stub.progress_dialog.start.assert_called_once_with("Hashing files", False)
+
+    def test_hot_folder_sequence_silent_for_discovery_and_thumbnails(self):
+        from negpy.desktop.view.main_window import MainWindow
+
+        stub = self._stub(hot_folder_sequence_active=True, hot_folder_checked=True)
+
+        MainWindow._on_batch_started(stub, "Hashing files", False)
+        MainWindow._on_batch_started(stub, "Generating thumbnails", False)
+
+        stub.progress_dialog.start.assert_not_called()
+
+    def test_abortable_batch_always_shows_even_mid_hot_folder_sequence(self):
+        from negpy.desktop.view.main_window import MainWindow
+
+        stub = self._stub(hot_folder_sequence_active=True, hot_folder_checked=True)
+
+        MainWindow._on_batch_started(stub, "Exporting", True)
+
+        stub.progress_dialog.start.assert_called_once_with("Exporting", True)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Adding files or a folder while Hot Folder is on shows no progress at all. `MainWindow._on_batch_started` suppressed every non-abortable batch whenever the Hot Folder toggle was checked, with no way to tell what actually started the batch, so a manual import of a few hundred RAWs got the same silence as a single per-frame capture.

This replaces the toggle read with controller-owned sequence state. `AppController` sets `hot_folder_sequence_active` only when a hot-folder-triggered discovery claims the batch lane, and clears it at every exit of that sequence: normal completion after thumbnail generation, a discovery error, no assets found, a thumbnail error, or nothing left to thumbnail. `request_asset_discovery` gains a `hot_folder` keyword defaulting to `False` that only the folder-watch poll passes, so Add Files, Add Folder, drag-drop, session restore and RGB/half-frame re-discovery are unaffected.

Keying on the sequence rather than the toggle also covers the thumbnail phase, which the old check only silenced by accident: `_on_discovery_finished` calls `generate_missing_thumbnails()` after every successful discovery, and that opens its own non-abortable batch.

`batch_started` keeps its `(str, bool)` signature, so the other connected consumer in `sidebar/scanlight.py` needed no change.

Full suite on 2f47e37: 5312 passed, 27 skipped, 14 deselected, 0 failed. `ruff check` clean on the touched files. The nine new tests fail on unpatched code for the defect's own reason, including a manual import while the toggle is checked.
