### PR TITLE
fix(metadata): carry GPS seconds rounding into minutes and degrees

### DIFF
--- a/negpy/features/metadata/capture.py
+++ b/negpy/features/metadata/capture.py
@@ -161,6 +161,14 @@ def _dms(value: float) -> tuple[tuple[int, int], tuple[int, int], tuple[int, int
     minutes_full = (total - degrees) * 60.0
     minutes = int(minutes_full)
     seconds = round((minutes_full - minutes) * 60.0 * 100.0)
+    # Rounding the hundredths can carry seconds to 60.00, an invalid GPS
+    # rational; fold that carry into minutes, and minutes into degrees.
+    if seconds >= 6000:
+        seconds -= 6000
+        minutes += 1
+    if minutes >= 60:
+        minutes -= 60
+        degrees += 1
     return (degrees, 1), (minutes, 1), (int(seconds), 100)
 
 

--- a/tests/metadata/test_capture.py
+++ b/tests/metadata/test_capture.py
@@ -111,6 +111,16 @@ class TestGps:
         assert lat.startswith("35,40.57") and lat.endswith("N")
         assert lon.startswith("139,39.01") and lon.endswith("W")
 
+    def test_seconds_do_not_round_up_to_sixty(self) -> None:
+        # 45 degrees plus exactly one arc-minute. Float error puts the fractional
+        # minute so close to 1.0 that the raw seconds computation rounds to 60.00,
+        # an invalid GPS rational that should instead have carried into minutes.
+        gps = exif_gps_rationals(45.016666666666666, 0.0)
+        degrees, minutes, seconds = gps[piexif.GPSIFD.GPSLatitude]
+        assert seconds[0] / seconds[1] < 60.0
+        assert minutes[0] < 60
+        assert (degrees[0], minutes[0], seconds[0]) == (45, 1, 0)
+
 
 class TestTileMath:
     @pytest.mark.parametrize("zoom", [2, 8, 18])


### PR DESCRIPTION
`_dms()` floors the fractional minutes, then rounds the remainder to hundredths of a second, but never checks whether that rounding carried. When float error leaves the fractional minute just under `1.0`, the rounded value lands on exactly 6000 hundredths and `exif_gps_rationals` writes a 60.00″ GPS rational. That is invalid EXIF, and it is also the wrong coordinate — it should have carried into the next minute.

`45.016666666666666` is 45° 1′ 0″. It came out as 45° 0′ 60.00″.

The carry now folds seconds into minutes, and minutes into degrees in case that first carry overflows in turn.

Reverting only `capture.py` and keeping the new test:

```
>       assert seconds[0] / seconds[1] < 60.0
E       assert (6000 / 100) < 60.0
```

With it, `tests/metadata/test_capture.py` is 59 passed. Full suite 5322 passed, 27 skipped, 14 deselected, 0 failed. `ruff check`, `ruff format --check`, and `ty check` with CI's ignore list are all clean.
