### PR TITLE
fix: add optional inter-exposure delay for trichrome capture

### DIFF
--- a/docs/CAMERA_SCANNING.md
+++ b/docs/CAMERA_SCANNING.md
@@ -104,7 +104,10 @@ preset's channel only, because the Scanlight cannot light it together with RGB.
 **Scan.** Pick an output folder and a preset, then press **Scan** for each frame. Files
 land in a per-roll subfolder, auto-numbered, and are imported and merged automatically, so
 the inverted positive appears a moment after the shutter. **Retake** re-shoots the current
-frame without advancing the counter.
+frame without advancing the counter. The **Delay between exposures** control adds a pause
+between red/green/blue captures so older bodies can finish flushing the previous shot before
+the next one arrives; this avoids the USB/PTP lockups that some cameras trigger when they are
+bombarded with a new capture command too quickly.
 
 **Narrowband Scan.** Scans lit by narrowband RGB LEDs render more saturated than
 white-light scans, because each channel samples its dye near the absorption peak and the

--- a/negpy/desktop/view/sidebar/scanlight.py
+++ b/negpy/desktop/view/sidebar/scanlight.py
@@ -253,6 +253,26 @@ class ScanlightSidebar(QWidget):
         self._conn_hint.setWordWrap(True)
         self._conn_hint.setStyleSheet(f"color: {THEME.text_hint}; font-size: {THEME.font_size_small}px;")
         layout.addWidget(self._conn_hint)
+
+        self.inter_exposure_delay_row = QWidget()
+        self.inter_exposure_delay_layout = QHBoxLayout(self.inter_exposure_delay_row)
+        self.inter_exposure_delay_layout.setContentsMargins(0, 0, 0, 0)
+        self.inter_exposure_delay_layout.setSpacing(6)
+        self.inter_exposure_delay_slider = QSlider(Qt.Orientation.Horizontal)
+        self.inter_exposure_delay_slider.setRange(0, 5000)
+        self.inter_exposure_delay_slider.setSingleStep(100)
+        self.inter_exposure_delay_slider.setValue(self._settings.inter_exposure_delay_ms)
+        self.inter_exposure_delay_slider.setToolTip(
+            "Wait this long between successive trichrome channel exposures so the camera can flush the previous shot."
+        )
+        self.inter_exposure_delay_value = QLabel(f"{self._settings.inter_exposure_delay_ms} ms")
+        self.inter_exposure_delay_value.setMinimumWidth(64)
+        self.inter_exposure_delay_value.setStyleSheet(f"color: {THEME.text_muted}; font-size: {THEME.font_size_small}px;")
+        self.inter_exposure_delay_label = QLabel("Delay between exposures")
+        self.inter_exposure_delay_layout.addWidget(self.inter_exposure_delay_label)
+        self.inter_exposure_delay_layout.addWidget(self.inter_exposure_delay_slider, 1)
+        self.inter_exposure_delay_layout.addWidget(self.inter_exposure_delay_value)
+        layout.addWidget(self.inter_exposure_delay_row)
         status_row = QHBoxLayout()
         self.cam_status = QLabel()
         self.light_status = QLabel()
@@ -394,6 +414,8 @@ class ScanlightSidebar(QWidget):
         self.preset_del_btn.clicked.connect(self._on_preset_delete)
         # Typing an invalid path greys Scan immediately (with the reason), not on the next click.
         self.folder_edit.editingFinished.connect(self._apply_gating)
+        self.inter_exposure_delay_slider.valueChanged.connect(self._update_inter_exposure_delay_label)
+        self.inter_exposure_delay_slider.valueChanged.connect(self._update_settings_from_ui)
         for w in (self.roll_edit, self.folder_edit):
             w.editingFinished.connect(self._update_settings_from_ui)
 
@@ -1330,6 +1352,7 @@ class ScanlightSidebar(QWidget):
             output_folder=roll_folder,
             levels=(s.r_level, s.g_level, s.b_level),
             settle_s=_LED_SETTLE_S,
+            inter_exposure_delay_s=s.inter_exposure_delay_ms / 1000.0,
             port=s.port,
             # Normal mode has no calibrated shutter or white level: the operator sets the exposure
             # with the live-view steppers, so leave the shutter blank and the camera keeps its own.
@@ -1660,6 +1683,9 @@ class ScanlightSidebar(QWidget):
         self.lv_window.set_scanning(active)
         self._apply_gating()  # a running scan locks the "+" calibration button
 
+    def _update_inter_exposure_delay_label(self) -> None:
+        self.inter_exposure_delay_value.setText(f"{self.inter_exposure_delay_slider.value()} ms")
+
     def _update_settings_from_ui(self) -> None:
         # white_mode / white_process_mode are set by preset selection, not by widgets. Exposure
         # comes from the steppers only while building a manual preset. Otherwise it is the preset
@@ -1676,6 +1702,7 @@ class ScanlightSidebar(QWidget):
             g_level=self.g_slider.value(),
             b_level=self.b_slider.value(),
             w_level=self.w_slider.value(),
+            inter_exposure_delay_ms=self.inter_exposure_delay_slider.value(),
             shutter_r=shutter,
             shutter_g=shutter,
             shutter_b=shutter,

--- a/negpy/desktop/workers/capture_worker.py
+++ b/negpy/desktop/workers/capture_worker.py
@@ -38,6 +38,7 @@ class CaptureRequest:
     output_folder: str
     levels: tuple[int, int, int]
     settle_s: float = 0.4
+    inter_exposure_delay_s: float = 0.0
     port: str = ""
     shutters: tuple[str, str, str] = ("", "", "")
     white_mode: bool = False
@@ -263,6 +264,7 @@ class CaptureWorker(QObject):
                 output_folder=req.output_folder,
                 levels=req.levels,
                 settle_s=req.settle_s,
+                inter_exposure_delay_s=req.inter_exposure_delay_s,
                 shutters=_shutters_or_none(req.shutters),
                 iso=req.iso or None,  # force the preset's exposure on the body before each shot
                 aperture=req.aperture or None,

--- a/negpy/infrastructure/capture/base.py
+++ b/negpy/infrastructure/capture/base.py
@@ -66,6 +66,7 @@ class CaptureSettings:
     output_folder: str
     levels: tuple[int, int, int]  # (r, g, b) LED levels, 0-255
     settle_s: float = 0.4
+    inter_exposure_delay_s: float = 0.0
     min_raw_bytes: int = 8 * 1024 * 1024
     max_raw_bytes: int = 200 * 1024 * 1024
     shutters: Optional[tuple[Optional[str], Optional[str], Optional[str]]] = None

--- a/negpy/infrastructure/capture/settings.py
+++ b/negpy/infrastructure/capture/settings.py
@@ -42,6 +42,7 @@ class ScanlightSettings:
     shutter_w: str = ""
     iso: str = ""  # RGB preset's calibrated ISO/aperture, forced on the body at scan time
     aperture: str = ""  # "" for a manual-aperture lens (set by hand on the ring)
+    inter_exposure_delay_ms: int = 0
     white_process_mode: WhiteCaptureMode = WhiteCaptureMode.AUTO
     roll_name: str = "Roll001"
     output_folder: str = ""

--- a/negpy/services/capture/service.py
+++ b/negpy/services/capture/service.py
@@ -219,6 +219,9 @@ class CaptureService:
                 if progress is not None:
                     progress((i + 1) / len(CAPTURE_ORDER))
 
+                if i < len(CAPTURE_ORDER) - 1:
+                    self._sleep(settings.inter_exposure_delay_s)
+
             if cancel is not None and cancel.is_set():
                 raise CaptureError("capture cancelled")
             paths = _promote_triplet(staged_paths, settings.output_folder)

--- a/tests/test_capture_service.py
+++ b/tests/test_capture_service.py
@@ -6,6 +6,7 @@ import threading
 import pytest
 
 from negpy.infrastructure.capture.base import CaptureSettings
+from negpy.infrastructure.capture.settings import ScanlightSettings
 from negpy.services.capture.service import CaptureError, CaptureService
 
 
@@ -63,6 +64,12 @@ def _settings(tmp_path, **kw):
     return CaptureSettings(**base)
 
 
+def test_capture_defaults_to_zero_inter_exposure_delay(tmp_path):
+    settings = _settings(tmp_path)
+    assert settings.inter_exposure_delay_s == 0.0
+    assert ScanlightSettings().inter_exposure_delay_ms == 0
+
+
 def test_capture_triplet_sequence_and_filenames(tmp_path):
     light, cam = FakeLight(), FakeCamera()
     svc = CaptureService(light, cam, sleep=lambda _s: None)
@@ -113,6 +120,16 @@ def test_capture_triplet_reports_each_channel(tmp_path):
     channels = []
     svc.capture_triplet(_settings(tmp_path), on_channel=channels.append)
     assert channels == ["R", "G", "B"]
+
+
+def test_capture_triplet_waits_between_channels(tmp_path):
+    light, cam = FakeLight(), FakeCamera()
+    sleeps = []
+    svc = CaptureService(light, cam, sleep=lambda s: sleeps.append(s))
+
+    svc.capture_triplet(_settings(tmp_path, settle_s=0.2, inter_exposure_delay_s=2.5))
+
+    assert sleeps == [0.2, 2.5, 0.2, 2.5, 0.2]
 
 
 def test_capture_triplet_turns_light_off_on_error(tmp_path):


### PR DESCRIPTION
Some older USB/PTP bodies, including the Canon EOS 450D, need a short pause between successive capture commands. A trichrome scan fires red, green and blue back-to-back, and the camera may still be clearing the previous transfer when the next command arrives.

Keep the default at zero for normal cameras, while preserving the user-controlled inter-exposure delay for affected bodies.