### PR TITLE
fix(capture): recognise the v4b Scanlight, which has a white LED

### DIFF
--- a/negpy/infrastructure/capture/protocol.py
+++ b/negpy/infrastructure/capture/protocol.py
@@ -81,13 +81,15 @@ def decode_fw_version(data: bytes) -> tuple[int, int]:
 
 
 # Known Scanlight hardware IDs, from HW_VERSION_ID in jackw01's firmware (config.h). The
-# family shares this wire protocol, so NegPy drives any of them identically.
-HARDWARE_NAMES = {0: "Big Scanlight", 1: "Scanlight v4"}
+# family shares this wire protocol, so NegPy drives any of them identically. v4a and v4b
+# are PCB revisions 26a901a and 26a901b of the one v4 body, named as upstream names their
+# firmware binaries (sl4a, sl4b); only v4b has focus support.
+HARDWARE_NAMES = {0: "Big Scanlight", 1: "Scanlight v4a", 2: "Scanlight v2/v3", 3: "Scanlight v4b"}
 
 # Models with a dedicated white LED. The white channel arrived with the v4, so the Big
-# Scanlight (0) and v4 (1) have it. The earlier v1, v2 and v3 are RGB-only, as is any id
-# we do not recognise; a future white-capable model would be added here.
-_WHITE_CAPABLE_HW = frozenset({0, 1})
+# Scanlight (0) and both v4 revisions (1, 3) have it. The earlier v1, v2 and v3 are
+# RGB-only, as is any id we do not recognise; a future white-capable model is added here.
+_WHITE_CAPABLE_HW = frozenset({0, 1, 3})
 
 
 def describe_hardware(hw_id: int) -> str:

--- a/tests/test_capture_protocol.py
+++ b/tests/test_capture_protocol.py
@@ -49,15 +49,19 @@ def test_channel_rgb_lights_only_one_channel():
 def test_describe_hardware_known_and_unknown():
     # HW_VERSION_ID values from jackw01's firmware config.h.
     assert proto.describe_hardware(0) == "Big Scanlight"
-    assert proto.describe_hardware(1) == "Scanlight v4"
+    assert proto.describe_hardware(2) == "Scanlight v2/v3"
+    # The two v4 PCB revisions are named apart: 1 is 26a901a, 3 is 26a901b.
+    assert proto.describe_hardware(1) == "Scanlight v4a"
+    assert proto.describe_hardware(3) == "Scanlight v4b"
     # An id we don't have a name for falls back to the raw value (no crash, no mislabel).
     assert proto.describe_hardware(7) == "hw7"
 
 
 def test_has_white_channel():
-    # Only the Big Scanlight (0) and v4 (1) have a dedicated white LED.
+    # The Big Scanlight (0) and both v4 revisions (1, 3) have a dedicated white LED.
     assert proto.has_white_channel(0) is True
     assert proto.has_white_channel(1) is True
+    assert proto.has_white_channel(3) is True
     # v1-v3 (and any unrecognised id) are RGB-only.
     assert proto.has_white_channel(2) is False
     assert proto.has_white_channel(7) is False

--- a/tests/test_scanlight_driver.py
+++ b/tests/test_scanlight_driver.py
@@ -75,7 +75,7 @@ def test_off_turns_every_channel_down(light):
 
 
 def test_get_fw_version_reads_the_device_reply(light):
-    word = (1 << 16) | 2  # hw=1 (Scanlight v4), fw=2
+    word = (1 << 16) | 2  # hw=1 (Scanlight v4a), fw=2
     threading.Timer(0.02, lambda: light.serial.feed(proto.D2H_FW_VERSION, word.to_bytes(4, "big"))).start()
     assert light.get_fw_version(timeout=2.0) == (2, 1)
 


### PR DESCRIPTION
Fixes #1050

## What

A Scanlight v4 on the 26a901b PCB reports hardware ID 3. `HARDWARE_NAMES` and
`_WHITE_CAPABLE_HW` in `negpy/infrastructure/capture/protocol.py` knew only ids 0
and 1, so such a device fell through to the `hw3` fallback name and the RGB-only
branch: the W slider row was hidden and the **White Light (B&W or Slide Film)**
preset was disabled on a body that has dedicated white LEDs.

This adds the two missing ids and names the v4 PCB revisions apart:

| id | name | white |
|---|---|---|
| 0 | Big Scanlight | yes |
| 1 | Scanlight v4a | yes |
| 2 | Scanlight v2/v3 | no |
| 3 | Scanlight v4b | yes |
| other | `hw<n>` | no |

## Why these names

Upstream's [hardware table](https://github.com/jackw01/scanlight/tree/main/automation#hardware-versions-and-binaries)
gives the two v4 PCB revisions separate ids and separate firmware binaries
(`sl4a_controller`, `sl4b_controller`), so `v4a` / `v4b` reuses vocabulary anyone
who has flashed the board already knows. The alternative — naming both
"Scanlight v4" — discards the only thing that distinguishes them in the
connection status line, which is what made this bug invisible on screen.

## Reviewer notes

- The sidebar gate reads `has_white_channel` through the `light_has_white` status
  key and nothing else, so this one table drives the device name, the W slider row
  and the White Light preset together. No UI change was needed.
- Only `describe_hardware` and `has_white_channel` consume the table; the sole
  display site is `capture_worker.py`, which renders `"{name} (fw{n})"`.
- Id 2 stays as `Scanlight v2/v3` because upstream assigns one id to both bodies.
- The 26a901b revision is the one with focus support. If NegPy ever gates on that,
  the ids are now distinct — a `_FOCUS_CAPABLE_HW = frozenset({3})` beside the
  white one would be the shape.

## Testing

`make lint` and `make type` pass. The capture and scanlight-sidebar suites pass
(135 tests), including new coverage for both v4 revisions and the v2/v3 name.
Confirmed on real v4b hardware (hw3, fw2): the status line reads
`Scanlight v4b (fw2)` in place of `hw3 (fw2)`, the W slider row appears, the
White Light (B&W or Slide Film) preset is selectable, and a white-light capture
through it produces a correct frame.
