### PR TITLE
perf(retouch): bake painted heal strokes incrementally

### DIFF
--- a/negpy/features/retouch/logic.py
+++ b/negpy/features/retouch/logic.py
@@ -918,7 +918,15 @@ def film_scale(shape: Tuple[int, int]) -> float:
     return max(1.0, max(shape) / _IR_DETECT_REF)
 
 
-def repair_components(img: ImageBuffer, score_det: np.ndarray, *, floor: bool = True, factor: Optional[float] = None) -> ImageBuffer:
+def repair_components(
+    img: ImageBuffer,
+    score_det: np.ndarray,
+    *,
+    floor: bool = True,
+    factor: Optional[float] = None,
+    base_out: Optional[np.ndarray] = None,
+    dirty: Optional[np.ndarray] = None,
+) -> ImageBuffer:
     """``apply_score_repair`` per defect, each in its own padded crop.
 
     The fill is four convolutions over whatever buffer it is handed. That is right for an
@@ -926,6 +934,14 @@ def repair_components(img: ImageBuffer, score_det: np.ndarray, *, floor: bool = 
     painted strokes or detected specks this serves — at export resolution it would filter
     a hundred megapixels to repair a dozen. The support ladder and the mask's upsample
     factor still come from the whole frame, so a crop repairs exactly as it would there.
+
+    ``base_out``/``dirty`` support an incremental re-bake, for a session that adds one
+    stroke at a time: with both given, a component that contains no ``dirty`` pixel is
+    copied from ``base_out`` unchanged rather than re-filled, since neither its score nor
+    its source pixels moved since that buffer was made. ``dirty=None`` (every caller but
+    the painted-strokes bake) fills every component, matching the non-incremental result
+    exactly — the manual-bake caller reads ``base_out`` itself when nothing is dirty at
+    all, so an all-False mask never has to be passed in here.
     """
     h, w = img.shape[:2]
     if score_det.shape[:2] == (h, w):
@@ -934,22 +950,28 @@ def repair_components(img: ImageBuffer, score_det: np.ndarray, *, floor: bool = 
     else:
         factor = max(h / score_det.shape[0], w / score_det.shape[1])
         score = cv2.resize(score_det, (w, h), interpolation=cv2.INTER_LINEAR)
+        if dirty is not None and dirty.shape[:2] != (h, w):
+            dirty = cv2.resize(dirty.astype(np.uint8), (w, h), interpolation=cv2.INTER_NEAREST) > 0
     m = (score < 1.0).astype(np.uint8)
     if not m.any():
         return img
     n_lbl, labels, stats, _ = cv2.connectedComponentsWithStats(m, connectivity=8)
-    # Past this many, cropping costs more than the whole-frame convolutions it avoids.
+    # Past this many, cropping costs more than the whole-frame convolutions it avoids —
+    # and more than reusing base_out row by row, so this path stays non-incremental.
     if n_lbl - 1 > _REPAIR_MAX_COMPONENTS:
         return apply_score_repair(img, score, floor=floor, factor=factor)
     src = np.ascontiguousarray(img, dtype=np.float32)
-    out = src.copy()
+    out = np.ascontiguousarray(base_out, dtype=np.float32).copy() if base_out is not None else src.copy()
     # Reach of the coarsest support, so every crop holds the clean film the fill averages.
     pad = max(_fill_supports(max(h, w), factor))
     for i in range(1, n_lbl):
         bx, by = int(stats[i, cv2.CC_STAT_LEFT]), int(stats[i, cv2.CC_STAT_TOP])
+        cw, ch = int(stats[i, cv2.CC_STAT_WIDTH]), int(stats[i, cv2.CC_STAT_HEIGHT])
+        if dirty is not None and not dirty[by : by + ch, bx : bx + cw][labels[by : by + ch, bx : bx + cw] == i].any():
+            continue  # untouched since base_out was made: its fill there is already correct
         x0, y0 = max(0, bx - pad), max(0, by - pad)
-        x1 = min(w, bx + int(stats[i, cv2.CC_STAT_WIDTH]) + pad)
-        y1 = min(h, by + int(stats[i, cv2.CC_STAT_HEIGHT]) + pad)
+        x1 = min(w, bx + cw + pad)
+        y1 = min(h, by + ch + pad)
         sub = apply_score_repair(src[y0:y1, x0:x1], score[y0:y1, x0:x1], floor=floor, long_edge=max(h, w), factor=factor)
         # This component only: a neighbour clipped by the crop repairs badly here and gets
         # its own padded crop anyway.

--- a/negpy/services/rendering/image_processor.py
+++ b/negpy/services/rendering/image_processor.py
@@ -300,6 +300,22 @@ class ImageProcessor:
         self._luma_value: Optional[np.ndarray] = None
         self._manual_key: Optional[tuple] = None
         self._manual_value: Optional[tuple] = None
+        # Incremental baseline for _manual_bake: the (score, out) reached by the strokes/
+        # spots/lines baked so far, so painting one more stroke costs that stroke alone
+        # rather than redoing every earlier one. Reset whenever the new state is not a
+        # strict append of this baseline (an undo, an edit, a new source).
+        # Identity, not source_key: source_key folds in manual_bake_token, a hash of the
+        # whole stroke list, so it changes on every single stroke by design (it also
+        # invalidates the GPU/CPU engine's uploaded source) and could never match here.
+        # Nothing upstream of the manual bake reads the strokes, so the same decoded
+        # buffer object recurs across a painting session; identity is what to key on.
+        self._manual_inc_img: Optional[np.ndarray] = None
+        self._manual_inc_heal_strokes: tuple = ()
+        self._manual_inc_dust_spots: tuple = ()
+        self._manual_inc_lines: tuple = ()
+        self._manual_inc_threshold: Optional[float] = None
+        self._manual_inc_score: Optional[np.ndarray] = None
+        self._manual_inc_out: Optional[np.ndarray] = None
         # The OpenICE method's whole result, on its own slot. The two IR methods share no
         # state, so whichever loses can be deleted without unpicking the other.
         self._ice_key: Optional[tuple] = None
@@ -488,40 +504,109 @@ class ImageProcessor:
         so this runs before geometry and needs no mapping. Returns the buffer and the mask of
         defects too wide for the fill, for the caller to inpaint."""
         ret = settings.retouch
-        lines = getattr(ret, "scratch_lines", [])
-        if self._is_flat(settings) or not (ret.manual_heal_strokes or ret.manual_dust_spots or lines):
+        lines = tuple(getattr(ret, "scratch_lines", []))
+        heal_strokes = tuple(ret.manual_heal_strokes)
+        dust_spots = tuple(ret.manual_dust_spots)
+        threshold = getattr(ret, "scratch_threshold", 0.5)
+        if self._is_flat(settings) or not (heal_strokes or dust_spots or lines):
             return img, None
         key = (source_key, img.shape)
         if key == self._manual_key and self._manual_value is not None:
             return self._manual_value
+
+        self._slow_step("repairing dust")
+        score, out = self._manual_bake_incremental(img, heal_strokes, dust_spots, lines, threshold)
+        if score is None:
+            value: Tuple[np.ndarray, Optional[np.ndarray]] = (img, None)
+        else:
+            value = (out, route_wide_defects(score, budget=None))
+        self._manual_key = key
+        self._manual_value = value
+        return value
+
+    def _manual_bake_incremental(
+        self,
+        img: np.ndarray,
+        heal_strokes: tuple,
+        dust_spots: tuple,
+        lines: tuple,
+        threshold: float,
+    ) -> Tuple[Optional[np.ndarray], np.ndarray]:
+        """(combined_score, filled_buffer) for the current strokes/spots/lines.
+
+        A painted session is almost always additive — one more stroke on top of the ones
+        already there — so when every list is a strict extension of what was baked last
+        time (same source image, same scratch threshold), only the *new* entries run
+        through detection, and `repair_components` only re-fills the connected components
+        they actually touch; everything else is copied from the previous fill unchanged.
+        Repainting from scratch costs the same as before either way: undoing past the
+        cached baseline, or a fresh source, falls back to it below.
+        """
+        can_extend = (
+            self._manual_inc_img is img
+            and threshold == self._manual_inc_threshold
+            and heal_strokes[: len(self._manual_inc_heal_strokes)] == self._manual_inc_heal_strokes
+            and dust_spots[: len(self._manual_inc_dust_spots)] == self._manual_inc_dust_spots
+            and lines[: len(self._manual_inc_lines)] == self._manual_inc_lines
+            and self._manual_inc_score is not None
+        )
+        if can_extend:
+            new_strokes = heal_strokes[len(self._manual_inc_heal_strokes) :]
+            new_spots = dust_spots[len(self._manual_inc_dust_spots) :]
+            new_lines = lines[len(self._manual_inc_lines) :]
+            base_score = self._manual_inc_score
+            base_out = self._manual_inc_out
+        else:
+            new_strokes, new_spots, new_lines = heal_strokes, dust_spots, lines
+            base_score, base_out = None, None
+
         # One pass for both hand-placed sources: whichever calls a pixel more damaged wins,
         # and the fill sees every hole at once.
         parts = [
             s
             for s in (
-                strokes_to_score(img, ret.manual_heal_strokes, ret.manual_dust_spots),
-                lines_to_score(img, lines, getattr(ret, "scratch_threshold", 0.5)),
+                strokes_to_score(img, new_strokes, new_spots),
+                lines_to_score(img, new_lines, threshold),
             )
             if s is not None
         ]
-        score = parts[0] if len(parts) == 1 else (np.minimum(*parts) if parts else None)
-        if score is None:
-            value: Tuple[np.ndarray, Optional[np.ndarray]] = (img, None)
+        delta = parts[0] if len(parts) == 1 else (np.minimum(*parts) if parts else None)
+
+        if base_score is None:
+            score = delta
+            dirty = None  # nothing cached yet: repair_components fills every component
+        elif delta is None:
+            # The new entries alone found nothing worth repairing (clean film, or a stroke
+            # too faint) — the bake is unchanged from the cached baseline.
+            score, dirty = base_score, np.zeros(base_score.shape, dtype=bool)
         else:
-            self._slow_step("repairing dust")
+            score = np.minimum(base_score, delta)
+            dirty = delta < 1.0
+
+        if score is None:
+            out = img
+        elif base_out is not None and not dirty.any():
+            out = base_out
+        else:
             # floor=False: a scratch has lost emulsion and reads brighter than the film
             # around it, so a painted repair must be free to darken as well as lighten.
             # Film-footprint supports, not the buffer's own pixels: a painted score arrives
             # at full buffer resolution, where the fill's fine rungs sit at grain scale,
             # entirely inside the defect. Their candidate is then the defect's own value and
             # the repair only half-lands. The IR path measures its score coarse instead.
-            value = (
-                np.asarray(repair_components(img, score, floor=False, factor=film_scale(img.shape[:2]))),
-                route_wide_defects(score, budget=None),
-            )
-        self._manual_key = key
-        self._manual_value = value
-        return value
+            # dirty=None here means "nothing cached to reuse", not "nothing changed" — the
+            # None-vs-empty-array distinction repair_components relies on to skip the whole
+            # incremental path when there is no base_out to reuse from.
+            out = np.asarray(repair_components(img, score, floor=False, factor=film_scale(img.shape[:2]), base_out=base_out, dirty=dirty))
+
+        self._manual_inc_img = img
+        self._manual_inc_heal_strokes = heal_strokes
+        self._manual_inc_dust_spots = dust_spots
+        self._manual_inc_lines = lines
+        self._manual_inc_threshold = threshold
+        self._manual_inc_score = score
+        self._manual_inc_out = out
+        return score, out
 
     def run_pipeline(
         self,

--- a/tests/test_manual_bake_incremental.py
+++ b/tests/test_manual_bake_incremental.py
@@ -1,0 +1,163 @@
+"""_manual_bake's incremental re-bake: painting one more stroke must cost that stroke
+alone, not redo every earlier one, while producing exactly the same pixels as a
+from-scratch recompute at every step.
+"""
+
+from dataclasses import replace
+from unittest.mock import patch
+
+import numpy as np
+
+from negpy.domain.models import WorkspaceConfig
+from negpy.features.retouch.logic import manual_bake_token
+from negpy.features.retouch.models import HEAL_SIZE_REF
+from negpy.services.rendering import image_processor as ip_mod
+from negpy.services.rendering.image_processor import ImageProcessor
+
+
+def _size_at_ref(diameter_px, shape):
+    return diameter_px * HEAL_SIZE_REF / max(shape)
+
+
+def _grainy(h, w, level=0.5, sigma=0.01, seed=21):
+    rng = np.random.default_rng(seed)
+    return (np.full((h, w, 3), level) + rng.normal(0, sigma, (h, w, 3))).astype(np.float32)
+
+
+def _stroke(cx, cy, shape, diameter_px=15.0):
+    return ([[cx, cy]], _size_at_ref(diameter_px, shape), 0.0, 0.0)
+
+
+def _scene():
+    """Three well-separated specks, far enough apart that no two strokes' padded
+    fill supports ever touch — the common case a heal session actually looks like."""
+    img = _grainy(240, 240, seed=7)
+    img[30:33, 30:33] = 0.92
+    img[120:123, 120:123] = 0.92
+    img[190:193, 60:63] = 0.92
+    shape = img.shape[:2]
+    strokes = [
+        _stroke(31.5 / shape[1], 31.5 / shape[0], shape),
+        _stroke(121.5 / shape[1], 121.5 / shape[0], shape),
+        _stroke(61.5 / shape[1], 191.5 / shape[0], shape),
+    ]
+    return img, strokes
+
+
+def _config(strokes) -> WorkspaceConfig:
+    base = WorkspaceConfig()
+    return replace(base, retouch=replace(base.retouch, manual_heal_strokes=strokes))
+
+
+def _source_key(settings: WorkspaceConfig) -> str:
+    """Mirrors how run_pipeline folds the stroke identity into source_key — _manual_bake's
+    own cache is keyed on this, so a fixed key across different stroke lists would mask
+    the very re-bake this module tests."""
+    return "src" + manual_bake_token(settings.retouch)
+
+
+class TestIncrementalMatchesFullRecompute:
+    def test_appending_one_stroke_at_a_time(self):
+        img, strokes = _scene()
+        proc = ImageProcessor()
+        for n in range(1, len(strokes) + 1):
+            settings = _config(strokes[:n])
+            key = _source_key(settings)
+            got, got_wide = proc._manual_bake(img, settings, key)
+            want, want_wide = ImageProcessor()._manual_bake(img, settings, key)
+            np.testing.assert_array_equal(np.asarray(got), np.asarray(want), err_msg=f"mismatch at {n} strokes")
+            assert (got_wide is None) == (want_wide is None)
+
+    def test_appending_all_at_once_matches_one_at_a_time(self):
+        """The end state must not depend on how you got there."""
+        img, strokes = _scene()
+        stepwise = ImageProcessor()
+        for n in range(1, len(strokes) + 1):
+            settings = _config(strokes[:n])
+            out, _ = stepwise._manual_bake(img, settings, _source_key(settings))
+
+        settings_all = _config(strokes)
+        direct_out, _ = ImageProcessor()._manual_bake(img, settings_all, _source_key(settings_all))
+        np.testing.assert_array_equal(np.asarray(out), np.asarray(direct_out))
+
+    def test_a_stroke_that_finds_nothing_still_matches(self):
+        """Painting on clean film contributes no score — the incremental path must not
+        treat that as if the earlier strokes' bake had changed."""
+        img, strokes = _scene()
+        shape = img.shape[:2]
+        clean_stroke = _stroke(0.5, 0.5, shape, diameter_px=6.0)  # nothing there
+        proc = ImageProcessor()
+        settings1 = _config(strokes[:1])
+        proc._manual_bake(img, settings1, _source_key(settings1))
+        settings2 = _config(strokes[:1] + [clean_stroke])
+        got, _ = proc._manual_bake(img, settings2, _source_key(settings2))
+        want, _ = ImageProcessor()._manual_bake(img, settings2, _source_key(settings2))
+        np.testing.assert_array_equal(np.asarray(got), np.asarray(want))
+
+    def test_removing_a_stroke_falls_back_and_still_matches(self):
+        """Not a strict append (an undo) — must recompute correctly, not serve a stale
+        3-stroke result trimmed to 2."""
+        img, strokes = _scene()
+        proc = ImageProcessor()
+        settings3 = _config(strokes)
+        proc._manual_bake(img, settings3, _source_key(settings3))
+
+        settings2 = _config(strokes[:2])
+        got, _ = proc._manual_bake(img, settings2, _source_key(settings2))
+        want, _ = ImageProcessor()._manual_bake(img, settings2, _source_key(settings2))
+        np.testing.assert_array_equal(np.asarray(got), np.asarray(want))
+
+    def test_a_new_source_key_falls_back_and_still_matches(self):
+        """A different bake (flatfield toggle, new file) must not reuse another
+        source's cached baseline."""
+        img, strokes = _scene()
+        proc = ImageProcessor()
+        settings = _config(strokes[:2])
+        proc._manual_bake(img, settings, _source_key(settings) + "|other")
+        got, _ = proc._manual_bake(img, settings, _source_key(settings))
+        want, _ = ImageProcessor()._manual_bake(img, settings, _source_key(settings))
+        np.testing.assert_array_equal(np.asarray(got), np.asarray(want))
+
+
+class TestIncrementalSkipsUnchangedWork:
+    def test_appending_a_stroke_only_scores_the_new_one(self):
+        """The regression this module exists to fix: adding stroke N+1 must not re-run
+        detection for strokes 1..N."""
+        img, strokes = _scene()
+        proc = ImageProcessor()
+        seen_counts: list[int] = []
+        real = ip_mod.strokes_to_score
+
+        def counting(image, s, spots):
+            seen_counts.append(len(s))
+            return real(image, s, spots)
+
+        with patch.object(ip_mod, "strokes_to_score", side_effect=counting):
+            for n in range(1, len(strokes) + 1):
+                settings = _config(strokes[:n])
+                proc._manual_bake(img, settings, _source_key(settings))
+
+        assert seen_counts == [1, 1, 1], f"expected one new stroke scored per call, got {seen_counts}"
+
+    def test_appending_a_stroke_only_fills_the_new_component(self):
+        """apply_score_repair does the actual pixel fill per connected component; a
+        previously-filled, untouched component must not be redone. repair_components
+        looks the name up in its own defining module (retouch.logic), not image_processor's
+        imported reference to it, so that is what has to be patched."""
+        from negpy.features.retouch import logic as retouch_logic
+
+        img, strokes = _scene()
+        proc = ImageProcessor()
+        call_counts: list[int] = []
+        real = retouch_logic.apply_score_repair
+
+        def counting(*a, **k):
+            call_counts.append(1)
+            return real(*a, **k)
+
+        with patch.object(retouch_logic, "apply_score_repair", side_effect=counting):
+            for n in range(1, len(strokes) + 1):
+                call_counts.clear()
+                settings = _config(strokes[:n])
+                proc._manual_bake(img, settings, _source_key(settings))
+                assert call_counts == [1], f"expected exactly one fill for the new component at {n} strokes, got {len(call_counts)}"


### PR DESCRIPTION
## Problem

`manual_bake_token` hashes the *whole* `manual_heal_strokes` list as one blob, and `_manual_bake`'s cache is keyed on that single token — so adding one more stroke invalidates the entire bake, not just its own patch:

- `strokes_to_score()` re-walks **every stroke painted so far** — each gets its own crop, density conversion, local-blur z-score, connected-components pass, and distance transform.
- `repair_components()` re-runs the actual pixel fill for **every** defect's connected component again, not just the new one.

A session spotting a dusty scan with N heal strokes does roughly N passes of increasing size — stroke 5 redoes 5 regions, stroke 30 redoes 30 — so painting gets progressively, noticeably slower the more you use it on one frame.

## Fix

`_manual_bake` now keeps an incremental baseline. When the strokes/spots/lines are a strict extension of what was baked last time (same source image, same scratch threshold), only the *new* entries run through detection, and `repair_components` only re-fills the connected components they actually touch — everything else is copied from the previous fill unchanged. Undoing past the cached baseline, editing `scratch_threshold`, or a new source falls back to a full recompute, exactly like today.

Keyed on **object identity** (`img is self._manual_inc_img`), not `source_key`: `source_key` folds in `manual_bake_token`, which changes on every single stroke by design (it's also what invalidates the GPU/CPU engine's uploaded source texture), so it could never match between two stroke counts if used as the incremental gate — nothing upstream of the manual bake reads the strokes, so the same decoded buffer object recurs across a painting session, which is what actually makes the gate work.

`repair_components` gets two new optional kwargs, `base_out`/`dirty`, for the incremental reuse — every existing caller (the IR and detected-speck bakes) leaves them `None` and gets exactly today's from-scratch fill; nothing else changes for them.

## Tests

`tests/test_manual_bake_incremental.py`:
- Incremental output matches a from-scratch recompute at every step of a painting sequence, appending all at once, a stroke that finds nothing, removing a stroke (fallback), and a new source (fallback).
- The actual speedup, proven by counting `strokes_to_score`/`apply_score_repair` calls across a painting sequence — confirms each new stroke only triggers detection/fill for itself, not the accumulated list.

Full suite: 5445 passed (this repo's current `main`), one pre-existing unrelated failure (macOS Qt tooltip-rendering quirk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)