### PR TITLE
feat(plustek): add Multi-Pass ME scanning

### DIFF
--- a/negpy/desktop/view/sidebar/scan.py
+++ b/negpy/desktop/view/sidebar/scan.py
@@ -21,9 +21,38 @@ from negpy.desktop.view.sidebar.base import install_wheel_guards
 from negpy.desktop.view.styles.templates import StatusStrip, hint_label, icon_button as _icon_button, section_subheader
 from negpy.desktop.view.styles.theme import THEME
 from negpy.infrastructure.scanners.base import ScannerCapabilities, ScannerDevice
-from negpy.infrastructure.scanners.params import FILM_TYPES, FilmType, film_passes_infrared
+from negpy.infrastructure.scanners.params import (
+    FILM_TYPES,
+    MAX_ME_BRACKETS,
+    MIN_ME_BRACKETS,
+    FilmType,
+    MultiExposureMode,
+    film_passes_infrared,
+)
 from negpy.infrastructure.scanners.registry import DEFAULT_BACKEND_ID, backend_choices
 from negpy.infrastructure.scanners.settings import ScannerSettings
+
+#: Label + explanatory tooltip for each multi-exposure mode, in display order. The exposure
+#: count is spelled out in the label itself (not just the tooltip) so Dynamic/Fixed's shared
+#: 2-exposure behavior — as opposed to More exposures' 2-9 — is visible without hovering.
+_ME_MODE_LABELS: tuple[tuple[MultiExposureMode, str, str], ...] = (
+    (MultiExposureMode.OFF, "Off", "One exposure per frame. Fastest."),
+    (
+        MultiExposureMode.DYNAMIC,
+        "Dynamic (2 exposures)",
+        "Short and long exposures merged; the long exposure is picked automatically per frame from image content.",
+    ),
+    (
+        MultiExposureMode.FIXED_FAST,
+        "Fixed (2 exposures)",
+        "Short and long exposures merged; the long exposure is pinned to a fixed, validated value instead of chosen per frame.",
+    ),
+    (
+        MultiExposureMode.N_EXPOSURE,
+        "Multi-Pass (2-9)",
+        "2-9 exposures merged for lower noise, at a roughly proportional increase in scan time.",
+    ),
+)
 
 
 _SAMPLE_COUNTS = (1, 2, 4, 8, 16)
@@ -57,7 +86,7 @@ def estimated_frame_bytes(
 class ScanSidebar(QWidget):
     """Scanner control panel — replaces the originally planned modal ScanDialog."""
 
-    _INDETERMINATE_SCAN_PHASES = frozenset({"Preparing long exposure", "Merging exposures"})
+    _INDETERMINATE_SCAN_PHASES = frozenset({"Preparing long exposure", "Preparing next exposure", "Merging exposures"})
 
     def __init__(self, controller) -> None:
         super().__init__()
@@ -152,8 +181,16 @@ class ScanSidebar(QWidget):
         layout.addLayout(device_form)
 
         # ── CAPS INFO ───────────────────────────────────────
+        # Crop info sits to the right of Frame info, and only appears once there is a crop
+        # to report — Prescan's own crop, when the connected backend uses Prescan at all.
+        frame_info_row = QHBoxLayout()
+        frame_info_row.setContentsMargins(0, 0, 0, 0)
         self.frame_label = hint_label("")
-        layout.addWidget(self.frame_label)
+        self.crop_label = hint_label("")
+        self.crop_label.setVisible(False)
+        frame_info_row.addWidget(self.frame_label)
+        frame_info_row.addWidget(self.crop_label, 1)
+        layout.addLayout(frame_info_row)
 
         # ── SETTINGS ────────────────────────────────────────
         # Four labelled groups in one form, in the order the operator decides them: what is
@@ -211,9 +248,38 @@ class ScanSidebar(QWidget):
         self.form.addRow(self.clean_check)
         self.clean_check.setVisible(False)
 
-        self.me_check = QCheckBox("Multi-exposure")
-        self.me_check.setToolTip("Merge short and long color passes for more highlight and shadow detail. Takes longer.")
-        self.form.addRow(self.me_check)
+        self.me_combo = QComboBox()
+        for mode, label, tooltip in _ME_MODE_LABELS:
+            self.me_combo.addItem(label, mode.value)
+            self.me_combo.setItemData(self.me_combo.count() - 1, tooltip, Qt.ItemDataRole.ToolTipRole)
+        self.me_combo.setToolTip(
+            "Capture and merge more than one exposure per frame for extra shadow/highlight detail. "
+            "Slower than a single exposure."
+        )
+        self.me_label = QLabel("Multi-exposure")
+        self.form.addRow(self.me_label, self.me_combo)
+
+        self.me_brackets_row_widget = QWidget()
+        me_brackets_layout = QHBoxLayout(self.me_brackets_row_widget)
+        me_brackets_layout.setContentsMargins(0, 0, 0, 0)
+        me_brackets_layout.setSpacing(6)
+        self.me_brackets_slider = QSlider(Qt.Orientation.Horizontal)
+        self.me_brackets_slider.setRange(MIN_ME_BRACKETS, MAX_ME_BRACKETS)
+        self.me_brackets_slider.setSingleStep(1)
+        self.me_brackets_slider.setPageStep(1)
+        self.me_brackets_slider.setTickPosition(QSlider.TickPosition.TicksBelow)
+        self.me_brackets_slider.setTickInterval(1)
+        self.me_brackets_slider.setToolTip(
+            "Number of exposures to merge (2-9). Each additional exposure adds roughly one more scan pass."
+        )
+        self.me_brackets_value_label = QLabel(str(MIN_ME_BRACKETS))
+        self.me_brackets_value_label.setMinimumWidth(20)
+        me_brackets_layout.addWidget(self.me_brackets_slider, 1)
+        me_brackets_layout.addWidget(self.me_brackets_value_label)
+        self.me_brackets_label = QLabel("Exposures")
+        self.form.addRow(self.me_brackets_label, self.me_brackets_row_widget)
+        self.me_brackets_label.setVisible(False)
+        self.me_brackets_row_widget.setVisible(False)
 
         self.superfine_check = QCheckBox("Superfine")
         self.superfine_check.setToolTip("Read one line per pass: slower, and free of line registration")
@@ -257,56 +323,6 @@ class ScanSidebar(QWidget):
         self.exposure_label.setVisible(False)
         self.exposure_row_widget.setVisible(False)
 
-        self.framing_header = section_subheader("Framing")
-        self.form.addRow(self.framing_header)
-
-        # Which frames the batch scans, for roll and strip feeders only.
-        self.frame_spec_edit = QLineEdit()
-        self.frame_spec_edit.setPlaceholderText("All frames")
-        self.frame_spec_edit.setToolTip("Frames to scan: 1-6 or 1,2,5. Empty scans every frame.")
-        self.frame_spec_label = QLabel("Frames")
-        self.form.addRow(self.frame_spec_label, self.frame_spec_edit)
-        self.frame_spec_label.setVisible(False)
-        self.frame_spec_edit.setVisible(False)
-
-        # Scan window (strip/roll feeders): set once from a preview, reused per frame.
-        self.scan_window_widget = QWidget()
-        scan_window_row = QHBoxLayout(self.scan_window_widget)
-        scan_window_row.setContentsMargins(0, 0, 0, 0)
-        self.scan_window_btn = QPushButton("Set scan window…")
-        self.scan_window_btn.setToolTip("Preview a frame and set the scan window reused for every frame")
-        self.scan_window_clear_btn = QPushButton("Clear")
-        self.scan_window_clear_btn.setFixedWidth(56)
-        self.scan_window_clear_btn.setToolTip("Scan the whole default frame instead")
-        scan_window_row.addWidget(self.scan_window_btn, 1)
-        scan_window_row.addWidget(self.scan_window_clear_btn)
-        self.scan_window_row_label = QLabel("Batch")
-        self.form.addRow(self.scan_window_row_label, self.scan_window_widget)
-        self.scan_window_status = hint_label("")
-        self.form.addRow("", self.scan_window_status)
-        self.scan_window_row_label.setVisible(False)
-        self.scan_window_widget.setVisible(False)
-        self.scan_window_status.setVisible(False)
-
-        # Prescan + crop (Plustek SE): low-DPI full window → interactive crop → scan_window.
-        self.prescan_widget = QWidget()
-        prescan_row = QHBoxLayout(self.prescan_widget)
-        prescan_row.setContentsMargins(0, 0, 0, 0)
-        self.prescan_btn = QPushButton("Prescan…")
-        self.prescan_btn.setToolTip("Scan a low-DPI preview and set the crop for the next scan")
-        self.prescan_clear_btn = QPushButton("Clear")
-        self.prescan_clear_btn.setFixedWidth(56)
-        self.prescan_clear_btn.setToolTip("Scan the full window instead of a crop")
-        prescan_row.addWidget(self.prescan_btn, 1)
-        prescan_row.addWidget(self.prescan_clear_btn)
-        self.prescan_label = QLabel("Prescan")
-        self.form.addRow(self.prescan_label, self.prescan_widget)
-        self.prescan_status = hint_label("")
-        self.form.addRow("", self.prescan_status)
-        self.prescan_label.setVisible(False)
-        self.prescan_widget.setVisible(False)
-        self.prescan_status.setVisible(False)
-
         self.output_header = section_subheader("Output")
         self.form.addRow(self.output_header)
 
@@ -329,6 +345,67 @@ class ScanSidebar(QWidget):
         self.form.addRow("Filename", self.pattern_edit)
 
         layout.addLayout(self.form)
+
+        # ── FRAMING (bottom, right above Scan) ───────────────
+        # These are the last decisions before pressing Scan, not a settings-form field among
+        # Film/Quality/Output — full width, not squeezed into the form's shared label column.
+        self.framing_header = section_subheader("Framing")
+        layout.addWidget(self.framing_header)
+
+        # Which frames the batch scans, for roll and strip feeders only.
+        frame_spec_row = QHBoxLayout()
+        frame_spec_row.setContentsMargins(0, 0, 0, 0)
+        frame_spec_row.setSpacing(6)
+        self.frame_spec_label = QLabel("Frames")
+        self.frame_spec_edit = QLineEdit()
+        self.frame_spec_edit.setPlaceholderText("All frames")
+        self.frame_spec_edit.setToolTip("Frames to scan: 1-6 or 1,2,5. Empty scans every frame.")
+        frame_spec_row.addWidget(self.frame_spec_label)
+        frame_spec_row.addWidget(self.frame_spec_edit, 1)
+        layout.addLayout(frame_spec_row)
+        self.frame_spec_label.setVisible(False)
+        self.frame_spec_edit.setVisible(False)
+
+        # Scan window (strip/roll feeders): set once from a preview, reused per frame.
+        scan_window_row = QHBoxLayout()
+        scan_window_row.setContentsMargins(0, 0, 0, 0)
+        scan_window_row.setSpacing(6)
+        self.scan_window_row_label = QLabel("Batch")
+        self.scan_window_widget = QWidget()
+        scan_window_btn_row = QHBoxLayout(self.scan_window_widget)
+        scan_window_btn_row.setContentsMargins(0, 0, 0, 0)
+        self.scan_window_btn = QPushButton("Set scan window…")
+        self.scan_window_btn.setToolTip("Preview a frame and set the scan window reused for every frame")
+        self.scan_window_clear_btn = QPushButton("Clear")
+        self.scan_window_clear_btn.setFixedWidth(56)
+        self.scan_window_clear_btn.setToolTip("Scan the whole default frame instead")
+        scan_window_btn_row.addWidget(self.scan_window_btn, 1)
+        scan_window_btn_row.addWidget(self.scan_window_clear_btn)
+        scan_window_row.addWidget(self.scan_window_row_label)
+        scan_window_row.addWidget(self.scan_window_widget, 1)
+        layout.addLayout(scan_window_row)
+        self.scan_window_status = hint_label("")
+        layout.addWidget(self.scan_window_status)
+        self.scan_window_row_label.setVisible(False)
+        self.scan_window_widget.setVisible(False)
+        self.scan_window_status.setVisible(False)
+
+        # Prescan + crop (Plustek SE): low-DPI full window → interactive crop → scan_window.
+        # Full width, all the way to the left edge — no row label, this is the primary action
+        # in the group, not a field next to a caption. The crop it sets is reported next to
+        # Frame info above (self.crop_label), not here.
+        self.prescan_widget = QWidget()
+        prescan_row = QHBoxLayout(self.prescan_widget)
+        prescan_row.setContentsMargins(0, 0, 0, 0)
+        self.prescan_btn = QPushButton("Prescan")
+        self.prescan_btn.setToolTip("Scan a low-DPI preview and set the crop for the next scan")
+        self.prescan_clear_btn = QPushButton("Clear")
+        self.prescan_clear_btn.setFixedWidth(56)
+        self.prescan_clear_btn.setToolTip("Scan the full window instead of a crop")
+        prescan_row.addWidget(self.prescan_btn, 1)
+        prescan_row.addWidget(self.prescan_clear_btn)
+        layout.addWidget(self.prescan_widget)
+        self.prescan_widget.setVisible(False)
 
         # ── STATUS + SCAN BUTTON ────────────────────────────
         # One reserved row for all three: the pass that is running, the message it left, and
@@ -367,7 +444,8 @@ class ScanSidebar(QWidget):
         self.dpi_combo.currentTextChanged.connect(lambda: self._update_settings_from_ui())
         self.depth_combo.currentTextChanged.connect(lambda: self._update_settings_from_ui())
         self.ir_check.toggled.connect(lambda on: self._on_ir_pass_toggled(self.clean_check, on))
-        self.me_check.toggled.connect(lambda: self._update_settings_from_ui())
+        self.me_combo.currentIndexChanged.connect(lambda: self._on_me_mode_changed())
+        self.me_brackets_slider.valueChanged.connect(self._on_me_brackets_changed)
         self.autofocus_check.toggled.connect(lambda: self._update_settings_from_ui())
         self.ae_check.toggled.connect(lambda: self._on_ae_toggled())
         self.clean_check.toggled.connect(lambda on: self._on_ir_pass_toggled(self.ir_check, on))
@@ -482,9 +560,12 @@ class ScanSidebar(QWidget):
             self.depth_combo.setVisible(False)
             self.depth_label.setVisible(False)
             self.ir_check.setVisible(False)
-            self.me_check.setVisible(False)
+            self.me_label.setVisible(False)
+            self.me_combo.setVisible(False)
+            self.me_brackets_label.setVisible(False)
+            self.me_brackets_row_widget.setVisible(False)
             self.ir_check.setEnabled(False)
-            self.me_check.setEnabled(False)
+            self.me_combo.setEnabled(False)
             self.eject_btn.setVisible(False)
             self.frame_spec_label.setVisible(False)
             self.frame_spec_edit.setVisible(False)
@@ -495,9 +576,8 @@ class ScanSidebar(QWidget):
             self.exposure_row_widget.setVisible(False)
             self.autofocus_check.setVisible(False)
             self.ae_check.setVisible(False)
-            self.prescan_label.setVisible(False)
             self.prescan_widget.setVisible(False)
-            self.prescan_status.setVisible(False)
+            self.crop_label.setVisible(False)
             self.clean_check.setVisible(False)
             self.superfine_check.setVisible(False)
             self.samples_label.setVisible(False)
@@ -522,7 +602,7 @@ class ScanSidebar(QWidget):
         self.dpi_combo.setEnabled(True)
         self.depth_combo.setEnabled(True)
         self.ir_check.setEnabled(True)
-        self.me_check.setEnabled(True)
+        self.me_combo.setEnabled(True)
         self.eject_btn.setVisible(caps.can_eject)
         self.eject_btn.setEnabled(caps.can_eject and not self._scanning)
         self.frame_label.setText(f"Frame: {caps.max_area_mm[0]:.0f} × {caps.max_area_mm[1]:.0f} mm")
@@ -543,7 +623,8 @@ class ScanSidebar(QWidget):
         self.dpi_combo.blockSignals(True)
         self.depth_combo.blockSignals(True)
         self.ir_check.blockSignals(True)
-        self.me_check.blockSignals(True)
+        self.me_combo.blockSignals(True)
+        self.me_brackets_slider.blockSignals(True)
         self.ae_check.blockSignals(True)
         self.frame_spec_edit.blockSignals(True)
 
@@ -595,17 +676,30 @@ class ScanSidebar(QWidget):
             self.ir_check.setToolTip("IR scanning not supported by this device")
 
         # Multi-exposure (Plustek GL128 scan-ready models)
-        self.me_check.setVisible(bool(caps.multi_exposure))
-        self.me_check.setEnabled(caps.multi_exposure)
+        self.me_label.setVisible(bool(caps.multi_exposure))
+        self.me_combo.setVisible(bool(caps.multi_exposure))
+        self.me_combo.setEnabled(caps.multi_exposure)
         if caps.multi_exposure:
-            self.me_check.setChecked(self._settings.multi_exposure)
-            self.me_check.setToolTip(
-                "Merge short and long colour passes for more highlight and shadow detail. "
-                "The long pass exposure is chosen per frame. Takes longer."
+            n_exposure_idx = self.me_combo.findData(MultiExposureMode.N_EXPOSURE.value)
+            if n_exposure_idx >= 0:
+                item = self.me_combo.model().item(n_exposure_idx)
+                item.setEnabled(caps.me_n_exposure)
+                item.setToolTip(
+                    _ME_MODE_LABELS[3][2] if caps.me_n_exposure else "Not supported on this scanner."
+                )
+            saved_mode = self._settings.multi_exposure_mode
+            if saved_mode == MultiExposureMode.N_EXPOSURE.value and not caps.me_n_exposure:
+                saved_mode = MultiExposureMode.DYNAMIC.value
+            idx = self.me_combo.findData(saved_mode)
+            self.me_combo.setCurrentIndex(idx if idx >= 0 else 0)
+            self.me_brackets_slider.setRange(MIN_ME_BRACKETS, max(MIN_ME_BRACKETS, caps.me_max_brackets))
+            self.me_brackets_slider.setValue(
+                min(max(self._settings.me_brackets, MIN_ME_BRACKETS), caps.me_max_brackets)
             )
+            self.me_brackets_value_label.setText(str(self.me_brackets_slider.value()))
         else:
-            self.me_check.setChecked(False)
-            self.me_check.setToolTip("Multi-exposure not supported by this device")
+            self.me_combo.setCurrentIndex(0)
+        self._sync_me_brackets_visibility()
 
         # Autofocus and auto-exposure, shown only when the device reports them.
         self._caps_autofocus = bool(caps.autofocus)
@@ -730,16 +824,17 @@ class ScanSidebar(QWidget):
             self._update_scan_window_status()
 
         show_prescan = bool(caps.prescan)
-        self.prescan_label.setVisible(show_prescan)
         self.prescan_widget.setVisible(show_prescan)
-        self.prescan_status.setVisible(show_prescan)
         if show_prescan:
-            self._update_prescan_status()
+            self._update_crop_label()
+        else:
+            self.crop_label.setVisible(False)
 
         self.dpi_combo.blockSignals(False)
         self.depth_combo.blockSignals(False)
         self.ir_check.blockSignals(False)
-        self.me_check.blockSignals(False)
+        self.me_combo.blockSignals(False)
+        self.me_brackets_slider.blockSignals(False)
         self.ae_check.blockSignals(False)
         self.frame_spec_edit.blockSignals(False)
 
@@ -773,6 +868,24 @@ class ScanSidebar(QWidget):
             other.blockSignals(True)
             other.setChecked(False)
             other.blockSignals(False)
+        self._update_settings_from_ui()
+
+    def _me_mode(self) -> MultiExposureMode:
+        if not self.me_combo.isEnabled():
+            return MultiExposureMode.OFF
+        return MultiExposureMode(self.me_combo.currentData() or MultiExposureMode.OFF.value)
+
+    def _sync_me_brackets_visibility(self) -> None:
+        show = self.me_combo.isEnabled() and self._me_mode() == MultiExposureMode.N_EXPOSURE
+        self.me_brackets_label.setVisible(show)
+        self.me_brackets_row_widget.setVisible(show)
+
+    def _on_me_mode_changed(self) -> None:
+        self._sync_me_brackets_visibility()
+        self._update_settings_from_ui()
+
+    def _on_me_brackets_changed(self, value: int) -> None:
+        self.me_brackets_value_label.setText(str(value))
         self._update_settings_from_ui()
 
     def _samples(self) -> int:
@@ -893,7 +1006,7 @@ class ScanSidebar(QWidget):
         )
         if dialog.exec():
             self.settings = replace(self._settings, scan_window=dialog.scan_window())
-            self._update_prescan_status()
+            self._update_crop_label()
             self._save_settings()
             if dialog.scan_requested():
                 self._on_scan()
@@ -902,10 +1015,12 @@ class ScanSidebar(QWidget):
         from dataclasses import replace
 
         self.settings = replace(self._settings, scan_window=None)
-        self._update_prescan_status()
+        self._update_crop_label()
         self._save_settings()
 
-    def _update_prescan_status(self) -> None:
+    def _update_crop_label(self) -> None:
+        """Next to Frame info, and only shown when there is an actual crop to report —
+        a full-window scan says nothing here rather than stating the obvious."""
         from negpy.infrastructure.scanners.params import scan_window_to_area
 
         device = self._current_device()
@@ -915,10 +1030,11 @@ class ScanSidebar(QWidget):
             else None
         )
         if area is None:
-            self.prescan_status.setText("Full window")
+            self.crop_label.setVisible(False)
         else:
             tl_x, tl_y, br_x, br_y = area
-            self.prescan_status.setText(f"Crop {br_x - tl_x:.1f} × {br_y - tl_y:.1f} mm")
+            self.crop_label.setText(f"Crop: {br_x - tl_x:.1f} × {br_y - tl_y:.1f} mm")
+            self.crop_label.setVisible(True)
 
     def _update_scan_window_status(self) -> None:
         from negpy.infrastructure.scanners.params import scan_window_to_area
@@ -998,8 +1114,11 @@ class ScanSidebar(QWidget):
             passes.append("Superfine")
         if self._samples() > 1:
             passes.append(f"{self._samples()}× sampled")
-        if self.me_check.isEnabled() and self.me_check.isChecked():
-            passes.append("Multi-exposure")
+        me_mode = self._me_mode()
+        if me_mode == MultiExposureMode.N_EXPOSURE:
+            passes.append(f"{self.me_brackets_slider.value()}-exposure")
+        elif me_mode != MultiExposureMode.OFF:
+            passes.append(next(label for mode, label, _ in _ME_MODE_LABELS if mode == me_mode))
         # The count and the size are what the operator checks before committing, so they carry
         # primary weight; the rest of the line stays secondary.
         strong = f'<span style="color: {THEME.text_primary}">{{}}</span>'
@@ -1042,7 +1161,8 @@ class ScanSidebar(QWidget):
         dpi = self._dpi()
         depth = int(self.depth_combo.currentData() or 16)
         capture_ir = self.ir_check.isEnabled() and self.ir_check.isChecked()
-        multi_exposure = self.me_check.isEnabled() and self.me_check.isChecked()
+        me_mode = self._me_mode()
+        me_brackets = self.me_brackets_slider.value() if me_mode == MultiExposureMode.N_EXPOSURE else MIN_ME_BRACKETS
         autofocus = self._caps_autofocus and self.autofocus_check.isChecked()
         auto_exposure = self._caps_auto_exposure and self.ae_check.isChecked()
         pattern = self.pattern_edit.text().strip() or '{{ date }}_{{ "%03d" % seq }}'
@@ -1065,7 +1185,8 @@ class ScanSidebar(QWidget):
             dpi=dpi,
             depth=depth,
             capture_ir=capture_ir,
-            multi_exposure=multi_exposure,
+            multi_exposure_mode=me_mode,
+            me_brackets=me_brackets,
             autofocus=autofocus,
             auto_exposure=auto_exposure,
             exposure_time_us=exposure_time_us,
@@ -1219,7 +1340,10 @@ class ScanSidebar(QWidget):
             dpi=dpi,
             depth=depth,
             capture_ir=self.ir_check.isChecked() and self.ir_check.isEnabled(),
-            multi_exposure=self.me_check.isChecked() and self.me_check.isEnabled(),
+            multi_exposure_mode=self._me_mode().value,
+            me_brackets=(
+                self.me_brackets_slider.value() if self._me_mode() == MultiExposureMode.N_EXPOSURE else MIN_ME_BRACKETS
+            ),
             autofocus=self._caps_autofocus and self.autofocus_check.isChecked(),
             auto_exposure=self._caps_auto_exposure and self.ae_check.isChecked(),
             exposure_time_us=(self.exposure_slider.value() if self.exposure_row_widget.isVisible() else None),

--- a/negpy/infrastructure/scanners/base.py
+++ b/negpy/infrastructure/scanners/base.py
@@ -37,6 +37,10 @@ class ScannerCapabilities:
     prescan_mirror_x: bool = False
     prescan_default_crop: tuple[float, float, float, float] | None = None
     multi_exposure: bool = False
+    #: Whether the device supports MultiExposureMode.N_EXPOSURE (2+ brackets, not just short+long).
+    me_n_exposure: bool = False
+    #: Highest me_brackets value the device accepts; only meaningful when me_n_exposure is True.
+    me_max_brackets: int = 2
     adapter_frame_capacity: int | None = None  # transport capacity bound, not an exposure count
     adapter_frame_control: bool = False
     can_eject: bool = False

--- a/negpy/infrastructure/scanners/params.py
+++ b/negpy/infrastructure/scanners/params.py
@@ -8,12 +8,39 @@ class ScanMode(StrEnum):
     TRANSPARENCY = "Transparency"
 
 
+class MultiExposureMode(StrEnum):
+    """How many exposures to capture per frame and how the top one is chosen.
+
+    OFF: one exposure, the fast path. DYNAMIC: short+long merged, long exposure picked per
+    frame from image content (today's only multi-exposure behavior). FIXED_FAST: short+long
+    merged, long exposure pinned to a fixed, per-model-validated value instead of chosen per
+    frame. N_EXPOSURE: 2-9 exposures merged for lower noise, at a roughly proportional
+    increase in scan time (see ScanParams.me_brackets).
+    """
+
+    OFF = "off"
+    DYNAMIC = "dynamic"
+    FIXED_FAST = "fixed_fast"
+    N_EXPOSURE = "n_exposure"
+
+
+#: Bracket count is meaningful only in MultiExposureMode.N_EXPOSURE; every backend that
+#: supports it validates against this same range (mirrors pyopticfilm's own scan() bound).
+MIN_ME_BRACKETS = 2
+MAX_ME_BRACKETS = 9
+#: Starting point when a user first turns on Multi-Pass — comfortably past the 2-exposure
+#: floor (where it wouldn't differ from Dynamic/Fixed) without defaulting to the slow end.
+DEFAULT_ME_BRACKETS = 3
+
+
 @dataclass(frozen=True)
 class ScanParams:
     dpi: int
     depth: int
     capture_ir: bool
-    multi_exposure: bool = False
+    multi_exposure_mode: MultiExposureMode = MultiExposureMode.OFF
+    # Exposures to merge in MultiExposureMode.N_EXPOSURE (2-9); ignored in every other mode.
+    me_brackets: int = MIN_ME_BRACKETS
     # Normalized (x1,y1,x2,y2) window 0..1; backend maps to device units (coolscan3 int px).
     window: tuple[float, float, float, float] | None = None
     # coolscan3 `subframe` (mm), applied to every frame. 0 = scanner default.

--- a/negpy/infrastructure/scanners/plustek_backend.py
+++ b/negpy/infrastructure/scanners/plustek_backend.py
@@ -19,7 +19,13 @@ from negpy.infrastructure.scanners.base import (
     ScannerUnavailable,
     TransientScanError,
 )
-from negpy.infrastructure.scanners.params import ScanMode, ScanParams
+from negpy.infrastructure.scanners.params import (
+    MAX_ME_BRACKETS,
+    MIN_ME_BRACKETS,
+    MultiExposureMode,
+    ScanMode,
+    ScanParams,
+)
 from pyopticfilm.asic.gl128 import DEFAULT_IMAGE_USB_PACE_S
 from pyopticfilm.device.select import model_for_device, model_is_scan_ready
 from pyopticfilm.exceptions import (
@@ -60,6 +66,10 @@ def _caps_for(model: Any) -> ScannerCapabilities:
         prescan_mirror_x=bool(getattr(model, "mirror_x", False)) if prescan_ready else False,
         prescan_default_crop=default_frame_crop_norm(model) if prescan_ready else None,
         multi_exposure=bool(getattr(model, "scan_ready", False) and getattr(model, "exposure_long", None)),
+        # Every scan-ready GL128 model that supports ME at all supports the full N-bracket
+        # range pyopticfilm validates (2-9) — pyopticfilm has no per-model bracket-count limit.
+        me_n_exposure=bool(getattr(model, "scan_ready", False) and getattr(model, "exposure_long", None)),
+        me_max_brackets=MAX_ME_BRACKETS if getattr(model, "scan_ready", False) and getattr(model, "exposure_long", None) else MIN_ME_BRACKETS,
         adapter_frame_capacity=None,
         adapter_frame_control=False,
         can_eject=False,
@@ -89,10 +99,11 @@ def _safe_progress(
         progress(max(0.0, min(1.0, float(value))), phase)
 
 
-def _gl128_me_pass_layout(*, capture_ir: bool, multi_exposure: bool) -> tuple[int, int] | None:
+def _gl128_me_pass_layout(*, capture_ir: bool, multi_exposure: bool, n_brackets: int = 2) -> tuple[int, int] | None:
     if not multi_exposure:
         return None
-    n_early = 2 if capture_ir else 1
+    ir_extra = 1 if capture_ir else 0
+    n_early = ir_extra + max(1, n_brackets - 1)
     return n_early, n_early + 1
 
 
@@ -101,8 +112,9 @@ def _make_scan_progress(
     *,
     multi_exposure: bool,
     capture_ir: bool,
+    n_brackets: int = 2,
 ) -> Callable[[float], None]:
-    layout = _gl128_me_pass_layout(capture_ir=capture_ir, multi_exposure=multi_exposure)
+    layout = _gl128_me_pass_layout(capture_ir=capture_ir, multi_exposure=multi_exposure, n_brackets=n_brackets)
     if layout is None:
 
         def scan_progress(p: float) -> None:
@@ -110,27 +122,31 @@ def _make_scan_progress(
 
         return scan_progress
 
-    n_early, n_pass = layout
-    plateau = n_early / n_pass
-    state = {"long_started": False}
+    _n_early, n_pass = layout
+    ir_extra = 1 if capture_ir else 0
+    # Fraction-of-whole-scan point where each bracket after the first begins capturing.
+    # At n_brackets == 2 this is the single short→long boundary, unchanged from before.
+    boundaries = [(ir_extra + i) / n_pass for i in range(1, n_brackets)]
+    state = {"passed": 0}
 
     def scan_progress(p: float) -> None:
         frac = min(1.0, max(0.0, float(p)))
         if frac >= 1.0 - 1e-9:
             _safe_progress(progress, 0.85, "Merging exposures")
             return
-        if frac > plateau + 1e-6:
-            state["long_started"] = True
-            _safe_progress(progress, 0.10 + 0.72 * frac, "Scanning")
-        elif abs(frac - plateau) < 1e-6 and not state["long_started"]:
-            _safe_progress(progress, 0.83, "Preparing long exposure")
+        passed = state["passed"]
+        if passed < len(boundaries) and frac > boundaries[passed] + 1e-6:
+            state["passed"] = passed = passed + 1
+        if passed < len(boundaries) and abs(frac - boundaries[passed]) < 1e-6:
+            label = "Preparing long exposure" if n_brackets == 2 else "Preparing next exposure"
+            _safe_progress(progress, 0.10 + 0.72 * frac, label)
         else:
             _safe_progress(progress, 0.10 + 0.72 * frac, "Scanning")
 
     return scan_progress
 
 
-def _validate_params(params: ScanParams, *, model: Any | None = None) -> None:
+def _validate_params(params: ScanParams, *, model: Any | None = None, caps: ScannerCapabilities | None = None) -> None:
     from pyopticfilm.device.model_8200i import MODEL_8200I
 
     dpi = int(params.dpi)
@@ -154,8 +170,16 @@ def _validate_params(params: ScanParams, *, model: Any | None = None) -> None:
         raise RuntimeError("Autofocus requested but the device has no autofocus option")
     if params.capture_ir and model is not None and getattr(model, "supports_infrared", None) is False:
         raise RuntimeError(f"{getattr(model, 'model', 'device')} does not support infrared")
-    if params.multi_exposure and model is not None and not getattr(model, "exposure_long", None):
+    mode = params.multi_exposure_mode
+    if mode != MultiExposureMode.OFF and model is not None and not getattr(model, "exposure_long", None):
         raise RuntimeError(f"{getattr(model, 'model', 'device')} does not support multi-exposure")
+    if mode == MultiExposureMode.N_EXPOSURE:
+        if not (MIN_ME_BRACKETS <= params.me_brackets <= MAX_ME_BRACKETS):
+            raise RuntimeError(
+                f"me_brackets={params.me_brackets} out of range ({MIN_ME_BRACKETS}-{MAX_ME_BRACKETS})"
+            )
+        if caps is not None and not caps.me_n_exposure:
+            raise RuntimeError(f"{getattr(model, 'model', 'device')} does not support N-Exposure mode")
 
 
 class PlustekSession:
@@ -314,10 +338,19 @@ class PlustekBackend:
             if sys.platform != "win32":
                 msg += " Try Backend → SANE if that backend lists this scanner."
             raise RuntimeError(msg)
-        _validate_params(params, model=scanner.model)
+        caps = _caps_for(scanner.model)
+        _validate_params(params, model=scanner.model, caps=caps)
         dpi = int(params.dpi)
         capture_ir = bool(params.capture_ir)
-        multi_exposure = bool(params.multi_exposure)
+        me_mode = params.multi_exposure_mode
+        multi_exposure = me_mode != MultiExposureMode.OFF
+        # None defers to Model.me_default_exposure_mode (pyopticfilm PR #47) for N_EXPOSURE and
+        # for OFF (irrelevant there); Dynamic/Fixed Fast pin the mode explicitly, as before.
+        me_exposure_mode = {
+            MultiExposureMode.DYNAMIC: "adaptive",
+            MultiExposureMode.FIXED_FAST: "fixed",
+        }.get(me_mode)
+        n_brackets = params.me_brackets if me_mode == MultiExposureMode.N_EXPOSURE else MIN_ME_BRACKETS
         window = params.window
         geometry = self._default_scan_geometry(scanner, dpi=dpi, window=window)
 
@@ -339,6 +372,7 @@ class PlustekBackend:
                 progress,
                 multi_exposure=multi_exposure,
                 capture_ir=capture_ir,
+                n_brackets=n_brackets,
             )
 
             def on_status(status: str) -> None:
@@ -359,7 +393,8 @@ class PlustekBackend:
                 on_status=on_status,
                 multi_exposure=multi_exposure,
                 infrared=capture_ir,
-                me_exposure_mode="adaptive",
+                me_exposure_mode=me_exposure_mode,
+                n_brackets=n_brackets,
             )
             ir_plane = np.asarray(rgb_image.ir) if capture_ir and rgb_image.ir is not None else None
         except ScanCancelled as exc:

--- a/negpy/infrastructure/scanners/settings.py
+++ b/negpy/infrastructure/scanners/settings.py
@@ -1,6 +1,7 @@
 from collections.abc import Iterable
 from dataclasses import dataclass, field, fields
 
+from negpy.infrastructure.scanners.params import DEFAULT_ME_BRACKETS, MultiExposureMode
 from negpy.infrastructure.scanners.registry import DEFAULT_BACKEND_ID
 
 Rect = tuple[float, float, float, float]
@@ -16,7 +17,9 @@ class ScannerSettings:
     dpi: int = 3600
     depth: int = 16
     capture_ir: bool = False
-    multi_exposure: bool = False
+    multi_exposure_mode: str = MultiExposureMode.OFF.value
+    # Exposures to merge in MultiExposureMode.N_EXPOSURE (2-9); ignored in every other mode.
+    me_brackets: int = DEFAULT_ME_BRACKETS
     autofocus: bool = True
     auto_exposure: bool = False
     # Hardware scan exposure time in microseconds (SANE `scan-exposure-time`). None is the
@@ -68,6 +71,14 @@ class ScannerSettings:
         every unrelated preference with it.
         """
         data = dict(data)
+        # Pre-N-bracket blobs only ever had one multi-exposure behavior (today's "dynamic"):
+        # a checked box meant exactly that, unchecked meant none.
+        if "multi_exposure_mode" not in data and "multi_exposure" in data:
+            data["multi_exposure_mode"] = (
+                MultiExposureMode.DYNAMIC.value if data.pop("multi_exposure") else MultiExposureMode.OFF.value
+            )
+        if data.get("multi_exposure_mode") not in set(MultiExposureMode):
+            data["multi_exposure_mode"] = MultiExposureMode.OFF.value
         first, last = data.pop("frame_from", None), data.pop("frame_to", None)
         if not data.get("selected_frames") and isinstance(first, int) and isinstance(last, int) and (first, last) != (1, 1):
             data["selected_frames"] = tuple(range(first, last + 1))

--- a/tests/scanners/test_plustek_backend.py
+++ b/tests/scanners/test_plustek_backend.py
@@ -14,7 +14,7 @@ import numpy as np
 import pytest
 
 from negpy.infrastructure.scanners.base import ScannerUnavailable, TransientScanError
-from negpy.infrastructure.scanners.params import ScanParams
+from negpy.infrastructure.scanners.params import MultiExposureMode, ScanParams
 from negpy.infrastructure.scanners.result import ScanResult
 
 pytest.importorskip("pyopticfilm")
@@ -341,21 +341,80 @@ def test_multi_exposure_passthrough(monkeypatch):
     monkeypatch.setattr(f"{_BACKEND}.Scanner.open", _FakeOpen(scanner))
     PlustekBackend().scan(
         _DEVICE_ID,
-        _params(multi_exposure=True),
+        _params(multi_exposure_mode=MultiExposureMode.DYNAMIC),
         lambda *_: None,
         threading.Event(),
     )
     assert scanner.scan.call_args.kwargs.get("multi_exposure") is True
     assert scanner.scan.call_args.kwargs.get("me_exposure_mode") == "adaptive"
+    assert scanner.scan.call_args.kwargs.get("n_brackets") == 2
 
 
 def test_colour_scan_passes_adaptive_me_mode(monkeypatch):
     _patch_enum(monkeypatch)
     scanner = _fake_scanner()
     monkeypatch.setattr(f"{_BACKEND}.Scanner.open", _FakeOpen(scanner))
-    PlustekBackend().scan(_DEVICE_ID, _params(), lambda *_: None, threading.Event())
+    PlustekBackend().scan(
+        _DEVICE_ID,
+        _params(multi_exposure_mode=MultiExposureMode.DYNAMIC),
+        lambda *_: None,
+        threading.Event(),
+    )
     assert scanner.scan.call_args.kwargs.get("me_exposure_mode") == "adaptive"
     assert scanner.scan.call_args.kwargs.get("on_status") is not None
+
+
+def test_off_mode_defers_exposure_mode_to_model_default(monkeypatch):
+    """OFF is a no-op path — me_exposure_mode is irrelevant, so it must not be hardcoded."""
+    _patch_enum(monkeypatch)
+    scanner = _fake_scanner()
+    monkeypatch.setattr(f"{_BACKEND}.Scanner.open", _FakeOpen(scanner))
+    PlustekBackend().scan(_DEVICE_ID, _params(), lambda *_: None, threading.Event())
+    assert scanner.scan.call_args.kwargs.get("multi_exposure") is False
+    assert scanner.scan.call_args.kwargs.get("me_exposure_mode") is None
+
+
+def test_fixed_fast_mode_pins_exposure_mode(monkeypatch):
+    _patch_enum(monkeypatch)
+    scanner = _fake_scanner()
+    monkeypatch.setattr(f"{_BACKEND}.Scanner.open", _FakeOpen(scanner))
+    PlustekBackend().scan(
+        _DEVICE_ID,
+        _params(multi_exposure_mode=MultiExposureMode.FIXED_FAST),
+        lambda *_: None,
+        threading.Event(),
+    )
+    assert scanner.scan.call_args.kwargs.get("multi_exposure") is True
+    assert scanner.scan.call_args.kwargs.get("me_exposure_mode") == "fixed"
+    assert scanner.scan.call_args.kwargs.get("n_brackets") == 2
+
+
+def test_n_exposure_mode_passes_bracket_count(monkeypatch):
+    _patch_enum(monkeypatch)
+    scanner = _fake_scanner()
+    monkeypatch.setattr(f"{_BACKEND}.Scanner.open", _FakeOpen(scanner))
+    PlustekBackend().scan(
+        _DEVICE_ID,
+        _params(multi_exposure_mode=MultiExposureMode.N_EXPOSURE, me_brackets=5),
+        lambda *_: None,
+        threading.Event(),
+    )
+    assert scanner.scan.call_args.kwargs.get("multi_exposure") is True
+    assert scanner.scan.call_args.kwargs.get("me_exposure_mode") is None
+    assert scanner.scan.call_args.kwargs.get("n_brackets") == 5
+
+
+def test_n_exposure_rejects_out_of_range_bracket_count(monkeypatch):
+    _patch_enum(monkeypatch)
+    scanner = _fake_scanner()
+    monkeypatch.setattr(f"{_BACKEND}.Scanner.open", _FakeOpen(scanner))
+    with pytest.raises(RuntimeError, match="me_brackets"):
+        PlustekBackend().scan(
+            _DEVICE_ID,
+            _params(multi_exposure_mode=MultiExposureMode.N_EXPOSURE, me_brackets=10),
+            lambda *_: None,
+            threading.Event(),
+        )
 
 
 def test_on_status_reports_priming_then_scanning(monkeypatch):
@@ -385,7 +444,7 @@ def test_me_scan_reports_preparing_then_long_pass(monkeypatch):
 
     PlustekBackend().scan(
         _DEVICE_ID,
-        _params(multi_exposure=True),
+        _params(multi_exposure_mode=MultiExposureMode.DYNAMIC),
         progress,
         threading.Event(),
     )
@@ -406,12 +465,35 @@ def test_me_scan_reports_merging_at_completion(monkeypatch):
 
     PlustekBackend().scan(
         _DEVICE_ID,
-        _params(multi_exposure=True),
+        _params(multi_exposure_mode=MultiExposureMode.DYNAMIC),
         progress,
         threading.Event(),
     )
     assert "Merging exposures" in phases
     assert "Preparing long exposure" not in phases
+
+
+def test_n_exposure_scan_reports_preparing_next_exposure(monkeypatch):
+    """More than 2 brackets: every mid-scan boundary reports the generic label, not the
+    2-bracket-specific "Preparing long exposure" (there's no longer a single 'long' pass)."""
+    _patch_enum(monkeypatch)
+    scanner = _fake_scanner(me_fractions=[0.25, 0.5, 0.75, 1.0])
+    monkeypatch.setattr(f"{_BACKEND}.Scanner.open", _FakeOpen(scanner))
+    seen: list[tuple[float, str]] = []
+
+    def progress(fraction: float, phase: str = "Scanning") -> None:
+        seen.append((fraction, phase))
+
+    PlustekBackend().scan(
+        _DEVICE_ID,
+        _params(multi_exposure_mode=MultiExposureMode.N_EXPOSURE, me_brackets=4),
+        progress,
+        threading.Event(),
+    )
+    phases = [phase for _, phase in seen]
+    assert phases.count("Preparing next exposure") >= 2
+    assert "Preparing long exposure" not in phases
+    assert phases[-1] == "Merging exposures" or "Merging exposures" in phases
 
 
 def test_non_me_scan_skips_me_progress_phases(monkeypatch):

--- a/tests/scanners/test_scanner_settings.py
+++ b/tests/scanners/test_scanner_settings.py
@@ -139,3 +139,28 @@ def test_an_unset_saved_frame_range_selects_nothing():
 def test_a_key_this_version_dropped_keeps_the_rest_of_the_blob():
     restored = ScannerSettings.from_dict({"gone_in_this_version": True, "output_folder": "/scans"})
     assert restored.output_folder == "/scans"
+
+
+def test_legacy_multi_exposure_true_migrates_to_dynamic_mode():
+    restored = ScannerSettings.from_dict({"multi_exposure": True})
+    assert restored.multi_exposure_mode == "dynamic"
+
+
+def test_legacy_multi_exposure_false_migrates_to_off_mode():
+    restored = ScannerSettings.from_dict({"multi_exposure": False})
+    assert restored.multi_exposure_mode == "off"
+
+
+def test_a_blob_with_multi_exposure_mode_already_set_is_not_double_migrated():
+    restored = ScannerSettings.from_dict({"multi_exposure": True, "multi_exposure_mode": "fixed_fast"})
+    assert restored.multi_exposure_mode == "fixed_fast"
+
+
+def test_an_unknown_multi_exposure_mode_falls_back_to_off():
+    restored = ScannerSettings.from_dict({"multi_exposure_mode": "some_future_mode"})
+    assert restored.multi_exposure_mode == "off"
+
+
+def test_me_brackets_has_a_sane_starting_point_above_the_minimum():
+    """3, not 2 — at 2 brackets Multi-Pass wouldn't differ from Dynamic/Fixed."""
+    assert ScannerSettings.defaults().me_brackets == 3

--- a/tests/test_scan_sidebar.py
+++ b/tests/test_scan_sidebar.py
@@ -27,7 +27,7 @@ from PyQt6.QtWidgets import QApplication
 from negpy.desktop.view.sidebar.scan import ScanSidebar, estimated_frame_bytes
 from negpy.desktop.view.styles.theme import THEME
 from negpy.infrastructure.scanners.base import ScannerCapabilities, ScannerDevice
-from negpy.infrastructure.scanners.params import FILM_TYPES, ScanMode
+from negpy.infrastructure.scanners.params import FILM_TYPES, MultiExposureMode, ScanMode
 
 if not QApplication.instance():
     _app = QApplication(sys.argv)
@@ -222,10 +222,9 @@ def test_minimal_device_hides_coolscan_controls() -> None:
 def test_se_device_shows_prescan() -> None:
     sidebar, _ = _sidebar(SE_DEVICE, settings={"backend": "plustek"})
     assert sidebar.prescan_widget.isVisibleTo(sidebar) is True
-    assert sidebar.prescan_label.isVisibleTo(sidebar) is True
     assert sidebar.scan_window_widget.isVisibleTo(sidebar) is False
     assert sidebar.ir_check.isEnabled() is True
-    assert sidebar.me_check.isEnabled() is True
+    assert sidebar.me_combo.isEnabled() is True
     assert sidebar.frame_spec_edit.isVisibleTo(sidebar) is False
 
 
@@ -246,8 +245,8 @@ def test_sane_backend_keeps_single_holder_window_control(monkeypatch) -> None:
 
 def test_minimal_device_disables_multi_exposure() -> None:
     sidebar, _ = _sidebar(MINIMAL_DEVICE)
-    assert sidebar.me_check.isEnabled() is False
-    assert sidebar.me_check.isChecked() is False
+    assert sidebar.me_combo.isEnabled() is False
+    assert sidebar._me_mode() == MultiExposureMode.OFF
 
 
 def test_scan_params_include_prescan_crop() -> None:
@@ -985,11 +984,11 @@ def test_a_pass_the_device_cannot_run_is_not_shown_at_all() -> None:
     # Disabled-with-a-reason is for a pass the film blocks; one the transport lacks goes away.
     sidebar, _ = _sidebar(MINIMAL_DEVICE)
     assert sidebar.ir_check.isVisibleTo(sidebar) is False
-    assert sidebar.me_check.isVisibleTo(sidebar) is False
+    assert sidebar.me_combo.isVisibleTo(sidebar) is False
 
     sidebar, _ = _sidebar(SE_DEVICE, settings={"backend": "plustek"})
     assert sidebar.ir_check.isVisibleTo(sidebar) is True
-    assert sidebar.me_check.isVisibleTo(sidebar) is True
+    assert sidebar.me_combo.isVisibleTo(sidebar) is True
 
 
 def test_a_film_that_blocks_infrared_leaves_the_control_visible_to_explain_itself() -> None:


### PR DESCRIPTION
## Highlights

- **New: Multi-Pass mode.** Merge 2-9 exposures per frame for lower shadow
  noise, at a roughly proportional cost in scan time. pyopticfilm's own
  benchmark on an 8100 V2 (5 exposures vs. today's 2, same frame): **-26%
  relative chroma noise, -28% relative luma noise**, visibly smoother in flat
  regions.
- **Clearer control.** The old "Multi-exposure" checkbox — which secretly
  only ever meant one specific behavior — is now a single dropdown: **Off /
  Dynamic (2 exposures) / Fixed (2 exposures) / Multi-Pass (2-9)**. Choosing
  a mode is now an explicit decision instead of a hidden default.
- **Tidier scan setup.** Frame selection, scan-window/Prescan, and Clear now
  live together as one full-width block right above the Scan button — the
  last thing you touch before scanning, grouped where you touch it. Crop
  info, when a crop is set, shows next to Frame info instead of its own row.
- **No new risk surface.** Every mode is a name for a fully validated
  pipeline path — there's no raw exposure field, no way to type in an unsafe
  value. The debug-only raw exposure overrides pyopticfilm keeps for its own
  ScanLab tooling are never called from NegPy.
- **Fully backward compatible.** Off stays the default; Dynamic at 2
  exposures is byte-identical to today's only multi-exposure behavior. No
  existing scan or saved setting changes.

## Technical changes in NegPy

- `ScanParams`/`ScannerSettings` gain a `MultiExposureMode` enum replacing
  `multi_exposure: bool`, plus a bracket count meaningful only in Multi-Pass.
  Old settings blobs migrate automatically (`multi_exposure: true` →
  `dynamic`, `false` → `off`).
- `plustek_backend.py` translates the mode into pyopticfilm's
  `scan(multi_exposure=, me_exposure_mode=, n_brackets=)`, and generalizes
  the previously 2-pass-only scan progress model to N passes.
- `ScanSidebar`: mode combo + bracket slider replace the checkbox; the
  Framing section (frame spec, scan window, Prescan) moves to a full-width
  block above the Scan button; crop info relocates next to Frame info.

## Why this is a PR draft

This depends on `pyopticfilm` API surface (`n_brackets`, `me_exposure_mode`
widened to `str | None`, `Model.me_default_exposure_mode`) that only exists
on pyopticfilm's `feat/me-n-brackets` branch (#47), not in any released
version yet. **This will stay a draft until that pyopticfilm work is merged
and released**, since it can't be installed as a normal dependency or fully
verified against a real release until then.