### PR TITLE
fix(metadata): carry GPS minutes rounding into degrees in xmp_gps

### DIFF
--- a/negpy/features/metadata/capture.py
+++ b/negpy/features/metadata/capture.py
@@ -190,7 +190,13 @@ def xmp_gps(lat: float, lon: float) -> tuple[str, str]:
     def one(value: float, positive: str, negative: str) -> str:
         total = abs(value)
         degrees = int(total)
-        minutes = (total - degrees) * 60.0
+        minutes = round((total - degrees) * 60.0, 4)
+        # Rounding to four decimals can carry minutes to 60.0000, an invalid XMP
+        # rational; fold that carry into degrees, same shape as the EXIF seconds
+        # carry in _dms().
+        if minutes >= 60.0:
+            minutes -= 60.0
+            degrees += 1
         return f"{degrees},{minutes:.4f}{positive if value >= 0 else negative}"
 
     return one(lat, "N", "S"), one(lon, "E", "W")

--- a/tests/metadata/test_capture.py
+++ b/tests/metadata/test_capture.py
@@ -121,6 +121,15 @@ class TestGps:
         assert minutes[0] < 60
         assert (degrees[0], minutes[0], seconds[0]) == (45, 1, 0)
 
+    def test_xmp_minutes_do_not_round_up_to_sixty(self) -> None:
+        # 52 degrees minus a hair. The fractional-minute computation lands so close
+        # to 60 that formatting to four decimal places rounds it up to "60.0000", an
+        # invalid XMP GPSLatitude/GPSLongitude minute that should instead carry into
+        # degrees, the same shape as the EXIF seconds carry above.
+        lat, lon = xmp_gps(51.9999995, -51.9999995)
+        assert lat == "52,0.0000N"
+        assert lon == "52,0.0000W"
+
 
 class TestTileMath:
     @pytest.mark.parametrize("zoom", [2, 8, 18])


### PR DESCRIPTION
`xmp_gps()` formats fractional minutes to four decimals with no overflow check, so a value within roughly 1 part in 200,000 of a whole degree rounds up to `60.0000`. XMP minutes are `[0, 60)`, so the sidecar gets an invalid value and the wrong coordinate — it should have carried into the next degree.

`51.9999995` is 52° for any practical purpose. It came out as `51,60.0000N`.

This is the same carry #1043 fixed in `_dms()`, but `xmp_gps()` is a separate function on the XMP sidecar path and that fix never reached it.

Reverting only `capture.py` and keeping the new test:

```
>       assert lat == "52,0.0000N"
E       AssertionError: assert '51,60.0000N' == '52,0.0000N'
```

With it, `tests/metadata/test_capture.py` is 60 passed. Full suite 5343 passed, 27 skipped, 14 deselected, 0 failed. `ruff check`, `ruff format --check` and `ty check` are clean.
