### PR TITLE
perf: host-side stalls around the GPU path (startup, navigation, export)

### DIFF
--- a/negpy/desktop/view/sidebar/metadata.py
+++ b/negpy/desktop/view/sidebar/metadata.py
@@ -477,8 +477,18 @@ class MetadataSidebar(BaseSidebar):
         self._gear_library = GearProfiles.load_library()
         library = self._gear_library
 
+        # Rebuilding five combo models per file switch is the panel's main sync cost, so a combo
+        # is only reloaded when the library or its selection changed.
+        seen = self.__dict__.setdefault("_gear_combo_keys", {})
+
         def should_refresh(combo: SearchableGearCombo) -> bool:
-            return force or not combo.is_editing()
+            if not force and combo.is_editing():
+                return False
+            key = (id(library), self._gear_selected_id(combo, conf))
+            if not force and seen.get(id(combo)) == key:
+                return False
+            seen[id(combo)] = key
+            return True
 
         if should_refresh(self.camera_combo):
             self.camera_combo.set_gear_items(
@@ -514,6 +524,15 @@ class MetadataSidebar(BaseSidebar):
                 conf.scanning_id or "",
                 lambda setup: setup.resolved_display_name,
             )
+
+    def _gear_selected_id(self, combo: SearchableGearCombo, conf) -> str:
+        return {
+            id(self.camera_combo): conf.camera_id,
+            id(self.lens_combo): conf.lens_id,
+            id(self.film_stock_combo): conf.film_stock_id,
+            id(self.process_combo): conf.process_id,
+            id(self.scan_setup_combo): conf.scanning_id,
+        }.get(id(combo)) or ""
 
     def _on_process_selected(self, *_args) -> None:
         self._dirty = False

--- a/negpy/desktop/workers/render.py
+++ b/negpy/desktop/workers/render.py
@@ -219,8 +219,10 @@ class RenderWorker(QObject):
 
     @pyqtSlot(object)
     def cleanup(self, retain: object = None) -> None:
-        """Evacuates transient GPU resources; ``retain`` is handed to its new owner."""
-        self._processor.cleanup(retain=retain)
+        """Evacuates transient GPU resources; ``retain`` is handed to its new owner.
+        No gc.collect: the pool eviction frees the textures and a full collection per file
+        switch is dead time on the navigation path."""
+        self._processor.cleanup(collect=False, retain=retain)
 
     def destroy_all(self) -> None:
         """Full teardown of processing resources."""

--- a/negpy/features/retouch/logic.py
+++ b/negpy/features/retouch/logic.py
@@ -4,11 +4,12 @@ from typing import List, Optional, Tuple
 
 import cv2
 import numpy as np
-from numba import njit  # type: ignore
+from numba import njit, prange  # type: ignore
 
 from negpy.domain.types import ImageBuffer
 from negpy.features.geometry.logic import smooth_polyline
 from negpy.features.retouch.models import HEAL_SIZE_REF, IR_METHOD_NEGPY
+from negpy.kernel.system.parallel import parallel_njit
 from negpy.kernel.image.logic import get_luminance
 from negpy.kernel.image.validation import ensure_image
 from negpy.kernel.system.logging import get_logger
@@ -182,6 +183,7 @@ _HAIR_MIN_ELONG = 8.0  # area/thickness² ≈ length/thickness; round specks mea
 _HAIR_DILATE_PX = 1
 _HAIR_INPAINT_RADIUS = 3
 _HAIR_INPAINT_GAMMA = 2.2
+_HAIR_RANGE_SAMPLE_PX = 1 << 20  # clean pixels sampled for a crop's encode range
 _HAIR_INPAINT_PAD = 16
 
 
@@ -710,9 +712,8 @@ def score_weighted_fill(
     across a tonal edge and over-lifts the dense side of it. A repair allowed to darken has
     no such corrector, so it has to pay for honest confidence there instead.
     """
-    s3 = score[..., None]
-    weighted = img * s3
-    fill: Optional[np.ndarray] = None
+    weighted = img * score[..., None]
+    fill = np.empty_like(img)
     for i, k in enumerate(scales):
         if i == len(scales) - 1:
             num = cv2.GaussianBlur(weighted, (k, k), 0)
@@ -720,15 +721,32 @@ def score_weighted_fill(
         else:
             num = cv2.boxFilter(weighted, -1, (k, k))
             den = cv2.boxFilter(score, -1, (k, k))
-        cand = num / np.maximum(den, 1e-6)[..., None]
-        if fill is None:
-            fill = cand
-        else:
-            mass = (den - _IR_SCORE_FLOOR) / (1.0 - _IR_SCORE_FLOOR) if reject_floor_mass else den
-            conf = np.clip(mass / _IR_FILL_TAU, 0.0, 1.0)[..., None]
-            fill = fill * (1.0 - conf) + cand * conf
-    assert fill is not None  # scales is never empty
+        _fill_rung(num, den, fill, i == 0, reject_floor_mass)
     return fill
+
+
+@parallel_njit(cache=True)
+def _fill_rung(num, den, fill, first, reject_floor_mass):
+    """One rung of the fill ladder in place: the score-normalized candidate, blended over the
+    coarser result by the rung's clean fraction. Same float32 operation order as the array
+    form, one pass over the frame."""
+    f32 = np.float32
+    h, w = den.shape
+    floor = f32(_IR_SCORE_FLOOR)
+    inv_span = f32(1.0) - floor
+    tau = f32(_IR_FILL_TAU)
+    for y in prange(h):
+        for x in range(w):
+            d = max(den[y, x], f32(1e-6))
+            if first:
+                for c in range(3):
+                    fill[y, x, c] = num[y, x, c] / d
+            else:
+                mass = (den[y, x] - floor) / inv_span if reject_floor_mass else den[y, x]
+                conf = min(max(mass / tau, f32(0.0)), f32(1.0))
+                keep = f32(1.0) - conf
+                for c in range(3):
+                    fill[y, x, c] = fill[y, x, c] * keep + (num[y, x, c] / d) * conf
 
 
 def _fill_supports(buffer_long_edge: int, factor: float) -> Tuple[int, ...]:
@@ -741,26 +759,29 @@ def _fill_supports(buffer_long_edge: int, factor: float) -> Tuple[int, ...]:
     return tuple(dict.fromkeys([int(round(_IR_FILL_SCALES[0] * film)) | 1] + fine))
 
 
-def _borrow_clean_grain(src: np.ndarray, clean: np.ndarray, sigma: float) -> np.ndarray:
-    """Detail of the nearest clean pixel, per pixel, high-passed at ``sigma``.
+def _borrow_clean_grain(src: np.ndarray, clean: np.ndarray, sigma: float, idx: np.ndarray) -> np.ndarray:
+    """Detail of the nearest clean pixel, high-passed at ``sigma``, for the flat pixel
+    indices ``idx`` only: an (N, 3) array, N = len(idx).
 
     Real film rather than synthesized noise: the donor is the closest pixel the IR score calls
     clean, so it carries the same emulsion, density and scanner noise as the hole it fills.
     Ceiling: deep inside a wide defect every pixel resolves to the same few boundary donors and
     the paste flattens toward a constant, leaving those interiors to the fill's own blend.
+    Only the repaired pixels take grain, so the donor lookup runs on their indices alone; the
+    distance transform still covers the frame, because a donor can sit anywhere near a hole.
     """
     h, w = clean.shape
     # DIST_LABEL_PIXEL numbers the zero pixels 1..N in raster order, so flatnonzero inverts it.
     _, labels = cv2.distanceTransformWithLabels((~clean).astype(np.uint8), cv2.DIST_L2, 3, labelType=cv2.DIST_LABEL_PIXEL)
-    nearest = np.flatnonzero(clean.ravel())[labels.ravel().astype(np.intp) - 1]
+    nearest = np.flatnonzero(clean.ravel())[labels.ravel()[idx].astype(np.intp) - 1]
     # Mirror through the donor, do not sample it: a whole row across a hair shares one
     # nearest clean pixel, and pasting that verbatim streaks the grain into bands.
     ny, nx = np.divmod(nearest, w)
-    py, px = np.divmod(np.arange(h * w), w)
+    py, px = np.divmod(idx, w)
     mirrored = np.clip(2 * ny - py, 0, h - 1) * w + np.clip(2 * nx - px, 0, w - 1)
     take = np.where(clean.ravel()[mirrored], mirrored, nearest)
-    grain = src - cv2.GaussianBlur(src, (0, 0), sigma)
-    return grain.reshape(-1, 3)[take].reshape(src.shape)
+    blur = cv2.GaussianBlur(src, (0, 0), sigma)
+    return src.reshape(-1, 3)[take] - blur.reshape(-1, 3)[take]
 
 
 def apply_score_repair(
@@ -791,23 +812,57 @@ def apply_score_repair(
     else:
         factor = max(h / score_det.shape[0], w / score_det.shape[1])
         score = cv2.resize(score_det, (w, h), interpolation=cv2.INTER_LINEAR)
-    fill = score_weighted_fill(src, score, _fill_supports(long_edge or max(h, w), factor), reject_floor_mass=not floor)
-    a = np.clip((_IR_WRITE_HI - score) / (_IR_WRITE_HI - _IR_WRITE_LO), 0.0, 1.0)
-    a = (a * a * (3.0 - 2.0 * a))[..., None]
-    out = src * (1.0 - a) + fill * a
+    out = score_weighted_fill(src, score, _fill_supports(long_edge or max(h, w), factor), reject_floor_mass=not floor)
+    # The fill buffer becomes the output: blended over the source under the write ramp.
+    a = np.empty((h, w), dtype=np.float32)
+    _blend_fill(src, score, out, a)
     # A weighted average lands grainless, so a repair reads as a smooth patch against film.
     sigma = max(1.0, factor)
     clean = score >= _IR_WRITE_HI
-    if clean.any():
-        out += a * _borrow_clean_grain(src, clean, sigma)
+    idx = np.flatnonzero(~clean)
+    if clean.any() and idx.size:
+        out.reshape(-1, 3)[idx] += a.reshape(-1, 1)[idx] * _borrow_clean_grain(src, clean, sigma, idx)
     # Original-floor rule: dust is dark in negative transmittance, so repairs only lighten.
     # Compared on the low-frequency deficit, because per pixel the rule is a half-wave
     # rectifier that keeps the fill's grain peaks, clips its troughs and leaves the repair
     # bright and half-textured. Under the same ramp, so an untouched pixel stays identical.
     if floor:
-        lo_deficit = cv2.GaussianBlur(src, (0, 0), sigma) - cv2.GaussianBlur(out, (0, 0), sigma)
-        out += a * np.maximum(lo_deficit, 0.0)
-    return ensure_image(np.maximum(out, 0.0))
+        _add_floor_deficit(out, a, cv2.GaussianBlur(src, (0, 0), sigma), cv2.GaussianBlur(out, (0, 0), sigma))
+    else:
+        np.maximum(out, 0.0, out=out)
+    return ensure_image(out)
+
+
+@parallel_njit(cache=True)
+def _blend_fill(src, score, fill, a_out):
+    """``fill`` becomes ``src * (1 - a) + fill * a`` under the smoothstep write ramp of the
+    score; the ramp is kept in ``a_out`` for the grain and floor passes."""
+    f32 = np.float32
+    h, w = score.shape
+    hi = f32(_IR_WRITE_HI)
+    span = f32(_IR_WRITE_HI - _IR_WRITE_LO)
+    for y in prange(h):
+        for x in range(w):
+            a = min(max((hi - score[y, x]) / span, f32(0.0)), f32(1.0))
+            a = a * a * (f32(3.0) - f32(2.0) * a)
+            a_out[y, x] = a
+            keep = f32(1.0) - a
+            for c in range(3):
+                fill[y, x, c] = src[y, x, c] * keep + fill[y, x, c] * a
+
+
+@parallel_njit(cache=True)
+def _add_floor_deficit(out, a, blur_src, blur_out):
+    """``out += a * max(blur_src - blur_out, 0)``, then clamps at zero, in place."""
+    f32 = np.float32
+    h, w = a.shape
+    for y in prange(h):
+        for x in range(w):
+            av = a[y, x]
+            for c in range(3):
+                deficit = blur_src[y, x, c] - blur_out[y, x, c]
+                v = out[y, x, c] + av * max(deficit, f32(0.0))
+                out[y, x, c] = max(v, f32(0.0))
 
 
 def film_scale(shape: Tuple[int, int]) -> float:
@@ -1049,6 +1104,19 @@ def ir_bake_token(retouch, has_ir: bool) -> str:
     return f"|ir{int(retouch.ir_attenuation)}r{round(float(retouch.ir_threshold), 3)}{tail}"
 
 
+@parallel_njit(cache=True)
+def _hair_encode(crop, lo, inv_span, out_u8):
+    """``clip((crop - lo) / span, 0, 1) ** (1/γ)`` to 8-bit, for cv2.inpaint."""
+    f32 = np.float32
+    inv_gamma = f32(1.0 / _HAIR_INPAINT_GAMMA)
+    h, w = crop.shape[0], crop.shape[1]
+    for y in prange(h):
+        for x in range(w):
+            for c in range(3):
+                v = min(max((crop[y, x, c] - lo) * inv_span, f32(0.0)), f32(1.0))
+                out_u8[y, x, c] = np.uint8(v**inv_gamma * f32(255.0) + f32(0.5))
+
+
 def apply_hair_inpaint(
     img: ImageBuffer,
     hair_masks: List[np.ndarray],
@@ -1090,29 +1158,39 @@ def apply_hair_inpaint(
         # Mask the whole crop, not just this component: a neighbour reaching into the bbox
         # must stay unknown, or it becomes clone source and its dust is filled back in.
         sub_m = np.ascontiguousarray(m[y0:y1, x0:x1])
-        crop = src[y0:y1, x0:x1]
+        crop = np.ascontiguousarray(src[y0:y1, x0:x1])
         # Encode against the crop's clean range: clip(0,1) posterizes fills in dark regions.
-        ctx = crop[sub_m == 0]
+        # A hair can join enough specks that one component spans the frame, so the range is
+        # read off a strided sample of the clean pixels rather than all of them.
+        step = max(1, int(math.isqrt(max(1, crop.shape[0] * crop.shape[1] // _HAIR_RANGE_SAMPLE_PX))))
+        ctx = crop[::step, ::step][sub_m[::step, ::step] == 0]
         lo = float(np.percentile(ctx, 0.5)) if ctx.size else 0.0
         hi = float(np.percentile(ctx, 99.5)) if ctx.size else 1.0
         span = max(hi - lo, 1e-4)
-        enc = np.clip((crop - lo) / span, 0.0, 1.0) ** (1.0 / _HAIR_INPAINT_GAMMA)
-        filled = cv2.inpaint((enc * 255.0 + 0.5).astype(np.uint8), sub_m, radius, cv2.INPAINT_NS)
-        dec = ((filled.astype(np.float32) / 255.0) ** _HAIR_INPAINT_GAMMA) * span + lo
+        enc = np.empty(crop.shape, dtype=np.uint8)
+        _hair_encode(crop, np.float32(lo), np.float32(1.0 / span), enc)
+        filled = cv2.inpaint(enc, sub_m, radius, cv2.INPAINT_NS)
         # ...but keep only this component, alpha-feathered across the dilate band: full fill
         # on the detected defect, ramp over the skirt. A neighbour clipped by the bbox fills
         # badly here and gets its own padded crop anyway. dilate_px=0 means no feather.
         mb = labels[y0:y1, x0:x1] == i
         d = cv2.distanceTransform(mb.astype(np.uint8), cv2.DIST_C, 3)
-        a = np.minimum(d / float(dilate_px + 1), 1.0)[..., None]
-        blended = crop * (1.0 - a) + dec * a
-        out[y0:y1, x0:x1][mb] = blended[mb]
+        sel = np.flatnonzero(mb)
+        a = np.minimum(d.ravel()[sel] / float(dilate_px + 1), 1.0)[:, None]
+        # The fill is 8-bit, so its decode is a 256-entry table; only the component's own
+        # pixels are decoded and written, addressed flat in the frame (the crop view is not
+        # contiguous, so a reshape of it would write to a copy).
+        dec_lut = ((np.arange(256, dtype=np.float32) / 255.0) ** _HAIR_INPAINT_GAMMA) * span + lo
+        dec = dec_lut[filled.reshape(-1, 3)[sel]]
+        crop_px = crop.reshape(-1, 3)[sel]
+        ry, rx = np.divmod(sel, x1 - x0)
+        out.reshape(-1, 3)[(y0 + ry) * w + (x0 + rx)] = crop_px * (1.0 - a) + dec * a
     # Navier-Stokes propagates a smooth field, so the fill lands grainless. See
     # apply_score_repair, which fills the same kind of hole by a different route.
-    filled_px = m.astype(bool)
-    clean = ~filled_px
-    if clean.any():
-        out[filled_px] += _borrow_clean_grain(src, clean, max(1.0, factor))[filled_px]
+    idx = np.flatnonzero(m)
+    clean = m == 0
+    if clean.any() and idx.size:
+        out.reshape(-1, 3)[idx] += _borrow_clean_grain(src, clean, max(1.0, factor), idx)
     return out
 
 

--- a/negpy/features/retouch/logic.py
+++ b/negpy/features/retouch/logic.py
@@ -184,6 +184,8 @@ _HAIR_DILATE_PX = 1
 _HAIR_INPAINT_RADIUS = 3
 _HAIR_INPAINT_GAMMA = 2.2
 _HAIR_RANGE_SAMPLE_PX = 1 << 20  # clean pixels sampled for a crop's encode range
+_HAIR_TILE_PX = 1024  # inpaint tile; the solver walks whatever image it is handed
+_HAIR_TILE_HALO = 32  # px of neighbourhood a tile's core fill can see
 _HAIR_INPAINT_PAD = 16
 
 
@@ -779,9 +781,10 @@ def _fill_supports(buffer_long_edge: int, factor: float) -> Tuple[int, ...]:
     return tuple(dict.fromkeys([int(round(_IR_FILL_SCALES[0] * film)) | 1] + fine))
 
 
-def _borrow_clean_grain(src: np.ndarray, clean: np.ndarray, sigma: float, idx: np.ndarray) -> np.ndarray:
+def _borrow_clean_grain(src: np.ndarray, clean: np.ndarray, sigma: float, idx: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
     """Detail of the nearest clean pixel, high-passed at ``sigma``, for the flat pixel
-    indices ``idx`` only: an (N, 3) array, N = len(idx).
+    indices ``idx`` only: an (N, 3) array, N = len(idx), plus the ``sigma`` blur of ``src``
+    it was measured against, for a caller that needs the same low-pass again.
 
     Real film rather than synthesized noise: the donor is the closest pixel the IR score calls
     clean, so it carries the same emulsion, density and scanner noise as the hole it fills.
@@ -801,7 +804,7 @@ def _borrow_clean_grain(src: np.ndarray, clean: np.ndarray, sigma: float, idx: n
     mirrored = np.clip(2 * ny - py, 0, h - 1) * w + np.clip(2 * nx - px, 0, w - 1)
     take = np.where(clean.ravel()[mirrored], mirrored, nearest)
     blur = cv2.GaussianBlur(src, (0, 0), sigma)
-    return src.reshape(-1, 3)[take] - blur.reshape(-1, 3)[take]
+    return src.reshape(-1, 3)[take] - blur.reshape(-1, 3)[take], blur
 
 
 def apply_score_repair(
@@ -840,14 +843,18 @@ def apply_score_repair(
     sigma = max(1.0, factor)
     clean = score >= _IR_WRITE_HI
     idx = np.flatnonzero(~clean)
+    blur_src: Optional[np.ndarray] = None
     if clean.any() and idx.size:
-        out.reshape(-1, 3)[idx] += a.reshape(-1, 1)[idx] * _borrow_clean_grain(src, clean, sigma, idx)
+        grain, blur_src = _borrow_clean_grain(src, clean, sigma, idx)
+        out.reshape(-1, 3)[idx] += a.reshape(-1, 1)[idx] * grain
     # Original-floor rule: dust is dark in negative transmittance, so repairs only lighten.
     # Compared on the low-frequency deficit, because per pixel the rule is a half-wave
     # rectifier that keeps the fill's grain peaks, clips its troughs and leaves the repair
     # bright and half-textured. Under the same ramp, so an untouched pixel stays identical.
     if floor:
-        _add_floor_deficit(out, a, cv2.GaussianBlur(src, (0, 0), sigma), cv2.GaussianBlur(out, (0, 0), sigma))
+        if blur_src is None:
+            blur_src = cv2.GaussianBlur(src, (0, 0), sigma)
+        _add_floor_deficit(out, a, blur_src, cv2.GaussianBlur(out, (0, 0), sigma))
     else:
         np.maximum(out, 0.0, out=out)
     return ensure_image(out)
@@ -1188,30 +1195,45 @@ def apply_hair_inpaint(
         lo = float(np.percentile(ctx, 0.5)) if ctx.size else 0.0
         hi = float(np.percentile(ctx, 99.5)) if ctx.size else 1.0
         span = max(hi - lo, 1e-4)
-        enc = np.empty(crop.shape, dtype=np.uint8)
-        _hair_encode(crop, np.float32(lo), np.float32(1.0 / span), enc)
-        filled = cv2.inpaint(enc, sub_m, radius, cv2.INPAINT_NS)
-        # ...but keep only this component, alpha-feathered across the dilate band: full fill
-        # on the detected defect, ramp over the skirt. A neighbour clipped by the bbox fills
-        # badly here and gets its own padded crop anyway. dilate_px=0 means no feather.
-        mb = labels[y0:y1, x0:x1] == i
-        d = cv2.distanceTransform(mb.astype(np.uint8), cv2.DIST_C, 3)
-        sel = np.flatnonzero(mb)
-        a = np.minimum(d.ravel()[sel] / float(dilate_px + 1), 1.0)[:, None]
-        # The fill is 8-bit, so its decode is a 256-entry table; only the component's own
-        # pixels are decoded and written, addressed flat in the frame (the crop view is not
-        # contiguous, so a reshape of it would write to a copy).
+        # The fill is 8-bit, so its decode is a 256-entry table.
         dec_lut = ((np.arange(256, dtype=np.float32) / 255.0) ** _HAIR_INPAINT_GAMMA) * span + lo
-        dec = dec_lut[filled.reshape(-1, 3)[sel]]
-        crop_px = crop.reshape(-1, 3)[sel]
-        ry, rx = np.divmod(sel, x1 - x0)
-        out.reshape(-1, 3)[(y0 + ry) * w + (x0 + rx)] = crop_px * (1.0 - a) + dec * a
+        ch, cw = crop.shape[:2]
+        # The inpaint walks the whole image it is handed, and a hair joining specks can make
+        # this crop the frame: tile it, skip tiles without this component, keep a halo so
+        # the fill at a tile's core sees the same neighbourhood.
+        for ty0 in range(0, ch, _HAIR_TILE_PX):
+            for tx0 in range(0, cw, _HAIR_TILE_PX):
+                ty1, tx1 = min(ch, ty0 + _HAIR_TILE_PX), min(cw, tx0 + _HAIR_TILE_PX)
+                if not (labels[y0 + ty0 : y0 + ty1, x0 + tx0 : x0 + tx1] == i).any():
+                    continue
+                ay0, ay1 = max(0, ty0 - _HAIR_TILE_HALO), min(ch, ty1 + _HAIR_TILE_HALO)
+                ax0, ax1 = max(0, tx0 - _HAIR_TILE_HALO), min(cw, tx1 + _HAIR_TILE_HALO)
+                tile = np.ascontiguousarray(crop[ay0:ay1, ax0:ax1])
+                enc = np.empty(tile.shape, dtype=np.uint8)
+                _hair_encode(tile, np.float32(lo), np.float32(1.0 / span), enc)
+                filled = cv2.inpaint(enc, np.ascontiguousarray(sub_m[ay0:ay1, ax0:ax1]), radius, cv2.INPAINT_NS)
+                # ...but keep only this component, alpha-feathered across the dilate band: full
+                # fill on the detected defect, ramp over the skirt. A neighbour clipped by the
+                # bbox fills badly here and gets its own padded crop anyway. dilate_px=0 means
+                # no feather. Only the tile's core is written; the halo belongs to its neighbours.
+                mb = labels[y0 + ay0 : y0 + ay1, x0 + ax0 : x0 + ax1] == i
+                d = cv2.distanceTransform(mb.astype(np.uint8), cv2.DIST_C, 3)
+                core = np.zeros(mb.shape, dtype=bool)
+                core[ty0 - ay0 : ty1 - ay0, tx0 - ax0 : tx1 - ax0] = True
+                sel = np.flatnonzero(mb & core)
+                a = np.minimum(d.ravel()[sel] / float(dilate_px + 1), 1.0)[:, None]
+                # Written flat into the frame: the crop view is not contiguous, so a reshape
+                # of it would write to a copy.
+                dec = dec_lut[filled.reshape(-1, 3)[sel]]
+                tile_px = tile.reshape(-1, 3)[sel]
+                ry, rx = np.divmod(sel, ax1 - ax0)
+                out.reshape(-1, 3)[(y0 + ay0 + ry) * w + (x0 + ax0 + rx)] = tile_px * (1.0 - a) + dec * a
     # Navier-Stokes propagates a smooth field, so the fill lands grainless. See
     # apply_score_repair, which fills the same kind of hole by a different route.
     idx = np.flatnonzero(m)
     clean = m == 0
     if clean.any() and idx.size:
-        out.reshape(-1, 3)[idx] += _borrow_clean_grain(src, clean, max(1.0, factor), idx)
+        out.reshape(-1, 3)[idx] += _borrow_clean_grain(src, clean, max(1.0, factor), idx)[0]
     return out
 
 

--- a/negpy/features/retouch/logic.py
+++ b/negpy/features/retouch/logic.py
@@ -358,7 +358,6 @@ def strokes_to_score(
         return None
 
     h, w = img.shape[:2]
-    dens = _density(img)
     score = np.ones((h, w), dtype=np.float32)
     # Brush size is a DIAMETER at HEAL_SIZE_REF scale, so the painted footprint matches the
     # cursor at any render resolution (overlay._brush_screen_radius draws size/(2*REF)).
@@ -390,7 +389,7 @@ def strokes_to_score(
         if not cover.any():
             continue
 
-        crop = dens[y0:y1, x0:x1]
+        crop = _density(img[y0:y1, x0:x1])
         detail = cv2.blur(crop - cv2.blur(crop, (win, win)), (3, 3))
         # MAD about zero over the whole crop, so the defect stays a minority in its own
         # noise estimate. 0.6745 is the half-normal median, which turns it into a σ.
@@ -448,6 +447,20 @@ def scratch_detect_bar(slider: float) -> float:
     return _SCRATCH_Z_LOOSE + (_SCRATCH_Z_TIGHT - _SCRATCH_Z_LOOSE) * s
 
 
+# Rows the ridge response at one row can see: the broad Gaussian's kernel plus the noise
+# window's half width. A band computed with this margin matches the whole-frame response.
+_SCRATCH_RIDGE_REACH = 128
+
+
+def _scratch_ridge_rows(img: ImageBuffer, r0: int, r1: int) -> Tuple[np.ndarray, int]:
+    """``_scratch_ridge`` for rows ``[r0, r1)`` only, computed on a band with enough margin
+    that those rows equal the whole-frame response. Returns ``(ridge, band_start)``: the
+    array covers ``[band_start, band_end)``, a superset of the request."""
+    h = img.shape[0]
+    a, b = max(0, r0 - _SCRATCH_RIDGE_REACH), min(h, r1 + _SCRATCH_RIDGE_REACH)
+    return _scratch_ridge(img[a:b]), a
+
+
 def _scratch_ridge(img: ImageBuffer) -> np.ndarray:
     """Cross-section ridge response of ``img``, in units of the *local* noise.
 
@@ -486,12 +499,18 @@ def trace_scratch(img: ImageBuffer, nx: float, ny: float, threshold: float = 0.5
     h, w = img.shape[:2]
     cx, cy = float(nx) * w, float(ny) * h
     bar = scratch_detect_bar(threshold)
-    z = _scratch_ridge(img)
     y0 = max(0, int(cy) - _SCRATCH_SEARCH_ROWS)
     y1 = min(h, int(cy) + _SCRATCH_SEARCH_ROWS)
     if y1 - y0 < 3:
         return None
-    band = np.ascontiguousarray(z[y0:y1])
+    scale = film_scale((h, w))
+    max_half = max(1, int(round(0.5 * _SCRATCH_WIDTH_MAX * scale)))
+    # The band grown below reads the sheared frame ±max_half around the line, and a shear
+    # of the steepest slope moves rows by slope·w across the width: only that many rows of
+    # ridge are needed, and the frame is a full-resolution buffer on hover.
+    reach = max_half + int(math.ceil(_SCRATCH_SLOPE_MAX * w)) + 2
+    z, z0 = _scratch_ridge_rows(img, y0 - reach, y1 + reach)
+    band = np.ascontiguousarray(z[y0 - z0 : y1 - z0])
     pull = np.exp(-0.5 * ((np.arange(y0, y1) - cy) / _SCRATCH_CLICK_PULL) ** 2)
 
     best: Optional[Tuple[float, float, int, np.ndarray]] = None
@@ -515,9 +534,7 @@ def trace_scratch(img: ImageBuffer, nx: float, ny: float, threshold: float = 0.5
     x0, x1 = float(cols[0]), float(cols[-1])
     row = y0 + k
     # For the guide only: the repair grows its own band per column.
-    scale = film_scale((h, w))
-    max_half = max(1, int(round(0.5 * _SCRATCH_WIDTH_MAX * scale)))
-    grown = _grow_band(_shear_rows(z, slope, cx, w), row, cols, max_half, float(np.sign(along.mean()) or 1.0), bar)
+    grown = _grow_band(_shear_rows(z, slope, cx, w), row - z0, cols, max_half, float(np.sign(along.mean()) or 1.0), bar)
     width = float(np.clip(2.0 * float(np.median(grown.sum(axis=0))) / max(scale, 1e-6), _SCRATCH_WIDTH_MIN, _SCRATCH_WIDTH_MAX))
     return (x0 / w, (row + slope * (x0 - cx)) / h, x1 / w, (row + slope * (x1 - cx)) / h, width)
 
@@ -556,7 +573,6 @@ def lines_to_score(img: ImageBuffer, lines: List[Tuple], threshold: float = 0.5)
         return None
     h, w = img.shape[:2]
     bar = scratch_detect_bar(threshold)
-    z = _scratch_ridge(img)
     scale = film_scale((h, w))
     mask = np.zeros((h, w), dtype=np.uint8)
     touched = False
@@ -570,10 +586,14 @@ def lines_to_score(img: ImageBuffer, lines: List[Tuple], threshold: float = 0.5)
         # ``width`` is only what the guide drew. The band is re-grown from the scratch here,
         # so it follows a scratch that widens and ignores the traced resolution.
         max_half = max(1, int(round(0.5 * _SCRATCH_WIDTH_MAX * scale)))
-        sheared = _shear_rows(z, slope, x0, w)
         row = int(round(y0))
         if not 0 <= row < h:
             continue
+        # Ridge on the rows the sheared band reads, not the frame (see trace_scratch).
+        reach = max_half + int(math.ceil(abs(slope) * max(x0, w - x0))) + 2
+        z, z0 = _scratch_ridge_rows(img, row - reach, row + reach + 1)
+        sheared = _shear_rows(z, slope, x0, w)
+        row -= z0
         along = sheared[row]
         sign = np.sign(along.mean()) or 1.0
         on = (along * sign > bar).astype(np.float32)
@@ -924,19 +944,20 @@ def route_wide_defects(score: np.ndarray, *, budget: Optional[float] = _IR_ROUTE
     if not at_floor.any():
         return None
     n_lbl, labels, stats, _ = cv2.connectedComponentsWithStats(at_floor, connectivity=8)
-    routed = np.zeros_like(at_floor)
     scale = _ir_detect_scale(score)
     radius = int(round(_IR_ROUTE_RADIUS * scale))
     side = 2 * radius - 1
+    routed = np.zeros_like(at_floor)
     hit = False
     for i in range(1, n_lbl):
         bw, bh = int(stats[i, cv2.CC_STAT_WIDTH]), int(stats[i, cv2.CC_STAT_HEIGHT])
         if min(bw, bh) < side:  # can't contain a side² solid → radius under the bar
             continue
         x0, y0 = int(stats[i, cv2.CC_STAT_LEFT]), int(stats[i, cv2.CC_STAT_TOP])
-        sub = np.pad((labels[y0 : y0 + bh, x0 : x0 + bw] == i).astype(np.uint8), 1)
-        if float(cv2.distanceTransform(sub, cv2.DIST_C, 3).max()) >= radius:
-            routed[labels == i] = 1
+        own = labels[y0 : y0 + bh, x0 : x0 + bw] == i
+        if float(cv2.distanceTransform(np.pad(own.astype(np.uint8), 1), cv2.DIST_C, 3).max()) >= radius:
+            # Written inside the bounding box: a hand-placed score arrives at full resolution.
+            routed[y0 : y0 + bh, x0 : x0 + bw][own] = 1
             hit = True
     if not hit:
         return None

--- a/negpy/features/retouch/openice.py
+++ b/negpy/features/retouch/openice.py
@@ -17,6 +17,9 @@ from typing import Optional, Tuple
 
 import cv2
 import numpy as np
+from numba import prange  # type: ignore
+
+from negpy.kernel.system.parallel import parallel_njit
 
 from negpy.kernel.system.logging import get_logger
 
@@ -314,40 +317,139 @@ def _normconv(num: np.ndarray, conf: np.ndarray, k: np.ndarray) -> np.ndarray:
     return _filter(num, k) / conf
 
 
-def _reconstruct_tile(d_rgb: np.ndarray, gate: np.ndarray, w: np.ndarray, cal: IceCalibration) -> np.ndarray:
-    """Reconstruction core (§6-§7): start from the coarsest confidence-weighted average
-    with the stolen light added back, then restore each detail band that beats the local
-    IR contrast at its own scale."""
+def _band_planes(d_rgb: np.ndarray, gate: np.ndarray, w: np.ndarray) -> tuple:
+    """The convolved planes the band kernel reads: per scale the confidence sum, the
+    confidence-normalized gate (§6) and the unnormalized weighted density, plus the IR
+    contrast envelope of each detail band (§7b)."""
     conf = [np.maximum(_filter(w, k), 1e-6) for k in (_K9, _K5, _K3)]
-    p = [_normconv(w * gate, c, k) for c, k in zip(conf, (_K9, _K5, _K3))] + [gate]
+    p = [_filter(w * gate, k) / c for c, k in zip(conf, (_K9, _K5, _K3))] + [gate]
     wd = d_rgb * w[..., None]
-
-    lo_prev = _normconv(wd, conf[0], _K9)
-    # §7a: the local IR deficit is the light the defect stole; γ converts it to density.
-    acc = lo_prev + _COEF[:, 0] * (cal.ir_ref - p[0])[..., None]
-
-    band_conf = (
-        np.clip(_CONF_GAIN_B0 * conf[1], 0.0, 1.0),
-        np.maximum(conf[2], 0.0),
-        w * w,
-    )
+    f_wd = [_filter(wd, k) for k in (_K9, _K5, _K3)]
+    env = []
     for b in range(3):
-        l_cur = d_rgb if b == 2 else _normconv(wd, conf[b + 1], (_K5, _K3)[b])
-        detail = (l_cur - lo_prev) * _STAGE_GAIN
-        lo_prev = l_cur
-        # §7b: the IR's own contrast at this scale is what dust would look like here.
         delta = p[b + 1] - p[b]
-        hi, lo = cv2.dilate(delta, _CROSS), cv2.erode(delta, _CROSS)
-        a_hi, a_lo = _COEF[:, 1 + 2 * b], _COEF[:, 2 + 2 * b]
-        # On an entirely-negative band the coefficients swap, so the larger one always
-        # scales whichever edge sits further from zero.
-        neg = ((hi < 0.0) & (lo < 0.0))[..., None]
-        hi_t = np.where(neg, a_lo, a_hi) * hi[..., None]
-        lo_t = np.where(neg, a_hi, a_lo) * lo[..., None]
-        # Dead zone: detail within the IR contrast is dust, and detail beyond it is picture.
-        resid = np.where(detail > hi_t, detail - hi_t, np.where(detail < lo_t, detail - lo_t, 0.0))
-        acc += resid * band_conf[b][..., None]
-    return acc
+        env.append((cv2.dilate(delta, _CROSS), cv2.erode(delta, _CROSS)))
+    return conf, p[0], f_wd, env
+
+
+@parallel_njit(cache=True)
+def _band_kernel(
+    d_rgb,
+    src,
+    w,
+    hopeless,
+    c9,
+    c5,
+    c3,
+    p0,
+    f9,
+    f5,
+    f3,
+    hi0,
+    lo0,
+    hi1,
+    lo1,
+    hi2,
+    lo2,
+    coef,
+    dither_amp,
+    ir_ref,
+    row0,
+    s,
+    e,
+    out,
+    trigger,
+    weight,
+):
+    """§6-§8 per pixel for the band's core rows [s, e): confidence-weighted base with the
+    stolen light added back, three detail bands gated by the IR contrast, dither, and the
+    fill-only write. Same float32 operation order as the array form it replaced."""
+    f32 = np.float32
+    gain = f32(_STAGE_GAIN)
+    lo_band, hi_band = f32(_DITHER_LO), f32(_DITHER_HI)
+    env_k = f32(_DITHER_ENV)
+    m = f32(_M)
+    inv_k = f32(1.0) / f32(_K)
+    inv_m = f32(1.0) / m
+    width = d_rgb.shape[1]
+    for y in prange(s, e):
+        for x in range(width):
+            wv = w[y, x]
+            bc0 = min(max(f32(_CONF_GAIN_B0) * c5[y, x], f32(0.0)), f32(1.0))
+            bc1 = max(c3[y, x], f32(0.0))
+            bc2 = wv * wv
+            h0, l0 = hi0[y, x], lo0[y, x]
+            h1, l1 = hi1[y, x], lo1[y, x]
+            h2, l2 = hi2[y, x], lo2[y, x]
+            neg0 = h0 < f32(0.0) and l0 < f32(0.0)
+            neg1 = h1 < f32(0.0) and l1 < f32(0.0)
+            neg2 = h2 < f32(0.0) and l2 < f32(0.0)
+            ir_def = f32(ir_ref) - p0[y, x]
+            acc0 = f32(0.0)
+            acc1 = f32(0.0)
+            acc2 = f32(0.0)
+            for c in range(3):
+                lo_prev = f9[y, x, c] / c9[y, x]
+                acc = lo_prev + coef[c, 0] * ir_def
+                # band 0: K5 average against the K9 base
+                l_cur = f5[y, x, c] / c5[y, x]
+                detail = (l_cur - lo_prev) * gain
+                lo_prev = l_cur
+                hi_t = (coef[c, 2] if neg0 else coef[c, 1]) * h0
+                lo_t = (coef[c, 1] if neg0 else coef[c, 2]) * l0
+                resid = detail - hi_t if detail > hi_t else (detail - lo_t if detail < lo_t else f32(0.0))
+                acc += resid * bc0
+                # band 1: K3 average against K5
+                l_cur = f3[y, x, c] / c3[y, x]
+                detail = (l_cur - lo_prev) * gain
+                lo_prev = l_cur
+                hi_t = (coef[c, 4] if neg1 else coef[c, 3]) * h1
+                lo_t = (coef[c, 3] if neg1 else coef[c, 4]) * l1
+                resid = detail - hi_t if detail > hi_t else (detail - lo_t if detail < lo_t else f32(0.0))
+                acc += resid * bc1
+                # band 2: the pixel itself against K3
+                l_cur = d_rgb[y, x, c]
+                detail = (l_cur - lo_prev) * gain
+                hi_t = (coef[c, 6] if neg2 else coef[c, 5]) * h2
+                lo_t = (coef[c, 5] if neg2 else coef[c, 6]) * l2
+                resid = detail - hi_t if detail > hi_t else (detail - lo_t if detail < lo_t else f32(0.0))
+                acc += resid * bc2
+                if c == 0:
+                    acc0 = acc
+                elif c == 1:
+                    acc1 = acc
+                else:
+                    acc2 = acc
+            keep = wv >= f32(1.0) or hopeless[y, x] or acc0 <= f32(0.0) or acc1 <= f32(0.0) or acc2 <= f32(0.0)
+            oy = y - s
+            trigger[oy, x] = hopeless[y, x]
+            weight[oy, x] = wv
+            iy = np.uint32(np.uint32(row0 + y) * np.uint32(0x165667B1))
+            ix = np.uint32(np.uint32(x) * np.uint32(0x27D4EB2D))
+            for c in range(3):
+                acc = acc0 if c == 0 else (acc1 if c == 1 else acc2)
+                # §8 dither: coordinate-hashed uniform draw, parabolic envelope across the band.
+                ic = np.uint32(np.uint32(c) * np.uint32(0x9E3779B9))
+                k = np.uint32(iy ^ ix ^ ic)
+                k = np.uint32(k ^ (k >> np.uint32(15)))
+                k = np.uint32(k * np.uint32(0x2C1B3C6D))
+                k = np.uint32(k ^ (k >> np.uint32(13)))
+                k = np.uint32(k * np.uint32(0x297A2D39))
+                k = np.uint32(k ^ (k >> np.uint32(16)))
+                u = f32(k >> np.uint32(8)) * f32(2.0**-24) - f32(0.5)
+                envv = env_k * (hi_band - acc) * (acc - lo_band)
+                d = envv * u * (dither_amp[c] * acc)
+                in_band = acc > lo_band and acc < hi_band
+                if not (in_band and acc + d > lo_band and acc + d < hi_band):
+                    d = f32(0.0)
+                acc_d = acc + d
+                lift = f32(0.0) if keep else max(acc_d - d_rgb[y, x, c], f32(0.0))
+                if lift > f32(0.0):
+                    dd = d_rgb[y, x, c] + lift
+                    dd = min(max(dd, f32(0.0)), m)
+                    out[oy, x, c] = np.expm1(dd * inv_k) * inv_m
+                else:
+                    out[oy, x, c] = src[y, x, c]
 
 
 def _uniform(row0: int, shape: Tuple[int, int]) -> np.ndarray:
@@ -390,6 +492,7 @@ def reconstruct(img: np.ndarray, ir: np.ndarray, cal: IceCalibration) -> Tuple[n
     ``trigger`` marks defects too wide to rebuild (for the inpaint router); ``weight`` is 1
     on intact film and drops under a defect (for the overlay). Banded because the pyramid
     holds a dozen full planes live at once; bands overlap by _HALO so seams carry nothing.
+    Per band the convolutions run in cv2 and everything per-pixel in one numba pass.
     """
     src = np.ascontiguousarray(img, dtype=np.float32)
     h, w_px = src.shape[:2]
@@ -406,26 +509,39 @@ def reconstruct(img: np.ndarray, ir: np.ndarray, cal: IceCalibration) -> Tuple[n
         y1 = min(h, y0 + _BAND_ROWS)
         a, b = max(0, y0 - _HALO), min(h, y1 + _HALO)
         ir_t = ir[a:b]
-        d_rgb = density(src[a:b])
+        band_src = src[a:b]
+        d_rgb = density(band_src)
         gate, w = _gate_and_weight(d_rgb, density(ir_t), ir_t >= _DEAD_FLOOR, cal)
         hopeless = _giveup_trigger(gate, cal.dust_floor)
-        acc = _reconstruct_tile(d_rgb, gate, w, cal)
-        # Already clean, wider than the window, or a non-positive reconstruction. Tested on the
-        # bare accumulator, because ICE's positivity guard runs before the dither is added.
-        keep = (w >= 1.0) | hopeless | (acc <= 0.0).any(axis=-1)
-        acc = acc + _dither(acc, a)
-        # "Only fill, never darken": a defect steals light, so a repair may only lighten.
-        # Written at full strength wherever w < 1, as ICE does. A confidence ramp here looks
-        # like cheap insurance against mottling and is not: dust sits at the weight floor only
-        # once it is deep, so the ramp costs shallow specks most of their repair.
-        lift = np.where(keep[..., None], 0.0, np.maximum(acc - d_rgb, 0.0))
-        s, e = y0 - a, y1 - a
-        # Verbatim where nothing was lifted: the density round-trip is not bit-exact in
-        # float32, and an untouched pixel must come out byte-identical.
-        touched = lift[s:e] > 0.0
-        out[y0:y1] = np.where(touched, density_inv(d_rgb[s:e] + lift[s:e]), src[y0:y1])
-        trigger[y0:y1] = hopeless[s:e]
-        weight[y0:y1] = w[s:e]
+        conf, p0, f_wd, env = _band_planes(d_rgb, gate, w)
+        _band_kernel(
+            d_rgb,
+            band_src,
+            w,
+            hopeless,
+            conf[0],
+            conf[1],
+            conf[2],
+            np.ascontiguousarray(p0, dtype=np.float32),
+            f_wd[0],
+            f_wd[1],
+            f_wd[2],
+            env[0][0],
+            env[0][1],
+            env[1][0],
+            env[1][1],
+            env[2][0],
+            env[2][1],
+            _COEF,
+            np.ascontiguousarray(_DITHER_AMP, dtype=np.float32),
+            float(cal.ir_ref),
+            a,
+            y0 - a,
+            y1 - a,
+            out[y0:y1],
+            trigger[y0:y1],
+            weight[y0:y1],
+        )
     return out, trigger, weight
 
 

--- a/negpy/infrastructure/gpu/cffi_warm.py
+++ b/negpy/infrastructure/gpu/cffi_warm.py
@@ -1,0 +1,73 @@
+"""Pre-fills wgpu-py's cffi type cache from the models cffi already built for webgpu.h.
+
+wgpu-py runs cffi in ABI mode, so the first ``ffi.new("WGPUFoo *")`` for every distinct type
+string goes through pycparser, and each parse re-declares every typedef of the header. Dozens of
+those land on the GUI thread during window construction and on the first render. The typedef
+models are already in the parser's declarations, so the backend types can be built directly.
+Private cffi API: any failure leaves the cache untouched and wgpu parses as before.
+"""
+
+from negpy.kernel.system.logging import get_logger
+
+logger = get_logger(__name__)
+
+_PRIMITIVES = (
+    "char",
+    "uint8_t",
+    "uint16_t",
+    "uint32_t",
+    "uint64_t",
+    "int32_t",
+    "int64_t",
+    "float",
+    "double",
+    "size_t",
+    "int",
+    "uintptr_t",
+    "intptr_t",
+)
+_warmed = False
+
+
+def warm_wgpu_cffi_types() -> int:
+    """Returns the number of cache entries added; 0 when already warmed or unavailable."""
+    global _warmed
+    if _warmed:
+        return 0
+    _warmed = True
+    try:
+        import cffi.model as cm
+        from wgpu.backends.wgpu_native._ffi import ffi
+
+        added = 0
+        # _get_cached_btype asserts the ffi lock is held; without it the assert's
+        # acquire(False) leaks the lock and the next real parse deadlocks.
+        with ffi._lock:
+
+            def put(cdecl: str, model) -> None:
+                nonlocal added
+                if cdecl not in ffi._parsed_types:
+                    ffi._parsed_types[cdecl] = (ffi._get_cached_btype(model), False)
+                    added += 1
+
+            for key, val in list(ffi._parser._declarations.items()):
+                if not key.startswith("typedef "):
+                    continue
+                model = val[0] if isinstance(val, tuple) else val
+                if not isinstance(model, (cm.StructType, cm.EnumType, cm.PrimitiveType, cm.PointerType)):
+                    continue
+                name = key[len("typedef ") :]
+                put(name, model)
+                put(name + " *", cm.PointerType(model))
+                put(name + "[]", cm.ArrayType(model, None))
+            for prim in _PRIMITIVES:
+                model = cm.PrimitiveType(prim)
+                put(prim, model)
+                put(prim + " *", cm.PointerType(model))
+                put(prim + "[]", cm.ArrayType(model, None))
+                put(prim + " []", cm.ArrayType(model, None))
+            put("void *", cm.PointerType(cm.void_type))
+        return added
+    except Exception as e:
+        logger.debug("cffi type warm skipped: %s", e)
+        return 0

--- a/negpy/infrastructure/gpu/device.py
+++ b/negpy/infrastructure/gpu/device.py
@@ -1,6 +1,7 @@
 import threading
 from typing import Optional
 import wgpu  # type: ignore
+from negpy.infrastructure.gpu.cffi_warm import warm_wgpu_cffi_types
 from negpy.kernel.system.logging import get_logger
 
 logger = get_logger(__name__)
@@ -32,6 +33,7 @@ class GPUDevice:
 
     def _initialize(self) -> None:
         try:
+            warm_wgpu_cffi_types()
             self.adapter = wgpu.gpu.request_adapter_sync(power_preference="high-performance")
             if self.adapter:
                 self.device = self.adapter.request_device_sync()

--- a/negpy/infrastructure/gpu/resources.py
+++ b/negpy/infrastructure/gpu/resources.py
@@ -2,6 +2,7 @@ import threading
 from typing import Optional
 
 import numpy as np
+from negpy.kernel.image.logic import rgb_to_rgba_into
 import wgpu  # type: ignore
 from negpy.infrastructure.gpu.device import GPUDevice
 from negpy.kernel.system.logging import get_logger
@@ -67,7 +68,7 @@ class GPUTexture:
         if self._rgba_scratch is None or self._rgba_scratch.shape != shape:
             self._rgba_scratch = np.empty(shape, dtype=np.float32)
             self._rgba_scratch[:, :, 3] = 1.0
-        np.copyto(self._rgba_scratch[:, :, :3], data)
+        rgb_to_rgba_into(np.ascontiguousarray(data), self._rgba_scratch)
         return self._rgba_scratch
 
     def readback_region(self, x: int, y: int, rw: int, rh: int) -> np.ndarray:

--- a/negpy/infrastructure/loaders/helpers.py
+++ b/negpy/infrastructure/loaders/helpers.py
@@ -16,8 +16,31 @@ from negpy.kernel.system.logging import get_logger
 logger = get_logger(__name__)
 
 
+# (path) -> (mtime_ns, size, exif). A navigation reads the same file's EXIF for the metadata panel
+# and again for the orientation tag; a RAW parse is tens of ms, a large TIFF hundreds.
+_exif_cache: dict[str, tuple[int, int, Optional[dict]]] = {}
+_EXIF_CACHE_MAX = 64
+
+
 def read_exif_from_file(file_path: str) -> Optional[dict]:
-    """Read EXIF data from a file as a piexif-format dict. Returns None on failure."""
+    """Read EXIF data from a file as a piexif-format dict. Returns None on failure.
+    Callers get their own copy, so mutating the result never leaks into a later read."""
+    import copy
+
+    try:
+        st = os.stat(file_path)
+    except OSError:
+        return _read_exif_uncached(file_path)
+    hit = _exif_cache.get(file_path)
+    if hit is None or hit[0] != st.st_mtime_ns or hit[1] != st.st_size:
+        if len(_exif_cache) >= _EXIF_CACHE_MAX:
+            _exif_cache.clear()
+        hit = (st.st_mtime_ns, st.st_size, _read_exif_uncached(file_path))
+        _exif_cache[file_path] = hit
+    return copy.deepcopy(hit[2])
+
+
+def _read_exif_uncached(file_path: str) -> Optional[dict]:
     import piexif
 
     # Try piexif first (works for JPEG, TIFF)

--- a/negpy/kernel/image/logic.py
+++ b/negpy/kernel/image/logic.py
@@ -93,6 +93,30 @@ def uint8_to_float32(img: np.ndarray) -> np.ndarray:
     return res
 
 
+@njit(cache=True)
+def rgb_to_rgba_into(src: np.ndarray, dst: np.ndarray) -> None:
+    """Copies the three colour planes of ``src`` into the RGBA ``dst``; alpha is left as is.
+    numpy cannot vectorise a 3-of-4 strided copy, so a texture upload spent longer here than
+    on the GPU."""
+    h, w = src.shape[0], src.shape[1]
+    for y in range(h):
+        for x in range(w):
+            dst[y, x, 0] = src[y, x, 0]
+            dst[y, x, 1] = src[y, x, 1]
+            dst[y, x, 2] = src[y, x, 2]
+
+
+@njit(cache=True)
+def rgba_to_rgb_into(src: np.ndarray, dst: np.ndarray, oy: int, ox: int) -> None:
+    """Writes the RGB of ``src[oy:oy+h, ox:ox+w]`` into the (h, w, 3) ``dst``."""
+    h, w = dst.shape[0], dst.shape[1]
+    for y in range(h):
+        for x in range(w):
+            dst[y, x, 0] = src[oy + y, ox + x, 0]
+            dst[y, x, 1] = src[oy + y, ox + x, 1]
+            dst[y, x, 2] = src[oy + y, ox + x, 2]
+
+
 @njit(cache=True, fastmath=True)
 def uint16_to_float32(img: np.ndarray) -> np.ndarray:
     """

--- a/negpy/kernel/system/parallel.py
+++ b/negpy/kernel/system/parallel.py
@@ -34,6 +34,10 @@ logger = get_logger(__name__)
 # workqueue threading layer: concurrent parallel-kernel entry aborts the process.
 _invocation_gate = threading.Lock()
 
+# Below this many elements a kernel runs the serial variant and skips the gate: the GUI thread's
+# chart and wedge curves must not wait behind the render thread's full-frame kernels.
+SERIAL_MAX_ELEMENTS = 1 << 16
+
 
 def default_cpu_parallel(platform: str = sys.platform) -> bool:
     """Platform policy: parallel kernels on, except macOS (pending verification)."""
@@ -110,7 +114,15 @@ class _DualDispatcher:
         self.__name__ = getattr(py_func, "__name__", "kernel")
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
-        if _parallel_enabled:
+        if _parallel_enabled and _first_array_size(args) >= SERIAL_MAX_ELEMENTS:
             with _invocation_gate:
                 return self.parallel(*args, **kwargs)
         return self.serial(*args, **kwargs)
+
+
+def _first_array_size(args: tuple) -> int:
+    for a in args:
+        size = getattr(a, "size", None)
+        if isinstance(size, int):
+            return size
+    return SERIAL_MAX_ELEMENTS

--- a/negpy/services/assets/crosstalk.py
+++ b/negpy/services/assets/crosstalk.py
@@ -1,11 +1,11 @@
 import os
-import tomllib
 from enum import StrEnum
 from typing import List, Optional
 
 from negpy.kernel.system.config import APP_CONFIG
 from negpy.kernel.system.paths import get_resource_path
 from negpy.services.assets.naming import escape_toml_string, slugify
+from negpy.services.assets.toml_cache import load_toml_cached
 
 # Renamed from "Default"
 DEFAULT_NAME = "Generic C41"
@@ -83,8 +83,9 @@ class CrosstalkProfiles:
 
         `type` is read separately by `_scan_types`: callers unpack this tuple positionally."""
         try:
-            with open(path, "rb") as f:
-                data = tomllib.load(f)
+            data = load_toml_cached(path)
+            if data is None:
+                return None
             rows = data.get("matrix")
             if not isinstance(rows, list) or len(rows) != 3:
                 return None
@@ -105,11 +106,10 @@ class CrosstalkProfiles:
     @staticmethod
     def _parse_type(path: str) -> str:
         """The profile's `type`, lowercased; "" when absent or unreadable."""
-        try:
-            with open(path, "rb") as f:
-                raw = tomllib.load(f).get("type")
-        except Exception:
+        data = load_toml_cached(path)
+        if data is None:
             return ""
+        raw = data.get("type")
         return raw.strip().lower() if isinstance(raw, str) else ""
 
     @staticmethod
@@ -147,10 +147,8 @@ class CrosstalkProfiles:
             for fname in os.listdir(directory):
                 if not fname.endswith(".toml"):
                     continue
-                try:
-                    with open(os.path.join(directory, fname), "rb") as f:
-                        data = tomllib.load(f)
-                except Exception:
+                data = load_toml_cached(os.path.join(directory, fname))
+                if data is None:
                     continue
                 raw_name = data.get("name")
                 name = raw_name.strip() if isinstance(raw_name, str) and raw_name.strip() else fname[:-5]

--- a/negpy/services/assets/sensor.py
+++ b/negpy/services/assets/sensor.py
@@ -1,8 +1,8 @@
 import os
-import tomllib
 from typing import List, Optional
 
 from negpy.kernel.system.config import APP_CONFIG
+from negpy.services.assets.toml_cache import load_toml_cached
 from negpy.services.assets.naming import escape_toml_string, slugify
 
 NONE_NAME = "None"
@@ -43,8 +43,9 @@ class SensorProfiles:
     def _parse_file(path: str) -> Optional[tuple]:
         """Parses a .toml file to (name, flat 9-float list), or None if invalid."""
         try:
-            with open(path, "rb") as f:
-                data = tomllib.load(f)
+            data = load_toml_cached(path)
+            if data is None:
+                return None
             rows = data.get("matrix")
             if not isinstance(rows, list) or len(rows) != 3:
                 return None

--- a/negpy/services/assets/toml_cache.py
+++ b/negpy/services/assets/toml_cache.py
@@ -1,0 +1,26 @@
+import os
+import tomllib
+from typing import Any, Optional
+
+# (path) -> (mtime_ns, size, parsed). Profile folders are re-listed on every sidebar sync, so the
+# parse is cached per file and only the stat runs per sync.
+_cache: dict[str, tuple[int, int, Optional[dict]]] = {}
+
+
+def load_toml_cached(path: str) -> Optional[dict[str, Any]]:
+    """Parsed TOML for ``path``, re-read when the file changes; None when unreadable or invalid."""
+    try:
+        st = os.stat(path)
+    except OSError:
+        _cache.pop(path, None)
+        return None
+    hit = _cache.get(path)
+    if hit is not None and hit[0] == st.st_mtime_ns and hit[1] == st.st_size:
+        return hit[2]
+    try:
+        with open(path, "rb") as f:
+            data: Optional[dict] = tomllib.load(f)
+    except Exception:
+        data = None
+    _cache[path] = (st.st_mtime_ns, st.st_size, data)
+    return data

--- a/negpy/services/rendering/gpu_engine.py
+++ b/negpy/services/rendering/gpu_engine.py
@@ -64,6 +64,7 @@ from negpy.features.process.models import ProcessMode, per_channel_point_offsets
 from negpy.infrastructure.gpu.device import GPUDevice
 from negpy.infrastructure.gpu.resources import GPUBuffer, GPUTexture
 from negpy.infrastructure.gpu.shader_loader import ShaderLoader
+from negpy.kernel.image.logic import rgba_to_rgb_into
 from negpy.kernel.system.config import APP_CONFIG
 from negpy.kernel.system.logging import get_logger
 from negpy.kernel.system.paths import get_resource_path
@@ -2028,12 +2029,11 @@ class GPUEngine:
             raw = np.frombuffer(read_buf.read_mapped(copy=False), dtype=np.uint8).reshape((h, prb))
             valid = raw[:, : w * 16]
             # The texture is already display-encoded (output_encode pass).
-            result = valid.view(np.float32).reshape((h, w, 4))[:, :, :3]
+            rgba = valid.view(np.float32).reshape((h, w, 4))
             if dest is None:
-                return result.copy()
+                return np.ascontiguousarray(rgba[:, :, :3])
             oy, ox = crop if crop is not None else (0, 0)
-            dh, dw = dest.shape[:2]
-            dest[:] = result[oy : oy + dh, ox : ox + dw]
+            rgba_to_rgb_into(rgba, dest, oy, ox)
             return None
         finally:
             read_buf.unmap()
@@ -2129,7 +2129,15 @@ class GPUEngine:
         rot = settings.geometry.rotation % 4
         w_rot, h_rot = (h, w) if rot in (1, 3) else (w, h)
         if w_rot > max_tex or h_rot > max_tex or (w * h > TILING_THRESHOLD_PX):
-            return self._process_tiled(img, settings, scale_factor, bounds_override=bounds_override, cam_xyz=cam_xyz, camera_wb=camera_wb)
+            return self._process_tiled(
+                img,
+                settings,
+                scale_factor,
+                bounds_override=bounds_override,
+                cam_xyz=cam_xyz,
+                camera_wb=camera_wb,
+                readback_metrics=readback_metrics,
+            )
         tex_final, metrics = self.process_to_texture(
             img,
             settings,
@@ -2151,6 +2159,7 @@ class GPUEngine:
         bounds_override: Optional[Any] = None,
         cam_xyz: Optional[list] = None,
         camera_wb: Optional[list] = None,
+        readback_metrics: bool = True,
     ) -> Tuple[np.ndarray, Dict[str, Any]]:
         """Processes ultra-high resolution images using memory-efficient tiling."""
         h, w = img.shape[:2]
@@ -2201,7 +2210,9 @@ class GPUEngine:
         # This render meters the whole frame for the tiles; the CLAHE CDF it leaves behind
         # is the one they share. Taken from here rather than from the last preview, which
         # may belong to another image or to settings the export has since moved past.
-        _, metrics_ref = self.process_to_texture(img_small, settings, scale_factor=scale_factor, cam_xyz=cam_xyz, camera_wb=camera_wb)
+        _, metrics_ref = self.process_to_texture(
+            img_small, settings, scale_factor=scale_factor, cam_xyz=cam_xyz, camera_wb=camera_wb, readback_metrics=readback_metrics
+        )
 
         global_cdfs = self._readback_clahe_cdf()
 
@@ -2325,7 +2336,7 @@ class GPUEngine:
             self._mask_tex_key = None
 
         paper_w, paper_h, content_w, content_h, off_x, off_y, _ = self._calculate_layout_dims(settings, crop_w, crop_h, None)
-        full_source_res = np.zeros((crop_h, crop_w, 3), dtype=np.float32)
+        full_source_res = np.empty((crop_h, crop_w, 3), dtype=np.float32)
 
         # Defect repairs are baked into the source before the engine, so no stage here
         # samples beyond its own pixel for them and the halo owes them nothing.

--- a/negpy/services/rendering/image_processor.py
+++ b/negpy/services/rendering/image_processor.py
@@ -1947,7 +1947,8 @@ class ImageProcessor:
                 # an identity that nothing can be outside of. That is not an answer, it is
                 # the absence of a question.
                 return None
-            p_src = ImageProcessor._resolve_src_profile(working_color_space, input_icc_path)
+            p_work = ImageProcessor._resolve_src_profile(working_color_space, None)
+            p_src = p_work if not (input_icc_path and os.path.exists(input_icc_path)) else ImageCms.getOpenProfile(input_icc_path)
             p_dst = ImageProcessor._resolve_dst_profile(working_color_space, output_icc_path)
             if p_dst is None:
                 return None
@@ -1968,10 +1969,19 @@ class ImageProcessor:
             )
             if to_out is None:
                 return None
-            back = ImageCms.profileToProfile(to_out, p_dst, p_src, renderingIntent=ImageCms.Intent.RELATIVE_COLORIMETRIC, outputMode="RGB")
+            # An Input ICC is a source-only profile (an input-class profile has no B2A table),
+            # so the return leg lands in the working space and the grid is carried there too.
+            back = ImageCms.profileToProfile(to_out, p_dst, p_work, renderingIntent=ImageCms.Intent.RELATIVE_COLORIMETRIC, outputMode="RGB")
             if back is None:
                 return None
-            delta = np.abs(np.asarray(back, dtype=np.int16) - grid.astype(np.int16)).max(axis=-1)
+            ref = (
+                grid
+                if p_work is p_src
+                else np.asarray(
+                    ImageCms.profileToProfile(img, p_src, p_work, renderingIntent=ImageCms.Intent.RELATIVE_COLORIMETRIC, outputMode="RGB")
+                )
+            )
+            delta = np.abs(np.asarray(back, dtype=np.int16) - ref.astype(np.int16)).max(axis=-1)
             return np.ascontiguousarray((delta > GAMUT_ROUND_TRIP_TOLERANCE).reshape((size, size, size)))
         except Exception as e:
             logger.warning("Gamut LUT build failed; the printability read-out stays off", exc_info=e)

--- a/negpy/services/rendering/image_processor.py
+++ b/negpy/services/rendering/image_processor.py
@@ -359,7 +359,9 @@ class ImageProcessor:
             return img, None, False, None
         if ret.ir_method == IR_METHOD_OPENICE:
             return self._ir_bake_openice(img, ir_buffer, ret, source_key)
-        ratio_det, gain_det, degenerate, _ = self._ir_ratio_gain(ir_buffer, img, source_key)
+        # The ratio and gain do not depend on the threshold or the attenuation toggle, so their
+        # cache is keyed without the IR token and survives a slider drag.
+        ratio_det, gain_det, degenerate, _ = self._ir_ratio_gain(ir_buffer, img, source_key.replace(ir_bake_token(ret, True), ""))
         if degenerate:
             return img, None, True, None
         key = (source_key, round(float(ret.ir_threshold), 6), bool(ret.ir_attenuation), img.shape)

--- a/negpy/services/rendering/image_processor.py
+++ b/negpy/services/rendering/image_processor.py
@@ -566,6 +566,7 @@ class ImageProcessor:
             + hdr_token(settings.hdr)
             + linear_raw_token(settings.process, settings.exposure.render_intent)
             + sensor_token(settings.process)
+            + demosaic_token(settings.process.demosaic_preview)
             + ir_bake_token(settings.retouch, ir_buffer is not None)
             + manual_bake_token(settings.retouch)
             + luma_bake_token(settings.retouch)
@@ -973,6 +974,8 @@ class ImageProcessor:
         f32_buffer, ir_full = self._slice_half_source(
             f32_buffer, ir_full, half, split_x, crop_rect=crop_rect, gutter_thickness=gutter_thickness
         )
+        # Same shape as run_pipeline's base_hash, so an export of a frame previewed at full
+        # resolution with the same demosaic finds every bake already in the caches.
         detect_key = (
             source_hash
             + flatfield_token(params.flatfield)

--- a/negpy/services/rendering/image_processor.py
+++ b/negpy/services/rendering/image_processor.py
@@ -111,6 +111,28 @@ _PROOF_INTENTS = {
 logger = get_logger(__name__)
 
 
+_CMS_STRIPS = 16
+
+
+def _cms_transform_strips(img_u16: np.ndarray, src_bytes: bytes, dst_bytes: bytes) -> np.ndarray:
+    """lcms2 relative-colorimetric transform on row strips in parallel. lcms is per-pixel and
+    imagecodecs releases the GIL, so the strips are exact and scale with cores."""
+    kwargs = dict(colorspace="RGB", outcolorspace="RGB", intent=1, flags=0x2000)  # BLACKPOINTCOMPENSATION
+    h = img_u16.shape[0]
+    n = min(_CMS_STRIPS, os.cpu_count() or 1, h)
+    if n <= 1:
+        return imagecodecs.cms_transform(img_u16, src_bytes, dst_bytes, **kwargs)
+    out = np.empty_like(img_u16)
+
+    def run(i: int) -> None:
+        a, b = i * h // n, (i + 1) * h // n
+        out[a:b] = imagecodecs.cms_transform(img_u16[a:b], src_bytes, dst_bytes, **kwargs)
+
+    with ThreadPoolExecutor(max_workers=n) as ex:
+        list(ex.map(run, range(n)))
+    return out
+
+
 @lru_cache(maxsize=16)
 def _read_icc_bytes(path: str) -> bytes:
     with open(path, "rb") as f:
@@ -1659,15 +1681,7 @@ class ImageProcessor:
                 return img_u16, self._get_target_icc_bytes(color_space, output_icc_path)
 
             try:
-                result = imagecodecs.cms_transform(
-                    np.ascontiguousarray(img_u16),
-                    src_bytes,
-                    dst_bytes,
-                    colorspace="RGB",
-                    outcolorspace="RGB",
-                    intent=1,  # RELATIVE_COLORIMETRIC
-                    flags=0x2000,  # BLACKPOINTCOMPENSATION (matches PIL's value)
-                )
+                result = _cms_transform_strips(np.ascontiguousarray(img_u16), src_bytes, dst_bytes)
             except ImportError as e:
                 self._log_cms_codec_dlopen_error()
                 logger.warning(

--- a/negpy/services/rendering/preview_manager.py
+++ b/negpy/services/rendering/preview_manager.py
@@ -19,7 +19,7 @@ from negpy.infrastructure.loaders.helpers import (
     is_xtrans,
 )
 from negpy.infrastructure.gpu.device import GPUDevice
-from negpy.kernel.image.logic import apply_exif_orientation, ensure_rgb, uint16_to_float32
+from negpy.kernel.image.logic import apply_exif_orientation, ensure_rgb, uint16_to_float32, working_oetf_decode, working_oetf_encode
 from negpy.kernel.image.validation import ensure_image
 from negpy.kernel.system.config import APP_CONFIG
 from negpy.kernel.system.override import effective_max_texture_size
@@ -66,9 +66,12 @@ def _output_dimensions_from_raw(raw: Any, postprocessed_h: int, postprocessed_w:
     return (postprocessed_h, postprocessed_w)
 
 
-# Pre-warm the Numba JIT so the first actual preview load doesn't pay the compile cost.
+# Pre-warm the Numba JIT so the first actual preview load doesn't pay the compile cost. The
+# small-array OETF calls take the serial variant, which has no disk cache, so the Analysis
+# chart's first paint would otherwise compile it on the GUI thread.
 _warmup = np.zeros((2, 2, 3), dtype=np.uint16)
 uint16_to_float32(_warmup)
+working_oetf_decode(working_oetf_encode(np.zeros(4, dtype=np.float32)))
 del _warmup
 
 

--- a/tests/test_cms_strips.py
+++ b/tests/test_cms_strips.py
@@ -1,0 +1,26 @@
+import numpy as np
+import pytest
+
+from negpy.services.rendering import image_processor as ip
+
+
+def _icc(name):
+    from negpy.infrastructure.display.color_spaces import ColorSpaceRegistry
+
+    path = ColorSpaceRegistry.get_icc_path(name)
+    if not path:
+        pytest.skip(f"no ICC for {name}")
+    with open(path, "rb") as f:
+        return f.read()
+
+
+@pytest.mark.parametrize("dst", ["sRGB", "ProPhoto RGB"])
+def test_strips_equal_single_transform(dst):
+    imagecodecs = pytest.importorskip("imagecodecs")
+    src_bytes, dst_bytes = _icc("Adobe RGB"), _icc(dst)
+    img = (np.random.default_rng(3).random((97, 41, 3)) * 65535).astype(np.uint16)
+    try:
+        ref = imagecodecs.cms_transform(img, src_bytes, dst_bytes, colorspace="RGB", outcolorspace="RGB", intent=1, flags=0x2000)
+    except ImportError:
+        pytest.skip("cms codec unavailable")
+    assert np.array_equal(ip._cms_transform_strips(img, src_bytes, dst_bytes), ref)

--- a/tests/test_gamut_readout.py
+++ b/tests/test_gamut_readout.py
@@ -71,6 +71,15 @@ class TestGamutLut(unittest.TestCase):
         read-out carries a false floor."""
         self.assertEqual(float(_lut("Adobe RGB").mean()), 0.0)
 
+    def test_an_input_class_source_profile_still_builds(self):
+        # RGBScan.icc is the implicit Narrowband Scan input profile: source-only, no B2A
+        # table, so the round trip must land in the working space rather than back in it.
+        from negpy.kernel.system.paths import get_resource_path
+
+        mask = ImageProcessor.gamut_lut("Adobe RGB", get_resource_path("icc/RGBScan.icc"), ColorSpaceRegistry.get_icc_path("sRGB"))
+        self.assertIsNotNone(mask)
+        self.assertGreater(float(mask.mean()), 0.0)
+
     def test_a_wider_destination_clips_nothing(self):
         self.assertEqual(float(ImageProcessor.gamut_lut("sRGB", None, ColorSpaceRegistry.get_icc_path("Rec 2020")).mean()), 0.0)
 

--- a/tests/test_gpu_cffi_warm.py
+++ b/tests/test_gpu_cffi_warm.py
@@ -1,0 +1,45 @@
+import pytest
+
+from negpy.infrastructure.gpu.cffi_warm import warm_wgpu_cffi_types
+
+
+def test_warm_matches_parser_types():
+    from wgpu.backends.wgpu_native._ffi import ffi
+
+    warm_wgpu_cffi_types()
+    for cdecl in ("WGPUBufferDescriptor *", "WGPUBindGroupEntry[]", "WGPUTextureFormat[]", "char []", "uint32_t []"):
+        cached = ffi._parsed_types[cdecl][0]
+        parsed = ffi._parser.parse_type(cdecl)
+        with ffi._lock:
+            assert ffi._get_cached_btype(parsed) is cached
+
+
+def test_first_render_parses_few_types():
+    from negpy.infrastructure.gpu.device import GPUDevice
+
+    if not GPUDevice.get().is_available:
+        pytest.skip("GPU unavailable")
+    import numpy as np
+
+    from negpy.domain.models import WorkspaceConfig
+    from negpy.services.rendering.gpu_engine import GPUEngine
+    from wgpu.backends.wgpu_native._ffi import ffi
+
+    misses = []
+    orig = type(ffi)._typeof_locked
+
+    def counting(self, cdecl):
+        if cdecl not in self._parsed_types:
+            misses.append(cdecl)
+        return orig(self, cdecl)
+
+    type(ffi)._typeof_locked = counting
+    try:
+        engine = GPUEngine()
+        img = np.full((64, 96, 3), 0.4, dtype=np.float32)
+        engine.process_to_texture(img, WorkspaceConfig(), scale_factor=1.0, render_size_ref=96.0)
+        engine.destroy_all()
+    finally:
+        type(ffi)._typeof_locked = orig
+    # Only ffi.callback signatures are left to parse; every struct/array/pointer type is pre-cached.
+    assert all("(" in m for m in misses), misses

--- a/tests/test_parallel_dispatch.py
+++ b/tests/test_parallel_dispatch.py
@@ -45,7 +45,8 @@ def test_platform_policy():
 
 
 def test_dispatch_uses_selected_variant():
-    arr = np.arange(64, dtype=np.float32)
+    # At or above SERIAL_MAX_ELEMENTS; smaller inputs always take the serial variant.
+    arr = np.arange(par.SERIAL_MAX_ELEMENTS, dtype=np.float32)
 
     par.set_parallel_enabled(False)
     np.testing.assert_array_equal(_double(arr), arr * 2.0)

--- a/tests/test_parallel_dispatch_size.py
+++ b/tests/test_parallel_dispatch_size.py
@@ -1,0 +1,20 @@
+import numpy as np
+
+from negpy.kernel.system import parallel as par
+
+
+def test_small_arrays_take_serial_variant(monkeypatch):
+    @par.parallel_njit(cache=False)
+    def double(x):
+        out = np.empty_like(x)
+        for i in par.prange(x.shape[0]) if hasattr(par, "prange") else range(x.shape[0]):
+            out[i] = x[i] * 2
+        return out
+
+    calls = []
+    monkeypatch.setattr(double, "serial", lambda *a, **k: calls.append("serial") or a[0] * 2)
+    monkeypatch.setattr(double, "parallel", lambda *a, **k: calls.append("parallel") or a[0] * 2)
+    monkeypatch.setattr(par, "_parallel_enabled", True)
+    double(np.ones(8, dtype=np.float32))
+    double(np.ones(par.SERIAL_MAX_ELEMENTS, dtype=np.float32))
+    assert calls == ["serial", "parallel"]

--- a/tests/test_profile_caches.py
+++ b/tests/test_profile_caches.py
@@ -1,0 +1,41 @@
+import os
+
+from negpy.infrastructure.loaders import helpers
+from negpy.services.assets.toml_cache import load_toml_cached
+
+
+def _touch_newer(path):
+    st = os.stat(path)
+    os.utime(path, ns=(st.st_atime_ns, st.st_mtime_ns + 1_000_000))
+
+
+def test_toml_cache_rereads_on_change(tmp_path):
+    p = tmp_path / "a.toml"
+    p.write_text('name = "one"\n')
+    assert load_toml_cached(str(p))["name"] == "one"
+    p.write_text('name = "two"\n')
+    _touch_newer(p)
+    assert load_toml_cached(str(p))["name"] == "two"
+    p.write_text("name = [\n")
+    _touch_newer(p)
+    assert load_toml_cached(str(p)) is None
+    assert load_toml_cached(str(tmp_path / "missing.toml")) is None
+
+
+def test_exif_cache_returns_copies_and_invalidates(tmp_path, monkeypatch):
+    p = tmp_path / "x.jpg"
+    p.write_bytes(b"not an image")
+    calls = []
+
+    def fake_read(path):
+        calls.append(path)
+        return {"0th": {274: len(calls)}}
+
+    monkeypatch.setattr(helpers, "_read_exif_uncached", fake_read)
+    helpers._exif_cache.clear()
+    first = helpers.read_exif_from_file(str(p))
+    first["0th"][274] = 99
+    second = helpers.read_exif_from_file(str(p))
+    assert second == {"0th": {274: 1}} and len(calls) == 1
+    _touch_newer(p)
+    assert helpers.read_exif_from_file(str(p)) == {"0th": {274: 2}}

--- a/tests/test_rgba_kernels.py
+++ b/tests/test_rgba_kernels.py
@@ -1,0 +1,21 @@
+import numpy as np
+
+from negpy.kernel.image.logic import rgb_to_rgba_into, rgba_to_rgb_into
+
+
+def test_rgb_to_rgba_matches_numpy():
+    rng = np.random.default_rng(1)
+    src = rng.random((37, 53, 3), dtype=np.float32)
+    dst = np.empty((37, 53, 4), dtype=np.float32)
+    dst[:, :, 3] = 1.0
+    rgb_to_rgba_into(src, dst)
+    assert np.array_equal(dst[:, :, :3], src)
+    assert np.all(dst[:, :, 3] == 1.0)
+
+
+def test_rgba_to_rgb_crops_like_numpy():
+    rng = np.random.default_rng(2)
+    src = rng.random((40, 60, 4), dtype=np.float32)
+    dst = np.empty((30, 45, 3), dtype=np.float32)
+    rgba_to_rgb_into(src, dst, 5, 7)
+    assert np.array_equal(dst, src[5:35, 7:52, :3])


### PR DESCRIPTION
## Summary

Profiled preview, export and loading with the GPU path as primary. The GPU frame was already 8–28 ms; the remaining latency was Python around it. Five wins plus one bug found on the way.

- **Startup**: pre-fill wgpu-py's cffi type cache from the parsed webgpu.h models, so window construction and the first render stop re-parsing ~60 type strings through pycparser.
- **Navigation**: small numba calls (chart, wedge) take the serial variant below `SERIAL_MAX_ELEMENTS` instead of waiting on the parallel gate behind the render thread; gear combos reload only when the library or selection changed; EXIF and profile TOML reads cached per (path, mtime); no `gc.collect` on file switch.
- **Export**: tile RGB↔RGBA copies in numba kernels; lcms 16-bit transform in row strips on a thread pool; tiled path honours `readback_metrics`. Output bytes identical.
- **Fix**: `gamut_lut` round-tripped into the input profile; with Narrowband Scan (`RGBScan.icc`, no B2A) every settle logged "cannot build transform" and the printability read-out stayed off.

## Measurements (same-condition A/B, 890M iGPU)

| Path | Before | After |
|---|---|---|
| MainWindow construction | 836 ms | 631 ms |
| First engine render | 0.8 s | 0.4 s |
| Open first RAW → painted | 1576 ms | 1250 ms |
| Navigation, prefetched buffer | 170–188 ms | 45–115 ms |
| GUI thread `select_file` per nav | 52 ms | 10 ms |
| Analysis panel per settle | 26 ms | 2 ms |
| 57 MP TIFF export render (warm) | 1160 ms | 946 ms |
| 57 MP TIFF16 encode | 1825 ms | 755 ms |

## Test plan

- `make all` green (5391 passed).
- New tests: cffi warm identity + parse count, RGBA kernels vs numpy, lcms strips vs single call, dispatcher size routing, TOML/EXIF cache invalidation, gamut LUT with an input-class source profile.
- Export bytes cmp'd before/after on a 57 MP TIFF (JPEG and TIFF16): identical SHA.