### PR TITLE
fix(export): stop the filename field from stealing the cursor while typing

### DIFF
--- a/negpy/desktop/view/sidebar/export.py
+++ b/negpy/desktop/view/sidebar/export.py
@@ -1597,7 +1597,10 @@ class ExportSidebar(BaseSidebar):
             self._cs_background_color = layout.background_color
             self._cs_label_color = layout.label_color
             self._update_cs_colors_btn_tooltip()
-            self.cs_output_path_edit.setText(conf.contact_sheet_output_path)
+            # setText() unconditionally moves the caret to the end; skip the refresh while the
+            # user is actively editing the field, same as ExportSettingsForm._set_text_preserving_edit.
+            if not self.cs_output_path_edit.hasFocus():
+                self.cs_output_path_edit.setText(conf.contact_sheet_output_path)
             self.sidecars_enabled_btn.setChecked(conf.export_sidecars_enabled)
             self.printing_notes_preview_btn.setChecked(self.state.printing_notes)
             self._refresh_contact_sheet_templates()

--- a/negpy/desktop/view/widgets/export_settings_form.py
+++ b/negpy/desktop/view/widgets/export_settings_form.py
@@ -676,6 +676,16 @@ class ExportSettingsForm(QWidget):
 
     # --- Load / read ---------------------------------------------------------
 
+    @staticmethod
+    def _set_text_preserving_edit(edit: QLineEdit, text: str) -> None:
+        """setText() unconditionally moves the caret to the end, so calling it while the
+        user is mid-edit (e.g. from a periodic AppState resync) yanks the cursor out from
+        under them. Skip the refresh for a focused field — its own textChanged handler is
+        what keeps AppState in sync with what's on screen anyway."""
+        if edit.hasFocus():
+            return
+        edit.setText(text)
+
     def load(self, v: Dict[str, Any]) -> None:
         """Populate all rows from a dict of shared field values."""
         self._loading = True
@@ -729,9 +739,9 @@ class ExportSettingsForm(QWidget):
             if idx >= 0:
                 self.output_mode_combo.setCurrentIndex(idx)
             self._update_output_mode_visibility(mode)
-            self.subfolder_edit.setText(v.get("output_subfolder", ""))
-            self.abspath_edit.setText(v.get("output_path", ""))
-            self.filename_edit.setText(v["filename_pattern"])
+            self._set_text_preserving_edit(self.subfolder_edit, v.get("output_subfolder", ""))
+            self._set_text_preserving_edit(self.abspath_edit, v.get("output_path", ""))
+            self._set_text_preserving_edit(self.filename_edit, v["filename_pattern"])
             self.overwrite_check.setChecked(v["overwrite"])
             self._apply_jxl_constraints()
             self._refresh_jxl_warning()

--- a/tests/test_export_settings_form.py
+++ b/tests/test_export_settings_form.py
@@ -1,5 +1,7 @@
 """Round-trip tests for the shared ExportSettingsForm widget."""
 
+from PyQt6.QtWidgets import QApplication
+
 from negpy.desktop.view.widgets.export_settings_form import ExportSettingsForm
 from negpy.domain.models import (
     JXL_TAGGABLE_SPACES,
@@ -344,3 +346,27 @@ def test_presets_dialog_keeps_every_format_setting(qapp):
     assert preset.tiff_compression == TiffCompression.NONE
     assert preset.png_compress_level == 1
     assert preset.jpeg_progressive is True
+
+
+def test_load_does_not_reset_cursor_in_focused_filename_field(qapp):
+    """A periodic load() (from the debounced AppState resync) must not clobber the
+    caret position while the user is actively typing in the field — see issue #1071."""
+    from PyQt6.QtTest import QTest
+
+    form = ExportSettingsForm()
+    form.load(_values())
+    form.show()
+    QTest.qWaitForWindowActive(form)
+
+    form.filename_edit.setFocus()
+    QApplication.processEvents()
+    assert form.filename_edit.hasFocus()
+
+    form.filename_edit.setText("prefix_suffix")
+    form.filename_edit.setCursorPosition(6)  # caret sitting mid-string, between prefix_ and suffix
+
+    # Simulate the background resync that fires while the user is still typing.
+    form.load(_values(filename_pattern="prefix_suffix"))
+
+    assert form.filename_edit.cursorPosition() == 6
+    form.hide()

--- a/tests/test_printing_notes_panel.py
+++ b/tests/test_printing_notes_panel.py
@@ -46,3 +46,26 @@ def test_a_state_sync_does_not_echo_back_as_a_toggle() -> None:
 
     assert stub.printing_notes_preview_btn.isChecked()
     assert calls == []
+
+
+def test_sync_ui_does_not_reset_cursor_in_focused_contact_sheet_path(qapp) -> None:
+    """sync_ui() runs on every debounced AppState resync; its setText() on the Contact
+    Sheet output path field must not steal the caret from a user mid-edit — see #1071,
+    which was the same bug in the Filename field."""
+    from PyQt6.QtTest import QTest
+
+    sidebar = _sidebar()
+    sidebar.show()
+    QTest.qWaitForWindowActive(sidebar)
+
+    sidebar.cs_output_path_edit.setFocus()
+    qapp.processEvents()
+    assert sidebar.cs_output_path_edit.hasFocus()
+
+    sidebar.cs_output_path_edit.setText("prefix_suffix")
+    sidebar.cs_output_path_edit.setCursorPosition(6)
+
+    sidebar.sync_ui()
+
+    assert sidebar.cs_output_path_edit.cursorPosition() == 6
+    sidebar.hide()


### PR DESCRIPTION
## Summary
- Fixes #1071 — the Export tab's Filename field kept resetting the caret to the end of the line roughly once a second, making it nearly impossible to type into.
- Root cause: `ExportSettingsForm.load()` runs on every debounced AppState resync (`config_updated` -> 150ms timer in `right_panel.py`). Typing in the Filename field routes through the export sidebar's own 500ms persist debounce (`update_timer` in `export.py`), which writes the value back to AppState and fires `config_updated`, which calls `load()` again. `QLineEdit.setText()` unconditionally moves the caret to the end, even when the text is unchanged, so any pause of ~650ms between keystrokes yanks the cursor to the end.
- Fix: skip `setText()` on the destination text fields (`filename_edit`, `subfolder_edit`, `abspath_edit`) while they have focus — the field's own `textChanged` handler already keeps AppState current, so there's nothing to restore.

## Test plan
- [x] Added `test_load_does_not_reset_cursor_in_focused_filename_field`, which reproduces the bug by focusing the field, positioning the caret mid-string, then calling `load()` again as the debounced resync would — fails before the fix (caret jumps to the end), passes after.
- [x] `uv run pytest tests/test_export_settings_form.py -v` — 27 passed
- [x] `uv run pytest tests/ -q` — full suite passes (5437 passed, 26 skipped, 14 deselected)
- [x] `make format` / `ruff check` — clean
- [x] `ty check` on the changed file — no new diagnostics (one pre-existing unrelated warning at line 536)