### PR TITLE
fix(text): let the displayed number pick the unit in human_bytes

### DIFF
--- a/negpy/kernel/system/text.py
+++ b/negpy/kernel/system/text.py
@@ -24,7 +24,11 @@ def human_bytes(n: float) -> str:
     """A byte count in the largest unit that keeps it under 1024."""
     size = float(n)
     for unit in ("B", "KB", "MB", "GB"):
-        if size < 1024 or unit == "GB":
+        # Compare the number as it will be shown. 1023.95 KB is displayed as
+        # "1024.0 KB", which is not under 1024, so the rounded value decides
+        # the unit rather than the raw one.
+        shown = round(size) if unit == "B" else round(size, 1)
+        if shown < 1024 or unit == "GB":
             return f"{size:.0f} {unit}" if unit == "B" else f"{size:.1f} {unit}"
         size /= 1024
     return f"{size:.1f} GB"

--- a/tests/test_text_human_bytes.py
+++ b/tests/test_text_human_bytes.py
@@ -1,0 +1,38 @@
+"""A size reads in the unit that actually keeps it under 1024."""
+
+import pytest
+
+from negpy.kernel.system.text import human_bytes
+
+
+@pytest.mark.parametrize(
+    "count,expected",
+    [
+        (0, "0 B"),
+        (1023, "1023 B"),
+        (1024, "1.0 KB"),
+        (1048576, "1.0 MB"),
+        (1073741824, "1.0 GB"),
+    ],
+)
+def test_each_unit_starts_at_its_own_threshold(count, expected):
+    assert human_bytes(count) == expected
+
+
+@pytest.mark.parametrize(
+    "count,expected",
+    [
+        (1048575, "1.0 MB"),
+        (1073741823, "1.0 GB"),
+    ],
+)
+def test_a_size_just_under_the_threshold_moves_up(count, expected):
+    """One byte short of the next unit still rounds to 1024.0 at one decimal
+    place, so the displayed number has to decide the unit, not the raw value."""
+    assert human_bytes(count) == expected
+
+
+def test_gb_is_the_last_unit():
+    """There is no TB, so a value past 1024 GB stays in GB rather than
+    silently losing its magnitude."""
+    assert human_bytes(1024 * 1024 * 1024 * 1024) == "1024.0 GB"


### PR DESCRIPTION
`human_bytes` compares the raw value against 1024 but prints it to one decimal place, so a size just under a threshold rounds up past the unit it was already given. `human_bytes(1048575)` returns `"1024.0 KB"` and `human_bytes(1073741823)` returns `"1024.0 MB"`. Neither is under 1024, which is what the docstring promises.

This compares the value as it will be shown. The `B` branch rounds to zero decimals to match its own format, and `GB` still absorbs anything past 1024 GB since there is no larger unit.

It reaches the two size labels in the scan sidebar and the database dialog. Only values within about 0.05% of a boundary change.

Before:

```
assert human_bytes(1073741823) == "1.0 GB"
AssertionError: assert '1024.0 MB' == '1.0 GB'
```

After: 5311 passed, 27 skipped, 0 failed, against 5303 on `main` plus the eight added cases. `ruff format --check` and `ruff check` are clean.
