### PR TITLE
fix(plustek): stop compressing multi-exposure scan progress into a false plateau

### DIFF
--- a/negpy/infrastructure/scanners/plustek_backend.py
+++ b/negpy/infrastructure/scanners/plustek_backend.py
@@ -119,13 +119,16 @@ def _make_scan_progress(
         if frac >= 1.0 - 1e-9:
             _safe_progress(progress, 0.85, "Merging exposures")
             return
-        if frac > plateau + 1e-6:
-            state["long_started"] = True
-            _safe_progress(progress, 0.10 + 0.72 * frac, "Scanning")
-        elif abs(frac - plateau) < 1e-6 and not state["long_started"]:
-            _safe_progress(progress, 0.83, "Preparing long exposure")
+        # 0.10-0.85 mirrors the acquisition span used below; the leftover 0.15 is
+        # reserved for the host-side merge/makeup work after the last pass lands,
+        # which reports no incremental progress of its own.
+        value = 0.10 + 0.75 * frac
+        if abs(frac - plateau) < 1e-6 and not state["long_started"]:
+            _safe_progress(progress, value, "Preparing long exposure")
         else:
-            _safe_progress(progress, 0.10 + 0.72 * frac, "Scanning")
+            if frac > plateau + 1e-6:
+                state["long_started"] = True
+            _safe_progress(progress, value, "Scanning")
 
     return scan_progress
 

--- a/tests/scanners/test_plustek_backend.py
+++ b/tests/scanners/test_plustek_backend.py
@@ -395,6 +395,26 @@ def test_me_scan_reports_preparing_then_long_pass(monkeypatch):
     assert phases.count("Scanning") >= 2
 
 
+def test_me_scan_progress_does_not_regress_at_long_pass_boundary(monkeypatch):
+    """Reported fractions never decrease across the short/long pass boundary."""
+    _patch_enum(monkeypatch)
+    scanner = _fake_scanner(me_fractions=[0.25, 0.5, 0.5, 0.6, 0.75, 1.0])
+    monkeypatch.setattr(f"{_BACKEND}.Scanner.open", _FakeOpen(scanner))
+    seen: list[tuple[float, str]] = []
+
+    def progress(fraction: float, phase: str = "Scanning") -> None:
+        seen.append((fraction, phase))
+
+    PlustekBackend().scan(
+        _DEVICE_ID,
+        _params(multi_exposure=True),
+        progress,
+        threading.Event(),
+    )
+    scanning_or_preparing = [v for v, phase in seen if phase in ("Scanning", "Preparing long exposure")]
+    assert scanning_or_preparing == sorted(scanning_or_preparing)
+
+
 def test_me_scan_reports_merging_at_completion(monkeypatch):
     _patch_enum(monkeypatch)
     scanner = _fake_scanner(me_fractions=[1.0])


### PR DESCRIPTION
## Summary
- The GL128 multi-exposure scan progress bar undershot reality: at the short/long exposure pass boundary (a real, correctly-reported 50% pass-fraction milestone from pyopticfilm) it displayed ~46% instead, then briefly jumped to 83% before dropping back down once the long pass started streaming bytes.
- Root cause is in `_make_scan_progress()` (`negpy/infrastructure/scanners/plustek_backend.py`), introduced in #1007: it scaled the whole `[0, 1]` pass fraction by an arbitrary `0.72` and reported a hardcoded `0.83` for the "Preparing long exposure" label, which is discontinuous with the surrounding `0.10 + 0.72 * frac` values.
- Fixed by mapping the pass fraction linearly across the full `0.10-0.85` scanning span (`0.10 + 0.75 * frac`), so the plateau value is continuous with both neighboring passes and the bar never jumps backward. The `0.85-1.0` tail stays reserved for the host-side merge/makeup step, which has no incremental progress of its own.
- pyopticfilm's own progress fraction (`(idx + p) / n_pass` in `session_gl128.py`) was verified correct; this is purely a NegPy-side display/mapping fix.

## Test plan
- [x] `uv run pytest tests/scanners/test_plustek_backend.py -q` (31 passed, includes a new regression test asserting the reported fraction never decreases across the short/long pass boundary — fails against the old formula, passes against the fix)
- [x] `uv run pytest tests/ -q` (5444 passed, 22 skipped; one pre-existing unrelated failure in `test_crosstalk_profiles.py`, unaffected by this change)
- [x] `uv run ruff check` / `uv run ruff format --check` on the changed files
- [x] `uv run ty check` on the changed file