### PR TITLE
fix(canvas): stop a stale texture view from raising during draw

### DIFF
--- a/negpy/desktop/view/canvas/gpu_widget.py
+++ b/negpy/desktop/view/canvas/gpu_widget.py
@@ -468,26 +468,37 @@ class GPUCanvasWidget(QWidget):
                 ),
             )
 
-            bind_group = self.device.create_bind_group(
-                layout=self.bind_group_layout,
-                entries=[
-                    {"binding": 0, "resource": self.current_texture_view},
-                    {
-                        "binding": 1,
-                        "resource": {
-                            "buffer": self.uniform_buffer,
-                            "offset": 0,
-                            "size": 48,
+            try:
+                bind_group = self.device.create_bind_group(
+                    layout=self.bind_group_layout,
+                    entries=[
+                        {"binding": 0, "resource": self.current_texture_view},
+                        {
+                            "binding": 1,
+                            "resource": {
+                                "buffer": self.uniform_buffer,
+                                "offset": 0,
+                                "size": 48,
+                            },
                         },
-                    },
-                    {"binding": 2, "resource": self.lut_view},
-                    {"binding": 3, "resource": self.lut_sampler},
-                ],
-            )
+                        {"binding": 2, "resource": self.lut_view},
+                        {"binding": 3, "resource": self.lut_sampler},
+                    ],
+                )
+            except (RuntimeError, wgpu.GPUError) as exc:
+                # The engine's texture pool can destroy a size it no longer needs (e.g. a
+                # border/crop change resizes the paper texture) one render generation after
+                # update_texture() last handed this widget a view onto it. A stray repaint
+                # (resize/expose) landing in that window would otherwise raise here; skip
+                # this one frame like the swapchain-unavailable case above -- the next real
+                # frame calls update_texture() with a fresh view and self-heals.
+                logger.debug("stale texture view during draw: %s", exc)
+                bind_group = None
 
-            pass_enc.set_pipeline(self.render_pipeline)
-            pass_enc.set_bind_group(0, bind_group)
-            pass_enc.draw(4, 1, 0, 0)
+            if bind_group is not None:
+                pass_enc.set_pipeline(self.render_pipeline)
+                pass_enc.set_bind_group(0, bind_group)
+                pass_enc.draw(4, 1, 0, 0)
 
         pass_enc.end()
         self.device.queue.submit([enc.finish()])


### PR DESCRIPTION
## Summary
- Dragging Finish > Border Width (or any control that resizes the paper output — crop, aspect ratio) changes paper_w/paper_h every frame, so GPUEngine's texture pool retires the previous size's tex_final via evict_stale_textures() one render generation later.
- GPUCanvasWidget._draw_frame() also fires independently on resize/expose/window-move, so a repaint landing in that window could call create_bind_group() against an already-destroyed texture, raising GPUValidationError: "Texture ... has been destroyed". It escaped uncaught into rendercanvas's own exception logger — non-fatal (self-heals next frame) but noisy.
- Wrapped the bind-group creation in the same try/except style already used a few lines up for the swapchain-unavailable case, since GPUValidationError is a subclass of wgpu.GPUError: on that race, skip drawing this one frame and log at debug instead of leaking the traceback.

## Test plan
- [ ] Reproduce pre-fix: drag the Border Width slider while resizing the window; confirm the traceback appears
- [ ] Confirm it no longer appears with this change
- [ ] `python -m py_compile negpy/desktop/view/canvas/gpu_widget.py` passes
