### PR TITLE
fix(ui): keyboard-step a fractional slider by its declared step, not 1/precision

### DIFF
--- a/negpy/desktop/view/sidebar/geometry.py
+++ b/negpy/desktop/view/sidebar/geometry.py
@@ -144,19 +144,21 @@ class GeometrySidebar(BaseSidebar):
         # Internally geometry.fine_rotation keeps the cv2/warp convention, where positive is
         # counter-clockwise and flip-independent because flips apply before fine rotation, so
         # saved edits keep their meaning: display = -stored at this boundary.
-        self.fine_rot_slider = CompactSlider("Fine Rotation", -FINE_ROTATION_LIMIT, FINE_ROTATION_LIMIT, -conf.fine_rotation, unit="°")
+        self.fine_rot_slider = CompactSlider(
+            "Fine Rotation", -FINE_ROTATION_LIMIT, FINE_ROTATION_LIMIT, -conf.fine_rotation, step=0.1, unit="°"
+        )
         align_row.addWidget(self.fine_rot_slider, 1)
         align_row.addWidget(self.straighten_btn, 0)
         self.layout.addLayout(align_row)
 
-        self.converge_v_slider = CompactSlider("Tilt", -15.0, 15.0, conf.converge_v, unit="%")
+        self.converge_v_slider = CompactSlider("Tilt", -15.0, 15.0, conf.converge_v, step=0.1, unit="%")
         self.converge_v_slider.setToolTip(
             "Easel Tilt: tip the easel about a horizontal axis to straighten converging verticals, "
             "the building that leans back because the camera pointed up. Positive stretches the top "
             "edge. Per-cent of the frame, what you would measure on the easel, not a tilt angle: "
             "the same tilt keystones differently at every enlargement."
         )
-        self.converge_h_slider = CompactSlider("Swing", -15.0, 15.0, conf.converge_h, unit="%")
+        self.converge_h_slider = CompactSlider("Swing", -15.0, 15.0, conf.converge_h, step=0.1, unit="%")
         self.converge_h_slider.setToolTip(
             "Easel Swing: the same movement about a vertical axis, for converging horizontals. A "
             "wall shot from one side, or a copy stand not square to the film. Positive stretches "

--- a/negpy/desktop/view/widgets/sliders.py
+++ b/negpy/desktop/view/widgets/sliders.py
@@ -313,10 +313,13 @@ class CompactSlider(BaseSlider):
         self._edited_dot = EditedDot()
 
         self.spin.setSingleStep(step)
+        # The slider's own arrow-key step lives in its internal precision-scaled int
+        # space; without the scaling, a fractional step (most of them) never reaches
+        # it and every slider falls back to Qt's raw 1-unit default (1/precision).
+        self.slider.setSingleStep(max(1, round(step * precision)))
         if step >= 1.0:
             self.spin.setDecimals(0)
             self.slider.setTickInterval(int(step))
-            self.slider.setSingleStep(int(step))
 
         if unit:
             self.spin.setSuffix(unit)

--- a/tests/test_slider_widgets.py
+++ b/tests/test_slider_widgets.py
@@ -36,6 +36,25 @@ def test_adjust_by_clamps_to_range(qapp):
     assert slider.value() == 0.0
 
 
+def test_slider_keyboard_step_matches_the_declared_step(qapp):
+    """The slider's own arrow-key step lives in its internal precision-scaled int
+    space. Passing step=0.1 at precision=100 must move the handle by 0.1, not by
+    Qt's raw 1-unit default (1/precision = 0.01), which read as no movement at all."""
+    slider = CompactSlider("Fine Rotation", -45.0, 45.0, 0.0, step=0.1)
+    assert slider.slider.singleStep() == 10  # 0.1 * precision(100)
+
+
+def test_slider_keyboard_step_scales_with_a_nondefault_precision(qapp):
+    slider = CompactSlider("Hue Trim", -30.0, 30.0, 0.0, step=0.5, precision=10)
+    assert slider.slider.singleStep() == 5  # 0.5 * precision(10)
+
+
+def test_integer_slider_keyboard_step_is_unaffected(qapp):
+    """precision=1 sliders (ISO, grade points) already worked; the fix must not move them."""
+    slider = CompactSlider("Grade", -40.0, 40.0, 0.0, step=5.0, precision=1)
+    assert slider.slider.singleStep() == 5
+
+
 def test_label_scrub_debounces_value_changes(qapp):
     """The handle must never wait on a render.
 


### PR DESCRIPTION
Slider that rotates the images (and others) are basically unusable by using the keyboard as the keyboard steps is super small, this pr changes that.

from the AI:

CompactSlider's own arrow-key step lives in the slider's internal precision-scaled integer space, but only ever got set when `step >= 1.0` — using `int(step)` as the raw integer value directly, which is only correct at `precision=1`. Every fractional-precision slider with an explicit `step` (lith/cyanotype exposure, burn, feather, hue trim, render exposure…) had that step silently ignored by the slider widget itself, which fell back to Qt's raw default of 1 internal unit — `1/precision` in real units, invisible on a wide range. Grade, at `precision=100` with `step=1.0`, moved 0.01 ISO-R points per arrow press instead of the declared 1.0.

Fixed by always scaling `step` through `precision` for the slider's own `singleStep`, independent of the `>= 1.0` branch (which stays for tick spacing and integer display).

Also gives Fine Rotation, Tilt and Swing an explicit `step=0.1` (was the default `0.01`, which happened to match Qt's old fallback exactly, so the wiring fix alone would not have changed anything for them) — an arrow press on any of the three was imperceptible on a ±45°/±15% range.