### PR TITLE
fix(crosstalk): keep two profiles whose names slugify alike

### DIFF
--- a/negpy/services/assets/crosstalk.py
+++ b/negpy/services/assets/crosstalk.py
@@ -220,8 +220,25 @@ class CrosstalkProfiles:
 
     @staticmethod
     def path_for_name(name: str) -> str:
-        """Filesystem path a user profile with this display name would use."""
-        return os.path.join(APP_CONFIG.crosstalk_dir, f"{slugify(name, 'crosstalk')}.toml")
+        """Filesystem path a user profile with this display name would use.
+
+        Steps past a file that already holds a different display name: two names can
+        slugify to the same stem, and saving one profile must not overwrite another."""
+        directory = APP_CONFIG.crosstalk_dir
+        listing = sorted(os.listdir(directory)) if os.path.isdir(directory) else []
+        for fname in listing:
+            if not fname.endswith(".toml"):
+                continue
+            existing = os.path.join(directory, fname)
+            parsed = CrosstalkProfiles._parse_file(existing)
+            if parsed is not None and (parsed[0] or fname[:-5]) == name:
+                return existing
+        base = slugify(name, "crosstalk")
+        for stem in (base, *(f"{base}_{i}" for i in range(2, 1000))):
+            free = os.path.join(directory, f"{stem}.toml")
+            if not os.path.isfile(free):
+                return free
+        return os.path.join(directory, f"{base}.toml")
 
     @staticmethod
     def save(name: str, matrix: List[float], profile_type: str = CrosstalkType.TUNED, process: Optional[str] = None) -> str:

--- a/negpy/services/assets/sensor.py
+++ b/negpy/services/assets/sensor.py
@@ -81,8 +81,25 @@ class SensorProfiles:
 
     @staticmethod
     def path_for_name(name: str) -> str:
-        """Filesystem path a user profile with this display name would use."""
-        return os.path.join(APP_CONFIG.sensor_dir, f"{slugify(name, 'sensor')}.toml")
+        """Filesystem path a user profile with this display name would use.
+
+        Steps past a file that already holds a different display name: two names can
+        slugify to the same stem, and saving one profile must not overwrite another."""
+        directory = APP_CONFIG.sensor_dir
+        listing = sorted(os.listdir(directory)) if os.path.isdir(directory) else []
+        for fname in listing:
+            if not fname.endswith(".toml"):
+                continue
+            existing = os.path.join(directory, fname)
+            parsed = SensorProfiles._parse_file(existing)
+            if parsed is not None and (parsed[0] or fname[:-5]) == name:
+                return existing
+        base = slugify(name, "sensor")
+        for stem in (base, *(f"{base}_{i}" for i in range(2, 1000))):
+            free = os.path.join(directory, f"{stem}.toml")
+            if not os.path.isfile(free):
+                return free
+        return os.path.join(directory, f"{base}.toml")
 
     @staticmethod
     def save(name: str, matrix: List[float]) -> str:

--- a/tests/test_crosstalk_profiles.py
+++ b/tests/test_crosstalk_profiles.py
@@ -226,3 +226,29 @@ def test_legacy_process_names_still_match_their_mode(tmp_path, monkeypatch):
     flat = [n for _h, names in CrosstalkProfiles.grouped_profiles(ProcessMode.E6) for n in names]
     assert flat == ["Old Slide"]
     assert CrosstalkProfiles.grouped_profiles(ProcessMode.C41) == [("Built-in", [CrosstalkProfiles.DEFAULT_NAME])]
+
+
+def test_two_names_sharing_a_slug_stay_two_profiles(tmp_path, monkeypatch):
+    """Names that slugify to the same stem stay separate profiles."""
+    monkeypatch.setattr(APP_CONFIG, "crosstalk_dir", str(tmp_path))
+
+    CrosstalkProfiles.save("Portra 400", [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0])
+    CrosstalkProfiles.save("Portra-400", [2.0, 0.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0, 2.0])
+
+    found = CrosstalkProfiles.scan_user()
+    assert sorted(found) == ["Portra 400", "Portra-400"]
+    assert found["Portra 400"][0] == 1.0
+    assert found["Portra-400"][0] == 2.0
+
+
+def test_saving_again_keeps_the_profile_in_its_own_file(tmp_path, monkeypatch):
+    """A profile keeps the file it already has, so a later save is not stranded behind a stale copy."""
+    monkeypatch.setattr(APP_CONFIG, "crosstalk_dir", str(tmp_path))
+
+    CrosstalkProfiles.save("Portra 400", [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0])
+    CrosstalkProfiles.save("Portra-400", [2.0, 0.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0, 2.0])
+    CrosstalkProfiles.delete("Portra 400")
+    CrosstalkProfiles.save("Portra-400", [9.0, 0.0, 0.0, 0.0, 9.0, 0.0, 0.0, 0.0, 9.0])
+
+    assert len(list(tmp_path.glob("*.toml"))) == 1
+    assert CrosstalkProfiles.scan_user()["Portra-400"][0] == 9.0

--- a/tests/test_sensor_profiles.py
+++ b/tests/test_sensor_profiles.py
@@ -161,3 +161,12 @@ def test_sidebar_sync_rebuilds_combo_after_save(qapp, tmp_path):
     SensorProfiles.save("New Rig", [1, 0, 0, 0, 1, 0, 0, 0, 1])
     sidebar.sync_ui()
     assert [sidebar.sensor_combo.itemText(i) for i in range(sidebar.sensor_combo.count())] == ["None", "New Rig"]
+
+
+def test_two_names_sharing_a_slug_stay_two_profiles(tmp_path):
+    """Names that slugify to the same stem stay separate profiles."""
+    SensorProfiles.save("Rig A", [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0])
+    SensorProfiles.save("Rig-A", [2.0, 0.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0, 2.0])
+
+    assert SensorProfiles.get_matrix("Rig A") == [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0]
+    assert SensorProfiles.get_matrix("Rig-A") == [2.0, 0.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0, 2.0]


### PR DESCRIPTION
`path_for_name` derived the filename as `slugify(name) + ".toml"` with no collision check, and `save()` wrote straight to it. `slugify` collapses runs of spaces and hyphens to one underscore, so distinct display names share a stem and saving one profile silently destroyed another:

```
stem('Portra 400') = portra_400.toml    stem('Portra-400') = portra_400.toml
save 'Portra 400'  -> files ['portra_400.toml']  names ['Portra 400']
save 'Portra-400'  -> files ['portra_400.toml']  names ['Portra-400']
'Portra 400' survived: False
```

No warning, no error, and reachable from the crosstalk editor's Save button, which only guards bundled names.

`path_for_name` now returns the file already holding this display name, matching `delete()`, which has always identified a profile by its TOML `name` field rather than its filename. Otherwise it takes the first free stem. Re-saving an existing name still overwrites its own file rather than creating a second, which the third test pins.

`sensor.py` carried the byte-identical defect and is fixed alongside.

Both collision tests fail on unpatched code and pass with it; the two profile test files run 29 passed. `ruff check` and `ruff format --check` clean.

One thing worth your call: I fixed this in the service layer, so filenames stay opaque and no control changes. You already handle the same risk in the contact-sheet store with an "already exists. Replace it?" prompt at `export.py:532`. Say the word if you would rather these match that.
