### PR TITLE
fix(canvas): make a peek say it is on, and let Esc leave it

### DIFF
--- a/docs/KEYBOARD.md
+++ b/docs/KEYBOARD.md
@@ -43,8 +43,10 @@ Numpad keys can be bound separately from the number row (for example `Num+9` and
 | `Shift + R` | Toggle Analysis Region draw |
 | `Shift + T` | Print the density × grade test strip |
 | `Shift + F` | Print the color ring-around (M/Y filtration) |
-| `\|` | Peek flat scan (digital intermediate preview) |
-| `Esc` | First press clears in-progress points. Second press puts the tool down |
+| `M` | Peek flat scan (digital intermediate preview) |
+| `N` | Peek negative (the source as it was loaded) |
+| `\` | Before/after split against the auto baseline |
+| `Esc` | Leaves whatever has the canvas (peek, before/after split, test strip). Otherwise clears in-progress points, then puts the tool down |
 
 ## Geometry and orientation
 | Key | Action |

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -24,11 +24,13 @@ If Windows blocks writes to NegPy's default data folder, NegPy suggests `%LOCALA
 
 The canvas toolbar's **◑** button (or `\`) splits the canvas in two. Left of the divider is the auto baseline: the same frame with the same film process, crop and rotation, but with every creative control (exposure, tone, Lab, dodge/burn, toning, retouch and finishing) back at its default. Right of it is your edit. Drag the divider to move the split, or grab its knob in the middle.
 
-The split stays up while you work, so a slider moves the after side against a fixed reference. Press `\` again, or move to another frame, to close it. Peek Negative, Peek Flat Scan and the test strip take the canvas over, so they close it too.
+The split stays up while you work, so a slider moves the after side against a fixed reference. Press `\` or `Esc`, or move to another frame, to close it. Peek Negative, Peek Flat Scan and the test strip take the canvas over, so they close it too.
 
 ### Peek Negative
 
 The canvas toolbar's film button (or `N`) shows the scan as it was loaded: the negative, un-inverted, with no metering, no film-base normalization and none of your edits. Use it to judge the scan rather than the print: whether the frame is thin or dense, what color the mask really is, whether the scanner clipped. It changes nothing and closes as soon as you touch a control. Your crop, rotation and flip still apply, so the frame stays where you put it. The frame is color managed, so a C-41 mask is as orange here as in the file, and Linear RAW does not change how it looks, except on a narrowband capture, where white balance never applies at all (there is no full-spectrum scene for it to describe), so Linear RAW on shows the true neutral scan and off shows the camera's own (meaningless) as-shot cast. The soft proof stays off: this is the scan, not a print.
+
+While either peek is up the canvas carries a **NEGATIVE** or **FLAT SCAN** badge in its top corner, and the menu item shows a checkmark, so a view you left on is never mistaken for a broken render. `Esc` leaves whichever view has the canvas — either peek, the before/after split, or a test strip.
 
 ### The workflow (and the order things happen)
 

--- a/negpy/desktop/view/canvas/overlay.py
+++ b/negpy/desktop/view/canvas/overlay.py
@@ -737,6 +737,10 @@ class CanvasOverlay(QWidget):
         if self._compare_split_active() and content_aligned:
             self._draw_compare_split(painter)
 
+        # Exclusive with the split above, so the two badges cannot land on each other.
+        if self.state.negative_peek or self.state.flat_peek:
+            self._draw_peek_badge(painter)
+
         # Last: the glass sits over everything else and claims no content rect, so it stays out
         # of the exclusion ladder above. It is suppressed wherever something else replaced the
         # frame with a *different* QImage than `_qimage` holds (the test strip's mosaic, the raw
@@ -827,17 +831,27 @@ class CanvasOverlay(QWidget):
         painter.drawText(knob, Qt.AlignmentFlag.AlignCenter, "◂▸")
 
         if x - target.left() > 92:
-            self._draw_compare_label(painter, "BEFORE", target.left() + 12, target.top() + 12)
+            self._draw_view_badge(painter, "BEFORE", target.left() + 12, target.top() + 12)
         if target.right() - x > 92:
-            self._draw_compare_label(painter, "AFTER", target.right() - 80, target.top() + 12)
+            self._draw_view_badge(painter, "AFTER", target.right() - 80, target.top() + 12)
 
-    def _draw_compare_label(self, painter: QPainter, text: str, x: float, y: float) -> None:
-        badge = QRectF(x, y, 68, 22)
+    def _draw_view_badge(self, painter: QPainter, text: str, x: float, y: float, width: float = 68.0) -> None:
+        badge = QRectF(x, y, width, 22)
         painter.setBrush(QColor(0, 0, 0, 170))
         painter.setPen(Qt.PenStyle.NoPen)
         painter.drawRoundedRect(badge, 4, 4)
         painter.setPen(QColor(THEME.accent_primary))
         painter.drawText(badge, Qt.AlignmentFlag.AlignCenter, text)
+
+    def _draw_peek_badge(self, painter: QPainter) -> None:
+        """Name the peek on the canvas. A peek replaces the print with something that is not
+        one, and the only other thing that says so is a toolbar button off at the edge."""
+        text = "NEGATIVE" if self.state.negative_peek else "FLAT SCAN"
+        rect = self._content_view_rect()
+        if rect.isEmpty():
+            return
+        width = painter.fontMetrics().horizontalAdvance(text) + 24.0
+        self._draw_view_badge(painter, text, rect.left() + 12, rect.top() + 12, width)
 
     def _draw_brush(self, painter: QPainter) -> None:
         radius = self._brush_screen_radius(self.state.config.retouch.manual_dust_size)

--- a/negpy/desktop/view/canvas/toolbar.py
+++ b/negpy/desktop/view/canvas/toolbar.py
@@ -265,6 +265,8 @@ class ActionToolbar(QWidget):
         # current canvas width. "More actions" is a stable, complete menu the user can always
         # find everything in, not a residue of the row's responsive collapse. It used to lose
         # entries whenever a side panel toggle gave the row enough width to show them directly.
+        # A checkable item carries no icon. Under the app stylesheet Qt draws a menu icon in
+        # the check column, and the checkmark is the only thing that says the view is on.
         self._ov_hq_action = overflow_menu.addAction("Toggle HQ Preview")
         self._ov_hq_action.setCheckable(True)
         self._ov_hq_action.setToolTip("Toggle High Quality Preview")
@@ -281,17 +283,17 @@ class ActionToolbar(QWidget):
                 "zoom_100",
             )
         )
-        self._ov_compare_action = overflow_menu.addAction(qta.icon("fa5s.adjust", color=icon_color), "Before / After")
+        self._ov_compare_action = overflow_menu.addAction("Before / After")
         self._ov_compare_action.setCheckable(True)
         self._ov_compare_action.setToolTip(
             tooltip_with_shortcut("Before / After — split against the auto baseline, drag the divider", "toggle_compare")
         )
-        self._ov_flat_peek_action = overflow_menu.addAction(qta.icon("fa5s.eye", color=icon_color), "Peek Flat Scan")
+        self._ov_flat_peek_action = overflow_menu.addAction("Peek Flat Scan")
         self._ov_flat_peek_action.setCheckable(True)
         self._ov_flat_peek_action.setToolTip(
             tooltip_with_shortcut("Peek flat scan — temporarily show the flat master (does not change your edit)", "toggle_flat_peek")
         )
-        self._ov_negative_peek_action = overflow_menu.addAction(qta.icon("fa5s.film", color=icon_color), "Peek Negative")
+        self._ov_negative_peek_action = overflow_menu.addAction("Peek Negative")
         self._ov_negative_peek_action.setCheckable(True)
         self._ov_negative_peek_action.setToolTip(
             tooltip_with_shortcut(
@@ -299,12 +301,12 @@ class ActionToolbar(QWidget):
                 "toggle_negative_peek",
             )
         )
-        self._ov_zones_action = overflow_menu.addAction(qta.icon("mdi.grid", color=icon_color), "Zone Overlay")
+        self._ov_zones_action = overflow_menu.addAction("Zone Overlay")
         self._ov_zones_action.setCheckable(True)
         self._ov_zones_action.setToolTip(
             tooltip_with_shortcut("Zone overlay — label each region of the print with its Adams zone", "toggle_zones")
         )
-        self._ov_loupe_action = overflow_menu.addAction(qta.icon("fa5s.search-plus", color=icon_color), "Grain Focuser")
+        self._ov_loupe_action = overflow_menu.addAction("Grain Focuser")
         self._ov_loupe_action.setCheckable(True)
         self._ov_loupe_action.setToolTip(
             tooltip_with_shortcut(
@@ -323,10 +325,10 @@ class ActionToolbar(QWidget):
         self._ov_rot_l_action.setToolTip(tooltip_with_shortcut("Rotate CCW", "rotate_ccw"))
         self._ov_rot_r_action = overflow_menu.addAction(qta.icon("mdi6.file-rotate-right", color=icon_color), "Rotate CW")
         self._ov_rot_r_action.setToolTip(tooltip_with_shortcut("Rotate CW", "rotate_cw"))
-        self._ov_flip_h_action = overflow_menu.addAction(qta.icon("fa5s.arrows-alt-h", color=icon_color), "Flip Horizontal")
+        self._ov_flip_h_action = overflow_menu.addAction("Flip Horizontal")
         self._ov_flip_h_action.setCheckable(True)
         self._ov_flip_h_action.setToolTip(tooltip_with_shortcut("Flip Horizontal", "flip_h"))
-        self._ov_flip_v_action = overflow_menu.addAction(qta.icon("fa5s.arrows-alt-v", color=icon_color), "Flip Vertical")
+        self._ov_flip_v_action = overflow_menu.addAction("Flip Vertical")
         self._ov_flip_v_action.setCheckable(True)
         self._ov_flip_v_action.setToolTip(tooltip_with_shortcut("Flip Vertical", "flip_v"))
         overflow_menu.addSeparator()

--- a/negpy/desktop/view/keyboard_shortcuts.py
+++ b/negpy/desktop/view/keyboard_shortcuts.py
@@ -29,11 +29,22 @@ def _context_undo(controller) -> None:
 
 
 def _context_cancel(controller, window) -> None:
-    """Esc ladder: a test strip is dismissed first (it owns the canvas while up), then the
-    grain focuser loupe, then an armed zone, then in-progress tool geometry (polyline
-    points, straighten line, zone pins), then the tool itself."""
+    """Esc ladder: whatever has taken the canvas over goes first — a test strip, either peek,
+    the before/after split — then the grain focuser loupe, then an armed zone, then
+    in-progress tool geometry (polyline points, straighten line, zone pins), then the tool
+    itself. Each of those is a view the user is inside and has to get out of, and a toggle
+    they have to find again to leave is the thing Esc is for."""
     if controller.state.test_strip or controller.state.test_strip_pending:
         controller.toggle_test_strip(force=False)
+        return
+    if controller.state.negative_peek:
+        controller.toggle_negative_peek(force=False)
+        return
+    if controller.state.flat_peek:
+        controller.toggle_flat_peek(force=False)
+        return
+    if controller.state.compare_mode:
+        controller.toggle_compare()
         return
     if controller.state.grain_focuser:
         controller.toggle_grain_focuser(force=False)

--- a/negpy/desktop/view/shortcut_registry.py
+++ b/negpy/desktop/view/shortcut_registry.py
@@ -63,7 +63,7 @@ REGISTRY: dict[str, ShortcutEntry] = {
     "toggle_grain_focuser": ShortcutEntry("Shift+L", "Grain focuser loupe", "Tools"),
     "toggle_printing_notes": ShortcutEntry("Shift+N", "Printing notes (dodge/burn map + print recipe)", "Tools"),
     "toggle_soft_proof": ShortcutEntry("Shift+P", "Soft proof the print on screen", "Tools"),
-    "cancel_tool": ShortcutEntry("Esc", "Cancel active tool (first press clears in-progress points)", "Tools"),
+    "cancel_tool": ShortcutEntry("Esc", "Leave the current view (peek, split, strip) or cancel the active tool", "Tools"),
     "cyan_dec": ShortcutEntry("", "Cyan down", "Exposure"),
     "cyan_inc": ShortcutEntry("", "Cyan up", "Exposure"),
     "magenta_down": ShortcutEntry("D", "Magenta down", "Exposure"),

--- a/tests/test_canvas_polyline_finish.py
+++ b/tests/test_canvas_polyline_finish.py
@@ -188,6 +188,9 @@ def test_context_cancel_two_stage() -> None:
     controller, window = MagicMock(), MagicMock()
     controller.state.test_strip = False
     controller.state.test_strip_pending = False
+    controller.state.negative_peek = False
+    controller.state.flat_peek = False
+    controller.state.compare_mode = False
     controller.state.grain_focuser = False
     controller.state.zone_arm_target = None
     controller.state.zone_pins = []
@@ -207,6 +210,9 @@ def test_context_cancel_dismisses_a_test_strip_before_any_tool() -> None:
 
     controller, window = MagicMock(), MagicMock()
     controller.state.test_strip_pending = False
+    controller.state.negative_peek = False
+    controller.state.flat_peek = False
+    controller.state.compare_mode = False
     controller.state.grain_focuser = False
     window.canvas.overlay.cancel_in_progress.return_value = True
 
@@ -233,6 +239,9 @@ def test_context_cancel_closes_the_grain_focuser_before_any_tool() -> None:
     controller, window = MagicMock(), MagicMock()
     controller.state.test_strip = False
     controller.state.test_strip_pending = False
+    controller.state.negative_peek = False
+    controller.state.flat_peek = False
+    controller.state.compare_mode = False
     controller.state.grain_focuser = True
     window.canvas.overlay.cancel_in_progress.return_value = True
 
@@ -289,3 +298,49 @@ def test_fresh_crop_draw_keeps_immediate_feel() -> None:
     overlay.mouseReleaseEvent(_mouse_event(QEvent.Type.MouseButtonRelease, QPointF(20, 20), Qt.MouseButton.NoButton))
 
     assert len(emitted) == 1
+
+
+def test_context_cancel_leaves_a_view_that_owns_the_canvas_before_any_tool() -> None:
+    """A peek and the split are views the user is inside, so Esc is how you get out: the
+    toggle that opened one sits in a toolbar the user has to go back and find."""
+    from unittest.mock import MagicMock
+
+    from negpy.desktop.view.keyboard_shortcuts import _context_cancel
+
+    def _fixture():
+        controller, window = MagicMock(), MagicMock()
+        controller.state.test_strip = False
+        controller.state.test_strip_pending = False
+        controller.state.negative_peek = False
+        controller.state.flat_peek = False
+        controller.state.compare_mode = False
+        controller.state.grain_focuser = False
+        window.canvas.overlay.cancel_in_progress.return_value = True
+        return controller, window
+
+    controller, window = _fixture()
+    controller.state.negative_peek = True
+    _context_cancel(controller, window)
+    controller.toggle_negative_peek.assert_called_once_with(force=False)
+    window.canvas.overlay.cancel_in_progress.assert_not_called()
+    controller.cancel_active_tool.assert_not_called()
+
+    controller, window = _fixture()
+    controller.state.flat_peek = True
+    _context_cancel(controller, window)
+    controller.toggle_flat_peek.assert_called_once_with(force=False)
+    controller.cancel_active_tool.assert_not_called()
+
+    controller, window = _fixture()
+    controller.state.compare_mode = True
+    _context_cancel(controller, window)
+    controller.toggle_compare.assert_called_once_with()
+    controller.cancel_active_tool.assert_not_called()
+
+    # The strip still outranks them: it is the one that replaces the frame entirely.
+    controller, window = _fixture()
+    controller.state.test_strip = True
+    controller.state.negative_peek = True
+    _context_cancel(controller, window)
+    controller.toggle_test_strip.assert_called_once_with(force=False)
+    controller.toggle_negative_peek.assert_not_called()

--- a/tests/test_canvas_toolbar.py
+++ b/tests/test_canvas_toolbar.py
@@ -148,6 +148,7 @@ class TestCanvasToolbarResponsive(unittest.TestCase):
             tb._ov_original_action,
             tb._ov_compare_action,
             tb._ov_flat_peek_action,
+            tb._ov_negative_peek_action,
             tb._ov_zones_action,
             tb._ov_loupe_action,
             tb._ov_undo_action,
@@ -192,6 +193,15 @@ class TestCanvasToolbarResponsive(unittest.TestCase):
         ):
             self.assertNotIn(gone, labels)
         self.assertTrue(any("Preferences" in label for label in labels))
+
+    def test_a_checkable_overflow_item_carries_no_icon(self):
+        """Under the app stylesheet Qt draws a menu icon in the check column, so an icon on
+        a checkable item costs the checkmark — and with it the only sign in the menu that
+        the view is already on."""
+        tb = _make_toolbar()
+        for action in self._all_overflow_actions(tb):
+            if action.isCheckable():
+                self.assertTrue(action.icon().isNull(), f"{action.text()!r} would lose its checkmark to its icon")
 
     def test_overflow_menu_always_shows_full_action_set(self):
         """Regression: the overflow menu previously mirrored only whatever the row's

--- a/tests/test_compare_split.py
+++ b/tests/test_compare_split.py
@@ -246,3 +246,33 @@ class TestControllerKeepsTheSplit(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestPeekBadge(unittest.TestCase):
+    """A peek replaces the print with something that is not one. The badge is what says so
+    on the canvas itself; the toolbar toggle that opened it is off at the edge of the view."""
+
+    @staticmethod
+    def _painted(**flags) -> QPixmap:
+        overlay = _overlay(compare_mode=False, before=False)
+        for name, value in flags.items():
+            setattr(overlay.state, name, value)
+        pixmap = QPixmap(W, H)
+        pixmap.fill()
+        painter = QPainter(pixmap)
+        overlay._draw_ui(painter)
+        painter.end()
+        return pixmap
+
+    @staticmethod
+    def _badge_pixels(pixmap: QPixmap) -> int:
+        """Non-white pixels in the badge's corner of an otherwise blank canvas."""
+        image = pixmap.toImage()
+        return sum(1 for y in range(12, 34) for x in range(12, 120) if image.pixelColor(x, y).lightness() < 200)
+
+    def test_each_peek_paints_a_badge(self):
+        self.assertGreater(self._badge_pixels(self._painted(negative_peek=True)), 100)
+        self.assertGreater(self._badge_pixels(self._painted(flat_peek=True)), 100)
+
+    def test_the_plain_edit_paints_none(self):
+        self.assertEqual(self._badge_pixels(self._painted()), 0)


### PR DESCRIPTION
Peek Negative could only be left by finding its toggle again: the overflow menu item is checkable and synced, but the checkmark never drew, so the item looked the same on as off and the canvas gave no sign either.

Under the app stylesheet Qt draws a menu icon in the check column, which costs the checkmark. Every checkable overflow item therefore carries no icon now (both peeks, Before/After, Zone Overlay, Grain Focuser, and the two flips, which reflect saved geometry the same way); action items keep theirs. A NEGATIVE or FLAT SCAN badge marks the canvas while a peek is up, in the same idiom as the BEFORE/AFTER labels, so a view left on does not read as a broken render. Esc grows two rungs above the grain focuser and leaves whatever owns the canvas - either peek or the split - before it touches the active tool.

Peek Negative keeps its own toolbar button and N, unchanged: the five checkable items share one menu, so a verb-swapped title on one of them would read as a different kind of control than it is.

docs/KEYBOARD.md listed the flat peek under a key it does not use and omitted the negative peek and the split; all three now match the registry.